### PR TITLE
Gazebo 11.13.0 -> 11.14.0

### DIFF
--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -10,7 +10,7 @@
 
 mkDerivation rec {
   pname = "gazebo";
-  version = "11.13.0";
+  version = "11.14.0";
 
   src = fetchurl {
     url = "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/${pname}-${version}.tar.bz2";

--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -18,10 +18,10 @@ mkDerivation rec {
   };
 
   # Fix build with Protobuf >= 22
-  patches = [ (fetchpatch {
-    url = "https://github.com/gazebosim/gazebo-classic/commit/17e09f574a4f39caff279cd70364cd1a3ea46f70.patch";
-    hash = "sha256-YrepsP3TOQsJaF+rIF4CmfEHSRfL2j9dqQCmd1UR2b8=";
-  }) ];
+  # patches = [ (fetchpatch {
+  #  url = "https://github.com/gazebosim/gazebo-classic/commit/17e09f574a4f39caff279cd70364cd1a3ea46f70.patch";
+  #  hash = "sha256-YrepsP3TOQsJaF+rIF4CmfEHSRfL2j9dqQCmd1UR2b8=";
+  # }) ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -14,7 +14,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/${pname}-${version}.tar.bz2";
-    hash = "sha256-L2W5j+ZSpXTgG3yubPEuFKndKTQ/3pngZqxRk6jQPnE=";
+    hash = "sha256-fphCwEbJ4HVTVbJ0wkCoq79Olivnznt/WRlOX0tYT0U=";
   };
 
   # Fix build with Protobuf >= 22


### PR DESCRIPTION
This PR updates the version of Gazebo from `11.13.0` to `11.14.0`. The fix for Protobuf is already included in the upstream repo [here](https://github.com/gazebosim/gazebo-classic/blob/9b72949304e409d5f33150e87e6b348c54b5c015/cmake/SearchForStuff.cmake#L35-L37), thus it has been removed. At least for me, this updated also fixed some compilation errors regarding FFmpeg.