### PR TITLE
rosdistro sync, Fri Nov 17 13:45:24 2023

### DIFF
--- a/distros/humble/aerostack2/default.nix
+++ b/distros/humble/aerostack2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-classic-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
 buildRosPackage {
   pname = "ros-humble-aerostack2";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "703cd39bf60a2034ed1cf12e66bea26d15ed41b7aa05560e5b549fb4a5ff4a90";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f9aea9ab9b8cf166b5f2cd9e465389e42027ed40f0154ac3c33c2eefa0e81aea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-black/default.nix
+++ b/distros/humble/ament-black/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/botsandus/ament_black-release/archive/release/humble/ament_black/0.2.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_black/0.2.3-1.tar.gz";
     name = "0.2.3-1.tar.gz";
     sha256 = "2bbc4f8fd92ea8ba2ff4710f4f70796fd2989f1c61b659845723fc7830314e54";
   };

--- a/distros/humble/ament-cmake-black/default.nix
+++ b/distros/humble/ament-cmake-black/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/botsandus/ament_black-release/archive/release/humble/ament_cmake_black/0.2.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_cmake_black/0.2.3-1.tar.gz";
     name = "0.2.3-1.tar.gz";
     sha256 = "b841f007d2b41dbac17073a72a89f166b8001976db42811d91ac011ca82ff4db";
   };

--- a/distros/humble/as2-alphanumeric-viewer/default.nix
+++ b/distros/humble/as2-alphanumeric-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, ncurses, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-alphanumeric-viewer";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "4f9e8ec680a6597297c83c1b9ae7ef4299b7079e79280a01e2fcf458d6ba0b80";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "82b58c4ce27f3d47275bc4574b97c0440869126eaaf1fafcdeab399fe042d813";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior-tree/default.nix
+++ b/distros/humble/as2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, behaviortree-cpp-v3, geometry-msgs, nav2-behavior-tree, nav2-msgs, rclcpp, rclcpp-action, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior-tree";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "64d75a4cd1ea59f1294a3c427e4ea695a447990574c3eb65577b1b444f0e10f1";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "c8e17492362c44bc33b80de4c5940b9023cb44888eb8582db2cda09d08ae5b52";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior/default.nix
+++ b/distros/humble/as2-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "e4b53a0d477973ca724de405a3f4dcb9f84ccf8119b6f3072766f47fd26faa8c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "aca711d115623b2429912d121a1f4a45feef00c22f661d05b12c95c02dfd061c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-motion/default.nix
+++ b/distros/humble/as2-behaviors-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-motion";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "056ae3bf19f704ba1ad819f586ec7a9fb8a14e0c47d2ed121f12c96171593f0e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7fe84746625746af69c9da401ad563b6b6dc27f8cddf05cbd452487795b00d39";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-perception/default.nix
+++ b/distros/humble/as2-behaviors-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-perception";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d8510b47c8271a522e920f39bef535620a7cb515feb1a6a9954b87b58a3bf0c0";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "effb1aee242b3c53abdf5e8d0732471a2e0e4c35dfdd8724775105f35fe25a4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-platform/default.nix
+++ b/distros/humble/as2-behaviors-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-platform";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "058083f1b3643a4050f332f95e76fa0f1974981e4f672a8cdfa86d9cda380204";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "8ea6418de1f9030810bc7d5163ed7457400eb8007a6e37ae58b5c2cd66546639";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-trajectory-generation/default.nix
+++ b/distros/humble/as2-behaviors-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-trajectory-generation";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "5112e8edf75ea6b129e4a67bc839bdbc2cf4b65f1f5ce8cc602b71610a4c173b";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ca9e8d8c000e7987d83b60d9c7ac97450a1bd6178705eb1bb1f704b7473d8d05";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-cli/default.nix
+++ b/distros/humble/as2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-as2-cli";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "932595c3f947c4b0126787f0c19fb112cbd4275824ce1f0c527957a1a592553e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "278d842c1d536063e670f73a79f7e59b1a2627b162c66cfef9f8df3cd884f939";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "eb5956d7bc06424068dcaafd29360ea3f9918407618386857aefb326e9b058b6";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "0ca84d13b256a395ced866e52c5e05f9cc3df5a9c32a4990eec2bc62e9b6bd60";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-gazebo-classic-assets/default.nix
+++ b/distros/humble/as2-gazebo-classic-assets/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, python3Packages, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-gazebo-classic-assets";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7069101a62e3d672b2638dc5f61d7b48c3e6298d61a37448374cab4016a81299";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9d5293f81cbdd0ee8d8dec3f8e5740ba71db68c3b4f5da28d7d1c301594bad47";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ python3Packages.jinja2 ];
+  propagatedBuildInputs = [ gazebo-ros-pkgs python3Packages.jinja2 rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-keyboard-teleoperation/default.nix
+++ b/distros/humble/as2-keyboard-teleoperation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-motion-reference-handlers, as2-python-api, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-as2-keyboard-teleoperation";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "a7deadf8de45042334476701877fa9a934a575c5a4d881e70b01be5d37ec2ce2";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "49b62b7fbb4578940cc5ae0a689654e3ca6a2902e695f6e025da13ce67e475fa";
   };
 
   buildType = "ament_python";

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7956a57e1e5274aa161886b84f73b00c0647fd4f3962b7321f9d10defd584ac2";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "8c9956716bc483195b98420fbb337af4ddaa5a82cc3d8ccae59e7add55af2a7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-motion-reference-handlers/default.nix
+++ b/distros/humble/as2-motion-reference-handlers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-action, rclpy, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-reference-handlers";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "ead1fea4e336c6633633a50929576c6863b7f2f092c2868c539e89e66cdb5e4a";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "54c398eb61847c4165f73ba625fb5414f1c214bce4bb2659bcb7c7f0f20d2d02";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-msgs/default.nix
+++ b/distros/humble/as2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-msgs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "8172400d6bcc5a6662be356025919e5bbbf403ff7cad2012cf1864fe0ccec185";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7a682a29256a6a53ba3595fb43a636bc8a3d37623ec82b3113f930e76a156ada";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-crazyflie/default.nix
+++ b/distros/humble/as2-platform-crazyflie/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-crazyflie";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "8453727786f019d02e3c28c75d3a19defe622d6bff040502f30a1b2550daa339";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "67883ba6e82a9e3e733347c0bacc5fef1a6e6bdd3b38fbf37d98a84f9af451dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-dji-osdk/default.nix
+++ b/distros/humble/as2-platform-dji-osdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-dji-osdk";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "6db579851f9d7e85d55a404f542f91ed22ce984a9558d4e3cd7a5940e7ac0f25";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "de5e2f968f4eeb8b77376990c1a12fbbfacbc41eb04a0988a72b5a02b4111c56";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-ign-gazebo/default.nix
+++ b/distros/humble/as2-platform-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-ign-gazebo-assets, as2-msgs, geometry-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-ign-gazebo";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_ign_gazebo/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "43f69b74c541d7a1d77ade49ed162d498912c2e8ac6831f148b397d16964c3fa";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_ign_gazebo/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3cf0e921c28d05c2e11cce276dedbc257a910b31c5031ea31f50cabf038c4d8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-tello/default.nix
+++ b/distros/humble/as2-platform-tello/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-tello";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "a9abefbee3aa96c0d632b333ea32a959b6753325d38c1eee780e06311146ec4e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "d96120b0aff26b914ff860504cb7468e41fd5b5acee0a7eb7b579853eebb2000";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-realsense-interface/default.nix
+++ b/distros/humble/as2-realsense-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, geometry-msgs, librealsense2, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-realsense-interface";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "758ef2622088bde407471d760b1e56a2344f3a6ee6d239df7fd55a06d4c18f65";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ac99c3ea9f6a61c7b1aca9adf34966fe9e4b8b4e012c092e2eee701d36aab29f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-state-estimator/default.nix
+++ b/distros/humble/as2-state-estimator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, geometry-msgs, nav-msgs, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-state-estimator";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "b1dce3edb70b6f0db5fef185e4c42611790f377e35e4f23be6270fc611dcdc0e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7628adadf2c6828fa88a7f97498cb2643105f7f43980d0a4183925714fdd07ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-usb-camera-interface/default.nix
+++ b/distros/humble/as2-usb-camera-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-usb-camera-interface";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "15b4049cfd9ec3d42f8af9f3cf47799eb3f95c44df7fdc60d83425fc105f94eb";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3a866848c2f5b6a0ef14287e4c394d3a389c61b0bd958d087f113e6448180e9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "d1b6894e7489602fca7cf0329179252b7bce0138f6bad9ec266ed13179e0a262";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "c1f18f59f7a55fc8fb8b991b1cd1ab9b7198507963787b7ce8e70f68e2566ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "8ce2d99e9986395463fe975e06a57f3dd0a17665cf09308289494d7358b39c85";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "4828a9ac823df3ca381c385c68c096990593ed75605a65adedd840e3b71a2975";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "37ed801ef0488e895d6329177c1a740d875b51077cbb89f5fe5012ee8786145f";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "1880971ca205da73b6bc1d27e68ef0c3caddd46ea134070c7951ef75142d9054";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "16455b7299b5218cc1f95aef891ac0f3cf6f2d8cf2069d4ba6460ebb296cd112";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "8f47715d546fdf765e0971cc196abd2179aff5ef89bd9a4decec4c8322ebf5a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "62f37665fb1864d6e53b02f7a6be33451be93fa6f46a206400d1c494d5e1bdd7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "a5c52ae442ddff243787cdec278a5b17471784f7b11c820c325444bfb193e33d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "9a5afe4f2fa8f02c0c73b69b1a8574e7eff6fe6e5cc0b7021b5cc6bad0ba8b89";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "6bff4cd4a980a0311702d51925bb9feaccb1d2889316cc1cd1bebbc9f1f0caa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "0573623bba39b926633059b84f8b1b30e7cec819f444df61f19193b11803958a";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "06bc2252305f5f5c3e4b9eadca92005943cfa032521716758ecc33199d1e8dbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "4a2cc5de27a43a09a19b7e1130d68a918fb6f77564e73308828aa9171274ae7a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "3dd3df249a6a0ec0013c6f8e68584b19525999ba096d359a250e7c79ffcb9881";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "89b4ebbd283a01ff152ce5da4b2850631f9e78e2d7c09c583fb89f6ea416e02a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "9ba561d2bdc3a1bb5aca1070ffd8773255f0c410959148f904bd3a113b998fc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "9ca6df16fc19d3f915fad2220f1b69e80af9d1901de042356d6914d4257a4f19";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "4c4d2da316ab6b4988c495be25b716fb1a4aa3907f97019c0ea8be7fb883a92c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "20f912b5e6ff122a3e0213cb698c1cb4d40582d116610db4d5b1651c2936ef53";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "fb19e76f81a1f91f2f8aea4833f69481070065fa4e634070c1a2458cc6f9df5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "b2346f054496e33d1732d190bd2886fea1c350df2c964e69acdf3cde2e33edd8";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "47325ebc27d286931d2c104021e98301baca116b792de46635873a3e8fbf5e2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cob-actions/default.nix
+++ b/distros/humble/cob-actions/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, actionlib-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-cob-actions";
+  version = "2.7.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/humble/cob_actions/2.7.9-1.tar.gz";
+    name = "2.7.9-1.tar.gz";
+    sha256 = "2f15e4d75a5e8ea045adc811825f20d0dee6da82e3fbee342eebbda6fafe990c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs actionlib-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This Package contains Care-O-bot specific action definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cob-msgs/default.nix
+++ b/distros/humble/cob-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-cob-msgs";
+  version = "2.7.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/humble/cob_msgs/2.7.9-1.tar.gz";
+    name = "2.7.9-1.tar.gz";
+    sha256 = "48f582be55db8b0083101a1ddd19e80376a6ec39bf3594552dfa1695cf613fcd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces diagnostic-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for representing state information, such as battery information and emergency stop status.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/cob-srvs/default.nix
+++ b/distros/humble/cob-srvs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-cob-srvs";
+  version = "2.7.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/humble/cob_srvs/2.7.9-1.tar.gz";
+    name = "2.7.9-1.tar.gz";
+    sha256 = "80f9372180b3d1bca14f9d1ddc175a6e02e7181774b37468acdac33ae43995d8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This Package contains Care-O-bot specific service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "81f9f7607751de4f27d1308d81c75563d8457945feab169cf6702ecd4bf07383";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "33249604146be0857066fd2f156b948879c098902dbb906ca56e237f8a2d5206";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "72fbe23aee674b9c0e52ee40374c5f9e96f1e62953e8c6bdd44803d3c96231cf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "a081b51e6c05e29ab1f696a28a4d65ca27214d6378c8f888a2ecf5b618abfb95";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "afded5e52b3892ee7159fa0c666b427f3cdb3d6df407e4c76bc054bc83ef4212";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "de768403a309e33992e94e143c4a437a2ce60a243e173c45bfdef73614bbe027";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/humble/event-camera-msgs/default.nix
+++ b/distros/humble/event-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-event-camera-msgs";
-  version = "1.1.4-r1";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/humble/event_camera_msgs/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "83d1d4dd82b4ba311e06152075ab04116312e1f7dc7f8065a4db8a85392a3b02";
+    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/humble/event_camera_msgs/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "08a1e4504d25b090101a36079d3cd3e448fd97c0b7fc65be99345683b3e7f414";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-video-monitor-interfaces/default.nix
+++ b/distros/humble/gazebo-video-monitor-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-gazebo-video-monitor-interfaces";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_video_monitors-release/archive/release/humble/gazebo_video_monitor_interfaces/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "47c60a8b0587a4aab988082dbe2108ad1384e457d72e3c820c3107d32c883aa5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''gazebo_video_monitor_interfaces defines interfaces for the gazebo_video_monitor_plugins package.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/gazebo-video-monitor-plugins/default.nix
+++ b/distros/humble/gazebo-video-monitor-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-ros, gazebo-video-monitor-interfaces, opencv, rclcpp, std-srvs, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-humble-gazebo-video-monitor-plugins";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_video_monitors-release/archive/release/humble/gazebo_video_monitor_plugins/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "34d9a3447cd3f325bc80f777a8490b1ef9014481e56291b62592abdc20db670c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake yaml-cpp-vendor ];
+  propagatedBuildInputs = [ gazebo-dev gazebo-ros gazebo-video-monitor-interfaces opencv rclcpp std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gazebo_video_monitor_plugins is a package that lets the user record videos of a <a href="http://gazebosim.org/">Gazebo</a> simulation. It provides a multicamera sensor that can be used for creating different types of videos with multiple views from inside the gazebo world. There is a number of plugins already available in the package, but more can be developed by the user, with minimal effort, to fit arbitrary use cases.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/gazebo-video-monitor-utils/default.nix
+++ b/distros/humble/gazebo-video-monitor-utils/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, gazebo-msgs, rclpy, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-gazebo-video-monitor-utils";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_video_monitors-release/archive/release/humble/gazebo_video_monitor_utils/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "b21bf1b8e79a8c933369b3aba4dad47ac35c121952c499c52ccf2494ca0cbf6f";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ gazebo-msgs rclpy std-srvs ];
+
+  meta = {
+    description = ''Contains utility scripts that are meant to interact with the gazebo video monitor plugins.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/gazebo-video-monitors/default.nix
+++ b/distros/humble/gazebo-video-monitors/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-video-monitor-interfaces, gazebo-video-monitor-plugins, gazebo-video-monitor-utils }:
+buildRosPackage {
+  pname = "ros-humble-gazebo-video-monitors";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_video_monitors-release/archive/release/humble/gazebo_video_monitors/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "c5664bb170a3dc9f449377cb87c3f031abb415e2a55bf23e736ea613ce8d5f0b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ gazebo-video-monitor-interfaces gazebo-video-monitor-plugins gazebo-video-monitor-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage that groups together the gazebo_video_monitors packages.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -354,6 +354,12 @@ self: super: {
 
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
+ cob-actions = self.callPackage ./cob-actions {};
+
+ cob-msgs = self.callPackage ./cob-msgs {};
+
+ cob-srvs = self.callPackage ./cob-srvs {};
+
  collision-log-msgs = self.callPackage ./collision-log-msgs {};
 
  color-names = self.callPackage ./color-names {};
@@ -706,6 +712,14 @@ self: super: {
 
  gazebo-ros-pkgs = self.callPackage ./gazebo-ros-pkgs {};
 
+ gazebo-video-monitor-interfaces = self.callPackage ./gazebo-video-monitor-interfaces {};
+
+ gazebo-video-monitor-plugins = self.callPackage ./gazebo-video-monitor-plugins {};
+
+ gazebo-video-monitor-utils = self.callPackage ./gazebo-video-monitor-utils {};
+
+ gazebo-video-monitors = self.callPackage ./gazebo-video-monitors {};
+
  gc-spl-2022 = self.callPackage ./gc-spl-2022 {};
 
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
@@ -984,9 +998,15 @@ self: super: {
 
  leo-fw = self.callPackage ./leo-fw {};
 
+ leo-gz-bringup = self.callPackage ./leo-gz-bringup {};
+
+ leo-gz-worlds = self.callPackage ./leo-gz-worlds {};
+
  leo-msgs = self.callPackage ./leo-msgs {};
 
  leo-robot = self.callPackage ./leo-robot {};
+
+ leo-simulator = self.callPackage ./leo-simulator {};
 
  leo-teleop = self.callPackage ./leo-teleop {};
 
@@ -1243,6 +1263,10 @@ self: super: {
  nao-lola = self.callPackage ./nao-lola {};
 
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
+
+ naoqi-bridge-msgs = self.callPackage ./naoqi-bridge-msgs {};
+
+ naoqi-libqi = self.callPackage ./naoqi-libqi {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "911e5653930df225830d3ab58596bd6a8bdc890970a26c14c22e726d1e64aa2a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "b100f85f9c1f4d8a490da86aaaf70b0ed5fac70c35ec3efbfc8b34e2d04a7518";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "dca663cec17d3bf034f2bffef037d84854eff759c600f6b6db58ab994a84878c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "32f1dc611b3fd25084b88fba6e61cded7fde27c0d15a60788def2d23f11d4f13";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-gz-bringup/default.nix
+++ b/distros/humble/leo-gz-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
+buildRosPackage {
+  pname = "ros-humble-leo-gz-bringup";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_bringup/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "78faf4fc14a162280007901398620ee931e760d11a6a2d0d1e101228f6a113db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-black ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ ament-index-python leo-gz-plugins leo-gz-worlds robot-state-publisher ros-gz-bridge ros-gz-image ros-gz-sim xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bringup package for Leo Rover Gazebo simulation in ROS 2'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/leo-gz-worlds/default.nix
+++ b/distros/humble/leo-gz-worlds/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto }:
+buildRosPackage {
+  pname = "ros-humble-leo-gz-worlds";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_worlds/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "198f023c6bf44ad18dc5b452f6f2960f8850bb5021444a0ce833b9e120950067";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Gazebo worlds for Leo Rover simulation in ROS 2'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/leo-simulator/default.nix
+++ b/distros/humble/leo-simulator/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, leo-gz-bringup, leo-gz-plugins, leo-gz-worlds }:
+buildRosPackage {
+  pname = "ros-humble-leo-simulator";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_simulator/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "78d6a1b3a872e19e2c10b5c1e374aec2edc19b3a184988de8baa2606430b69ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ leo-gz-bringup leo-gz-plugins leo-gz-worlds ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for Leo Rover Gazebo simulation in ROS2'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/magic-enum/default.nix
+++ b/distros/humble/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-humble-magic-enum";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "a920be4a38da07d0c58348e6317e6caca9f38e09b2b5f894254704d8ef313773";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "0298ab19d8207a2656226a2178268032ba23a49d8b04ebcb3e6ac0cdd8aad69d";
   };
 
   buildType = "cmake";

--- a/distros/humble/marti-can-msgs/default.nix
+++ b/distros/humble/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-can-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_can_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "dc9465cab56a09c74e29d36b31e200f0d8b3bbf7f162638e35449f8bbc07441c";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_can_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "bb14598e0e8d7886655e21fa4f12e9d866501533434464fa2c2a3efabb1a0c9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-common-msgs/default.nix
+++ b/distros/humble/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-common-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_common_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "8334cb25d2b9f1724dd697e2e9dda5b6ab04210398434b222a705060c52aed51";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_common_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "667e78d2fbba4bce0ee3e8950e68e551f1296186e02622c0e413b86a4a013bb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-dbw-msgs/default.nix
+++ b/distros/humble/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-dbw-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_dbw_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "dd921a880f67354409b79ba0e99639706ff3f767205cf05db55078d531966870";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_dbw_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "e53f7aaaa830a9ebe5750ec365882043b9cb3f7e326ba8059cbd39a1ba451c98";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-introspection-msgs/default.nix
+++ b/distros/humble/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-introspection-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_introspection_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "6b148194032ffcdd2181c31581ff5089d3af6e18559ee0ffa7581e9843ea2bad";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_introspection_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "48a3c8f99a7c72ebf1e62e8aa9245d5771c4c4fde98c7c77727cd44c2f4b3886";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-nav-msgs/default.nix
+++ b/distros/humble/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-nav-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_nav_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "a85e4525533030312a1111e6f48c451ec512ab8b980d7c4f76b6d1327ed22b21";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_nav_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "8ba61e8e2f0ee41b2ca68516f6bb3c90867656bde813d586b4a3a9673431ad2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-perception-msgs/default.nix
+++ b/distros/humble/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-perception-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_perception_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "a93c9606cda1365abccfe392ca59f9dbf18895d9c4dad75b2bed2c16fdcdf06e";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_perception_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "d32dd7f76589c206aca4f6ec0248a55e988f0d464e3a001d5ff5f70204879602";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-sensor-msgs/default.nix
+++ b/distros/humble/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-marti-sensor-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_sensor_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "ec26b8103da127b30a8d55c936cf4c4a32eaa9aeca3d08188f53968290d6a446";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_sensor_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "717abe3ddef59e663eb49f95416dbb8461f9a10fadd4a2d94c446ce004678c3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-status-msgs/default.nix
+++ b/distros/humble/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-status-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_status_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "443e9685e9cec9a6f3ace091a180f167013672131961afd873d7e51a690d977d";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_status_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "a971e1665f0aabdf62621833bd3be9324a7321365e0cf58dd049f0dedd0ff10c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-visualization-msgs/default.nix
+++ b/distros/humble/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-visualization-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_visualization_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "99c041386e3626c2cd51774fd3fcf5f18dca8e6cdcd2567bbb1676ad2116fed0";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_visualization_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "cde59f88eb9b40480695cbe2bed8d8e7fca9a5a81261bbda39f7e7f166d34168";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/metavision-driver/default.nix
+++ b/distros/humble/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-xmllint, boost, cmake, curl, event-camera-msgs, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb1, opencv, openscenegraph, rclcpp, rclcpp-components, ros-environment, std-srvs, unzip, wget }:
 buildRosPackage {
   pname = "ros-humble-metavision-driver";
-  version = "1.1.7-r1";
+  version = "1.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/1.1.7-1.tar.gz";
-    name = "1.1.7-1.tar.gz";
-    sha256 = "ace307e9b21e692962cb97fa4211f3b6048e9d65e3a99ebf528cd3b1edbdbee6";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "06775747fa8e9d2427839ab7507ae612ebaf85d1a056cb2445310628325211d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/naoqi-bridge-msgs/default.nix
+++ b/distros/humble/naoqi-bridge-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-humble-naoqi-bridge-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/naoqi_bridge_msgs2-release/archive/release/humble/naoqi_bridge_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1c19aec33f2a15fd41455e3a81ece62c34ad8ade6b79af32fdc8072c9e0e07fa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs nav-msgs rosidl-default-runtime sensor-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The naoqi_bridge_msgs package provides custom messages for running Aldebaran's robots in ROS2.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/naoqi-libqi/default.nix
+++ b/distros/humble/naoqi-libqi/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, openssl }:
+buildRosPackage {
+  pname = "ros-humble-naoqi-libqi";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqi-release/archive/release/humble/naoqi_libqi/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "0d3e8e26b36fa564c0459c630b1ea3c14921fbbfe6304919748fd0f472400a16";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ boost openssl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Aldebaran's libqi: a core library for NAOqiOS development'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ntrip-client-node/default.nix
+++ b/distros/humble/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ntrip-client-node";
-  version = "0.4.4-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ntrip_client_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "d5af493070521f55cefec922cebdb349a7fba3ac49c124053f0cfbb244a405f5";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ntrip_client_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "4ffbf7c179d9617de36704888b0ca71eb9e77e6c3cc18510c1550d88b867d405";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.7.1-r1";
+  version = "3.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "bbed979a0e04312f61b0ae5c19038406a9452c2c87a2c36409146787bf49b4de";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.7.1-2.tar.gz";
+    name = "3.7.1-2.tar.gz";
+    sha256 = "6431f2c3869c100316ade057fdecb814299df93a16a7fa3de68afd7cf781284d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-description/default.nix
+++ b/distros/humble/raspimouse-description/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ign-ros2-control, joint-state-publisher, joint-state-publisher-gui, launch, realsense2-description, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-description";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "268227e0f3f6c8de12e561198830ff870384d74901e3e65de669a6fc1a924d28";
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1efeb025cfb4d1d272507302a820654ad5f10c7cd199f42a6806678a4f6be0f2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 urdf xacro ];
+  propagatedBuildInputs = [ ign-ros2-control joint-state-publisher joint-state-publisher-gui launch realsense2-description robot-state-publisher rviz2 urdf xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/raspimouse-ros2-examples/default.nix
+++ b/distros/humble/raspimouse-ros2-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-ros2-examples";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d17f48b74fd8e1b8babfdcb2fd6a41f41d5bf20b5e7e8d47ec6d47bfb19cdad7";
+    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "4567bff84be33ef7d59c41fb4945ba38adb19accd63aa094748f07cf385e20ba";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs v4l-utils ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "0843e86ac7b1e03d35d125294a88bc869e6828d886be8472c402643671fe9b40";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "1d025d952ebc695dc199b949d04a4f60e758b2417ee3ea16eec7e268531cfa0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "7dbac2104fe699e8c09a4de7291cd6fabfd201427d733be40329aada2470b1da";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "b057063213b3b88ccbed87bac2c3d39668eb3f139b8e88ae1a10c51e05279183";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "499662c5cb95bbbc84436d12c5f53db92fa04a0ef4e47653a71292e33df43101";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "7139a307f02bd8cd7742edf9a680db4b7d8ab65cb7efeb94e9bf95288a710bd6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "cbe74c776498a04d3eae4ede9578012c2a555cce63bae8e626a1a8f77f546476";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "bb0a6e0b36f3effd6eebe46a4e982724a62dc6fe112390021371cfd5dc786af3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.33.0-r1";
+  version = "2.35.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.33.0-1.tar.gz";
-    name = "2.33.0-1.tar.gz";
-    sha256 = "e55c8b2d11a763ef3c63c8770d7f4825b452f1b467384194f43d83469ee70e25";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.35.0-1.tar.gz";
+    name = "2.35.0-1.tar.gz";
+    sha256 = "36a5930168eb16dd917f159f12e798bd7e5a566322cb0c1c011ab985f5bee3a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-base/default.nix
+++ b/distros/humble/turtlebot4-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, libgpiod, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, turtlebot4-msgs, turtlebot4-node }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-base";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_base/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "50feccadb6791bbab01d60f169314fcc4071a3659d975d76c8d65badf3c9d258";
+    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_base/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d5e6f53c4e4affb0f0c546897dc316cc93f5211585cead36a337d3083d7b6876";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-bringup/default.nix
+++ b/distros/humble/turtlebot4-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, depthai-bridge, depthai-examples, depthai-ros-driver, depthai-ros-msgs, joy-linux, nav2-common, rplidar-ros, teleop-twist-joy, tf2-ros, turtlebot4-description, turtlebot4-diagnostics, turtlebot4-node }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-bringup";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_bringup/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "dfc655f048ffb8fe09ce5485e45f3c6416ad49a5b172e9c544fcfa3c0c5ee1c1";
+    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_bringup/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "1a27452eb08bdb086e428a383ce2e506c25eb6c8c07fbb79385a7851bb59a8a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-description/default.nix
+++ b/distros/humble/turtlebot4-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-description, joint-state-publisher, robot-state-publisher, urdf }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-description";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_description/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "36a18c35b30d8df33daa4dbf6b68d0ec76c5b4489f2b9e0ac4dff10eebb1c212";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_description/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "cbdac376de0ce1ab83d109b39e7fccb8861b201fcc022d6696c023142805c0d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-diagnostics/default.nix
+++ b/distros/humble/turtlebot4-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, irobot-create-msgs, pythonPackages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-diagnostics";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_diagnostics/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "3075aef4be6ca87548089e51f31b2f33dc58f4714be10d42da63e9dedc18a367";
+    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_diagnostics/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a883bb10490b649efa4fba0ddf90691a3605585f7321963737c42d577d412478";
   };
 
   buildType = "ament_python";

--- a/distros/humble/turtlebot4-ignition-bringup/default.nix
+++ b/distros/humble/turtlebot4-ignition-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-ignition-bringup, irobot-create-ignition-toolbox, irobot-create-msgs, irobot-create-nodes, irobot-create-toolbox, ros-ign-bridge, ros-ign-gazebo, ros-ign-interfaces, std-msgs, turtlebot4-description, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-ignition-bringup";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_bringup/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e206559248407574ba299b442b1d8a3113958640b55245872df7fce60319f570";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "fb89c26347df858b3e6e174537a5479a2790d0ed3af588658e99bf29b86541c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-ignition-toolbox/default.nix
+++ b/distros/humble/turtlebot4-ignition-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcutils, ros-ign-interfaces, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-ignition-toolbox";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_toolbox/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "930521bde26de2dbdd1373c30a7ddcb3d26689992d024d2abf95f4de3ab64927";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_ignition_toolbox/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7841d06d01e3833f8b7b154b57953fc9f18f9cb1c069c60e3d3cf79d8a36922a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-msgs/default.nix
+++ b/distros/humble/turtlebot4-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "122580eec41882b54d5335d72ffb15ec2d3f3703b73f793f2252c235ac08337f";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_msgs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "438ebb3c5cfd315661fab1d9ec0c005abc72154fbe0881d62da91cfc91bab113";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-navigation/default.nix
+++ b/distros/humble/turtlebot4-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, nav2-bringup, nav2-simple-commander, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-navigation";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_navigation/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "875f7f9a0ce28eed9cc5269abdd234a9db593c0c95eff1afd2b23a81456ec50e";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_navigation/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "99c7354d5f9c074c43dd57d0fec9f008d86cec1911e4f113ec821c703b71a7aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-node/default.nix
+++ b/distros/humble/turtlebot4-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, std-srvs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-node";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_node/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "849e89480d67d14b130555939d565fedd8b35b889a5843c3da74187b329abb5e";
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/humble/turtlebot4_node/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "bda907cce8f8288a80bb7345187e953c5ef22e8f0adcc00c1adf5e1ffb543389";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-robot/default.nix
+++ b/distros/humble/turtlebot4-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-base, turtlebot4-bringup, turtlebot4-diagnostics, turtlebot4-tests }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-robot";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_robot/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6a186f2c52e2daf508dfbde69442a9181dce6cf250a52eb84b73800b3a6e5b3d";
+    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_robot/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "15f674e8ac77a945e6120291321bd7ba7e77927897a5dd19cbc13605acf0d29f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-setup/default.nix
+++ b/distros/humble/turtlebot4-setup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, robot-upstart, simple-term-menu-vendor }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-setup";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/humble/turtlebot4_setup/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b54ef68ed6802787b40e804c9b12c9de0c3cbe1eb9926cf9234409191e76a47a";
+    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/humble/turtlebot4_setup/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "aafc593b14187de58e059c6c1b38f80efe12a7f74a683990d64dcfc46fa2d27b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-simulator/default.nix
+++ b/distros/humble/turtlebot4-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-ignition-bringup, turtlebot4-ignition-gui-plugins, turtlebot4-ignition-toolbox }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-simulator";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_simulator/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "58848c4638e007fc994b34cc2a93b26ffe85892e6cd4407bfa3a410aeb75a744";
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/humble/turtlebot4_simulator/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f0f8970ce43ca8446f3cf21a413c52985bdad1f42052a8df421582ef21c8b555";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-tests/default.nix
+++ b/distros/humble/turtlebot4-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, irobot-create-msgs, python3Packages, pythonPackages, sensor-msgs, std-msgs, turtlebot4-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-tests";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_tests/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "a0e9e4f22b8b5e2dd0c673dbe2a458d20743c2d03e9fe1438ba0465708390d92";
+    url = "https://github.com/ros2-gbp/turtlebot4_robot-release/archive/release/humble/turtlebot4_tests/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "f78afdf9bce90da7b88451e1b435988774c9d47c73819a3739ae2852f1fdd74f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/twist-mux/default.nix
+++ b/distros/humble/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-twist-mux";
-  version = "4.2.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/humble/twist_mux/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "aadd3971ff9120bdc519259c805dec73a2ea4c5a4b4d2fa584a839b1ef127dd1";
+    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/humble/twist_mux/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "9068ad795275d61a376b8a5fd81dad38855f3b834dd96c8850de3e54a567bf2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-dgnss-node/default.nix
+++ b/distros/humble/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-dgnss-node";
-  version = "0.4.4-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "6f9281db9b8add7513abc3a2e8db235f0ed6a1d2f67c2fda66e8200bfa036c66";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "2df3de0b2f8f80cdd538a176cc02cecd07dadcce47ef2552e5c069d2fef00c85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-dgnss/default.nix
+++ b/distros/humble/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-dgnss";
-  version = "0.4.4-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "e7e2726066ee16605623e5f6ec5b871a2ba2ab42cc9a004bece230732453aa1b";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_dgnss/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "982bce6d30cddd3baabe022f60d82c1039820de214e1fa1976ef3be0b64fab8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/humble/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-nav-sat-fix-hp-node";
-  version = "0.4.4-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_nav_sat_fix_hp_node/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "d62d42dc536e02c9756a65a98f7b0ad8d49c5b0183a1d432200493205e81c865";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_nav_sat_fix_hp_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "4a4dfac5c35ac5a4ccc5a7a1dd9625f5d6984f3c31baef5224e8e61f766c4aa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-ubx-interfaces/default.nix
+++ b/distros/humble/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-ublox-ubx-interfaces";
-  version = "0.4.4-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_interfaces/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "52f656c2fb8e21df24d355d35ce3b5e12ad401d4d48dcb08bedf6e5c3622aba5";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_interfaces/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "c87f3ec97371f42177a50e350f010dae1d59c09cb216cd0c81341f952d8623be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ublox-ubx-msgs/default.nix
+++ b/distros/humble/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ublox-ubx-msgs";
-  version = "0.4.4-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_msgs/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "acdb1839e2fd55c9646886fdaf1b4a47c5d17d969473d52b6b59bc680e41651c";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/humble/ublox_ubx_msgs/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "66aea925378b7084248ddb525590d0fa1b685202fac1a9e3bd66e2607d31a43e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-black/default.nix
+++ b/distros/iron/ament-black/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/botsandus/ament_black-release/archive/release/iron/ament_black/0.2.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/iron/ament_black/0.2.3-1.tar.gz";
     name = "0.2.3-1.tar.gz";
     sha256 = "19a6a5f68d8f767aa06b624117db7e714b42526718c64b89918b67dbfe13848e";
   };

--- a/distros/iron/ament-cmake-black/default.nix
+++ b/distros/iron/ament-cmake-black/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/botsandus/ament_black-release/archive/release/iron/ament_cmake_black/0.2.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/iron/ament_cmake_black/0.2.3-1.tar.gz";
     name = "0.2.3-1.tar.gz";
     sha256 = "77c248f9044667c82d772c247e8cbf308be21e06e7de2cdb7f63a511c5109809";
   };

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "293e774d2f8c79a2617a663a93afad8cc72872ba098df9337f80582925efeeb7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "40c929276c012f96595295303579d5ebce756f5e9fa3aeb8108f8dabd9f713c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "48fd36ddce7a861d01618c90e585eadb6eb78271f91273e4cd2ab1cffb7449b4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "8b856edb4af612e595be3debd3a0b1e5b95e134db99c4d64ed22e1e701b5b79d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "64c22b7c0dec52c31031e328b41a7ea56941b5ac81778a017c36ce5c640bb1f3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "b0c136b5d26ab3427567cf4f570c35b6e67c48e3d763c83c963c7c326eeba040";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/event-camera-codecs/default.nix
+++ b/distros/iron/event-camera-codecs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, class-loader, event-camera-msgs, rclcpp, ros-environment, rosbag2-cpp }:
+buildRosPackage {
+  pname = "ros-iron-event-camera-codecs";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/iron/event_camera_codecs/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "9e7da24cd13ba0483a6b804648298020fc7eb41f5e70bdfe45abc5ff759676a3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp rosbag2-cpp ];
+  propagatedBuildInputs = [ class-loader event-camera-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''package to encode and decode event_camera_msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/event-camera-msgs/default.nix
+++ b/distros/iron/event-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-event-camera-msgs";
+  version = "1.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/iron/event_camera_msgs/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "14f8f639290f459ae97a7ea7e6f50a0d7a4cde52acc8faf7479dda2d8e584580";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ros-environment ];
+
+  meta = {
+    description = ''messages for event based cameras'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/iron/fastrtps-cmake-module/default.nix
+++ b/distros/iron/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-iron-fastrtps-cmake-module";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/iron/fastrtps_cmake_module/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "92a37a9cdb931aede6b41726547a38f831e34c84f3213ad40c695344a81555ac";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/iron/fastrtps_cmake_module/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "1c4a05159a240769159d3a22d754f54fd84c5548882bf56b4864b74b53e3d09d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -440,6 +440,10 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ event-camera-codecs = self.callPackage ./event-camera-codecs {};
+
+ event-camera-msgs = self.callPackage ./event-camera-msgs {};
+
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-async-client = self.callPackage ./examples-rclcpp-async-client {};
@@ -812,6 +816,18 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ leo = self.callPackage ./leo {};
+
+ leo-description = self.callPackage ./leo-description {};
+
+ leo-desktop = self.callPackage ./leo-desktop {};
+
+ leo-msgs = self.callPackage ./leo-msgs {};
+
+ leo-teleop = self.callPackage ./leo-teleop {};
+
+ leo-viz = self.callPackage ./leo-viz {};
+
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcreate = self.callPackage ./libcreate {};
@@ -1043,6 +1059,8 @@ self: super: {
  nao-lola = self.callPackage ./nao-lola {};
 
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
+
+ naoqi-libqi = self.callPackage ./naoqi-libqi {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "c9417f9623d5941461edd153522b8b5ab2d1f0c0a1528b6756f40d6cab35e9ac";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "9bda4b4b8029add939649b443b981d533ed3344d8294ad0d1c9c5017afde2907";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "f688d575a0b66042548e4ef579f4837dc7d625db1b6f4002e7eceaf00ee50ab6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "9022c7f389761a3d855db5fcff67b32d77ef05f4e54d57f274a06500ab040cd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-description/default.nix
+++ b/distros/iron/leo-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-iron-leo-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d71823d97a81facd16395f8fb69994a815b024fc3cdf9c018eb613cf2e82a766";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF Description package for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/leo-desktop/default.nix
+++ b/distros/iron/leo-desktop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-viz }:
+buildRosPackage {
+  pname = "ros-iron-leo-desktop";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/iron/leo_desktop/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c717c10df8ff0e789d9f67b3d6ce8b70a942888d4d070c85a6f2621ff67442e3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ leo leo-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for operating Leo Rover from ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/leo-msgs/default.nix
+++ b/distros/iron/leo-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-iron-leo-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "0f399726183b68519d150a1e6ed5460f360b963062c3107f4701e15f2cd4a8d3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Message and Service definitions for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/leo-teleop/default.nix
+++ b/distros/iron/leo-teleop/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-iron-leo-teleop";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_teleop/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "82476720a61f60cc10d58f70aa950e6857fb838cfda3bb7b5bc6f2e15a692e62";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joy-linux teleop-twist-joy teleop-twist-keyboard ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Scripts and launch files for Leo Rover teleoperation'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/leo-viz/default.nix
+++ b/distros/iron/leo-viz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, leo-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-iron-leo-viz";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/iron/leo_viz/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "09e790f31c149655e161dc2f873a572cbfae4b2f3463d864396eeb06291fb963";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/leo/default.nix
+++ b/distros/iron/leo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
+buildRosPackage {
+  pname = "ros-iron-leo";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "405ca4b6028d273af6fd41d6b8fcc94f2703db2be8a6065d176d3345d81ca5c9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ leo-description leo-msgs leo-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for Leo Rover common to the robot and ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/libstatistics-collector/default.nix
+++ b/distros/iron/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-libstatistics-collector";
-  version = "1.5.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/iron/libstatistics_collector/1.5.1-2.tar.gz";
-    name = "1.5.1-2.tar.gz";
-    sha256 = "f735cbfd9c8d2c05543c7f12eee62d5935933d4031890a3a8add6b1fd27dffee";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/iron/libstatistics_collector/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "46146d8869230b4a9a4bc95fb8e2d1167788fd303ad9634885990d763c2d119f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-can-msgs/default.nix
+++ b/distros/iron/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-can-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_can_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "391abb6f63866ae6a58925450df7fce495d4f21ab749ef7e4ff620fc4de814a6";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_can_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "c974389da23212052a11f8bad136b1a3017fe83b3c809256e78b7c41ba08d528";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-common-msgs/default.nix
+++ b/distros/iron/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-common-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_common_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "c43c038308845492b350752b5f68416fdadb2dc6064828e9e1480be626a1b1de";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_common_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "59c2e2384fe7a087c40fbe19ef289f8c8a8ab29e2e5d240e44309ca87f2897e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-dbw-msgs/default.nix
+++ b/distros/iron/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-dbw-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_dbw_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "7369c7f7015dc6e83341ba9a1ee17c88f7e824678bea2878b69dfa249304b638";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_dbw_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "613d8162f9ed5073c67c61d771de1fb0633bd27a0d80cc981a9c965b5f1f5b2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-introspection-msgs/default.nix
+++ b/distros/iron/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-introspection-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_introspection_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "23c4e375469713b69570fffa33d94d37736196611a410ec623cc90877269c7d2";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_introspection_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "eadc92a5e236b4f067a81bc23e85e9f82fd1e324d3aec8ce7adf825302b99d36";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-nav-msgs/default.nix
+++ b/distros/iron/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-nav-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_nav_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "3a52a59b55606eb7f6050202488d8453b2513bec3ad1f8e629349a9095bec3a7";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_nav_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "86edbe77443e40fa7d0eeaff575f72211d9069c91ce9a807c2479c110ab56a2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-perception-msgs/default.nix
+++ b/distros/iron/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-perception-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_perception_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "05dd94d9eced6e125c847574c0f64fd04cf04c8f1f989bb6150c9b2b86d45a70";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_perception_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "b64aac9cd9f47c4997342caaba77f7d71f8066173170503d70111f7942008d1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-sensor-msgs/default.nix
+++ b/distros/iron/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-marti-sensor-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_sensor_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "2e7f8a1344591e5ae49647dda0fc3814c4c97feea68ba8937366ac7f5b59655e";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_sensor_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "2355c62b76cd66f7f6549d26ec36ab863083363072a10e46f936d3ab16f00ed2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-status-msgs/default.nix
+++ b/distros/iron/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-status-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_status_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "35679b04bede45c2b717f511be954aeec60577791a594cd4fac77e56a44330bd";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_status_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "e1adf0843c4c98e9377a290d4753caf6eda541710f05f364c1ef88b69d1c9ee2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marti-visualization-msgs/default.nix
+++ b/distros/iron/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-marti-visualization-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_visualization_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "35ac36f7ddcb847f6802d3551caf1a68f8d8e7fffd4409bed5cbf3ff89d5a098";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/iron/marti_visualization_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "00a61f185e7b088f5232a8d4c2bd441904c5daaa3f557fed073648a726f75ec5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/naoqi-libqi/default.nix
+++ b/distros/iron/naoqi-libqi/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, gmock, openssl }:
+buildRosPackage {
+  pname = "ros-iron-naoqi-libqi";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqi-release/archive/release/iron/naoqi_libqi/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "7a0a93f9b172044f25a2900fd9498f0bbfa15304b8121fcdbf01c5241cd02213";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ gmock ];
+  propagatedBuildInputs = [ boost openssl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Aldebaran's libqi: a core library for NAOqiOS development'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/ntrip-client-node/default.nix
+++ b/distros/iron/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ntrip-client-node";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "8d1b428f9739a2e999a1dae75fa0dc86a34f81c8b1cabb2cc8bceb635a63a99d";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "9f32ec85eff3e1578a8547ce2ee758528cc34ed1a1312265d3bfb98f153dfaa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-action/default.nix
+++ b/distros/iron/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rcl-action";
-  version = "6.0.3-r1";
+  version = "6.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_action/6.0.3-1.tar.gz";
-    name = "6.0.3-1.tar.gz";
-    sha256 = "a2e4b4a68161292ab74b8746b85444cb4675cb05e007304f5e26cd26043503f1";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_action/6.0.4-1.tar.gz";
+    name = "6.0.4-1.tar.gz";
+    sha256 = "3e286aba073091865ce5dde7e11aeba3eebbf51eed7bd03c2c14506cd28436b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-lifecycle/default.nix
+++ b/distros/iron/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rcl-lifecycle";
-  version = "6.0.3-r1";
+  version = "6.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_lifecycle/6.0.3-1.tar.gz";
-    name = "6.0.3-1.tar.gz";
-    sha256 = "fee37dadbfb4fda033142bd2580467a5e34492cdb87d6bc17fb6ef31849e1c6c";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_lifecycle/6.0.4-1.tar.gz";
+    name = "6.0.4-1.tar.gz";
+    sha256 = "0f7781e08592705505593d5acb6182c29b13fbcc5ed77b2d33d1cb2120bade38";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-yaml-param-parser/default.nix
+++ b/distros/iron/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-iron-rcl-yaml-param-parser";
-  version = "6.0.3-r1";
+  version = "6.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_yaml_param_parser/6.0.3-1.tar.gz";
-    name = "6.0.3-1.tar.gz";
-    sha256 = "b3483b539a64ab2f650c4be230081ef1302bac35b81d766d07a3352dc0b01e35";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_yaml_param_parser/6.0.4-1.tar.gz";
+    name = "6.0.4-1.tar.gz";
+    sha256 = "bf62fb9a0a9e41f820daf7acf67d6d3d32e0a19467ddd647d9cd414dc04e9d39";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl/default.nix
+++ b/distros/iron/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-iron-rcl";
-  version = "6.0.3-r1";
+  version = "6.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl/6.0.3-1.tar.gz";
-    name = "6.0.3-1.tar.gz";
-    sha256 = "d44fd776022482552273348cdd57e828697a04c8e75f4abbe4f4c68430d7818c";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl/6.0.4-1.tar.gz";
+    name = "6.0.4-1.tar.gz";
+    sha256 = "eb2635f14661f39a73641c8d9fa4c13d9a6d28408ec7ecff526f9a046d1fe64e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-action/default.nix
+++ b/distros/iron/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-action";
-  version = "21.0.3-r1";
+  version = "21.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_action/21.0.3-1.tar.gz";
-    name = "21.0.3-1.tar.gz";
-    sha256 = "a3ba210614e40d3bac8235498d22557a6bafe7ec83fe362d22a4bc1862c6d2d5";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_action/21.0.4-1.tar.gz";
+    name = "21.0.4-1.tar.gz";
+    sha256 = "bd2dea03f58fc3ac81ef7d73bd6ac5d83a9cb40549aacd7ecce5b5a0ce3a107c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-components/default.nix
+++ b/distros/iron/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-components";
-  version = "21.0.3-r1";
+  version = "21.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_components/21.0.3-1.tar.gz";
-    name = "21.0.3-1.tar.gz";
-    sha256 = "32cafc693db18117266f9b24f86232cf272e1ad4120f6e6f248bd83ec9ecf590";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_components/21.0.4-1.tar.gz";
+    name = "21.0.4-1.tar.gz";
+    sha256 = "4bdb7b9966ad9348303c59d21bee01f553d7d561937657d76cea780eed01fd61";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-lifecycle/default.nix
+++ b/distros/iron/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-lifecycle";
-  version = "21.0.3-r1";
+  version = "21.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_lifecycle/21.0.3-1.tar.gz";
-    name = "21.0.3-1.tar.gz";
-    sha256 = "11d7ee59d0855fe68fbf8ea35a3aa6cf8997b06207c149c8e814a6a7e1e6a36f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_lifecycle/21.0.4-1.tar.gz";
+    name = "21.0.4-1.tar.gz";
+    sha256 = "dae71348e6226c3c7790cd7ce8278b30cccd192549201959e9ef30627fa97bc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp/default.nix
+++ b/distros/iron/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rclcpp";
-  version = "21.0.3-r1";
+  version = "21.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp/21.0.3-1.tar.gz";
-    name = "21.0.3-1.tar.gz";
-    sha256 = "8d554b515556a8d43321147871716a2e13f4bfd50bca33ef18873772eb7b16fa";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp/21.0.4-1.tar.gz";
+    name = "21.0.4-1.tar.gz";
+    sha256 = "dec56f861e44cf7ab949f4f4f1ba002467bf3c04c004738754a546f23354a071";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclpy/default.nix
+++ b/distros/iron/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclpy";
-  version = "4.1.3-r1";
+  version = "4.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/iron/rclpy/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "444812389be762808f7c0502f8b50dcd4a1a52ffb2492b67f70006eea1a76be2";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/iron/rclpy/4.1.4-1.tar.gz";
+    name = "4.1.4-1.tar.gz";
+    sha256 = "8cb97fe0cf3b57c10d0ced31ce485fb76246533be58c46c05a0d304f02b06589";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcpputils/default.nix
+++ b/distros/iron/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-iron-rcpputils";
-  version = "2.6.1-r3";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/iron/rcpputils/2.6.1-3.tar.gz";
-    name = "2.6.1-3.tar.gz";
-    sha256 = "94bf99dc5eccabd7d2b6fa02f189aef89ddd87944d3b786ca94d88c9aaa18ed1";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/iron/rcpputils/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "ee44666a692192ca3a3c93629b750b13f616c7af78d531dc0334cd311a4915fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcutils/default.nix
+++ b/distros/iron/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-rcutils";
-  version = "6.2.1-r2";
+  version = "6.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/iron/rcutils/6.2.1-2.tar.gz";
-    name = "6.2.1-2.tar.gz";
-    sha256 = "41e2e53c5617d66b3c2823b2c1b41e4ac7df7800de2d73a77fa69176db2f90eb";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/iron/rcutils/6.2.2-2.tar.gz";
+    name = "6.2.2-2.tar.gz";
+    sha256 = "ad2df7ad7760e301049583cd09d819f7bf7ca52359c53cd2bf9eb1e8cb7ad8e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmw-fastrtps-cpp/default.nix
+++ b/distros/iron/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rmw-fastrtps-cpp";
-  version = "7.1.1-r2";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_cpp/7.1.1-2.tar.gz";
-    name = "7.1.1-2.tar.gz";
-    sha256 = "473f262db87e85480b058eac7b51ff385f9ee079022a7dfc6a14e5cf4bc28aab";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_cpp/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "75cbc1333e20ca207b79f459b5724afb1c73c341fe83eee17cfabda1bdedb6ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/iron/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rmw-fastrtps-dynamic-cpp";
-  version = "7.1.1-r2";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_dynamic_cpp/7.1.1-2.tar.gz";
-    name = "7.1.1-2.tar.gz";
-    sha256 = "5b3ad5fd7fb6b8d017975ea6370bb121596bf618614693b5f5d8507b21e9a491";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_dynamic_cpp/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "d8919146e21768d87f8a8ba00884131bed2ac3fa2f6009957505af813c448391";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/iron/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rmw-fastrtps-shared-cpp";
-  version = "7.1.1-r2";
+  version = "7.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_shared_cpp/7.1.1-2.tar.gz";
-    name = "7.1.1-2.tar.gz";
-    sha256 = "a3e56bb26562bfb6865fef40db807ba3555ebc2f3def35dc05638a13e7d0e15e";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_shared_cpp/7.1.2-1.tar.gz";
+    name = "7.1.2-1.tar.gz";
+    sha256 = "205addb95860d06c1cff35b5fa9215caf04566b9eb0691dd8b12ab91e21d1ae7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "44aaf55da3e67e6dd3a4122dd22729fc7ad671f8c26673f4f9cbefe0e9653350";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "66f31c50db215ed723275d601ac11b9d8fdeb3cf8d0214d0acd85cbc64ea7206";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "5a1f9f0e3944180bb718816c8d1efb973f830c53cd214c6b97f7fae4bb201c30";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "eaf15388b919aad2d05a6efbc121d14a8e3ccd1a66a113e45f8d1d7944a13ef8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2action/default.nix
+++ b/distros/iron/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2action";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2action/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "30d0e155ea4b0551a2a03cd346bc6f026a16470de7998df6d1464d236ed70acf";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2action/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "e5231d987a960badbb8473f384471799bfd9b6942a111975c371f19a68d098e8";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2cli-test-interfaces/default.nix
+++ b/distros/iron/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ros2cli-test-interfaces";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli_test_interfaces/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "8fdf71545dc4947700b79ee420ebf3a428cae387c960cb6f1c26f1bdafaa8c67";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli_test_interfaces/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "a461ddb4b7f435e1c8d97ceaae01fae7cdd9067c791d955fe0ecc2bd071e5944";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2cli/default.nix
+++ b/distros/iron/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2cli";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "e608c25989300151f075c59f238ac291714951d55cc71082e2f92b7aa60247e9";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "2687f0234f06e38361ed959e74f4452c16251548347de54c4ebc8cd565e0a5da";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2component/default.nix
+++ b/distros/iron/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2component";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2component/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "8500c4052da783584aed9f20690dbd26b8e8db294d2b53f70e8508b08d9f626d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2component/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "520c16777146fba5a05af9ab57abb81bac43280e2cdfd1d028c4d1d9a8444d04";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "21748d57d0d4301f5358d09049935449b682273e9f0c81210d75e43be9dbc807";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "ee2d02e4eb403d604b46143aa89615bea11969cfc0a24cf19a7fca162b28e2d1";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2doctor/default.nix
+++ b/distros/iron/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2doctor";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2doctor/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "95241a96dde3557de4b385c1112f4866dc391e5d7511541e3bfa478cd3a0137e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2doctor/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "72ee59127a8d9a163eb1ddf954f68fe05da4889658e07e2b75bcdd33e75f91fa";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2interface/default.nix
+++ b/distros/iron/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2interface";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2interface/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "51755f04d21a5f9f973a4ac283957391ad41dd802d6793a3c0ef3764e18baf96";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2interface/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "2b0fa21076b4ac789bf03ad98a60c11d123e4485c796b62efa6158e8263dddbf";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/iron/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-ros2lifecycle-test-fixtures";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle_test_fixtures/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "c07cded52c1952a84d37416512c30db0c62ef0cfd0fd55220c687e5c2cbd36fa";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle_test_fixtures/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "76cc49e533b046df75020eba2eb1be618017b91f0078629038ad68b3c8447876";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2lifecycle/default.nix
+++ b/distros/iron/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-iron-ros2lifecycle";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "2b4f3daaad03d2929d806329298ec8e313d22e205fc8d293b79a869ded836878";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "6c1faa460f5a695bd8a1ea11a3be758614f9e1a0bdc47012a8230474d5f50914";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2multicast/default.nix
+++ b/distros/iron/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-iron-ros2multicast";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2multicast/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "d39285db0ac195e104a88544d9a80d31d7a7e108b99d05799f651126452320ba";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2multicast/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "e2d793ae8307bc8da4a7b05f767ffb9e556335ce5cb2ef0de606a8a909735190";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2node/default.nix
+++ b/distros/iron/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2node";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2node/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "9bd682f8476cf60276a1b887ff8f2162e720a021ce58bdaaa9cf74de46d563d5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2node/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "32263c81461cb106d8daa833f17a04dd51a55bc2b2d4a293f56b335bcb5f8267";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2param/default.nix
+++ b/distros/iron/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-iron-ros2param";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2param/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "1972132f2ca37a67e4475d417223cc99babcb59eac58b92fd7b8c26db8a2e86a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2param/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "d8c2f3f6711efcca5cbb96e066ba19cd53bd1a3a571e3af633999a6593447712";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2pkg/default.nix
+++ b/distros/iron/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-iron-ros2pkg";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2pkg/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "43fd89b524d9c20c9eff41e8b0239d000022736e7e81e1c8587eaa374b769a09";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2pkg/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "81b1381c88b0f823765c57d436d1c415c1294821e1bbb558d0ec77669aca4f25";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2run/default.nix
+++ b/distros/iron/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2run";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2run/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "7dec4ce515a575e8c28ff868ad3282dcb95941e793a12be88d017199dddb7b32";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2run/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "ebbdc09d65fde28449712ac017f21a73064c0a2fb7c43d4e995530f5b6de2ea4";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2service/default.nix
+++ b/distros/iron/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2service";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2service/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "73a005afc9db41d4fcc32e79a3ec8e671c67206e2643acac8220ff483af7a0eb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2service/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "f79363170d61a930405f099de44830abd390cc5676588dbab38a5bdebda38c51";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2topic/default.nix
+++ b/distros/iron/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2topic";
-  version = "0.25.3-r1";
+  version = "0.25.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2topic/0.25.3-1.tar.gz";
-    name = "0.25.3-1.tar.gz";
-    sha256 = "ed0ba7f39bf448e8e12495ecc53fec40d1e665095703113b6de5605a77b5500e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2topic/0.25.4-1.tar.gz";
+    name = "0.25.4-1.tar.gz";
+    sha256 = "367ba13be56aea197044f3c9e850f0457c36a7b8bff6827ab4bacd667aa361f9";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosidl-dynamic-typesupport/default.nix
+++ b/distros/iron/rosidl-dynamic-typesupport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rcutils, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-iron-rosidl-dynamic-typesupport";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/iron/rosidl_dynamic_typesupport/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "720020584762a48310e863ca7bc0556e1024519f30b8345a6dd54e5201c85755";
+    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/iron/rosidl_dynamic_typesupport/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "6261022b287480ff2d17d8782e35d76ea492d24d580e333396b2c0a31961ed77";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/iron/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-iron-rosidl-typesupport-fastrtps-c";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/iron/rosidl_typesupport_fastrtps_c/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "1f8ad2a936356c3f78cb64ad68792e02e0a3df4be13a2488b49f758d7ef21aff";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/iron/rosidl_typesupport_fastrtps_c/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "db7b66fb9800f4463edc8488d92811e283ecc9c14c4bb138291cb98a839d20f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/iron/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-iron-rosidl-typesupport-fastrtps-cpp";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/iron/rosidl_typesupport_fastrtps_cpp/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "8a32a9ba69e638c86bb67d7d5fb61edd1e9f0849a06f49e1640b7922a245390a";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/iron/rosidl_typesupport_fastrtps_cpp/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "1abf2e0b116d2d9e4d4b094df2e0eef1b6579b84652d830c4509db4d1a7d6481";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "ca2b9704a83d5d98f1ec6e205c62544dc68e7b8749cf9ed0da08519c179151a7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "0d0a9a2f380089a55d84d8a6d8295ce24f9e3969136f0aca637282336ba60623";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-reconfigure/default.nix
+++ b/distros/iron/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-iron-rqt-reconfigure";
-  version = "1.3.3-r2";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/iron/rqt_reconfigure/1.3.3-2.tar.gz";
-    name = "1.3.3-2.tar.gz";
-    sha256 = "3b380d77436a238932266a39294ca9eb8a0a4e98e585691f578fdbe6392d37ab";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/iron/rqt_reconfigure/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "c29c30f3aeb279b2eca567681bc1eb211a1b20d957378ffc2731c0f6f0b659c5";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rviz-assimp-vendor/default.nix
+++ b/distros/iron/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-iron-rviz-assimp-vendor";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "fad21e3e0fc8a78eb5d8b58a5dc3f6e867c25d20a0ad7af5715ad7d1d99f595e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "49959406b5a771a6caab8584777875b7f21402b1f754c9e336ef22c39dbdf6df";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-common/default.nix
+++ b/distros/iron/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-common";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "356e9f1960e552f307d33d127ebc7345b52d9329ac97fdc062f02d81cb4ec25d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "5dde4ef611617885d7cfc5d8d87228260e980cf0cd3ed9501d7dab8449bd35b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-default-plugins/default.nix
+++ b/distros/iron/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz-default-plugins";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "0b63a2697d195c386d600d0b1e7600def8ae770930e88e5a146301bcce783468";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "aaeeb57079f0ed9788dd4ed842ea16576185ef99af74ae91b7316fdcbb0fde0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-ogre-vendor/default.nix
+++ b/distros/iron/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-iron-rviz-ogre-vendor";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "fcf6511768fc700e05ce35e3d8cde3b46d4ec3742c1be2785c787975c0578bc3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "559ed5b8922f568f428a1942538d40b0f8bc73d43505570ce676560b976fc758";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering-tests/default.nix
+++ b/distros/iron/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering-tests";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "e5454e4d8ca46fa315ba03f4a2f13955dc7707b45ad7ee716710c991d2dd0180";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "19536fbbcbb63e38bda7cf8dcf769b88adcea76bc22c260a5fbb458b12ddbad1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering/default.nix
+++ b/distros/iron/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "1b4568d64b4622113b006101e9161e5162ddc5f036bf96c6651af91cb7bfbf10";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "39ddada3c77951a524a83a448abad9aa2a76fdc4b4345f4e1662170d73cce963";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-visual-testing-framework/default.nix
+++ b/distros/iron/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rviz-visual-testing-framework";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "474a59e4093843ff4d25309117cf4becad8ce30bc3e699f92b49c26139ecd536";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "5c041d932153180e125203275a1ffc0f5900a4e401b42fe04e293ec6481b144a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz2/default.nix
+++ b/distros/iron/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz2";
-  version = "12.4.4-r1";
+  version = "12.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.4-1.tar.gz";
-    name = "12.4.4-1.tar.gz";
-    sha256 = "940af7bff059faa0995f70a14cba23c581444f7d8fd2f1f8031aa7b3d35d5e8e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.5-1.tar.gz";
+    name = "12.4.5-1.tar.gz";
+    sha256 = "f181265e80703e2a13eb93e805415ad93e85c971c804364ada32784ac334000b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "d285b81da467fd6aabe917c4b11bc08eb638aab42f19ce9a2cfe95320ee95932";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "4714a0a650d5f53c1ba19cfdacf18c43b5295b402183a12b1571cdacf33e7fb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/twist-mux/default.nix
+++ b/distros/iron/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-twist-mux";
-  version = "4.2.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/iron/twist_mux/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "f9d2b5c2865e4076fa8e3145fef5922911d7eab1b63891f3a6e69946a834d149";
+    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/iron/twist_mux/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "02bb83be8b8e5073815d763c6748e86a093dc391cfe5521219d4398129bef4e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss-node/default.nix
+++ b/distros/iron/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss-node";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ba02308a7581d71191637118909afacaa6d34e773f3a722da2b9dcf9de7b41ca";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "104add79ef0961048558dfe70e263530f26e93c4cf007b529fbf0594ca984f82";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss/default.nix
+++ b/distros/iron/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "85e406ab84077cca7db8ce26b1c48766654119e6e615c655d9feebe2103d0a6c";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "21813d7ec62da342fcb8ea421e3c30827fd6145de945be6736c159c1a0cfc675";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-nav-sat-fix-hp-node";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d611d487273f5f44dc88a7e01831d464aa17b6af363bddbe5e2d8aa0266b1c3d";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "b2c5e8aa62fdc5bcd01799c3dc12f337c016788329fc462fe8cf254e926f6a55";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-interfaces/default.nix
+++ b/distros/iron/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-interfaces";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "e75b610c29b35db74cdef59ceb85d36a29ce33189b9a9b8e9b0d615441587ed5";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "529111489aaed27cf7f83db4feeee67f92849665290adc3f0dbeee7032065644";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-msgs/default.nix
+++ b/distros/iron/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-msgs";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "cbd72f52ae5b278bfadc704cfdd1e8f0bb7459efff88561bf4d7c4fe61d3dcb3";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "51b78d567117874f23f9f4e5cefe9ed0b56b4e4f9d2296cd08e6fd09659e9961";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/audio-to-spectrogram/default.nix
+++ b/distros/noetic/audio-to-spectrogram/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, catkin, cv-bridge, image-view, jsk-recognition-msgs, python3Packages, roslaunch, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-view, jsk-recognition-msgs, jsk-tools, jsk-topic-tools, python3Packages, roslaunch, rostest, rostopic, sensor-msgs, std-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-audio-to-spectrogram";
-  version = "1.2.15-r1";
+  version = "1.2.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/audio_to_spectrogram/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "0fab3f1ebc2e5af100b82a3212977344ed94c59fdac0f0bb7c71b2fb3b65d216";
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/audio_to_spectrogram/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "f5c30a7f4aefee0de4b61ef5eed0589b3cf2211e215850e7a022b1b7f156440e";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ audio-capture audio-common-msgs cv-bridge image-view jsk-recognition-msgs python3Packages.matplotlib sensor-msgs ];
+  checkInputs = [ jsk-tools roslaunch rostest ];
+  propagatedBuildInputs = [ audio-capture audio-common-msgs cv-bridge dynamic-reconfigure geometry-msgs image-view jsk-recognition-msgs jsk-topic-tools python3Packages.matplotlib rostopic sensor-msgs std-msgs topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/behaviortree-cpp/default.nix
+++ b/distros/noetic/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ros-environment, roslib, sqlite }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp";
-  version = "4.3.6-r2";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.3.6-2.tar.gz";
-    name = "4.3.6-2.tar.gz";
-    sha256 = "c5f74c1c7db149eb101bd91e9faf7fe3378aee1be66253aa5875f74c534047b6";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "f96332c54c9baef01333e079b7dbeffd95ec371c6c98faa8e72241da143ad9bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/checkerboard-detector/default.nix
+++ b/distros/noetic/checkerboard-detector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, image-geometry, image-publisher, jsk-recognition-msgs, jsk-tools, jsk-topic-tools, message-filters, posedetection-msgs, rosconsole, roscpp, rostest, sensor-msgs, tf, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-checkerboard-detector";
-  version = "1.2.15-r1";
+  version = "1.2.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/checkerboard_detector/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "70b9133ad9add9dcad01366b8a2969cdf43acea745ba922d1497d887aa58fed9";
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/checkerboard_detector/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "e82e2f249839372cbb7026733605d346bc2b8bd6a6503f94794ec5946f484db1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-configuration-msgs/default.nix
+++ b/distros/noetic/clearpath-configuration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-configuration-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_configuration_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "8ab4aaf233887c16af34f407db03e0ecf5b0173a20eedd7bc9e5046b9766ef94";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_configuration_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "57bdf422ca7119cabf6f1776bb22b039020d0b25bc0924e4ccdb68566d335302";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-control-msgs/default.nix
+++ b/distros/noetic/clearpath-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-control-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_control_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "1dff4b4ce2b6352531acbd2bc8d7fe0f8587979eebfb11bdee00243ab00620ba";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_control_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "a77f59d9b54bc1c9b62359c28494cc2d9b433e69c8a52b6af008172a70fe1486";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-dock-msgs/default.nix
+++ b/distros/noetic/clearpath-dock-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-dock-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_dock_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "2884ca14f2225a0ac0bc3d09dd6a37f3cc734129ad53c56c8db82279766a42e1";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_dock_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "a453f268fe2110884dd237d1a3650940514b1084a2156706047f7825618cf64e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-localization-msgs/default.nix
+++ b/distros/noetic/clearpath-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-localization-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_localization_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "3256ae117febd9aa03184454e70d51ef5e3a461e14698bf79e19a664dba77f19";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_localization_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "dfc32de3e525260dc4e5fb24857e4d89e490aac1340815174a6999115de70cbb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-mission-manager-msgs/default.nix
+++ b/distros/noetic/clearpath-mission-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clearpath-navigation-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-mission-manager-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_mission_manager_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "131754327cbf05f16374de6d3cb0791ccda337e3478bbf65c013e77921f60430";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_mission_manager_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "37576dfa510dad8a2a516948c3c29d9aef71a77bb9b3cc2b0b6b7ba6b63d6d24";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-mission-scheduler-msgs/default.nix
+++ b/distros/noetic/clearpath-mission-scheduler-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, clearpath-mission-manager-msgs, clearpath-navigation-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-mission-scheduler-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_mission_scheduler_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "e5de136398bf54b0f55f9445f97e75793eabf4108f3381408e47282e3c487688";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_mission_scheduler_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "cf4bb72cd10188db0765247b79ac7adf09ab3905b4fb655fee22833b2fdfa1cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-msgs/default.nix
+++ b/distros/noetic/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clearpath-configuration-msgs, clearpath-control-msgs, clearpath-dock-msgs, clearpath-localization-msgs, clearpath-mission-manager-msgs, clearpath-mission-scheduler-msgs, clearpath-navigation-msgs, clearpath-platform-msgs, clearpath-safety-msgs, dingo-msgs, husky-msgs, jackal-msgs, ridgeback-msgs, warthog-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "619e19f54bb97a67cb94ade14e543e4def1b9f7ff34f08f07b1b53a5ca394aa6";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "c4297a23ebefa32f90b6e9cacaa30a2b2299141a5ac5a2d540a485f3dec51634";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-navigation-msgs/default.nix
+++ b/distros/noetic/clearpath-navigation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-navigation-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_navigation_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "ec332edcfbdda8212208ab25aa7a9b3b7dd36383814d14f4421c931f114c7826";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_navigation_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "0ae9672ae871d7fb340fbba4f8e3f3753bfe3df1649897b64ac59f4268c3ee41";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-onav-api-examples-lib/default.nix
+++ b/distros/noetic/clearpath-onav-api-examples-lib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clearpath-msgs, geometry-msgs, nav-msgs, python3Packages, rospy, sensor-msgs, std-msgs, wireless-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-onav-api-examples-lib";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_api_examples_lib/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "811a1e17ff73542c8353c16a349a19c192d62c89d9b8a926637b06c36c1d666f";
+    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_api_examples_lib/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "3161e11971770161efcde1a54bc1a96540e4b555020464cc29fcf46394e32384";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-onav-api-examples/default.nix
+++ b/distros/noetic/clearpath-onav-api-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-onav-api-examples";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_api_examples/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "59af02945534b246abf04afb9f8ee82062e2fbc477bb2178d3109ea856c65795";
+    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_api_examples/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "3d3e490afc9d4aa1989bc885dff985a8fac738dd7628dd684afff856f3b7ca47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-onav-examples/default.nix
+++ b/distros/noetic/clearpath-onav-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clearpath-onav-api-examples, clearpath-onav-api-examples-lib }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-onav-examples";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_examples/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "17d2b112e183a927006dbbfe4ca91000aa3b92761002cc20c8c550828d8aa61b";
+    url = "https://github.com/clearpath-gbp/clearpath_onav_examples-release/archive/release/noetic/clearpath_onav_examples/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "4f51350485f6c8fdf615aeb3ae08aaf045c2df73088a0a6d30efb38ee46d8131";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-platform-msgs/default.nix
+++ b/distros/noetic/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-platform-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_platform_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "0cc273d4fc4a401fcfecd4c032e82c78a3ee583fb6359da4de1bc3cee3ef5c04";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_platform_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "2c74bffef0e128dd0e55cb8d419e3d40086ee724e9f7e7a302beff160ee29a72";
   };
 
   buildType = "catkin";

--- a/distros/noetic/clearpath-safety-msgs/default.nix
+++ b/distros/noetic/clearpath-safety-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-clearpath-safety-msgs";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_safety_msgs/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "169dff001239693b742ff5bc80d3aec42e8d0f773141ce418c6d97dfc69d3e93";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/noetic/clearpath_safety_msgs/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "4b093906a81b267f46edce0872080af924085ff090702a7ff61d595b3816d722";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-actions/default.nix
+++ b/distros/noetic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-actions";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "3b6e6a6d4a3ba976bcde2c76c69f24fcd752961e88550d912d0cdad0445abe06";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "222453e0319f0829005ed9d613f7af7ce9de9e223fab5b98845e27ac4984a8d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-drive-chain/default.nix
+++ b/distros/noetic/cob-base-drive-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-canopen-motor, cob-generic-can, cob-utilities, control-msgs, diagnostic-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-drive-chain";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "915e9b75cfe6cde57dcdcfa87bff346c6f2a4bffd212461282efb8f9125c8900";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "39a6faa136253910301a986ad33e4edc807e34aa07bb49d565e465164109e205";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bms-driver/default.nix
+++ b/distros/noetic/cob-bms-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, sensor-msgs, socketcan-interface, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-bms-driver";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "01bc847a132e3e17c52fb9d3a648ae73483a1f9682408787038611891b033606";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "52d53b4709e7c48b987bf98ddcf390b50ea5be2cb6df520dfa429e5a76b09a30";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-canopen-motor/default.nix
+++ b/distros/noetic/cob-canopen-motor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-generic-can, cob-utilities, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-canopen-motor";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "0219fd0b3a685455a1a1ed460ead00d5a3a56bf7dcd4bf3ed1f4acd889802444";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "d9dbb960f22d3c6145c87b641c9cd3dfb881a4c127c1c817187a0f8bdfacee55";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "5079ca7fb8e1edec99458abc9b969badfd0ef9aa76b1eb679824eecc3e4daaf1";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "1a484c8da8270240c261e8280a70c5ee6fd82564c2aba07a2e68a9ae839ed584";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "b5aed7a017a2c2a2addfb910caaa78aab75a37360f9d27dd91d7a35babc84e2b";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "207771e39629bb4c6ef616efbc4da8d7ff9915e734b3582f68dfab357b723807";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-common/default.nix
+++ b/distros/noetic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-noetic-cob-common";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "107d9ddf164b8d0bb175b49675311c97558a5b5f84cba6555c2bb15544595acc";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "e1fe87bb41db9dd0095825e90dcfb2d7dd1d484c6fde3088c5c9d47d688035e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "d591fbbbc537dd53c842095fa3af198ecdae93b61fe328469991b89d76796c05";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "d214c88a73fc1154a13d60d13e9bfd1ff6eeb10e6b2de0704a76e10635c69f0e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-description/default.nix
+++ b/distros/noetic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-description";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "ce971c4a6a08880102a23b90812eb0f97f7ee4f03a03887fc8d216a910e7231e";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "ee8f63df303ca0b7949e9d3bd36ae142ed118421c1a862f8d8f247ebbbb334e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-driver/default.nix
+++ b/distros/noetic/cob-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-drive-chain, cob-bms-driver, cob-canopen-motor, cob-elmo-homing, cob-generic-can, cob-light, cob-mimic, cob-phidgets, cob-relayboard, cob-scan-unifier, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-undercarriage-ctrl, cob-utilities, cob-voltage-control }:
 buildRosPackage {
   pname = "ros-noetic-cob-driver";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "f046db20dfebfe21501bc744b142335792dbed670af852c5c591c5f0f393d681";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "644a8c05ba870da0fcdc36f29e1ba7f4abe83deec5133731173defa5483d7779";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-elmo-homing/default.nix
+++ b/distros/noetic/cob-elmo-homing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-402, catkin, pluginlib, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-elmo-homing";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "7a87cbfc820d91e4530bb0e3e362b02424df4233210d67587639041a24bbe0a3";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "36d8c76a9e67b7ef718ea1dc7de40e716202a087a6ae13735bc1d2a497135a4a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-generic-can/default.nix
+++ b/distros/noetic/cob-generic-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-utilities, libntcan, libpcan, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-generic-can";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "5f7ecd3c637e6db0dc36805b2025cb5c229c1270abc17cee5a6445e310f593f9";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "af7d077b04938312aeb4e93615c0bb2c83e8bba1a4bb3d9e9d77f0050c214a8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, python3Packages, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "d72ccf4b1865263bd29bd35cc6bb775baf9b6cd964220871b880dd928090eed3";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "8216c2a2bab05f3a7df282656be44290b14e443c52ccbc2feed6efb5eafcb53b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-interactive-teleop/default.nix
+++ b/distros/noetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-interactive-teleop";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "f31bc863451139e38e9841e0677e2408e2a3c718b19b97e4932f745eff22c822";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "0de05013683f638fb46769409a641da41431f2544c698e15dbc33a9d5d81c336";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-light/default.nix
+++ b/distros/noetic/cob-light/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-light";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "83dc95b81792ea0ed57658f09109ca19f514a6d0620a7e0e2b010989e5e3a4d3";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "c014084a6122454fb9ae684fd062a7d3fd348eb192332d312574dba3dd916b23";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mimic/default.nix
+++ b/distros/noetic/cob-mimic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, diagnostic-updater, message-generation, message-runtime, roscpp, roslib, rospy, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-mimic";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "0834a9843a3d1ff9d4967b827a08d909b4efbc3b845ede93fba24cff178b029d";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "29b30dd3d0b6c2b3c5682d0f980841624c01f8c629f00a18908ef606bf59b6a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "25eb49463035dd9fab9f4a629e23142301ddd87d7e5a79b38f02b2e5f2596ca0";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "30846d6225eacee8c9e2303bd9615891fabc5e1e76a516a685171f04730b3f3f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-msgs/default.nix
+++ b/distros/noetic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-msgs";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "e871d7c85cfe1b83c13d3102365ec95e0d3741fa9820ea10b47a26aea9829571";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "f08b10f41163babd8fbc526e96591a38185d6cfd650a45f3c4035e495490deec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-em-state/default.nix
+++ b/distros/noetic/cob-phidget-em-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-em-state";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "7d9e3689ea439dffdfd0131286d75baf6c19d70d7e627eca986873ae84b9f975";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "6926b7d3d19a711990720e5d3a9f2cba233c40c9e4a6f875321eba1aa085b27a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-power-state/default.nix
+++ b/distros/noetic/cob-phidget-power-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-power-state";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "395047888e44c9a50a2de37d87a362eabb27251b86b2814e5d42787e61410986";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "a529e459525285cbb4580757dd8061775db19e64e4eedf4ba130b923f4a8c2a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidgets/default.nix
+++ b/distros/noetic/cob-phidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidgets, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidgets";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "d8951094e295eac9327e5a380b248ae135494ed2bc1cbea7589d1d078cb7b9b6";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "7c279d4265bb798f8d7355249b7b27eaf2fd08057394df29370e5bc6bbab90eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-relayboard/default.nix
+++ b/distros/noetic/cob-relayboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-relayboard";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "f649508e0d12c9f65cbe2c0d25dc369a6f7b604ccc29c4e97118569a91557ce3";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "cfb49eb4df06ec1f297fcc7632c7a25f26b3472ad3a7c4f52793d213f2158d5e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-scan-unifier/default.nix
+++ b/distros/noetic/cob-scan-unifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-scan-unifier";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "153771a870182ea0984850ae5ae3c7a620cf269d3694a988494a7004c07b4f00";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "942307cca2c410eb4f6a536586062cb8b093f0e09f4b7158705080439ca6701a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-cob-script-server";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "ac23af8df43a191e781094d38dd8d3f1e3f8864a77599b06c1cdcdaa151b774a";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "b6c71cc57acd88113277e2b4c4ee28d4d39f21e489913c8cd21be2d29263185a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-lms1xx/default.nix
+++ b/distros/noetic/cob-sick-lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-lms1xx";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "3a2a3faa3e57d2bbbd8fe63b9ec0a7f1b179f51cc324f76d7eae06e87cd5443a";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "91ab0b40879ea5df8273b1ccb460032c46685d98a4c36c4412bda3ea05af837f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-s300/default.nix
+++ b/distros/noetic/cob-sick-s300/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-s300";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "88a77ecaa55d61e9745ce8575b5b42b8913d841ab124c74f3d1e32a10c697519";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "825fe6cbd5edf33d8bdf966bc6459989fbe69c305c5e8b6f62d1e234e03484ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "0092e727c1de838ab9fd4ebef5776cc6e3f0b9a07e083e3416868ab978cff60a";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "ca3b0da4c45a6a8111a2ab8f2b6ddc4d6bd519534629ee2bf8bcbda844b5dcfc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-srvs/default.nix
+++ b/distros/noetic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-srvs";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "de7cbdbbd0eb14c1b9753b5e398fea1a492f63458de1b91beeec89e56d7e62e7";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "0f0d9aee5c2612bbe687f3bb7ed571940c83a62001900510d2e14ea46b63fd8f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "8a61fc4a7b64da03ad89c364950296414a32a4a72c61c5b8d5eeaf194aa8c1b9";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "4a614a4c2329a1e2357f7539b5c1c90b343430729b7743328355a7a2d56379e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-undercarriage-ctrl/default.nix
+++ b/distros/noetic/cob-undercarriage-ctrl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-utilities, control-msgs, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-undercarriage-ctrl";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "444d361b2320f23d6544b8eb45ed949b320e8e6f00bf5d516c920ae4ad061309";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "0acd34f9e470b0da42ee34d3b008339e09b53ca8a93ed6a94ba63b6219b1094a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-utilities/default.nix
+++ b/distros/noetic/cob-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-utilities";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "37d06a8c88254f4b1b18cf6b7b02fb9802434381f034d7b61be073c4f74869ca";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "5f24c761bc9867f51771008d1d3cce67410168293d2e46322ce68dfdd5a97028";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-voltage-control/default.nix
+++ b/distros/noetic/cob-voltage-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-voltage-control";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "23444630337c05279f657b9295693b7f565d3887af09056b6ee60633b0607ac0";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "9276a0be4b9b945d18ea655ce95d542775f4f1d4721f0dda7cb6acac8d70a033";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "932fc582103c2b88d2c31e04d45e972b3f9370c536732ab2121c0f27589f2318";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "6638533a0b883498d963232af07d4febf742667ec7a9c0c1bd985c5d0d48cca8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.22.0-r1";
+  version = "2.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.22.0-1.tar.gz";
-    name = "2.22.0-1.tar.gz";
-    sha256 = "2a587768273730151efa4bea742095e03eee23068f0dfea45f09487808c0e73e";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.23.0-1.tar.gz";
+    name = "2.23.0-1.tar.gz";
+    sha256 = "8c1f937648cc3f174604169dc79f0851fda2942653065798f5ab75bb5d1a23dc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/gazebo-video-monitor-msgs/default.nix
+++ b/distros/noetic/gazebo-video-monitor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-video-monitor-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitor_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "fb83f6679b5bca82292f7f0795c1d10487b89f50aa1512b00265b6850b118a7a";
+    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitor_msgs/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "bd36855ef5dc9dd53ed2bbeacc0ea6d97e2092ce86ae7094538257bdd26bd195";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-video-monitor-plugins/default.nix
+++ b/distros/noetic/gazebo-video-monitor-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, gazebo-video-monitor-msgs, opencv, roscpp, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-video-monitor-plugins";
-  version = "0.7.0-r1";
+  version = "0.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitor_plugins/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "75f65f76f92d6da2545a63a2fa23d93e55923cc576c973f11efdb2a5480a71ed";
+    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitor_plugins/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "6d90044eddbfa24b6cbae044368068ca8c4960fa72d9c6e5699e905b52961bc6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-video-monitor-utils/default.nix
+++ b/distros/noetic/gazebo-video-monitor-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, rospy, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-video-monitor-utils";
-  version = "0.7.0-r1";
+  version = "0.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitor_utils/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "6bde91c72bbd0a92a53a00ca2108ea313523e78789c0b989e35a1709dfbcf604";
+    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitor_utils/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "bb96cd219751dbbc6bed9bfa0ec1c972afab07fbaa151b2b78f7418e4cc76adf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-video-monitors/default.nix
+++ b/distros/noetic/gazebo-video-monitors/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gazebo-video-monitor-msgs, gazebo-video-monitor-plugins }:
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-video-monitor-msgs, gazebo-video-monitor-plugins, gazebo-video-monitor-utils }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-video-monitors";
-  version = "0.7.0-r1";
+  version = "0.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitors/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "3f826e78f7e83116edc3d110bd2df6ab8f2109e9447590e59d13325259a448a5";
+    url = "https://github.com/nlamprian/gazebo_video_monitors-release/archive/release/noetic/gazebo_video_monitors/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "72d8c707aa2e5a993ff11330df1ab0f6dd91b122cc643a392f2a5e7b653f23c0";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ gazebo-video-monitor-msgs gazebo-video-monitor-plugins ];
+  propagatedBuildInputs = [ gazebo-video-monitor-msgs gazebo-video-monitor-plugins gazebo-video-monitor-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1528,13 +1528,15 @@ self: super: {
 
  jsk-network-tools = self.callPackage ./jsk-network-tools {};
 
+ jsk-pcl-ros = self.callPackage ./jsk-pcl-ros {};
+
+ jsk-pcl-ros-utils = self.callPackage ./jsk-pcl-ros-utils {};
+
  jsk-pr2eus = self.callPackage ./jsk-pr2eus {};
 
  jsk-recognition = self.callPackage ./jsk-recognition {};
 
  jsk-recognition-msgs = self.callPackage ./jsk-recognition-msgs {};
-
- jsk-recognition-utils = self.callPackage ./jsk-recognition-utils {};
 
  jsk-roseus = self.callPackage ./jsk-roseus {};
 
@@ -1975,6 +1977,8 @@ self: super: {
  moveit-plugins = self.callPackage ./moveit-plugins {};
 
  moveit-resources = self.callPackage ./moveit-resources {};
+
+ moveit-resources-dual-panda-moveit-config = self.callPackage ./moveit-resources-dual-panda-moveit-config {};
 
  moveit-resources-fanuc-description = self.callPackage ./moveit-resources-fanuc-description {};
 
@@ -3427,6 +3431,8 @@ self: super: {
  sot-dynamic-pinocchio = self.callPackage ./sot-dynamic-pinocchio {};
 
  sot-tools = self.callPackage ./sot-tools {};
+
+ sound-classification = self.callPackage ./sound-classification {};
 
  spacenav-node = self.callPackage ./spacenav-node {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "d2f9387192531ec3f0a41f6fc7d069bdc642cfb441077ac9caf7a801f11e4c86";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "bab46157741cdb6b1a083c1e5e47a10532ee32e23868643a8bf8db7a11c97ac7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imagesift/default.nix
+++ b/distros/noetic/imagesift/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, image-transport, jsk-recognition-utils, jsk-topic-tools, libsiftfast, nodelet, posedetection-msgs, python3Packages, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imagesift";
-  version = "1.2.15-r1";
+  version = "1.2.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/imagesift/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "06cf6f1d7b56163b99a2de23e98a0fd897d8a8891fd2773ed98abee91be74a71";
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/imagesift/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "428e560c08942c65dc0a5b8277d9d7bc8b6913ff2beeb96520525d28aecb7210";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "2cba0b4614744c7f28156ecd2b659269d580088ff5d3b06790203e6c98607d72";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "bcc95d6d7eb04deb042f6a16c1b665d7da10f3928535637df2973e4032bb668d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-pcl-ros-utils/default.nix
+++ b/distros/noetic/jsk-pcl-ros-utils/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, compressed-depth-image-transport, compressed-image-transport, cv-bridge, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, eigen-conversions, geometry-msgs, image-geometry, image-transport, image-view, image-view2, interactive-markers, jsk-data, jsk-footstep-msgs, jsk-perception, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-tools, jsk-topic-tools, kdl-conversions, kdl-parser, laser-assembler, message-generation, message-runtime, moveit-core, moveit-ros-perception, nav-msgs, nodelet, octomap, octomap-msgs, octomap-ros, octomap-server, openni2-launch, pcl-conversions, pcl-msgs, pcl-ros, python3Packages, robot-self-filter, rosbag, rosboost-cfg, roscpp-tutorials, roslaunch, rostest, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-pcl-ros-utils";
+  version = "1.2.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/jsk_pcl_ros_utils/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "a7be57d03670f4a6908e0e11c8f22756b8e5dabd31907de219ff2f061589d9e9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation python3Packages.pyyaml ];
+  checkInputs = [ jsk-perception jsk-tools roslaunch rostest ];
+  propagatedBuildInputs = [ boost compressed-depth-image-transport compressed-image-transport cv-bridge diagnostic-msgs diagnostic-updater dynamic-reconfigure eigen-conversions geometry-msgs image-geometry image-transport image-view image-view2 interactive-markers jsk-data jsk-footstep-msgs jsk-recognition-msgs jsk-recognition-utils jsk-rviz-plugins jsk-topic-tools kdl-conversions kdl-parser laser-assembler message-runtime moveit-core moveit-ros-perception nav-msgs nodelet octomap octomap-msgs octomap-ros octomap-server openni2-launch pcl-conversions pcl-msgs pcl-ros python3Packages.scikitlearn robot-self-filter rosbag rosboost-cfg roscpp-tutorials rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs yaml-cpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS utility nodelets for pointcloud perception.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-pcl-ros/default.nix
+++ b/distros/noetic/jsk-pcl-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, checkerboard-detector, compressed-depth-image-transport, compressed-image-transport, cv-bridge, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, eigen-conversions, fetch-description, geometry-msgs, image-geometry, image-transport, image-view2, interactive-markers, jsk-data, jsk-footstep-msgs, jsk-interactive-marker, jsk-pcl-ros-utils, jsk-perception, jsk-recognition-msgs, jsk-recognition-utils, jsk-tools, jsk-topic-tools, kdl-conversions, kdl-parser, laser-assembler, moveit-core, moveit-ros-perception, nav-msgs, nodelet, octomap, octomap-server, openni-launch, openni2-launch, pcl-conversions, pcl-msgs, pcl-ros, python3Packages, resized-image-transport, robot-self-filter, rosboost-cfg, roscpp-tutorials, roslaunch, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf, tf-conversions, tf2-ros, topic-tools, visualization-msgs, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-pcl-ros";
+  version = "1.2.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/jsk_pcl_ros/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "2bfe1a979992b61b698fb0ff5ced0861a6ba1b0419bfd5e128fa2cabbe4917e4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ compressed-depth-image-transport compressed-image-transport jsk-perception jsk-tools roslaunch rostest ];
+  propagatedBuildInputs = [ boost checkerboard-detector cv-bridge diagnostic-msgs diagnostic-updater dynamic-reconfigure eigen-conversions fetch-description geometry-msgs image-geometry image-transport image-view2 interactive-markers jsk-data jsk-footstep-msgs jsk-interactive-marker jsk-pcl-ros-utils jsk-recognition-msgs jsk-recognition-utils jsk-topic-tools kdl-conversions kdl-parser laser-assembler moveit-core moveit-ros-perception nav-msgs nodelet octomap octomap-server openni-launch openni2-launch pcl-conversions pcl-msgs pcl-ros python3Packages.scikitlearn resized-image-transport robot-self-filter rosboost-cfg roscpp-tutorials sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf tf-conversions tf2-ros topic-tools visualization-msgs yaml-cpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS nodelets for pointcloud perception.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-pr2eus/default.nix
+++ b/distros/noetic/jsk-pr2eus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pr2eus }:
 buildRosPackage {
   pname = "ros-noetic-jsk-pr2eus";
-  version = "0.3.15-r3";
+  version = "0.3.15-r4";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/jsk_pr2eus/0.3.15-3.tar.gz";
-    name = "0.3.15-3.tar.gz";
-    sha256 = "96418335d29894832854311c01d6d6a2444ef49bd285af9ad580517a7caac092";
+    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/jsk_pr2eus/0.3.15-4.tar.gz";
+    name = "0.3.15-4.tar.gz";
+    sha256 = "ead27474a4142d16751712d6b3c25560c534c2186276471999a48c9e08a9394c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-recognition-msgs/default.nix
+++ b/distros/noetic/jsk-recognition-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, jsk-footstep-msgs, message-generation, pcl-msgs, rostest, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jsk-recognition-msgs";
-  version = "1.2.15-r1";
+  version = "1.2.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/jsk_recognition_msgs/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "a5a024053de6d9f174a22c418696d6097d53ab3b283255a359bb0d463ac3ea2f";
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/jsk_recognition_msgs/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "a2e7521972ca434907f45ef5ebe148792f8b00ac2e378bc76eafa375b2c73c51";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-recognition/default.nix
+++ b/distros/noetic/jsk-recognition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, checkerboard-detector, imagesift, jsk-pcl-ros, jsk-perception, jsk-recognition-msgs, jsk-recognition-utils, resized-image-transport }:
 buildRosPackage {
   pname = "ros-noetic-jsk-recognition";
-  version = "1.2.15-r1";
+  version = "1.2.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/jsk_recognition/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "eb418e1268b69ae5ac4dd14eaa396b081c86b6c02e7f64829e63fa7b3dc5ecc5";
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/jsk_recognition/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "c874f646fce25e14457751094ff62cfed6e55f32b41e75844c577df7d7c721cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-scan-densifier/default.nix
+++ b/distros/noetic/laser-scan-densifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-scan-densifier";
-  version = "0.7.14-r1";
+  version = "0.7.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.14-1.tar.gz";
-    name = "0.7.14-1.tar.gz";
-    sha256 = "2ac1c5545d1a8bf5553f3cc84d9da56e0b36ad93082262a3fa676fec40a20d7e";
+    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.15-1.tar.gz";
+    name = "0.7.15-1.tar.gz";
+    sha256 = "c8de2625fc0cd1bfb821db4c1b6f7100b1fe8c650cd82b64f58f701864e53b30";
   };
 
   buildType = "catkin";

--- a/distros/noetic/magic-enum/default.nix
+++ b/distros/noetic/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-magic-enum";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "e373d29493a4c9bad7be05105e9894f6905fe24ac54a607236853903499b0a9d";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/noetic/magic_enum/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "6d41a65dbaef7b73b5d2ca06e63c4e0217dc1edc9c8f80cd3a74f4edfd18c45d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "35b7c6a45cf458901cfaf308830376261a9bc828735a818f218ccdd95b0d6369";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "a9ed539186102070ab7d5b8045ceb9dc02a1c1d10a3827fc8d722a84173d24a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-can-msgs/default.nix
+++ b/distros/noetic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-can-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "e6740c7091b882593c87016d1d461181db9a3824f705adcec26e5a156c7e4b89";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "3409ab5b55dbcbffbf847aeeabefda8c5005dd16b30c2c6964c994ac6d50f0a6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-common-msgs/default.nix
+++ b/distros/noetic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-common-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "968cc36d590d251acb13171d91df17d08aabc95c8bc2a66eff21b45f03175299";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "c6cda852976c3517f0b0455be536d6313cf20648202aa4c74b9df7ceb060bb63";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-dbw-msgs/default.nix
+++ b/distros/noetic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-dbw-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "3f6b78d2703cd89348f444807c110d40b1b620c089f8620f156566204cae0234";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "e3682395c124a2e7d8be3feeff27ca157a6f21bbc3981ce0ae9cac5a7a85ecc4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-introspection-msgs/default.nix
+++ b/distros/noetic/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-introspection-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_introspection_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "172329317df6c256a77342da0e6e4b9f4367e1c6fbe78d9963ba714c34b4afb8";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_introspection_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "c57081f11c7bcc743cb7d27cdae88b9d9e1f0c5d62fb9a98fb6b483a0a15c1c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-nav-msgs/default.nix
+++ b/distros/noetic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-nav-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "07b6f2a704675e996345f128c33a8b8f8b11ddb7c9e5c073db0713e82b1c1b70";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "532f82802db992ee75ec38a2879facb6d54f5da87b5145e702fd347619856c64";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-perception-msgs/default.nix
+++ b/distros/noetic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-perception-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "d2e1c8e938aa48bd4733f7dd20fcf13b377ccd1d0eb52fd5b8275da0a9fe3b3c";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "272cecbebf46d265b2e7b57f3d58fe74f13da3f08f5e4432bc5194d1d6f1eb11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-sensor-msgs/default.nix
+++ b/distros/noetic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-sensor-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "a425718da781bf525ced7de5d28b40fb1b63ff14a99ae3dc9d06d5368e50e96a";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "305780b0f39323d1f78458eac9dbeef76cf8e2003ed22e1ac1a3ad051b15b72a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-status-msgs/default.nix
+++ b/distros/noetic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-status-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "44b46252468e4ed78955b4ad475cc899a48af157d627aad22a6476e296103601";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "0c727b78d70fad084a4f0f46479e1fcd48e4ddc5fc9156111e606fbe82bba59b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-visualization-msgs/default.nix
+++ b/distros/noetic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-visualization-msgs";
-  version = "0.12.1-r1";
+  version = "0.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "fb14d815e1617d82dc8fc2b94a1a46f97571f639b51c133dad7fb4e1f298778a";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.12.2-1.tar.gz";
+    name = "0.12.2-1.tar.gz";
+    sha256 = "ad017461218c31c81ee1ae553f1fc59f9060bc13d6a8dd7a7e5f0245d8bdc5c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "e845ad9c882a7e56d4083597e1197d25886f181e2d3cca35fe6832886364bf49";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "e3fa9a8617042ca7746036179396b3e314e3ad28be5c926dde07fb38f1ad7ab5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-dual-panda-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-dual-panda-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, rviz, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-resources-dual-panda-moveit-config";
+  version = "0.8.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_dual_panda_moveit_config/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "63d2b1a35d7aea4f10ecb045e569bdda23bc43f8155cfe8b76d610764a5c40cc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher rviz tf2-ros xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the panda with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-resources-fanuc-description/default.nix
+++ b/distros/noetic/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-fanuc-description";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_description/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "517b2216d7bbb6b14cac50556294a3d79d2f80da8851d799555b1a82eb18db44";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_description/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "74b7f8ef32b06c6760228a408479d37e639c377bdd3ec57c1f71b2c08042391b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-fanuc-moveit-config";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_moveit_config/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "5c2471a150b4ab84eb81b1c63e794eb982f9f600401f6d80666d5775d4f044c4";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_moveit_config/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "7ab8690930be817c2446bd0b906700ce95bae66b1a7519bb520a5da1d7a7024b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-panda-description/default.nix
+++ b/distros/noetic/moveit-resources-panda-description/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-panda-description";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_description/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "85a92c552a02e2aebd256f06253b2f188cfd606ca40f639a63757fe94f650f4e";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_description/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "fccba1dad2a53c26d729b048cd894b14d6f0d855cdfba89daf9e1b8071d5167f";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, rviz, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-panda-moveit-config";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_moveit_config/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "e5b5da7f3f30a6e0ddd98c802432f99fa526c623d00780c1c4e66759c3813164";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_moveit_config/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "9e8b22a17451fd6ef123e0af1ea5a68cf51151f37d0ea069400878d3e6abaf41";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-pr2-description/default.nix
+++ b/distros/noetic/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-pr2-description";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_pr2_description/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "df362edff68e3769c672f3105d63ae675d27e0f3f15a2d54f6e79ab00aa14aa1";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_pr2_description/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "0c5544f93bc837c78a2fd4062693f54bd19ce611c240b4218f039afe13701f56";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/noetic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "7b9a978e377e94714f8f1a13e6ca778e300453ffdc7d98f4a869989b3fddac11";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "e17bf9b993cd4692ab8f049856946687894397894203fba2a87e13b6cbde7ac7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-moveit-config";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_moveit_config/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "0d77142a1dc3fc0ee9b1bc1a21ca67939ac01345de09d456f0cec0cd36af22b2";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_moveit_config/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "4e16fd64b226c4d06ab9eb75fe279061956aa8c71debb6c77177ee60ee0ebc66";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/noetic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-pg70-support";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_pg70_support/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "12d22c95034d670242999e2fb67155c8a5fadc627e03003d67e636b92457dbef";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_pg70_support/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "afa3a22ef6867e8820b9769e47c8d3b216893f18908a487de0482db39875ec26";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-support/default.nix
+++ b/distros/noetic/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-support";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_support/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "ea64280d527970b6d0740709f21d84e8e2333c5f1eb2519ea51bbb6658a78d9f";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_support/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "bd307220ad6985220e8d8895f802e0c08c45ac5dbe74999977d400ea22272a11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources/default.nix
+++ b/distros/noetic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "70ef3cd5af45c756157a24608eaa89ffaa87619c3b02b50559b727f78fdff247";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "5aeb3217bf1ddf3b5858ed24b29611c3b13e4991472a94b7098e30a5c28ad18f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "cbc158c9401860bfaa9aafa9f6c94ddee04b005739227758aec1af91ddd3ba85";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "8f9a159760e41ddcc48fcf1a6187aaada183d6c10f82c6b531ff35589c9f238c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "c373547b36ebae3e0e1fce048b84544f3dde7ac9d71b9ca2b5154bc7daf082d0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "dc1a438b8baa90512baa4b75cbd7cd1c0b8276d9f38fa0b6ca8dfe8d7a30eaed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "1b0768c4ee26cf41b630b0610482452b191769d9ccfbf9cd093f8e7466573080";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "c3f0d5020abcde46f31d776514a9389082297deb98aa9c98f31b4a2b7be401b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "43aa82bae264c36263dc25af6597d3787e4c75cf743a55642049c1c52ce40bd5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "594ff2cec9cd00a309bb0b5dd923e2ba87c12621e88d7ec6a5846960ffc511e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "725e2c5e2143cb4cf36156562efbdad5013ef7b9d3862c35d8d14a366b71144c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "42a6dac6977283c15c41b66498306faa57f2d5715683c8ab38395e2df0f7304d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.7.1-r1";
+  version = "3.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "c74a1634225a8604bd2ed3bf69b35d9d12752dc91f038e0d30b9c5f1e7977160";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.7.1-2.tar.gz";
+    name = "3.7.1-2.tar.gz";
+    sha256 = "d8904325d861945a253d7a5221ce5c939a845292b91796c00388ecfba89cacf3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2eus-moveit/default.nix
+++ b/distros/noetic/pr2eus-moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, moveit-msgs, moveit-planners-ompl, pr2-gazebo, pr2eus, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-pr2eus-moveit";
-  version = "0.3.15-r3";
+  version = "0.3.15-r4";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus_moveit/0.3.15-3.tar.gz";
-    name = "0.3.15-3.tar.gz";
-    sha256 = "99b7121252a81953aa0ea54ec71f442ac207ed364775eec3ee72aaa8ab598c3c";
+    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus_moveit/0.3.15-4.tar.gz";
+    name = "0.3.15-4.tar.gz";
+    sha256 = "8d0002e02e4c555435091d74e938cb1ed54940ab70092239399ea7a8890ec2af";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2eus/default.nix
+++ b/distros/noetic/pr2eus/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-msgs, dwa-local-planner, dynamic-reconfigure, euscollada, fake-localization, map-server, move-base-msgs, nav-msgs, pr2-controllers-msgs, pr2-description, pr2-gazebo, pr2-mechanism-msgs, pr2-msgs, pr2-navigation-config, pr2-navigation-slam, robot-state-publisher, roseus, rosgraph-msgs, rostest, sound-play }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, dynamic-reconfigure, euscollada, move-base-msgs, nav-msgs, pr2-controllers-msgs, pr2-description, pr2-mechanism-msgs, pr2-msgs, roseus, rosgraph-msgs, rostest, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-pr2eus";
-  version = "0.3.15-r3";
+  version = "0.3.15-r4";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus/0.3.15-3.tar.gz";
-    name = "0.3.15-3.tar.gz";
-    sha256 = "6c262ab311df2cedfae2cf70166cc1b7fb3abc5ca26a342882f2fba1cdfbd45a";
+    url = "https://github.com/tork-a/jsk_pr2eus-release/archive/release/noetic/pr2eus/0.3.15-4.tar.gz";
+    name = "0.3.15-4.tar.gz";
+    sha256 = "acf36a9dfd06323cbc4d414f3447f61ccbd1af992049eb74649c2322947f21a2";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin rosgraph-msgs ];
-  checkInputs = [ dwa-local-planner fake-localization map-server pr2-gazebo pr2-navigation-config pr2-navigation-slam robot-state-publisher rostest ];
+  checkInputs = [ rostest ];
   propagatedBuildInputs = [ control-msgs dynamic-reconfigure euscollada move-base-msgs nav-msgs pr2-controllers-msgs pr2-description pr2-mechanism-msgs pr2-msgs roseus sound-play ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/raw-description/default.nix
+++ b/distros/noetic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-raw-description";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "68ac3ce6ad532c9ef2b4cf20e439b1294ec71ec76db56eac92376e8661ea2e9b";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "52001cbe8cd8fe39cd73ec11716e9b7af2cdc91152fdf14bc3a420d9fba4d7d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/resized-image-transport/default.nix
+++ b/distros/noetic/resized-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, jsk-recognition-utils, jsk-tools, jsk-topic-tools, message-generation, message-runtime, nodelet, rostest, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-resized-image-transport";
-  version = "1.2.15-r1";
+  version = "1.2.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/resized_image_transport/1.2.15-1.tar.gz";
-    name = "1.2.15-1.tar.gz";
-    sha256 = "9a64a0abf330c236a52bad2b2ffc0e9a2075a6d65d82c56485bf8315670aef6a";
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/resized_image_transport/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "2428068e71213ef08e93078e1b07ab1271cb8b3c67f5221feec605dd188d387a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "8b346c0d2333cb391aee666464b30e1b728afa257f64810e0582253b3843a1f8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "cc2cb3ce12a5879b26f0bde148d4fdf5634c4dfde0565967716477e988af7ee9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "92b65f440dccb2821552ad5dfb87da701657a6c9c5548dce99ca6cf7ee97b68b";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "a6024500d38b01fee71c48f2a2a840a3229149fd896b43a82bfe2d3f985c7af6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.32-r1";
+  version = "0.6.33-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.32-1.tar.gz";
-    name = "0.6.32-1.tar.gz";
-    sha256 = "09c245ff2e3f83cabef9d61c75087241e378dcc3a949caaac31696aefb00cb8a";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.33-1.tar.gz";
+    name = "0.6.33-1.tar.gz";
+    sha256 = "ba18250924d0144042b0dccaa4b9e4e92f3147b23fad54453bb5eea275798e59";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sound-classification/default.nix
+++ b/distros/noetic/sound-classification/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, audio-capture, audio-to-spectrogram, catkin, catkin-virtualenv, image-view, jsk-recognition-msgs, jsk-topic-tools, message-filters, message-generation, message-runtime, roslaunch, rospy, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sound-classification";
+  version = "1.2.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_recognition-release/archive/release/noetic/sound_classification/1.2.17-1.tar.gz";
+    name = "1.2.17-1.tar.gz";
+    sha256 = "3316141749e3a3de6aa816ec54e3c0618b88999981cd5b421c7a65c3e8a85a9f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin catkin-virtualenv message-generation ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ audio-capture audio-to-spectrogram image-view jsk-recognition-msgs jsk-topic-tools message-filters message-runtime rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The sound_classification package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "490238bc0bbf1d4888d2461d92fcd0c8658fcbb10ff94f1dfa17e3be2a66c367";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "82e5d3431e04eb994826a574cee62cff88a14d7bd147fad2a606c55fef82c393";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "6e0d2ebe3302c4c1da7dcd3b2f5fc17fdf1195365b43778485fa2a7b8fda3c86";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "8c4d8a5986d349efece748a71de8add6ce475409360fc9fe42333f288ac4737d";
   };
 
   buildType = "catkin";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "600d63c2288cad3e69b24e3fd27b53b2c30bedf00ee2bb7a6c1f7d023e88ad3f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "75b67991898f1f8b7995582eeedde4e54e1aebc0e8241519439fcf3f82dea511";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-interfaces/default.nix
+++ b/distros/rolling/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-interfaces";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "43a47ff6cf56bc044162c9b719e4dc74fbbe338887abd22de7210fcc7e991622";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "53c766af9192e47ff3640cf2f8832066c64a7b0a67641b134e2f8d9f6e85a430";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-lint-auto, ament-lint-common, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "062e8ee87353f12abbaa4b1f36df6011c3ce6b63e33b5ee64551327e59370c07";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "ce3126896021235a842c5ecddb6aacaa0ff3e9615bfaf0238006fbed6bf9279a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/actionlib-msgs/default.nix
+++ b/distros/rolling/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-actionlib-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "bfea597ece20fff5333c80360835a9043658af1b45d1df08a5d8d06c3b9ddbb8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "b0178d44e05f18dd93ecb2842b8f28ce9db4afcc2b90b5fb717301d4eb6fdc30";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-black/default.nix
+++ b/distros/rolling/ament-black/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-rolling-ament-black";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "ed67891d580bc98040dd26d07b1126a0a1a47734f56a175922f47642788e4dbc";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.unidiff python3Packages.uvloop pythonPackages.black ];
+
+  meta = {
+    description = ''The ability to check code against style conventions using
+    black and generate xUnit test result files.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "77c03e3940461063711ff0ecb4b34a1dd94b9379d9fae508ec7b7b895c475cb3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "2d8fa592729cf7db3ccb40c570dfca1c9f4e7755882bac4d4afb6565c3ea2f0b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "5a7ac9b93a24de3f9731ee935d15686a753d9290e75ae2aaf901b7fd6585007a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "e362b3025d243bd13513ea811cd4c4dbf270f1650c0c9254e15cf1a67ca4a089";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-auto/default.nix
+++ b/distros/rolling/ament-cmake-auto/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-auto";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "8f9db37c4d285c7568d996916f0acdf3fe532b2dc9fe475c2d0bd42acc80b2be";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "01af0ebe988556faf0bcf9a5e284bb0c969b4d1d12c50ede312c2b11ff61f37f";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-cmake ament-cmake-gtest ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-gtest ];
+  propagatedBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ];
 
   meta = {
     description = ''The auto-magic functions for ease to use of the ament buildsystem in CMake.'';

--- a/distros/rolling/ament-cmake-black/default.nix
+++ b/distros/rolling/ament-cmake-black/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
+buildRosPackage {
+  pname = "ros-rolling-ament-cmake-black";
+  version = "0.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "63f787a53c6faf7609bccd08d04fd8f44785f032c6f07f27fb83764cf82c9ff4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  propagatedBuildInputs = [ ament-black ament-cmake-test ];
+  nativeBuildInputs = [ ament-black ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''The CMake API for ament_black to lint Python code using black.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "88148b8944613ba89503d27028efdd4b843b1583e638899602f8071d2d66caaa";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "ddeb17c22cf27961861fd488b6fc5e11ac13581aea009465db7337cb916e0c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "a1bb73172d4c1ca55f4892cd9a5917845e39c3088a42255d58c50b5eb6749e50";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "5f2f85cc04b9906c8a2960df45ab63a89bc3d3894f39f07a89e2da0614f84107";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "5b7823a7288b087470646c6d5fc0fe23d6191a50f81e067aab197635dd26c077";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "0db968522cb49e429154173f92afc15f3b9309f9089df579a79de9ebcc417328";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-core/default.nix
+++ b/distros/rolling/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-core";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "d5cea40f1bfc9a4e390ddef3e7887bcbff2db36d66294c28e9ed07e65a499f29";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "0ce25698dae51100221c2611a793dda0f977d13cf9d4fcbbe0224a77030a1bb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "5625e07d0d26f0bf69fe42c5bab2d24f49c979fa70e742ad2b11140c84474638";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "c8e187cc15b367615704f97da3a1eae83ad244ca63878db70ffc0534258e98e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "76b5d955d927421f6f1a4f2bb960b9ef095113496c408ac2cc4b41524aec2e04";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "58477cd077d0cfb269a2b205d83b0a3d01a8a5cf95d8240cf3de4233659071ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-definitions/default.nix
+++ b/distros/rolling/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-definitions";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5d0b9cfa9ba0494eac9ad102e789ace949a063aba3bc304869bb93caecd94d82";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "1e3d42456d6cae1f52951f43531e7a8735650cede0c18d2a9c1006f38a292fe8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-dependencies";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "97766304c44ab6b6f2872e2db42eca6aaf29b6d5c64ec4f15e06926c99ea4ebd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "c073e7abf5904726230c220fad9d25834ef20a603e88e001d57b4500fcb3c817";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-include-directories";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "83ba156f9a89c6bda2421afb7dee501b3244724f8c0e7c61b466cb11a106d428";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "e3c2eec30dc9bc22aa978519645b1911e4edca3dc46423e2ee687b8ad5b01e36";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-interfaces/default.nix
+++ b/distros/rolling/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-interfaces";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "da00f7a32ed7a1d4437675afe075a96ab9ec401f5e959228129bd5836e4c790b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "45850fe37c25430996098adefdf5dd72f795acd3e94eee31cd0ac319b058fc6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-libraries/default.nix
+++ b/distros/rolling/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-libraries";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "4036d994f6e56c95888fb0705ee589ad3e015dc65a75183fd2275ee8c06de329";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "19b96da57cae954eeae8e11f329c48f859a8c2c4202125e84116054ebccccc6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-link-flags/default.nix
+++ b/distros/rolling/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-link-flags";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "57649e587176fe495aa756d39277f5f91fd40cd95a013e85d55f27f7f46dc448";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "4338f90d73f3e0ecb2c23b6f7068c68b31c04d900064cfb892de6f60c4d4294f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-targets/default.nix
+++ b/distros/rolling/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-targets";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f2e588a90e1ea1c986a129a1270207dbaa77e18d87dcc6355d7f84a0fb0a69cf";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "d252516b846daf209e395c9b35ffe08617a864455d43089194dfa2e11fb022d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "bfc00840fab1c3b7d1c9ed45588808fd87a4bd8d96ba59ae76e553e479dbde6a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "14cbb0a812a945590689a902a51380dbc54ba732e9e7061be1abe92738bb3152";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gen-version-h/default.nix
+++ b/distros/rolling/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gen-version-h";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "0a05613c630cf21b3e75dee7c6a5b988f62e51226ee40b3cf0b9ac60cbb9dc60";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ea6ecc9f27f1855cb0b663a7a18c08671deff680d40fb66ad083e997e84856f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gmock/default.nix
+++ b/distros/rolling/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gmock";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "587a21491b25d683806b7a62ab77cee2927ad684241f91d14dfc73e1796e8581";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "717ae7c6590e0da823e721782f95e1017d87e900c3dbf4ab07d29fd6f3fa53d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-google-benchmark/default.nix
+++ b/distros/rolling/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-google-benchmark";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5f345420c2fa171de1da2e8b995da0ed38e466c3e97442acc3be59209c497d44";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "014cce538781f69aa2bbe793b8a367983bc65197f2317b929378f7250c8b98b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gtest/default.nix
+++ b/distros/rolling/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gtest";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "6170b60b20bf02a78e41507606439441d692739a80cb354ad459d6ce4338156c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "37ee952bd68f0a5d6832969fc7e1696514b69c22ce7efdce51adc82e48705552";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-include-directories";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "ed1ee3cd5fb89e3d43eaef477e280facf683afba540cb0d787886e8f0c6d6822";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "ff8fe14a2a52082b0d10059b3917ee063b74ed6ee8f9fc5d1735a242816b8b23";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-libraries/default.nix
+++ b/distros/rolling/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-libraries";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a464c5dac574ca6433d0cbf251351584210157a6f32f06ff5543374f898d42f4";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "99b8610654be9651bb8bab7181ada2e0275e4a56a67404a71b0996bc9ff40545";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "8bc69b46fb1223a72721c8bcb9819729f57938d58b0e1712bce10057f287bea3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "1a718940c50e0a278a6f154dc9a85e6b669272874bc46b99c8ec1f9647105df0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "2f451e78b8ed5339ff6b920193153adc8b3a4c3050c3236ddb62c4d60981d96d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "502bcd55877aab13d15e0f36ec26c71e834936220c44f31831fd48e71bfdf014";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "8ace74db9f12ca1f1ab4c6bcb34007afbe974b35c8d08540ec207585f7c55ddf";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "a248ddc2762b623e208c35c395ec7424dc74c2c6e0f79db24b628d125de98635";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "9b87503dc4e382cba7485ddd090abd912906b9d8db74a4483b06a1971f4d6af3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "1efe53a78fed4569a971dae9631cf3f53dd5885d8289edd5f25ff09d5a5416a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "d4971d871ab34ed271ded51ae49c81e6aeb996dba4b7ff245e975845d6890371";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "a788311d0507ed5b30e3124bf65d5d793ca36cbf9bd3acaa49e252c10d4a74b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "e67d03629c64f719dc492e7224b8668a4b0983a6a699b25f270531d17958f077";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "59cefbc6ef6f362be609b7812e0ec5b48e768d279b56cc446dd9feb7b7bedd75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pytest/default.nix
+++ b/distros/rolling/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pytest";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a45ceac4186aa21143f2acafaf700b3f26666ef213bd7a585388820c1ffe28ac";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "be1f6ed403b39e526ab8635744a9c6a014bd98c95e26f22debe83e088978456a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-python/default.nix
+++ b/distros/rolling/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-python";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c1637e34b7f780af656f0d235da054b2aa4c39338fc05f421eead2598c57bccd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "1c1c9b05849a3afde159b808b3e5aad2339820ad5a6e7fa8217863ebc3ee8648";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-target-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-target-dependencies";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "20d5a255e095a59f310bdea2e30f4523321166ccfc3848ce4c44ad6df0a4dd82";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "8a4f31cb5e985d7e24ff6c033889a5578088f9580a0e2bcdf4c254456c43401c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-test/default.nix
+++ b/distros/rolling/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-test";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "2e42db5e706bed2da92c77217947e7d4e691e36269577599527925c14e02b799";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "2a16d8707f6978d0f88f221967d4039757097b3b80079273ef73a9056c8c94e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "8af06e69559da4be17d3abc24480c29d7d3f9513c22f3363f4429da6e88d8f29";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "5ec954839ef8677cf2781138863b211529993ba48cd45d57bf498bc45328f8e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-vendor-package/default.nix
+++ b/distros/rolling/ament-cmake-vendor-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-vendor-package";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c9f114060e0f30db57c06aa0aed163001e4bef976182a8221da3351618cb3f5b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "8f230bc958d69849bcdbecafb4aa10048ef298724cc66e9430ee6373052972ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-version/default.nix
+++ b/distros/rolling/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-version";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3086af945afc699190c8b9de5e1c57dbf999937d5f10150fdedf384b557d07a0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "9f9f29bd39831a830c47caf1be8edc08e4df660f583b5c4f3de2b78698d115a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "fd4504ada011a3b92f677904dec0a69d90ddc53455ad8ac9a77bcc2b0fd2f173";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "5c7ae13e78fea7fe464bed411f6ad4b6a70ca632a8f714a5a5c294be7ebb3b70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake/default.nix
+++ b/distros/rolling/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "76a43f6b98092e0f9b35ebbf0423a57e90969cb4bb472b20375eb31ab37616a3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "6c398774e0ce1066a90e353aee4a9ae5f754a5edd043f8ef55524b05aa0db676";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "b7407e925fbf577cb4375c49cfc7fc7601ae947b87cd9c5807b92000fc031b8d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "d2ea9f7fd9a90ea76296b595bf3e1af93edb3b5c2b65f5deac71f5223d138b13";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "7bb9abd73aa940603ed4d9064d140e195a251fee232003001cdbf73a5a1447ac";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "9e4ae8d48754918926812cc18bca630592b9de5631292f851aaf8112df7cb585";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "bb84d3c922e87b4c758e989056bae17c91b7f8e21f7f46135902ea580340d53a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "c5d2afabf1ee913bee8429176e703d1950cd2ea695a8935452cc10732813ed5f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "e7edf2c0020f2cca459c1049fbacbfc93a8df0cb6a4ae14ca9830c83e542556e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "4536f1c3e35ae926247e95d7b6e1659bbaad788e7edef23b828616dfe2364c62";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "207e8e3dae3850839ba7cf13e48c9bd4d668adf46db4b427032961bec746a214";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "f0ca49f8fac4c51117a20a4d48434b8e2ffe2337492026704c0848d0a3811d9a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "6ad4a1eb44b8445ba11ed065e7a69a9e6e2ac67cff1711c27fcf210c3268bb1b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "a7cf1a016073d12285deb414fbbee66b34a60143e1b4c42abd8c675e42b13699";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "f7fb82b5f4fe8e70fad466a08699dfa38cdaa2db47ed71f92fda4be4bc910c06";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "e56314a106f539c377d493ff9b120f513f100cd193f1e12a75b7d3d38e79bb30";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "bfcb2c8b32a16136d5e5b2c2bd654a62587a70e6aa602eccef1387c5603ea4d3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "df274e0f7512fcb2adc239689fc38a2e85f9c44fb0a1557e63383ada8a475f73";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "be880c47b85d7120d024519643542d47b1a399444a7638bd8c24f4d567d56444";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "71eb669d0a2089515c7cd2b02c971a58811272d3816ff247b49666aa3a75fded";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "5ac228223f314d20c5661e23a14babd2467b53dfaefd44a9a74b117aec05da36";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "73575b569a7461d198c88662ff86a73f165f02f225818af09621f177ff09fa48";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "ddcecaf36176ed35b47afca2e55bcb4dacc7c8ad62d3be137cd89120f9b100c7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "8c6cd4bdb2b98a0b44b6237902a3f72ebe75a2d48b20148697c1f44e90741e1a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "dc84a753490111c5c37200ccc1599fc52b2fb274750bad87fc06fee86deb2f09";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "ed9a8ad70b0b71c579f6388e3c48fae1044a65fac48be41641ba38083f1c8321";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "4f28afa9d9780dcf0c3feb3c72f4d9d26e0ee0439e942a739b22eef39d3f11cb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "0dfcdf59d5261bf54ca2e017a8cb3ecd6318d497e3798de70a8a2729c277e667";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.16.0-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "3961ce21c7187ac081d8b98b328ab4c70a581e5b57e018554f03c125fb073a46";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "085d7b0bc376d6de79ccc1e6ff6e1242ca7381a1f452a8f1e11c31f1b25e98c6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.4.0-r1";
+  version = "4.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "a9aee08e922314f3e56dce99bf10ef6f58113ef9e12058129944e70e55aa0002";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.1-1.tar.gz";
+    name = "4.4.1-1.tar.gz";
+    sha256 = "4c1d8002fb3c969a14f6edfb31903269e88d8e2f2627565bbdd477eab947e63a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "4.5.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/4.5.1-1.tar.gz";
-    name = "4.5.1-1.tar.gz";
-    sha256 = "01e39ffee1a2aa68d605b0709425be8c146ba88330796f926a87ca222eead248";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "097540e5f05835edf589ebc303167175466da1d86b863cffc5e6893b6d992ae6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "4.5.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/4.5.1-1.tar.gz";
-    name = "4.5.1-1.tar.gz";
-    sha256 = "21166dce373cf805f0ab95a507980376ee7a8097de6a94a366e44e3ae9221ac7";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "982cd5d23600071d3b62b2a159c4d1e7c46e5f99f52abe61dba1b261e638bebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "6a0516f8acca879475191c2f218255b547259e467220b02ebf01226eeb57845c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "e42cdd3af6cd9f6aceb33f0f15f8e9acd92e052113ad3ead28d94a6e73d7c70b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "006ae634e57c909e49fb5a2ffa91a871bf671f8b04e36cacf6fff5dbc635614e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "04de00bd4191d4799573ea8cf4bfd4019b18d3b8948ce5f0d007b7c48dd95d05";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "2bcfc7e9d42019bf451a64f9f2f7f4e802e7120ed0f2df341b0f4e2e9836db73";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "71d8e92583b5a9709db943b13b192ebdd27d0e08a09563700168a64c86dc2826";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "0e6bf0b6aa8dd3a4e771f1d341f26277ddcbab2049faf9bf68028f9116860adb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "dfbdb155e318ec3072d1cac4c3de952e7f7048b33662bdfa61e78d50c2c92886";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "c30e26cece1aefed12b8c6fcc67e5a766772aaa3e99323fc102dfed312342c9c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "d7392befa363a1d3a8d8285f37eb602ea3ab3f47980f5039968a0f0070d1cfc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "422557a197a9a20f789dfe99b1eca2d0c1ddeb5182ad9e82df51cb3403a51ad2";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "e9729b2bbfe52aaf53e7ced2c31899f0f409158630840b4de4558cfa81fb0ac5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "1f088cabc469cbdcb55d2e444399a4871330d654f1ca970f43a53e9867d02ec0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "d0326c1f912283185e352ced3689aacb9c5b4e680f3a3e0a3c37b1ea4415a678";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "724e9194ecd98205108d4b4fedd1e5889b6f479b500896d567003b466b8c5379";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "3065687451d133cb5cb6adf7d220ab419d2e7a3ba98d4f88c075db658d27192f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "622ef8a9077b19006ac5a0166947ee26dd53614b4c0ae43c9ba53aa7a3db308a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "2a4ac08d5890822590e7c24c29bce2d9a0a70d37b5c2a97bfdaadfcd9bbccf33";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "8d11e0d2f0a3bedba53b7ae3b09bd960c1ae9d8206712ad1d1a1cc648c6d2ab7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "b88621fc6ccb2965f6acd1c60c1736e98d99819b5241a8da66e8c7a606bd6294";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "9884bf6aed898d05e09d66b826eb4a6cfcd1ff8bbc74e307a728d2667f8548e5";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "4e6f6460af36b890b12eee42ebb88c34999928b6da3b42b027a0ad8f162df3d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "737b176f701523754b8b892b0b8ab1738f87a3ecb489b332b58e6586dda14f31";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "afee672117bdef5df26c3c2cfb7711f0a24e1dbdfa278ada826057707d68874b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-msgs/default.nix
+++ b/distros/rolling/event-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-event-camera-msgs";
-  version = "1.1.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/rolling/event_camera_msgs/1.1.4-1.tar.gz";
-    name = "1.1.4-1.tar.gz";
-    sha256 = "69cd21779d220d9f22921b6eee6c396074772e1fb996d86fb0c84b4a9b16b5e7";
+    url = "https://github.com/ros2-gbp/event_camera_msgs-release/archive/release/rolling/event_camera_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "6182bcd3db15ce3dc88f567a6e31e99d39df36b31e5f958b208dca69205fc187";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "73f5994c6f2ed29cbdd68b92d80d99c95421141c0f0f076687fd24671702d8ec";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "943e0b74e382fd384f7d5df54369df2757ed7f3dc12aba53377e605115884761";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  ament-acceleration = self.callPackage ./ament-acceleration {};
 
+ ament-black = self.callPackage ./ament-black {};
+
  ament-clang-format = self.callPackage ./ament-clang-format {};
 
  ament-clang-tidy = self.callPackage ./ament-clang-tidy {};
@@ -35,6 +37,8 @@ self: super: {
  ament-cmake = self.callPackage ./ament-cmake {};
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
+
+ ament-cmake-black = self.callPackage ./ament-cmake-black {};
 
  ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
 
@@ -779,6 +783,18 @@ self: super: {
  launch-yaml = self.callPackage ./launch-yaml {};
 
  lely-core-libraries = self.callPackage ./lely-core-libraries {};
+
+ leo = self.callPackage ./leo {};
+
+ leo-description = self.callPackage ./leo-description {};
+
+ leo-desktop = self.callPackage ./leo-desktop {};
+
+ leo-msgs = self.callPackage ./leo-msgs {};
+
+ leo-teleop = self.callPackage ./leo-teleop {};
+
+ leo-viz = self.callPackage ./leo-viz {};
 
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "00e6ee65dc7ef2d1db1e01beb9dfc0ca218850f3151e9dd35b07cabd5ee532c7";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "d5c23bb5181c0188271ab9866021950dc7f481220bb6455618866c40cb7be6a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "2c79fe0f7b3627aa91a50409b801a6ba72e51053c1c0f679cb90737d770fbdad";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "0f234a0f45ca72261adcb50830c15a3ed9d4dc7259c7fd46c4d80a4d4d4a6c5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "426802d49ed97df8e9ad709d0fed40471abdca2c8ac0bda60c8476f3dd972c75";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "be98755c9fc527286f9545bc94e8a95d9c400000a0423d004df291b7465173c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "4.5.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/4.5.1-1.tar.gz";
-    name = "4.5.1-1.tar.gz";
-    sha256 = "353eae354c3ba5c8c2b146a347a3a744d9cc81ba55c643c248e3dcf2df00a924";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "195a1574831752bb63bec8a0a8e60a976aec8aaf1489177d88f0b16819ebc704";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "c45b2816aff7e4256c51ea0fd0ff38f244d9b4f9cd2d76da910241f8cae875a5";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "c02f76cccafe92b557d8741a6e7a2652c5e324eadf8284bc321f24f1d8e9a768";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "4.5.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/4.5.1-1.tar.gz";
-    name = "4.5.1-1.tar.gz";
-    sha256 = "d03bb5ee785fd3141b88884f8ff4221ff58fe45fa8cc605769d2f97b2d1d8a18";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "8cee2262050ef848e86e3881f95801cdeaa2a25083e939433f59e2e8003676c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "f24b96a6a78cf36ac201cdd1a83f66fa96b394fa733da4aa71c164b85671710a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "1fc4265f7f7a78f43fea29d86dfd3cc2767c512921ad61af36c78e227f2116ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "74cb90f5395930d2170220e55931fef28ec85deefce365f783e3925c145f1e2a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "42314a7c04adfbf270b867890342eb31dd00c124669e50da8ebba7e39cef3153";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo-description/default.nix
+++ b/distros/rolling/leo-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-leo-description";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "ca3044aa4dae62289786a5e27ffa42b97cb8246206d9d47a6f3e4c84619df7e3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF Description package for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/leo-desktop/default.nix
+++ b/distros/rolling/leo-desktop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-viz }:
+buildRosPackage {
+  pname = "ros-rolling-leo-desktop";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/rolling/leo_desktop/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "269d7507793e2416e76bacfc5da987033c8c9afc0ea41cfed41674753c3117d6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ leo leo-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for operating Leo Rover from ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/leo-msgs/default.nix
+++ b/distros/rolling/leo-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-leo-msgs";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "ed4faaf97efd41a4469f7524c77efa8833b6a9a17adfd4b9fb285885c7b66e7c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Message and Service definitions for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/leo-teleop/default.nix
+++ b/distros/rolling/leo-teleop/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-rolling-leo-teleop";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_teleop/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "c29d644c1612b61d7e55e6a40894c0ef040b1663157bc27dc1360af77a8b49fd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joy-linux teleop-twist-joy teleop-twist-keyboard ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Scripts and launch files for Leo Rover teleoperation'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/leo-viz/default.nix
+++ b/distros/rolling/leo-viz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joint-state-publisher, joint-state-publisher-gui, leo-description, rviz2 }:
+buildRosPackage {
+  pname = "ros-rolling-leo-viz";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_desktop-release/archive/release/rolling/leo_viz/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "0b84e91b55bc6a40788f9de0a66e5c91ccd36a05ee21b03ee3b6b535f3f1cdf7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/leo/default.nix
+++ b/distros/rolling/leo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
+buildRosPackage {
+  pname = "ros-rolling-leo";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "144b10b51dae20d66f7d571271f0e803952c5ecc3c84ff525044b13c4a7749ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ leo-description leo-msgs leo-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of software for Leo Rover common to the robot and ROS desktop'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/libstatistics-collector/default.nix
+++ b/distros/rolling/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-libstatistics-collector";
-  version = "1.6.3-r1";
+  version = "1.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "b6c79600aa03d0c1168ead3fe58bf7b953622ca705b61204c48daf5a79cc5d5d";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.6.4-1.tar.gz";
+    name = "1.6.4-1.tar.gz";
+    sha256 = "df299180c5fe1005145580048cd9417b3ab4c14d9da01a966387d631e45328c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "34f901ee06d54002b7b03e2365f43ec0095bcdfc20e7f293031d12fc8c0c13ac";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "9db97aba277fbf6e5a177d058a9b777c6252d47bae60330a28528d867ed24637";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "e89219926137d8590b4edc89c525a92d7d52bfea61439cf32a24081094dd7e70";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "075386bf4d213b431430ba383aef6763b650642900032dd446e7fa923c75ca1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "ac818b156d76a9b22e40fbd51245a1b1dc9ac89a5c3721359abc4f5a55d7fe94";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "54dce412564e9e45c79e584c6bb12b973a9c2686cfcb4a7235d87549a23a72e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/magic-enum/default.nix
+++ b/distros/rolling/magic-enum/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-magic-enum";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/rolling/magic_enum/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "7254ba1e519089e0cbcf346d268e79acc910e305230b722b5bbd49b084611a3d";
+    url = "https://github.com/nobleo/magic_enum-release/archive/release/rolling/magic_enum/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "ae023accebf21b1b5377d2a089a283bb7b6c084ee50a2cbcb20e0a33fbe1b45c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/marti-can-msgs/default.nix
+++ b/distros/rolling/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-can-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_can_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "83f1967ee6a31c7a0141f25e8f6d37479e44c60e3dc3885457c08ce2881a5b36";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_can_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "67b97922eb704da4fca9961138f89f6e1f0be89aabd0ac61c546d914c16e6eb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-common-msgs/default.nix
+++ b/distros/rolling/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-common-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_common_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "cba4192ec366a86bca182d5c012d04cbc298e2d56dbeddb0fe905c38ae0dfea3";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_common_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "e880216dc35f5486e149ea422e52fb64396de93fe6b3cf5281a3e9b9430801cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-dbw-msgs/default.nix
+++ b/distros/rolling/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-dbw-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_dbw_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "36fe5148d3b19f248e9cd3c8937338aa920768291c3edf8ca8099ea6aa65c5ee";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_dbw_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "5c93c6040cc8bd154f8ad0cd50edefd4ce8c25e1a14496413a094ab83e5010c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-introspection-msgs/default.nix
+++ b/distros/rolling/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-introspection-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_introspection_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "c0b7aee81a4d8d26bfa7639df2e280a3062d807d435cbf9a03c3108053e86c12";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_introspection_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "25100648998db5163755a16016e1ef8512c9bafa809ae2ffa327071c6a03f87a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-nav-msgs/default.nix
+++ b/distros/rolling/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-nav-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_nav_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "913acb58f6e5733921d9b897b15da2b6d063e7131155a83b76f54ddb8114a023";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_nav_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "6e10b6cd392d2ee8c4e113ec65db842d686dc75b4805f2cc672f1ade2cd64ec7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-perception-msgs/default.nix
+++ b/distros/rolling/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-perception-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_perception_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "b4a0cf7989a9be121bc82c53adae7b20357335d0abd0b783c48d179f7472849a";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_perception_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "2ea2aef3a730b3d428186bcef9efc13f0ebafe89b2f55eaa0b3534e81c56634b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-sensor-msgs/default.nix
+++ b/distros/rolling/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-marti-sensor-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_sensor_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "95ef40d74c0139d3038527609e0fc56bef2e1d2f0d9413f3da78721373b47813";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_sensor_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "60d98802069c8137f2c20803950ae9e5b256ac6edebc3000588511d64a6c03ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-status-msgs/default.nix
+++ b/distros/rolling/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-status-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_status_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "ca91eb98a836f7c92f827fe792292979710f54f36e848c058a6a8522fa0fec88";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_status_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "ff97d7f949b55d449e5025bd5f2a544bcf52193bf25976aaaa56f615f83a1e8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-visualization-msgs/default.nix
+++ b/distros/rolling/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-visualization-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_visualization_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "dd1b4b4980c99b0cd118544c33312da3ff48de4d5780145778eb7d863cbbc524";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_visualization_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "9dda61c55ce40aae53aafff699e17e5d4adf990c61c606982d5d15efcf878f35";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "4.10.0-r1";
+  version = "4.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/4.10.0-1.tar.gz";
-    name = "4.10.0-1.tar.gz";
-    sha256 = "caf28a68d219b3271c0216e3fcdabc226558c4427f70ca9936d0b287b80f853f";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/4.10.1-1.tar.gz";
+    name = "4.10.1-1.tar.gz";
+    sha256 = "c6222d8e4ff32510062e45a791b82e5c5a12d9da4b5f531da03da70dcff5c1d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/metavision-driver/default.nix
+++ b/distros/rolling/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-xmllint, boost, cmake, curl, event-camera-msgs, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb1, opencv, openscenegraph, rclcpp, rclcpp-components, ros-environment, std-srvs, unzip, wget }:
 buildRosPackage {
   pname = "ros-rolling-metavision-driver";
-  version = "1.0.6-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/rolling/metavision_driver/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "e73626c58db755ca20e245b228db187e63f6dd37e5ed3346944022aab0993abc";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/rolling/metavision_driver/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "094547b4783737ad2b2af93152ac1c65e00047074565e1798a6f864c4cbabc42";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mimick-vendor/default.nix
+++ b/distros/rolling/mimick-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-mimick-vendor";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/rolling/mimick_vendor/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "f89903bf851a6159c2ac72cf8531ca8c94b3518c00e98473ed5a45c919527181";
+    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/rolling/mimick_vendor/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "4759f1bbc67d75b49de847cc23f5514b713f21490423531f6397081231f31195";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "d9f2cf21cace47fccfa49a2f64be3c9939cd58596e9ce7153e6a3d6c32612793";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "17ed06a49a4004ed36cc05cb376979917535153440dbc58a4c4d55d547a969f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ntrip-client-node/default.nix
+++ b/distros/rolling/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntrip-client-node";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "de82c3059868fc1d0ef030e2a84e6de7a1e33216c2f6c86a0b83521065bf2048";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "62372cd035fdf3bc43a861800c44c8c55176adcbca7f3a326946b370012d9477";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "c9f3e4d504eae49ccbc52dfab1179338a3b78b315f391f1cfef9341c4e59d42c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "83a5745eb9d7e8f82488036b56ac181ed408215950e514e81686217af15f3742";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "5c2343a485b578d75d300428c576acf955ed6088fcc0e11e46f2a7add7603142";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "bc8518e68eeda618aa2a493d7c9227cb3247337ac7546cd916814e04287a8f73";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/plotjuggler/default.nix
+++ b/distros/rolling/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler";
-  version = "3.7.1-r1";
+  version = "3.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "3cc3770713f92be41b269462ae33f24b76be56e2585de49dcb0a23c5585c87a4";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.7.1-2.tar.gz";
+    name = "3.7.1-2.tar.gz";
+    sha256 = "bc5dc27f49d6bf32dfd24cf0ef1aa34bb57d31af9589bfa81dfe642351e45141";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pluginlib/default.nix
+++ b/distros/rolling/pluginlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, class-loader, rcpputils, rcutils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-pluginlib";
-  version = "5.3.0-r1";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pluginlib-release/archive/release/rolling/pluginlib/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "c21be0387aa2a53b53045863d48809d412e867d6eb21329abde11dc0b00fda38";
+    url = "https://github.com/ros2-gbp/pluginlib-release/archive/release/rolling/pluginlib/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "36806517b3fa6bf45597b32c066cccea4cea5baf75a302bebe3fa706fc93902b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "fd99444e25f1d6ca85ec000798d2d416c0a30584a4a05ec1b7614a8c68fae529";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "5df6979f7647cacd726a8cd6b191fcc1baf06a299dd6a69c4451ceae746aae4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "2bac9cd7b0cd82d42bc33c30973759c6848c4e8c66b224636319b47fc5d9234a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "4b0d39167d3b18cff35ac97b39258badddc79b184e5d96cf8f712be6d685bcd6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "7.3.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/7.3.0-1.tar.gz";
-    name = "7.3.0-1.tar.gz";
-    sha256 = "0267faa2599a81c4e4e0b1299d0e9e1b5820277800c8942af9d0598073d009dc";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "ccb8c06a1d2cb95cb59a4f1563f1f815b441bd7ba0d440578a5ac2521264d431";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "7.3.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/7.3.0-1.tar.gz";
-    name = "7.3.0-1.tar.gz";
-    sha256 = "832886e3854244461c11c6a9e78151964e3bb8d1d6b02e562781e232e886d1ee";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "45c9612204f7a05a0c7c73540f44afbaf6275905e5584e642e14dbfb5a820ebe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "7.3.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/7.3.0-1.tar.gz";
-    name = "7.3.0-1.tar.gz";
-    sha256 = "de4cd8e3d9ee3f8919c51d3c147a88ef2d5baa45b706086d43fb0a2a7968e28b";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "96c7e65217acbb9079a924ae0414080cd36409cdd7a3302ea210b1fe0728023e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "7.3.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/7.3.0-1.tar.gz";
-    name = "7.3.0-1.tar.gz";
-    sha256 = "d58aac5e05a19c1569ed9c9c6f7f84ba706ab90adc433df1e1f1e21f01a89a0f";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "ada75a66144fcd496c6df2a5d8386cf4ec22f55c77902ae91e627a79981dad94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "23.2.0-r1";
+  version = "24.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/23.2.0-1.tar.gz";
-    name = "23.2.0-1.tar.gz";
-    sha256 = "bdb546ddcf3a4442dec9a60678f7788df606f143580f3660b2eb330b5484e11c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "60ed4b4cbf2eb3dad3ff21d035bb98d6c988eb6604754d2531e915834556945f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "23.2.0-r1";
+  version = "24.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/23.2.0-1.tar.gz";
-    name = "23.2.0-1.tar.gz";
-    sha256 = "6cdee431880b10517c0d1b550069ef3d68dc88594070b35a46c221ea9959d345";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "998be83549c2f99b11387137723b53df9670d98058ce9017d1ea69d2f48195c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "23.2.0-r1";
+  version = "24.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/23.2.0-1.tar.gz";
-    name = "23.2.0-1.tar.gz";
-    sha256 = "76125d7d855006014d436f02b92f3c6a6ab03f2664432c2382e64b55959daed1";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "3f2b6c0c9990bcc0396150eca9e3f7184af4f2dcfdc11315e02f6f90b8a7ba32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "23.2.0-r1";
+  version = "24.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/23.2.0-1.tar.gz";
-    name = "23.2.0-1.tar.gz";
-    sha256 = "67a93b5eb69de39ea02fe9939d0dd71f82b0e751a3b74cb424582c3f2055a328";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "90091b819234c574ae7f6970af214cc6b6660e61d3fa85fae7b604c416f46168";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "5.4.0-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/5.4.0-1.tar.gz";
-    name = "5.4.0-1.tar.gz";
-    sha256 = "9dff99c4864ff0d79b4f4bfcc8fb84ae165d0d8c2e514d261b74d4e8e43b0596";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b4855e0c5678d7f3bc61a316d5b849805b49c54192d78bf50512647f17bcb5ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.8.0-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "427f30e5cd2da2e83120f3d218523214655e122701c51d25b675903f5193a8c5";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "9f7ed953d5e78567f18a200ed7c1fba6c4159991f507b1743a103809144530fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.4.0-r1";
+  version = "6.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.4.0-1.tar.gz";
-    name = "6.4.0-1.tar.gz";
-    sha256 = "4f9ea18c584b95f45e1e115cfd4271643a42943b96ee53908b596a2abbda65bf";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.4.1-1.tar.gz";
+    name = "6.4.1-1.tar.gz";
+    sha256 = "a58dc3b07744603204e9be6ac05ac40545cc13a81dbf1b0faf2913b0f1c34f9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.18.0-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.18.0-1.tar.gz";
-    name = "0.18.0-1.tar.gz";
-    sha256 = "69353cf5fa431e0dfdaa9ba48a72cf88a603d0fa1c5c3cb39671f3adbff7c6fc";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "92ce341b10bdcb8dfd2fd954017915378acbc3fb78731f5a014bcb63ea2017e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.18.0-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.18.0-1.tar.gz";
-    name = "0.18.0-1.tar.gz";
-    sha256 = "b0d4213fd0688187e941e6f1bd17bf29a1b0e89422f80764a099ef3cd8800c06";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "aecf02a4fd1182eed49534a2abc98811cdf04c33053ac4a413fecf8ae6d403de";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "1.10.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "60e88a070b28c77baee1616790a4979c4eeb21edefcec8d7e0642437e67ab1e5";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "50f7363c422b85956534f0d67c5fa080d8ccae2c96c8de5bc9eba425ea9822c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-dds-common/default.nix
+++ b/distros/rolling/rmw-dds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-dds-common";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "172202f46c5819e0506e6078db8119e566a2144bca565ad1c90ff09365a41e04";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "94aeb502e6ae28c08d16eb0b1612d8c2acb26e14d2950db961d1fe9c94b6765b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "7.6.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/7.6.0-1.tar.gz";
-    name = "7.6.0-1.tar.gz";
-    sha256 = "2caa7db4c8874819aa494d3e87168caf862b19d8f6c02412e1e4946085806029";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "3dc14a772fc118d8c2f7239fe08562435e59f03331cfd03abac947cdfce8bb6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "7.6.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/7.6.0-1.tar.gz";
-    name = "7.6.0-1.tar.gz";
-    sha256 = "28ac6aeacaf3d97f1571cfe3fc5bbe86c141bfd4321c6e929078e86826f26150";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "06a7906bf744090ff8b8c1bf69cea010926a5a72b7bb1d5b36d0faf79ea7c3e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "7.6.0-r1";
+  version = "8.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/7.6.0-1.tar.gz";
-    name = "7.6.0-1.tar.gz";
-    sha256 = "f145a8f612f53796ba29e7aa9d7745da4248490286416eeaea18bfecb7340c90";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/8.0.0-1.tar.gz";
+    name = "8.0.0-1.tar.gz";
+    sha256 = "2b72b410f33f37f415080dda623d3b4195970ff94ad7b1a9028ea1d81685df47";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation-cmake/default.nix
+++ b/distros/rolling/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation-cmake";
-  version = "7.2.1-r1";
+  version = "7.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.2.1-1.tar.gz";
-    name = "7.2.1-1.tar.gz";
-    sha256 = "0e5281d339e1dbc69e3a179cc8eefabbdcdda0f1708bbe5bf95337b3b30f08fb";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.2.2-1.tar.gz";
+    name = "7.2.2-1.tar.gz";
+    sha256 = "1d6faad11d6938f52ed234b74bab51d6bf83573fe6286743ed0dc256312b3a18";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw/default.nix
+++ b/distros/rolling/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rmw";
-  version = "7.2.1-r1";
+  version = "7.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.2.1-1.tar.gz";
-    name = "7.2.1-1.tar.gz";
-    sha256 = "dfb5aed26620d5443cfb48bd94bd80a8143ff6b2fba14006e0b7b2df5e0f9788";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.2.2-1.tar.gz";
+    name = "7.2.2-1.tar.gz";
+    sha256 = "f454a5146045be8a3f28807b14d371bfccbd782ede47427f38b05e6c7618abb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-state-publisher/default.nix
+++ b/distros/rolling/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl-vendor, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-robot-state-publisher";
-  version = "3.3.1-r1";
+  version = "3.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/rolling/robot_state_publisher/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "57969a23341c6c166c29cc87692153414d8998a1590f85f81b0f24437763637c";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/rolling/robot_state_publisher/3.3.2-1.tar.gz";
+    name = "3.3.2-1.tar.gz";
+    sha256 = "ca9ebd6c5086583d8751dacab53e1f6e26b93fc8cfdd38b31fe21a4284d8e0c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "8f3ca488365e766e602203166780a50fe7e5faa98cb43949bd89ae521a6e7571";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "3ae6655b4f7dee2c16361284a633941c9824a9a44ad322cfe706c800eabfbc52";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "10cb20545d03a5e31bd25234fa0e78c8b93cd4d94e048ca2087663df1989cdf6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "57bb4021601a7039ef4c63f0853233aeac8ef34b2b8b0714db357e4bd856b970";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "3125ed682b8609f1c585bf270e51b327e0ecfd18de35d52215bf75600fa7db16";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "1a8ded653f63681217d95b6e2b49b4672cb8f81cd5993eb0423cad53ce3083fd";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "88e7d3d6842ebcbd1814b9702c33ea226311b9a3d27fc91708168937e25332b8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "b973b4ecfb5f580bafaf3826121a164a409748da6efe95b000b5b2ac890db85d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "26de20b950be8a911addbc28389cb987d4bf629f058e49f5e6a67a97ddd99905";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "6d77d7e9c87541c925816950c314da1b73096f0b0509793839af36269f9cd0f8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "eec1776052c4d37676d9de7630b366abf78cd614dd91875ede83e336a37d80b6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "3aa463ec548c765e216dd2d79eb74a289e9fd68c861b9d695cf2503babe3cba4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "a8ad353741420e35cd8e706d34b7248f89d5978b0461b15aac95c8cfdedfb430";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "9ac9acb50faddcdf138b9a3a8bda24bb32c028feb6f4be205fd440830c866853";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "0cc1828d6213011a0f65c6ddb106d256865c39c3f7a6c1c6d966b58e9d69d7e6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "08d862a6fab6a2567e5a9c34b87bfd0ec978cfdfeec0e32c1a159cd106aeb87b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "7f1f7f305240b50f7a0ab3c5bf15192a2864c0e2eae61e6b2e47b9bc1946507e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "c60b2dc07c008cfe8508ed49488d2f6c15acb235abdebba46df05bac6834c85a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "6dec7c13257c188527465795e4acf00a9baf2aa11992aa8b578ba7972f56d333";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "c9124f586793322020bbf2db05781e11f44443e7c340e29eeb314af57941cea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "55bb1e18ab59ccbacb962fe5bce5e63a3c40391dec46ac451b6a08c18e6a3b88";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "b4c48b1b4ffee99816a4da28c3e59cff653830e8b4103ebe35e2c5ecac959e54";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "3483d104a78c23f022474db6b693a48d1018d41cdca1b6c39d95b4274ec86262";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "8f686e4816efa3f149a07c4a7757fa9c5f449d95dff0f9517c4eb1898d0f36c3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "1bcbee979e89be6398b22aa854cf5c7bb673e3a055cfc883305c0a6e6f4e497d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "df329e0a2b8e279b7d3b6a09c4f5b9b03f24083caa2f0828476f7980a6d90d45";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "5f400e6af0297913a9e714f32d44d1f528e09dd3166442842ec4daaae5402fbc";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "62a87329b4bd564fa806b1085fccb53f4577cca35d9d247808e01c96dcab8784";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "756ea121b777453459682679ddf7140a3a4185762dfd257a6886f85f60818d64";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "25f6630e5b3851014f8df52e769d65390b13f7964f19d7cdcfd2aa1451487fdf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "5e73f4d83024aecf869a97bc0bf76f7559759544a376844043a251a7f89f321d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "be39790e3c3b0a9ae8fb8f0f262c9a28f9d69d5f45e7647109346173ef1c094d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "54f83eaafd91092c938ecaf469606fbd1574de45db2b25b63f13ffcc58f5ea50";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "e11323dcc776563519d210ba687731ad1dcea3eae7bf70acfdff6c44c33cdbb4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.29.1-r1";
+  version = "0.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.29.1-1.tar.gz";
-    name = "0.29.1-1.tar.gz";
-    sha256 = "6e1e351285fdefefd25115b7f57a078fa22437c9ea7973fd38512ba87aa634da";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.30.0-1.tar.gz";
+    name = "0.30.0-1.tar.gz";
+    sha256 = "d33def3232406c861ca32d05f55237fcc8540ab9435a08a4eedd4fb289415433";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "1270d9175b993f6f55ba6959b123111976d2623e6d8266199c491781435bf994";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "6ffdc188929a9759d7e990aadb1e561011cc975c30ce628791cc84ea5cac1e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "effed58f57b7f59c9ccde1d3066145ca632040b0e82ac9eab619896bdd0a6fc8";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "26ec1c6963074c63e438a4b113293b46bdcfa395dbb00fa7e09fa73c17fc4047";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "5b5ee0da8f37cfabdb86bb205581caf06c37e308183069cffe5fc778124d60d8";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "91f252a66e3c91c5bd5061d67c807c9adcdd2ba7d7a05f9f5b9e02442bc8533f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "173422a90788645b1586454db069b8b31f73b807c46dc54c395f06d197e27bc4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "ee2b73f65ce8920a9e7d81c302013b8e34b455705a3fc656a9c00350e00e8196";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "4415cc2a796593849642463037b25d6cf2499ac985a225f1ddc218019ee6c5ce";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "d51cc70f29f33d1a7ca2256e49e6c3c0c6e9299d9675a6fc82f08940ebfac4c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "7d0678e67ea2630d14eabbc82f5da660af6f6700ee5407a994ee3d11ba6d9196";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "173b464e726c127cdf80a52a20d0b55364f19590da229762ec9b01b5fd929f11";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "3bffb0b23e48c81adaf069b7c67bb027c8fd75086f090920dd5e120a06da6eaf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "2d3844aa10d5483efd20ab8e8b04b408f5e1f2aa44747d9d3ab34730ab6cb028";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "241735da5b68391e0cf8f5b9fc24f5025d44c094dfe57cecf9f35b34c16ffbbf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "47c46314d4c67aa0003beb0d4ad8b0a2f6b82d870c4f788f28ba8705e6e9eb30";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "8b43657529cea316c5dc3d366aad5bdaa14c1c63ab0651cb4f679971e6fd2b19";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "1756a73ebca8c66d4131250a49ec90e7441470ccb6a37c77e08b23683ec4c25d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "16b1f3dd75c8dad8a36b1ce7d79007bf83e419a51992de7f664ef08443da4198";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "78cb8afe7f8285cdf96bcff190f9b34278e4333dfc151809b7acb8a9eba99516";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "fdefdca593e37f65b1284929e6fc4153ed0dce5378c1a8afe9a97c092ddd8db3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "f0931be8e6d1a57bd0fb9b163be7b946b56b5d1613e0cda3352b7cc9cd7f4d6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "569fc6f3463e5875d7c8a13617ee05fb024a06d69a3b37b60cc9805a0bf93244";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "f5747d2f7f20bdb1e15f58bc413a9ad14cc44df9c1d46adf2c9a24a219f0009c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "afd56eb25b269701f98343ce58f88309aeabd3ce61e54a5593028daf717faba5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "252447e63a7e711c2e7f6451de9d30378e0444a5511323c4689e1f5cffa75eee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "4508cfe7b12d37c2b4e6af75d1dc4ed2aafcfa59d8834061c902d227c3f6255c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "0316559ba0814eaa6aa13fbc0ef787f5907931890a6eee27e39e25b86fa5316e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.18.0-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.18.0-1.tar.gz";
-    name = "0.18.0-1.tar.gz";
-    sha256 = "ae5da5853bd2bddf015c6e1984f4aa4a49e23309a77d22a29afdc5b65059d9ea";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "2191de91b4db2f5cc9d29b4d83d1f5d7a9d8f4c9eaae07712ec9ccd1011ae672";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rttest/default.nix
+++ b/distros/rolling/rttest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rttest";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "4d2b1dc75c4cd90345577fe01230d435925009215be129a8d173dcb889abfc89";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "c891a884ba68b176537ff1769237fa3c8d6845d57f54ffc6e37199249e2724bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "3ba7f4930448e973a9b91395f8a500de83c5db2a0eba161b730754726230cf28";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "227476b841183a4f36f7abe0086841e93d0d299f4d20625d6b686c162c1ff8e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "4d9c8b2a9b0552939bfd35e664eee309833486c2b62ec849089c825d1883f217";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "b9aa69e93d49291b08ae549f3fe7d37384b5b1d22a2ae824641b264b075f21fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "d5d99056753c84971e5075a2dd5f5a9ec16405b6412a3e7a14476c3946bd434f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "04abbc123aa069676fd38f1519206936d546189d60128dd89674fe33981b4f24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "18c6fc64dc46138ff21fb980235b7f56b902041b16021f71a5c71962e2614da5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "a6d06d651cfdba2f0aa978fb0e85e183efe1eb4795a4a92b1a5f79141f585967";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "f5f4b5bbc76800fb364c75b6cb30df0e768aa2c44c9d1a244ab992ba6e2a0333";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "54a64dbf2e319304ca98c6e70a34af2f892d825e96fea14bca9433dfb41f9e7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "d2e87bb2a1efd7ee24e07a5401239cc7d3bf5d747ae23c7b9fa3878b20ae471b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "a9284bed82e8b40e14ff7a5809482b32791f513a311b6bb3d40eb32c504c064d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "b469d20f2883dce76dfa6ecd23314dcdee679995a465ca2900f4dd74bc7a1267";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "958270317797f84fa3df385bbba01b824b7ebf7f7df2e6f7389e10eab3f7ebd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.1.2-r1";
+  version = "13.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.1.2-1.tar.gz";
-    name = "13.1.2-1.tar.gz";
-    sha256 = "834614b612773079160401f846a1ba4c3f8994e51a1fc55ee90abc214e281aeb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.2.0-1.tar.gz";
+    name = "13.2.0-1.tar.gz";
+    sha256 = "3947d91dac24ced6243a4d5dbcaed126fdfd1aedadde8f38f0da2f93fe37859b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "00a97b5d1fbedc925ff0fb5b5e1ba08722d1f8835a498cef2479322efcfbdc50";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "5cc8966225517909439f5e33df618067997de053c508b5c774fb6ff1ed10a9ef";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "7c78ad9a76d243907271f62b80cb5e66892b81cbfd68ccfb45dee261c8578bee";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "241b84d542666cb52ba536571205c8bcf997873f50c5e07eddb88bae9b05411a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "5d27c195d7e6db2a5838c821e8f23f850d375f9ba05caad1c230f9e99bbf6bc2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "aceb782dd7a0e9aa93cf576be864b4f41dcd4e4a80bf758aa9d1d15bdd5b7f73";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "b1130eb14f45d76317457e590d33438f152994325ebf9f22e3e7ee2f71214800";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "696ad7bd3736ce3d34b8f54807df887ecfed727380c24e51a2a0b69d78ba9b34";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "d0916fdb3fa423c49e80ae8047601c727f47624a0fc4025fcda22db9652c2779";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "5f2107f6764d73effe12d2086d11e03ddd224eea00111e794a84395bf6fda32c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "857cf09648a7319accd7a51df905b2e8e1639f277afb51a2706ab686347366dc";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "ce0d1ca055f36d99ef40872dba511e239d490c7309812725f7bc7da745ee5436";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "21755c9fb5018e0b88cd1f418eb89ec7bd2f4aeb99c02bd8993226f7ac2c1328";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "bc076bcf139bee39241dece4f770ab0b474f871a45885bcd17e0e1e3ad976e1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "7c3100a5454f46da2e6d02f4bb2f3f61fae76ceac4001dfdd94445c35c8a5f6a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "5c4a8de0846b1f298f9cabdc6d4b758b4be1aa74b49e950fbccc785c8e85a825";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "a5d425c1796fa466a7919546efd73e791fb0ee5b0e9c411a70766424ed05a560";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "9ec67f18d5c01e638782412e1cdf0cc0cef21a4cd60c781c87a3202e7e771c18";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "ece3bdf22389cd77234453fb336faedfd189dda6721f0d1f22cc61309242c3d4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "329f1c71d1e92ee30ee11064e74c26bc350014943699562cad76171d3ffe4e28";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "ccf015edf50cfc251f7ab13c4cebaf07e799173f3667a9d2c73d512ce290ece9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "1718e6514936793cea0901f3ef58da06894c503d43806957fb40f610bd2afc4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "115261c735abcd614975fa2bab1f11bc1a175f7d832a70064cd25d717fba336f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "2b26cdb0a254ddb54c9b774e7570fde98026a6a64109be71d5502fbe6f50a5ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "fdac2fa5fcb5dbbc1de1178ad507e79c41dbadec7e0a2e09e95a66066fad5fc1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "fff6c1d6643f172f26abf3601b96f8abb5bd51d5a8ec0b67ff3534bddee0ed36";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "d2ba1466757d28521c407f8bdca27555a88a0a63cfcf1844b2ff4fafe9a244fd";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "6d24ffa8a1e02805d4ae5a152e9e1f82d6e1cea868c922d9351153fa55f6cdc5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "db2a3cb4504b8a9d847f057d7eac196a7f40b634fe1163143431719f9477bb2a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "34e102f1c0d049b30b89f6842deca24698247e553d27bceaafd19b9e736f7a0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "4f8d18e5d7d2a70f971d73b57f4e45c76ab1fae2d02bc1923b365fc4d63e7b9f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "b56b9b497d596cc7060361b25c79a7a932cb5e50ef07bd959f18b8e0c31f634d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "a1a820c102eb2c747d28ec38cc7655e54e8de202ab11bed5c830871617c2491e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "5c4b32fcea453b8c2bc9baf2dc475375661e05645319bb78ee9938b783e90250";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.33.2-r1";
+  version = "0.34.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.33.2-1.tar.gz";
-    name = "0.33.2-1.tar.gz";
-    sha256 = "8bc91545d8cb859cc28a736d9cf58b8f53f669a80004751c4eaaf47f71859c43";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.34.0-1.tar.gz";
+    name = "0.34.0-1.tar.gz";
+    sha256 = "dd0d072f913c75a40b0512bb25a2ebda0cbb6dab8d053735c07ac61bec818e46";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tlsf-cpp/default.nix
+++ b/distros/rolling/tlsf-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rmw, rmw-implementation-cmake, std-msgs, tlsf }:
 buildRosPackage {
   pname = "ros-rolling-tlsf-cpp";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "dc2d6b995143a2fda8e03594509dea755756867a6083b674157667291d0d21eb";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "d2039712459b4cb30faa139e7370cc77739aca49a7e0fb32b0ea32f40fc5679d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "4e10bb3c43c33a9833bad8afb2696be25ef6e6ca0d92c70743dfef56eafffe93";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "a672825af19dd7103480693fcbdb1ff9227acab7373aee52668572dc72f648c9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.31.1-r1";
+  version = "0.32.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.31.1-1.tar.gz";
-    name = "0.31.1-1.tar.gz";
-    sha256 = "0f2ee8e4d9b557989c179dee96d18cbd6f246875d39a1916b235db83fda009f7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.32.0-1.tar.gz";
+    name = "0.32.0-1.tar.gz";
+    sha256 = "d89a959f783cccd98772a535f13c70e9b41509dc7317632216fde2074d598de8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "249ba4cc4889a2b250d0c661965410fb8a3520fe3afcc8dfd63a17c2afe73b26";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "6c86d4b1bf282bb57bb83c940c29614c3b250d301dced94929529aad0a417207";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "3.20.0-r1";
+  version = "3.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.20.0-1.tar.gz";
-    name = "3.20.0-1.tar.gz";
-    sha256 = "42a449cb555990e5a18d6971309fff6e84e6dd48c26e7d9952224f109f5fe33f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/3.21.0-1.tar.gz";
+    name = "3.21.0-1.tar.gz";
+    sha256 = "5f3d4f2237a1777e84e4b2aa45842647b3044ee3809a471cf0a9638f883d4a7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/twist-mux/default.nix
+++ b/distros/rolling/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-twist-mux";
-  version = "4.2.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/rolling/twist_mux/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "58e04bd273fd0582e02a16031dbca6f5b57517a53b58b515f237f01ffecb4466";
+    url = "https://github.com/ros2-gbp/twist_mux-release/archive/release/rolling/twist_mux/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "858dc0a8ba195a6a860e7f27630fa9a8b640c62011d382c437679797e6eb4d4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss-node/default.nix
+++ b/distros/rolling/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss-node";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "83f9688e1d221c6fd0fffb37befe56ff38d73739c78a93f908d1211e5e88d1df";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "d97e14f7edb74006629ce33161d60be628c741e5174f25970569dcfa372bd5c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss/default.nix
+++ b/distros/rolling/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "8923316678cedbb9b6e62bb0a09e4aa9d81d659123fd22a1e1dc657f89083bdd";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "32ed24a76822c4f076516927e559f8126273b4f2e192e4d12cb50ed1f518caa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-nav-sat-fix-hp-node";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d6502d7067d8c02893988a3c183158ef9bf0afe9349b1f44918f0bd95c4ca0b6";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "0f8c88f3a711c34f03fb5e0cc6f9261ed962474c0ad516edc6101f32a533f087";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-interfaces/default.nix
+++ b/distros/rolling/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-interfaces";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "54e6015289e658bad68a4379224ec515f69b98ece7389ba81b9e98724c747dbd";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "a9e45afda45bf76354a3ea0569906a6a46c744a328177b3d9c2c51931cc022b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-msgs/default.nix
+++ b/distros/rolling/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-msgs";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5579d28fd806515860f1804617ba9eb40432becec7f810c89cc9565a5a98a515";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "9913b38250f4744fb2546d8cd53d66153ba26807fed764d14630a4fac385594e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.2.0-r1";
+  version = "5.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "4ddb3b917612e9c1ae5d749845dee3bb097d83d217e9c84084b819908f5e176c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.2.1-1.tar.gz";
+    name = "5.2.1-1.tar.gz";
+    sha256 = "901b94bc15cec5e5c7625e5d93d6797632edbb765bc60f692cd92dbbd1bd876d";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 734153d7c1a802f5603dbd99a68441d5a7ef80c4.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aerostack2 1.0.4-r1 --> 1.0.5-r1*
* *as2-alphanumeric-viewer 1.0.4-r1 --> 1.0.5-r1*
* *as2-behavior 1.0.4-r1 --> 1.0.5-r1*
* *as2-behavior-tree 1.0.4-r1 --> 1.0.5-r1*
* *as2-behaviors-motion 1.0.4-r1 --> 1.0.5-r1*
* *as2-behaviors-perception 1.0.4-r1 --> 1.0.5-r1*
* *as2-behaviors-platform 1.0.4-r1 --> 1.0.5-r1*
* *as2-behaviors-trajectory-generation 1.0.4-r1 --> 1.0.5-r1*
* *as2-cli 1.0.4-r1 --> 1.0.5-r1*
* *as2-core 1.0.4-r1 --> 1.0.5-r1*
* *as2-gazebo-classic-assets 1.0.4-r1 --> 1.0.5-r1*
* *as2-keyboard-teleoperation 1.0.4-r1 --> 1.0.5-r1*
* *as2-motion-controller 1.0.4-r1 --> 1.0.5-r1*
* *as2-motion-reference-handlers 1.0.4-r1 --> 1.0.5-r1*
* *as2-msgs 1.0.4-r1 --> 1.0.5-r1*
* *as2-platform-crazyflie 1.0.4-r1 --> 1.0.5-r1*
* *as2-platform-dji-osdk 1.0.4-r1 --> 1.0.5-r1*
* *as2-platform-ign-gazebo 1.0.4-r1 --> 1.0.5-r1*
* *as2-platform-tello 1.0.4-r1 --> 1.0.5-r1*
* *as2-realsense-interface 1.0.4-r1 --> 1.0.5-r1*
* *as2-state-estimator 1.0.4-r1 --> 1.0.5-r1*
* *as2-usb-camera-interface 1.0.4-r1 --> 1.0.5-r1*
* *behaviortree-cpp 4.4.0-r1 --> 4.4.1-r1*
* *clearpath-common 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-control 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-description 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-generator-common 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-generator-gz 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-gz 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-mounts-description 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-platform 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-platform-description 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-sensors-description 0.1.2-r1 --> 0.1.3-r1*
* *clearpath-simulator 0.1.2-r1 --> 0.1.3-r1*
* *cob-actions 2.7.9-r1*
* *cob-msgs 2.7.9-r1*
* *cob-srvs 2.7.9-r1*
* *controller-interface 2.33.0-r1 --> 2.35.0-r1*
* *controller-manager 2.33.0-r1 --> 2.35.0-r1*
* *controller-manager-msgs 2.33.0-r1 --> 2.35.0-r1*
* *event-camera-msgs 1.1.4-r1 --> 1.1.5-r1*
* *gazebo-video-monitor-interfaces 0.8.0-r1*
* *gazebo-video-monitor-plugins 0.8.0-r1*
* *gazebo-video-monitor-utils 0.8.0-r1*
* *gazebo-video-monitors 0.8.0-r1*
* *hardware-interface 2.33.0-r1 --> 2.35.0-r1*
* *joint-limits 2.33.0-r1 --> 2.35.0-r1*
* *leo-gz-bringup 1.0.0-r1*
* *leo-gz-worlds 1.0.0-r1*
* *leo-simulator 1.0.0-r1*
* *magic-enum 0.9.3-r1 --> 0.9.4-r1*
* *marti-can-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-common-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-dbw-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-introspection-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-nav-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-perception-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-sensor-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-status-msgs 1.4.1-r2 --> 1.5.2-r1*
* *marti-visualization-msgs 1.4.1-r2 --> 1.5.2-r1*
* *metavision-driver 1.1.7-r1 --> 1.1.8-r1*
* *naoqi-bridge-msgs 2.1.0-r1*
* *naoqi-libqi 3.0.2-r1*
* *ntrip-client-node 0.4.4-r1 --> 0.5.2-r1*
* *plotjuggler 3.7.1-r1 --> 3.7.1-r2*
* *raspimouse-description 1.0.1-r1 --> 1.1.0-r1*
* *raspimouse-ros2-examples 2.0.0-r1 --> 2.1.0-r1*
* *ros2-control 2.33.0-r1 --> 2.35.0-r1*
* *ros2-control-test-assets 2.33.0-r1 --> 2.35.0-r1*
* *ros2controlcli 2.33.0-r1 --> 2.35.0-r1*
* *rqt-controller-manager 2.33.0-r1 --> 2.35.0-r1*
* *transmission-interface 2.33.0-r1 --> 2.35.0-r1*
* *turtlebot4-base 1.0.1-r1 --> 1.0.2-r1*
* *turtlebot4-bringup 1.0.1-r1 --> 1.0.2-r1*
* *turtlebot4-description 1.0.3-r1 --> 1.0.4-r1*
* *turtlebot4-diagnostics 1.0.1-r1 --> 1.0.2-r1*
* *turtlebot4-ignition-bringup 1.0.0-r1 --> 1.0.1-r1*
* *turtlebot4-ignition-toolbox 1.0.0-r1 --> 1.0.1-r1*
* *turtlebot4-msgs 1.0.3-r1 --> 1.0.4-r1*
* *turtlebot4-navigation 1.0.3-r1 --> 1.0.4-r1*
* *turtlebot4-node 1.0.3-r1 --> 1.0.4-r1*
* *turtlebot4-robot 1.0.1-r1 --> 1.0.2-r1*
* *turtlebot4-setup 1.0.2-r1 --> 1.0.3-r1*
* *turtlebot4-simulator 1.0.0-r1 --> 1.0.1-r1*
* *turtlebot4-tests 1.0.1-r1 --> 1.0.2-r1*
* *twist-mux 4.2.0-r1 --> 4.3.0-r1*
* *ublox-dgnss 0.4.4-r1 --> 0.5.2-r1*
* *ublox-dgnss-node 0.4.4-r1 --> 0.5.2-r1*
* *ublox-nav-sat-fix-hp-node 0.4.4-r1 --> 0.5.2-r1*
* *ublox-ubx-interfaces 0.4.4-r1 --> 0.5.2-r1*
* *ublox-ubx-msgs 0.4.4-r1 --> 0.5.2-r1*

Iron Changes:
-------------
* *controller-interface 3.20.0-r1 --> 3.21.0-r1*
* *controller-manager 3.20.0-r1 --> 3.21.0-r1*
* *controller-manager-msgs 3.20.0-r1 --> 3.21.0-r1*
* *event-camera-codecs 1.2.2-r1*
* *event-camera-msgs 1.2.5-r1*
* *fastrtps-cmake-module 3.0.1-r1 --> 3.0.2-r1*
* *hardware-interface 3.20.0-r1 --> 3.21.0-r1*
* *joint-limits 3.20.0-r1 --> 3.21.0-r1*
* *leo 2.0.0-r1*
* *leo-description 2.0.0-r1*
* *leo-desktop 2.0.0-r1*
* *leo-msgs 2.0.0-r1*
* *leo-teleop 2.0.0-r1*
* *leo-viz 2.0.0-r1*
* *libstatistics-collector 1.5.1-r2 --> 1.5.2-r1*
* *marti-can-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-common-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-dbw-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-introspection-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-nav-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-perception-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-sensor-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-status-msgs 1.4.1-r1 --> 1.5.2-r1*
* *marti-visualization-msgs 1.4.1-r1 --> 1.5.2-r1*
* *naoqi-libqi 3.0.1-r1*
* *ntrip-client-node 0.5.1-r1 --> 0.5.2-r1*
* *rcl 6.0.3-r1 --> 6.0.4-r1*
* *rcl-action 6.0.3-r1 --> 6.0.4-r1*
* *rcl-lifecycle 6.0.3-r1 --> 6.0.4-r1*
* *rcl-yaml-param-parser 6.0.3-r1 --> 6.0.4-r1*
* *rclcpp 21.0.3-r1 --> 21.0.4-r1*
* *rclcpp-action 21.0.3-r1 --> 21.0.4-r1*
* *rclcpp-components 21.0.3-r1 --> 21.0.4-r1*
* *rclcpp-lifecycle 21.0.3-r1 --> 21.0.4-r1*
* *rclpy 4.1.3-r1 --> 4.1.4-r1*
* *rcpputils 2.6.1-r3 --> 2.6.2-r1*
* *rcutils 6.2.1-r2 --> 6.2.2-r2*
* *rmw-fastrtps-cpp 7.1.1-r2 --> 7.1.2-r1*
* *rmw-fastrtps-dynamic-cpp 7.1.1-r2 --> 7.1.2-r1*
* *rmw-fastrtps-shared-cpp 7.1.1-r2 --> 7.1.2-r1*
* *ros2-control 3.20.0-r1 --> 3.21.0-r1*
* *ros2-control-test-assets 3.20.0-r1 --> 3.21.0-r1*
* *ros2action 0.25.3-r1 --> 0.25.4-r1*
* *ros2cli 0.25.3-r1 --> 0.25.4-r1*
* *ros2cli-test-interfaces 0.25.3-r1 --> 0.25.4-r1*
* *ros2component 0.25.3-r1 --> 0.25.4-r1*
* *ros2controlcli 3.20.0-r1 --> 3.21.0-r1*
* *ros2doctor 0.25.3-r1 --> 0.25.4-r1*
* *ros2interface 0.25.3-r1 --> 0.25.4-r1*
* *ros2lifecycle 0.25.3-r1 --> 0.25.4-r1*
* *ros2lifecycle-test-fixtures 0.25.3-r1 --> 0.25.4-r1*
* *ros2multicast 0.25.3-r1 --> 0.25.4-r1*
* *ros2node 0.25.3-r1 --> 0.25.4-r1*
* *ros2param 0.25.3-r1 --> 0.25.4-r1*
* *ros2pkg 0.25.3-r1 --> 0.25.4-r1*
* *ros2run 0.25.3-r1 --> 0.25.4-r1*
* *ros2service 0.25.3-r1 --> 0.25.4-r1*
* *ros2topic 0.25.3-r1 --> 0.25.4-r1*
* *rosidl-dynamic-typesupport 0.0.4-r1 --> 0.0.5-r1*
* *rosidl-typesupport-fastrtps-c 3.0.1-r1 --> 3.0.2-r1*
* *rosidl-typesupport-fastrtps-cpp 3.0.1-r1 --> 3.0.2-r1*
* *rqt-controller-manager 3.20.0-r1 --> 3.21.0-r1*
* *rqt-reconfigure 1.3.3-r2 --> 1.3.4-r1*
* *rviz-assimp-vendor 12.4.4-r1 --> 12.4.5-r1*
* *rviz-common 12.4.4-r1 --> 12.4.5-r1*
* *rviz-default-plugins 12.4.4-r1 --> 12.4.5-r1*
* *rviz-ogre-vendor 12.4.4-r1 --> 12.4.5-r1*
* *rviz-rendering 12.4.4-r1 --> 12.4.5-r1*
* *rviz-rendering-tests 12.4.4-r1 --> 12.4.5-r1*
* *rviz-visual-testing-framework 12.4.4-r1 --> 12.4.5-r1*
* *rviz2 12.4.4-r1 --> 12.4.5-r1*
* *transmission-interface 3.20.0-r1 --> 3.21.0-r1*
* *twist-mux 4.2.0-r1 --> 4.3.0-r1*
* *ublox-dgnss 0.5.1-r1 --> 0.5.2-r1*
* *ublox-dgnss-node 0.5.1-r1 --> 0.5.2-r1*
* *ublox-nav-sat-fix-hp-node 0.5.1-r1 --> 0.5.2-r1*
* *ublox-ubx-interfaces 0.5.1-r1 --> 0.5.2-r1*
* *ublox-ubx-msgs 0.5.1-r1 --> 0.5.2-r1*

Noetic Changes:
---------------
* *audio-to-spectrogram 1.2.15-r1 --> 1.2.17-r1*
* *behaviortree-cpp 4.3.6-r2 --> 4.4.1-r1*
* *checkerboard-detector 1.2.15-r1 --> 1.2.17-r1*
* *clearpath-configuration-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-control-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-dock-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-localization-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-mission-manager-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-mission-scheduler-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-navigation-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-onav-api-examples 0.0.3-r1 --> 0.0.4-r1*
* *clearpath-onav-api-examples-lib 0.0.3-r1 --> 0.0.4-r1*
* *clearpath-onav-examples 0.0.3-r1 --> 0.0.4-r1*
* *clearpath-platform-msgs 0.9.4-r1 --> 0.9.5-r1*
* *clearpath-safety-msgs 0.9.4-r1 --> 0.9.5-r1*
* *cob-actions 0.7.8-r1 --> 0.7.9-r1*
* *cob-base-drive-chain 0.7.14-r1 --> 0.7.15-r1*
* *cob-bms-driver 0.7.14-r1 --> 0.7.15-r1*
* *cob-canopen-motor 0.7.14-r1 --> 0.7.15-r1*
* *cob-command-gui 0.6.32-r1 --> 0.6.33-r1*
* *cob-command-tools 0.6.32-r1 --> 0.6.33-r1*
* *cob-common 0.7.8-r1 --> 0.7.9-r1*
* *cob-dashboard 0.6.32-r1 --> 0.6.33-r1*
* *cob-description 0.7.8-r1 --> 0.7.9-r1*
* *cob-driver 0.7.14-r1 --> 0.7.15-r1*
* *cob-elmo-homing 0.7.14-r1 --> 0.7.15-r1*
* *cob-generic-can 0.7.14-r1 --> 0.7.15-r1*
* *cob-helper-tools 0.6.32-r1 --> 0.6.33-r1*
* *cob-interactive-teleop 0.6.32-r1 --> 0.6.33-r1*
* *cob-light 0.7.14-r1 --> 0.7.15-r1*
* *cob-mimic 0.7.14-r1 --> 0.7.15-r1*
* *cob-monitoring 0.6.32-r1 --> 0.6.33-r1*
* *cob-msgs 0.7.8-r1 --> 0.7.9-r1*
* *cob-phidget-em-state 0.7.14-r1 --> 0.7.15-r1*
* *cob-phidget-power-state 0.7.14-r1 --> 0.7.15-r1*
* *cob-phidgets 0.7.14-r1 --> 0.7.15-r1*
* *cob-relayboard 0.7.14-r1 --> 0.7.15-r1*
* *cob-scan-unifier 0.7.14-r1 --> 0.7.15-r1*
* *cob-script-server 0.6.32-r1 --> 0.6.33-r1*
* *cob-sick-lms1xx 0.7.14-r1 --> 0.7.15-r1*
* *cob-sick-s300 0.7.14-r1 --> 0.7.15-r1*
* *cob-sound 0.7.14-r1 --> 0.7.15-r1*
* *cob-srvs 0.7.8-r1 --> 0.7.9-r1*
* *cob-teleop 0.6.32-r1 --> 0.6.33-r1*
* *cob-undercarriage-ctrl 0.7.14-r1 --> 0.7.15-r1*
* *cob-utilities 0.7.14-r1 --> 0.7.15-r1*
* *cob-voltage-control 0.7.14-r1 --> 0.7.15-r1*
* *costmap-cspace 0.16.0-r1 --> 0.17.0-r1*
* *depthai 2.22.0-r1 --> 2.23.0-r1*
* *gazebo-video-monitor-msgs 0.7.0-r1 --> 0.7.1-r2*
* *gazebo-video-monitor-plugins 0.7.0-r1 --> 0.7.1-r2*
* *gazebo-video-monitor-utils 0.7.0-r1 --> 0.7.1-r2*
* *gazebo-video-monitors 0.7.0-r1 --> 0.7.1-r2*
* *generic-throttle 0.6.32-r1 --> 0.6.33-r1*
* *imagesift 1.2.15-r1 --> 1.2.17-r1*
* *joystick-interrupt 0.16.0-r1 --> 0.17.0-r1*
* *jsk-pcl-ros 1.2.17-r1*
* *jsk-pcl-ros-utils 1.2.17-r1*
* *jsk-pr2eus 0.3.15-r3 --> 0.3.15-r4*
* *jsk-recognition 1.2.15-r1 --> 1.2.17-r1*
* *jsk-recognition-msgs 1.2.15-r1 --> 1.2.17-r1*
* *laser-scan-densifier 0.7.14-r1 --> 0.7.15-r1*
* *magic-enum 0.9.3-r1 --> 0.9.4-r1*
* *map-organizer 0.16.0-r1 --> 0.17.0-r1*
* *marti-can-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-common-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-dbw-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-introspection-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-nav-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-perception-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-sensor-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-status-msgs 0.12.1-r1 --> 0.12.2-r1*
* *marti-visualization-msgs 0.12.1-r1 --> 0.12.2-r1*
* *mcl-3dl 0.6.1-r1 --> 0.6.2-r1*
* *moveit-resources 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-dual-panda-moveit-config 0.8.3-r1*
* *moveit-resources-fanuc-description 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-fanuc-moveit-config 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-panda-description 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-panda-moveit-config 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-pr2-description 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-prbt-moveit-config 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-prbt-pg70-support 0.8.2-r1 --> 0.8.3-r1*
* *moveit-resources-prbt-support 0.8.2-r1 --> 0.8.3-r1*
* *neonavigation 0.16.0-r1 --> 0.17.0-r1*
* *neonavigation-common 0.16.0-r1 --> 0.17.0-r1*
* *neonavigation-launch 0.16.0-r1 --> 0.17.0-r1*
* *obj-to-pointcloud 0.16.0-r1 --> 0.17.0-r1*
* *planner-cspace 0.16.0-r1 --> 0.17.0-r1*
* *plotjuggler 3.7.1-r1 --> 3.7.1-r2*
* *pr2eus 0.3.15-r3 --> 0.3.15-r4*
* *pr2eus-moveit 0.3.15-r3 --> 0.3.15-r4*
* *raw-description 0.7.8-r1 --> 0.7.9-r1*
* *resized-image-transport 1.2.15-r1 --> 1.2.17-r1*
* *safety-limiter 0.16.0-r1 --> 0.17.0-r1*
* *scenario-test-tools 0.6.32-r1 --> 0.6.33-r1*
* *service-tools 0.6.32-r1 --> 0.6.33-r1*
* *sound-classification 1.2.17-r1*
* *track-odometry 0.16.0-r1 --> 0.17.0-r1*
* *trajectory-tracker 0.16.0-r1 --> 0.17.0-r1*

Rolling Changes:
----------------
* *action-tutorials-cpp 0.31.1-r1 --> 0.32.0-r1*
* *action-tutorials-interfaces 0.31.1-r1 --> 0.32.0-r1*
* *action-tutorials-py 0.31.1-r1 --> 0.32.0-r1*
* *actionlib-msgs 5.2.0-r1 --> 5.2.1-r1*
* *ament-black 0.2.3-r1*
* *ament-clang-format 0.16.0-r1 --> 0.16.1-r1*
* *ament-clang-tidy 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-auto 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-black 0.2.3-r1*
* *ament-cmake-clang-format 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-clang-tidy 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-copyright 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-core 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-cppcheck 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-cpplint 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-export-definitions 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-export-dependencies 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-export-include-directories 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-export-interfaces 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-export-libraries 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-export-link-flags 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-export-targets 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-flake8 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-gen-version-h 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-gmock 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-google-benchmark 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-gtest 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-include-directories 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-libraries 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-lint-cmake 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-mypy 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-pclint 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-pep257 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-pycodestyle 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-pyflakes 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-pytest 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-python 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-target-dependencies 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-test 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-uncrustify 0.16.0-r1 --> 0.16.1-r1*
* *ament-cmake-vendor-package 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-version 2.3.0-r1 --> 2.3.1-r1*
* *ament-cmake-xmllint 0.16.0-r1 --> 0.16.1-r1*
* *ament-copyright 0.16.0-r1 --> 0.16.1-r1*
* *ament-cppcheck 0.16.0-r1 --> 0.16.1-r1*
* *ament-cpplint 0.16.0-r1 --> 0.16.1-r1*
* *ament-lint 0.16.0-r1 --> 0.16.1-r1*
* *ament-lint-auto 0.16.0-r1 --> 0.16.1-r1*
* *ament-lint-cmake 0.16.0-r1 --> 0.16.1-r1*
* *ament-lint-common 0.16.0-r1 --> 0.16.1-r1*
* *ament-mypy 0.16.0-r1 --> 0.16.1-r1*
* *ament-pclint 0.16.0-r1 --> 0.16.1-r1*
* *ament-pep257 0.16.0-r1 --> 0.16.1-r1*
* *ament-pycodestyle 0.16.0-r1 --> 0.16.1-r1*
* *ament-pyflakes 0.16.0-r1 --> 0.16.1-r1*
* *ament-uncrustify 0.16.0-r1 --> 0.16.1-r1*
* *ament-xmllint 0.16.0-r1 --> 0.16.1-r1*
* *behaviortree-cpp 4.4.0-r1 --> 4.4.1-r1*
* *camera-calibration-parsers 4.5.1-r1 --> 5.0.0-r1*
* *camera-info-manager 4.5.1-r1 --> 5.0.0-r1*
* *common-interfaces 5.2.0-r1 --> 5.2.1-r1*
* *composition 0.31.1-r1 --> 0.32.0-r1*
* *controller-interface 3.20.0-r1 --> 3.21.0-r1*
* *controller-manager 3.20.0-r1 --> 3.21.0-r1*
* *controller-manager-msgs 3.20.0-r1 --> 3.21.0-r1*
* *demo-nodes-cpp 0.31.1-r1 --> 0.32.0-r1*
* *demo-nodes-cpp-native 0.31.1-r1 --> 0.32.0-r1*
* *demo-nodes-py 0.31.1-r1 --> 0.32.0-r1*
* *diagnostic-msgs 5.2.0-r1 --> 5.2.1-r1*
* *dummy-map-server 0.31.1-r1 --> 0.32.0-r1*
* *dummy-robot-bringup 0.31.1-r1 --> 0.32.0-r1*
* *dummy-sensors 0.31.1-r1 --> 0.32.0-r1*
* *event-camera-msgs 1.1.4-r1 --> 1.0.5-r1*
* *examples-tf2-py 0.33.2-r1 --> 0.34.0-r1*
* *geometry-msgs 5.2.0-r1 --> 5.2.1-r1*
* *geometry2 0.33.2-r1 --> 0.34.0-r1*
* *hardware-interface 3.20.0-r1 --> 3.21.0-r1*
* *image-common 4.5.1-r1 --> 5.0.0-r1*
* *image-tools 0.31.1-r1 --> 0.32.0-r1*
* *image-transport 4.5.1-r1 --> 5.0.0-r1*
* *intra-process-demo 0.31.1-r1 --> 0.32.0-r1*
* *joint-limits 3.20.0-r1 --> 3.21.0-r1*
* *leo 3.0.0-r1*
* *leo-description 3.0.0-r1*
* *leo-desktop 3.0.0-r1*
* *leo-msgs 3.0.0-r1*
* *leo-teleop 3.0.0-r1*
* *leo-viz 3.0.0-r1*
* *libstatistics-collector 1.6.3-r1 --> 1.6.4-r1*
* *lifecycle 0.31.1-r1 --> 0.32.0-r1*
* *lifecycle-py 0.31.1-r1 --> 0.32.0-r1*
* *logging-demo 0.31.1-r1 --> 0.32.0-r1*
* *magic-enum 0.9.3-r1 --> 0.9.4-r1*
* *marti-can-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-common-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-dbw-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-introspection-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-nav-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-perception-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-sensor-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-status-msgs 1.5.1-r1 --> 1.5.2-r1*
* *marti-visualization-msgs 1.5.1-r1 --> 1.5.2-r1*
* *message-filters 4.10.0-r1 --> 4.10.1-r1*
* *metavision-driver 1.0.6-r1 --> 1.0.8-r1*
* *mimick-vendor 0.5.0-r1 --> 0.6.0-r1*
* *nav-msgs 5.2.0-r1 --> 5.2.1-r1*
* *ntrip-client-node 0.5.1-r1 --> 0.5.2-r1*
* *pendulum-control 0.31.1-r1 --> 0.32.0-r1*
* *pendulum-msgs 0.31.1-r1 --> 0.32.0-r1*
* *plotjuggler 3.7.1-r1 --> 3.7.1-r2*
* *pluginlib 5.3.0-r1 --> 5.3.1-r1*
* *quality-of-service-demo-cpp 0.31.1-r1 --> 0.32.0-r1*
* *quality-of-service-demo-py 0.31.1-r1 --> 0.32.0-r1*
* *rcl 7.3.0-r1 --> 8.0.0-r1*
* *rcl-action 7.3.0-r1 --> 8.0.0-r1*
* *rcl-lifecycle 7.3.0-r1 --> 8.0.0-r1*
* *rcl-yaml-param-parser 7.3.0-r1 --> 8.0.0-r1*
* *rclcpp 23.2.0-r1 --> 24.0.0-r1*
* *rclcpp-action 23.2.0-r1 --> 24.0.0-r1*
* *rclcpp-components 23.2.0-r1 --> 24.0.0-r1*
* *rclcpp-lifecycle 23.2.0-r1 --> 24.0.0-r1*
* *rclpy 5.4.0-r1 --> 6.0.0-r1*
* *rcpputils 2.8.0-r1 --> 2.8.1-r1*
* *rcutils 6.4.0-r1 --> 6.4.1-r1*
* *rmw 7.2.1-r1 --> 7.2.2-r1*
* *rmw-connextdds 0.18.0-r1 --> 0.19.0-r1*
* *rmw-connextdds-common 0.18.0-r1 --> 0.19.0-r1*
* *rmw-cyclonedds-cpp 1.10.0-r1 --> 2.0.0-r1*
* *rmw-dds-common 2.1.1-r1 --> 3.0.0-r1*
* *rmw-fastrtps-cpp 7.6.0-r1 --> 8.0.0-r1*
* *rmw-fastrtps-dynamic-cpp 7.6.0-r1 --> 8.0.0-r1*
* *rmw-fastrtps-shared-cpp 7.6.0-r1 --> 8.0.0-r1*
* *rmw-implementation-cmake 7.2.1-r1 --> 7.2.2-r1*
* *robot-state-publisher 3.3.1-r1 --> 3.3.2-r1*
* *ros2-control 3.20.0-r1 --> 3.21.0-r1*
* *ros2-control-test-assets 3.20.0-r1 --> 3.21.0-r1*
* *ros2action 0.29.1-r1 --> 0.30.0-r1*
* *ros2cli 0.29.1-r1 --> 0.30.0-r1*
* *ros2cli-test-interfaces 0.29.1-r1 --> 0.30.0-r1*
* *ros2component 0.29.1-r1 --> 0.30.0-r1*
* *ros2controlcli 3.20.0-r1 --> 3.21.0-r1*
* *ros2doctor 0.29.1-r1 --> 0.30.0-r1*
* *ros2interface 0.29.1-r1 --> 0.30.0-r1*
* *ros2lifecycle 0.29.1-r1 --> 0.30.0-r1*
* *ros2lifecycle-test-fixtures 0.29.1-r1 --> 0.30.0-r1*
* *ros2multicast 0.29.1-r1 --> 0.30.0-r1*
* *ros2node 0.29.1-r1 --> 0.30.0-r1*
* *ros2param 0.29.1-r1 --> 0.30.0-r1*
* *ros2pkg 0.29.1-r1 --> 0.30.0-r1*
* *ros2run 0.29.1-r1 --> 0.30.0-r1*
* *ros2service 0.29.1-r1 --> 0.30.0-r1*
* *ros2topic 0.29.1-r1 --> 0.30.0-r1*
* *rosidl-adapter 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-cli 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-cmake 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-generator-c 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-generator-cpp 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-generator-type-description 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-parser 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-pycommon 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-runtime-c 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-runtime-cpp 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-typesupport-interface 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-typesupport-introspection-c 4.4.1-r1 --> 4.4.2-r1*
* *rosidl-typesupport-introspection-cpp 4.4.1-r1 --> 4.4.2-r1*
* *rqt-controller-manager 3.20.0-r1 --> 3.21.0-r1*
* *rti-connext-dds-cmake-module 0.18.0-r1 --> 0.19.0-r1*
* *rttest 0.16.0-r1 --> 0.17.0-r1*
* *rviz-assimp-vendor 13.1.2-r1 --> 13.2.0-r1*
* *rviz-common 13.1.2-r1 --> 13.2.0-r1*
* *rviz-default-plugins 13.1.2-r1 --> 13.2.0-r1*
* *rviz-ogre-vendor 13.1.2-r1 --> 13.2.0-r1*
* *rviz-rendering 13.1.2-r1 --> 13.2.0-r1*
* *rviz-rendering-tests 13.1.2-r1 --> 13.2.0-r1*
* *rviz-visual-testing-framework 13.1.2-r1 --> 13.2.0-r1*
* *rviz2 13.1.2-r1 --> 13.2.0-r1*
* *sensor-msgs 5.2.0-r1 --> 5.2.1-r1*
* *sensor-msgs-py 5.2.0-r1 --> 5.2.1-r1*
* *shape-msgs 5.2.0-r1 --> 5.2.1-r1*
* *std-msgs 5.2.0-r1 --> 5.2.1-r1*
* *std-srvs 5.2.0-r1 --> 5.2.1-r1*
* *stereo-msgs 5.2.0-r1 --> 5.2.1-r1*
* *tf2 0.33.2-r1 --> 0.34.0-r1*
* *tf2-bullet 0.33.2-r1 --> 0.34.0-r1*
* *tf2-eigen 0.33.2-r1 --> 0.34.0-r1*
* *tf2-eigen-kdl 0.33.2-r1 --> 0.34.0-r1*
* *tf2-geometry-msgs 0.33.2-r1 --> 0.34.0-r1*
* *tf2-kdl 0.33.2-r1 --> 0.34.0-r1*
* *tf2-msgs 0.33.2-r1 --> 0.34.0-r1*
* *tf2-py 0.33.2-r1 --> 0.34.0-r1*
* *tf2-ros 0.33.2-r1 --> 0.34.0-r1*
* *tf2-ros-py 0.33.2-r1 --> 0.34.0-r1*
* *tf2-sensor-msgs 0.33.2-r1 --> 0.34.0-r1*
* *tf2-tools 0.33.2-r1 --> 0.34.0-r1*
* *tlsf-cpp 0.16.0-r1 --> 0.17.0-r1*
* *topic-monitor 0.31.1-r1 --> 0.32.0-r1*
* *topic-statistics-demo 0.31.1-r1 --> 0.32.0-r1*
* *trajectory-msgs 5.2.0-r1 --> 5.2.1-r1*
* *transmission-interface 3.20.0-r1 --> 3.21.0-r1*
* *twist-mux 4.2.0-r1 --> 4.3.0-r1*
* *ublox-dgnss 0.5.1-r1 --> 0.5.2-r1*
* *ublox-dgnss-node 0.5.1-r1 --> 0.5.2-r1*
* *ublox-nav-sat-fix-hp-node 0.5.1-r1 --> 0.5.2-r1*
* *ublox-ubx-interfaces 0.5.1-r1 --> 0.5.2-r1*
* *ublox-ubx-msgs 0.5.1-r1 --> 0.5.2-r1*
* *visualization-msgs 5.2.0-r1 --> 5.2.1-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

