### PR TITLE
rosdistro sync, Fri Dec  1 13:12:32 2023

### DIFF
--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "c1f18f59f7a55fc8fb8b991b1cd1ab9b7198507963787b7ce8e70f68e2566ddc";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "d71643020988f11a82f0876e02afa68c1473fbab5d36149f1170c5b4cb2ca2c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "33249604146be0857066fd2f156b948879c098902dbb906ca56e237f8a2d5206";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "400e889b7e5e130205f407c2ca3b6dca0a59d0a2f447778ec9b7a5b3f2b99f90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "a081b51e6c05e29ab1f696a28a4d65ca27214d6378c8f888a2ecf5b618abfb95";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "2ba3f2a7ea8bedc186ee66fbb043510452cb4078b1f42e2d3fdd78f8957a9ad4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "de768403a309e33992e94e143c4a437a2ce60a243e173c45bfdef73614bbe027";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "5eb7e2b64dd31348143c4470899a62d7f05dc4a9a9f86073ed31e249e3c80271";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-coding/default.nix
+++ b/distros/humble/etsi-its-cam-coding/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-coding";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c675819043008faafa6b31ccd56c610f808e250350836da4fae02bb13897a3c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS CAMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-cam-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0d8117bb32c1e6630a9a69710020be25a81b1c9703776045c465939d1f3f7125";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-cam-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6e51a83c3164795a214c08ec95f6a21ee27e13d4306ad9ce4bfe0613dc0e1023";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS CAM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-coding/default.nix
+++ b/distros/humble/etsi-its-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-coding";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_coding/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "85246221594eefb2956b38b2fdab0db9a3ad9e7faa5b157ea3fc541298f8cd36";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-denm-coding ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS messages generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-conversion/default.nix
+++ b/distros/humble/etsi-its-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1acf3c3251a7cd3009e39305dc48ee5fc29d95c960490e74ad4a7bc0ed125889";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts ROS messages to and from ASN.1-encoded ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-coding/default.nix
+++ b/distros/humble/etsi-its-denm-coding/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-coding";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fec8c48799dee794ca18e339dbc62e4e3c897513c58fbd99426965bdec747134";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS DENMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b6f6cd4c41a9c3869500e9581842fbc1fae52cc8e2f48c221ec31a5adea81e66";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-coding etsi-its-denm-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "43c99b03c3c10a7fe416d2c720da0d325ece60230cf9d59a01368be6962c5262";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS DENM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-messages/default.nix
+++ b/distros/humble/etsi-its-messages/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-messages";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_messages/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4932be7ee7411ab229cf79644bc5bf4983f35c072d77e315274d64dc6285a5f1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-coding etsi-its-conversion etsi-its-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS support for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-msgs/default.nix
+++ b/distros/humble/etsi-its-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-denm-msgs, geographiclib, geometry-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c310330f25d230492db6fd34f12da2252d2365eb5e6a5b581150076170b64db6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-denm-msgs geographiclib geometry-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS messages and helper access functions for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-primitives-conversion/default.nix
+++ b/distros/humble/etsi-its-primitives-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-primitives-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f37f53dde38da60efa50dbffbc4fd5294f0bb2f81aed46fe978b646d9cdf5717";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS primitives to and from ASN.1-encoded primitives'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-rviz-plugins/default.nix
+++ b/distros/humble/etsi-its-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-rviz-plugins";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ffcb039d8546d62123ebfdd7cfaa550406aecd3dd96ac2491f7560f93b1ffc86";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-msgs pluginlib qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RViz plugin for ROS 2 messages based on ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -574,6 +574,30 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ etsi-its-cam-coding = self.callPackage ./etsi-its-cam-coding {};
+
+ etsi-its-cam-conversion = self.callPackage ./etsi-its-cam-conversion {};
+
+ etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
+
+ etsi-its-coding = self.callPackage ./etsi-its-coding {};
+
+ etsi-its-conversion = self.callPackage ./etsi-its-conversion {};
+
+ etsi-its-denm-coding = self.callPackage ./etsi-its-denm-coding {};
+
+ etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
+
+ etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-messages = self.callPackage ./etsi-its-messages {};
+
+ etsi-its-msgs = self.callPackage ./etsi-its-msgs {};
+
+ etsi-its-primitives-conversion = self.callPackage ./etsi-its-primitives-conversion {};
+
+ etsi-its-rviz-plugins = self.callPackage ./etsi-its-rviz-plugins {};
+
  event-camera-codecs = self.callPackage ./event-camera-codecs {};
 
  event-camera-msgs = self.callPackage ./event-camera-msgs {};
@@ -1268,7 +1292,11 @@ self: super: {
 
  naoqi-bridge-msgs = self.callPackage ./naoqi-bridge-msgs {};
 
+ naoqi-driver = self.callPackage ./naoqi-driver {};
+
  naoqi-libqi = self.callPackage ./naoqi-libqi {};
+
+ naoqi-libqicore = self.callPackage ./naoqi-libqicore {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "b100f85f9c1f4d8a490da86aaaf70b0ed5fac70c35ec3efbfc8b34e2d04a7518";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "fdde0b6de2437c670526babc21309a9c08c29f682ead6ec6d73e61b53ff651a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "32f1dc611b3fd25084b88fba6e61cded7fde27c0d15a60788def2d23f11d4f13";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "98ca99261cbdb9a5c6731a28f8a42ff0af9477c59f6a66963cf547370bc7a984";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "daeab571c665cc2f4797a3bd695843f3bf41ae9ec0f8876b62b4b1b93f81e19e";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "e25bc3b615338f37821f3bc6b9b85f05f5d11e072e6fe3930852d8fd4461a679";
   };
 
   buildType = "cmake";

--- a/distros/humble/naoqi-driver/default.nix
+++ b/distros/humble/naoqi-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geometry-msgs, image-transport, kdl-parser, naoqi-bridge-msgs, naoqi-libqi, naoqi-libqicore, rclcpp, rclcpp-action, robot-state-publisher, rosidl-default-generators, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-naoqi-driver";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/naoqi_driver2-release/archive/release/humble/naoqi_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "18dcc7c87ead29f92d9c933ed72296c86607ff5ae2a3b8d4a1d22c0e997f7352";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake diagnostic-msgs diagnostic-updater geometry-msgs rosidl-default-generators sensor-msgs tf2-geometry-msgs tf2-msgs ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs boost cv-bridge image-transport kdl-parser naoqi-bridge-msgs naoqi-libqi naoqi-libqicore rclcpp rclcpp-action robot-state-publisher tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Driver module between Aldebaran's NAOqiOS and ROS2. It publishes all sensor and actuator data as well as basic diagnostic for battery, temperature. It subscribes also to RVIZ simple goal and cmd_vel for teleop.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/naoqi-libqicore/default.nix
+++ b/distros/humble/naoqi-libqicore/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, naoqi-libqi }:
+buildRosPackage {
+  pname = "ros-humble-naoqi-libqicore";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqicore-release/archive/release/humble/naoqi_libqicore/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "f830abbbf5fccffc292cdbb19d5393bc1d129f03df5cf5bb7af414e8af005fde";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ naoqi-libqi ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Aldebaran's libqicore: a layer on top of libqi'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.8.0-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "47c93c2ee9cc941ae07c3e08cb3c816dd45f494bb7bc8a92aefa7281daa86e0a";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "4a0106affd5aaf22706c36699d0b0db47de2d89b61c57957ce1248c11e77af4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration-msgs/default.nix
+++ b/distros/humble/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration-msgs";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "416c8562484550974e108e3e7c3adcc48f50e2bbde1bf75a843d57ece74e927d";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "93f34e6c210cb3d68733bbf9ccdb9623672fa88895c010af1b85bc4fbbe7b2fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration/default.nix
+++ b/distros/humble/robot-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "61615283317eda03d7dd8cb7955576b5ff1904f58617c476c82610acfa70822d";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "75d51aa74e27d90f3007b4dcf0e09c5ded1d9dbe4e525bd5c2f21e18edcc7b77";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros tinyxml-2 tinyxml2-vendor visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "1d025d952ebc695dc199b949d04a4f60e758b2417ee3ea16eec7e268531cfa0d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "bafcdd1bf56a180e72521f7cb0cc5cff041df2b13fa91c86ee269ff03570e752";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "b057063213b3b88ccbed87bac2c3d39668eb3f139b8e88ae1a10c51e05279183";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "9013c42fb5608997b0689d2eb8f41e8fe3a0cf6df39a9bc0fcf76b6e824041c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "7139a307f02bd8cd7742edf9a680db4b7d8ab65cb7efeb94e9bf95288a710bd6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "465c0475627cd1ffeedafacecda3c0fb0e6e60dd94ec1b7dab485ad9e40a03c6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "bb0a6e0b36f3effd6eebe46a4e982724a62dc6fe112390021371cfd5dc786af3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "152836dec21836fba8c25a80d710279f2ba22238fcfa1fa51dc51d9a185e008a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/topic-tools-interfaces/default.nix
+++ b/distros/humble/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-topic-tools-interfaces";
-  version = "1.0.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools_interfaces/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "6e68d8fee9e39482da8aa56ba90086f41f79500ab073bc260216f5b6afb38676";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "28fbf6b17d7ceda9b3f1f0b62d449c82c63d35a5728be9f69bba3bf6939e4ca6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-tools/default.nix
+++ b/distros/humble/topic-tools/default.nix
@@ -2,25 +2,26 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-humble-topic-tools";
-  version = "1.0.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "1b98ac197a1ecd10a6d4209635987fce44a93a3e052d05cd9050a80af43732e9";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6b262f27054b6d627f765627eccef88fcfbf25c1dbbd9a56eb26b61f2530e151";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Tools for directing, throttling, selecting, and otherwise messing with
+    ROS 2 topics at a meta level.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.35.0-r1";
+  version = "2.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "36a5930168eb16dd917f159f12e798bd7e5a566322cb0c1c011ab985f5bee3a1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.35.1-1.tar.gz";
+    name = "2.35.1-1.tar.gz";
+    sha256 = "8b44dd6e6b124aa3d8801981b266e4fa67fef2135dda85db2e10dc150b0a74cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "45070ae96ea77d7a4e05d3f97f96ff65b0b679a0399fc12d8895c2c9aefe0d37";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "6ef2a334645266ad5f3dc96f44f59e15d09069bdbd2a86384a90b24381b0cd20";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-coding/default.nix
+++ b/distros/iron/etsi-its-cam-coding/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-coding";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_coding/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b3c47b76440bbcf7dac217253e68ff5775b89e364ac37ca138a4ce8e42573000";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS CAMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-cam-conversion/default.nix
+++ b/distros/iron/etsi-its-cam-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "aa16f88c57015bf0e407d0e53257f8bccd88bdf53dea6c409783b639c6bf5d0b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-cam-msgs/default.nix
+++ b/distros/iron/etsi-its-cam-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f05290adad7f1ce8822a1f0fb053e61d43a2a3a5dd0b290b0c7c6c0a2afa8b6b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS CAM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-coding/default.nix
+++ b/distros/iron/etsi-its-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-coding";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_coding/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3ee563ac9f67f5710900d35351b9be1f1d1ad16a8076c64040a26a23c2d8e7f0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-denm-coding ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS messages generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-conversion/default.nix
+++ b/distros/iron/etsi-its-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "dc828993103febae3beec042a336512cb722abb7c9c094e61d98f147c94494ac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts ROS messages to and from ASN.1-encoded ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-denm-coding/default.nix
+++ b/distros/iron/etsi-its-denm-coding/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-denm-coding";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_coding/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f3cb2ad807b28bb6e0aa0a5cbf766a6ba05a10ce874e65f6364cf5ff2d2ad921";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS DENMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-denm-conversion/default.nix
+++ b/distros/iron/etsi-its-denm-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-denm-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "30f1943732836dbe2b38dd122e68c294453dc44662d762aeb79603d674d425a1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-coding etsi-its-denm-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-denm-msgs/default.nix
+++ b/distros/iron/etsi-its-denm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-denm-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1d9b0fe2474aa82846bab6e75311dfbfa373e1dfb61d85a0b4ff69561813bbfb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS DENM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-messages/default.nix
+++ b/distros/iron/etsi-its-messages/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-messages";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_messages/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "28a6fdf9973d4d6d8ca5225895de094c22dedff2d92036daecba935e3b0f1e3b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-coding etsi-its-conversion etsi-its-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS support for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-msgs/default.nix
+++ b/distros/iron/etsi-its-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-denm-msgs, geographiclib, geometry-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "337ab1bbc5bf42b3c1a1c373d356154358bce51ce7d045c89e6625a7755dcb43";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-denm-msgs geographiclib geometry-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS messages and helper access functions for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-primitives-conversion/default.nix
+++ b/distros/iron/etsi-its-primitives-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-primitives-conversion";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_primitives_conversion/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "858b318ba7d9b390aeb54a931524064281adc0677c2f273d9812882e523db7e3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS primitives to and from ASN.1-encoded primitives'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-rviz-plugins/default.nix
+++ b/distros/iron/etsi-its-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-rviz-plugins";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_rviz_plugins/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "380645525c0d6f2f2736aad06851ed9a842a2a7a40f954d0e93d602ff48cb434";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-msgs pluginlib qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RViz plugin for ROS 2 messages based on ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -440,6 +440,30 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ etsi-its-cam-coding = self.callPackage ./etsi-its-cam-coding {};
+
+ etsi-its-cam-conversion = self.callPackage ./etsi-its-cam-conversion {};
+
+ etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
+
+ etsi-its-coding = self.callPackage ./etsi-its-coding {};
+
+ etsi-its-conversion = self.callPackage ./etsi-its-conversion {};
+
+ etsi-its-denm-coding = self.callPackage ./etsi-its-denm-coding {};
+
+ etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
+
+ etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-messages = self.callPackage ./etsi-its-messages {};
+
+ etsi-its-msgs = self.callPackage ./etsi-its-msgs {};
+
+ etsi-its-primitives-conversion = self.callPackage ./etsi-its-primitives-conversion {};
+
+ etsi-its-rviz-plugins = self.callPackage ./etsi-its-rviz-plugins {};
+
  event-camera-codecs = self.callPackage ./event-camera-codecs {};
 
  event-camera-msgs = self.callPackage ./event-camera-msgs {};

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "1acb05f82b28f697511b758004100dfa063250b5a05bf99fcee3cb417d94249d";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "481f131354faef95c7d93e59da2300afca010f05bf1894f1898c22a84193ad9e";
   };
 
   buildType = "cmake";

--- a/distros/iron/robot-calibration-msgs/default.nix
+++ b/distros/iron/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration-msgs";
-  version = "0.8.0-r3";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration_msgs/0.8.0-3.tar.gz";
-    name = "0.8.0-3.tar.gz";
-    sha256 = "4925c656bf34a541871b82f17af2fc8d26f149ddb68513305391e90c764891a2";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "c2b3f063003e105595d0bfa5540ec61fb4e9327ce6857d4641a8c9a458e35ea1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robot-calibration/default.nix
+++ b/distros/iron/robot-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration";
-  version = "0.8.0-r3";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration/0.8.0-3.tar.gz";
-    name = "0.8.0-3.tar.gz";
-    sha256 = "42e5025488c3a5680c8050a1522177cc343ae12141c8b42a8ce380c6c259390a";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "64d1f08611c4db7e99e4d751a683df59d6e0a16c287ccc56fa2027c8dc4f80fd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros tinyxml-2 tinyxml2-vendor visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/sick-safevisionary-driver/default.nix
+++ b/distros/iron/sick-safevisionary-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
 buildRosPackage {
   pname = "ros-iron-sick-safevisionary-driver";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_driver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "0ea1cd240972637ac20c1075854bf3f545d0509e84f80572f14135dadfe34ae7";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_driver/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "6e88f1e3fa21377f02ac37ed066a275074714d3b4a0b84a6abcaa207c936de3a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge lifecycle-msgs rclcpp rclcpp-lifecycle sensor-msgs sick-safevisionary-base sick-safevisionary-interfaces ];
+  propagatedBuildInputs = [ boost cv-bridge lifecycle-msgs rclcpp rclcpp-lifecycle sensor-msgs sick-safevisionary-base sick-safevisionary-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/sick-safevisionary-interfaces/default.nix
+++ b/distros/iron/sick-safevisionary-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-sick-safevisionary-interfaces";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_interfaces/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "408b47dd875927a06112deaa13939776281f1410b30f3d5f51436b5b8dd30801";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_interfaces/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "675f43ffc28d323f31e63f3d29fa7f291fee707954db17b3758bd27224439d99";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/sick-safevisionary-tests/default.nix
+++ b/distros/iron/sick-safevisionary-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing-ament-cmake, sick-safevisionary-driver }:
 buildRosPackage {
   pname = "ros-iron-sick-safevisionary-tests";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_tests/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "27c814b28fb520ec3812e2c43a9c6f9f6449662254f0ccf3d3a0f4ded7c312e4";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_tests/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "893885426b8cc012213793a5d6ec11edea9a2915ea8a1299d8ddc1378e35dd58";
   };
 
   buildType = "catkin";

--- a/distros/iron/topic-tools-interfaces/default.nix
+++ b/distros/iron/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-topic-tools-interfaces";
-  version = "1.0.0-r3";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools_interfaces/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "a7a4d73fdf60b9d55656500b129f51d579b359d76da9c9646f7f70c48aec8ac5";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools_interfaces/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "86e44b753d2b8e3cf529d0833cfcc7dc1f108c2dedaa89f11f3b9bb877ace4dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/topic-tools/default.nix
+++ b/distros/iron/topic-tools/default.nix
@@ -2,25 +2,26 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-iron-topic-tools";
-  version = "1.0.0-r3";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "900f7bd204ab7b94757cf01ee18fdc3dc2fa84e2bc13cf3e8041d71d8c4bc49e";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fa82a964f6cde5f571e72ba730698d0cd28a1d34e17647c947ea94f0fab7a86a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Tools for directing, throttling, selecting, and otherwise messing with
+    ROS 2 topics at a meta level.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/aruco-opencv-msgs/default.nix
+++ b/distros/noetic/aruco-opencv-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-aruco-opencv-msgs";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "f2ec4432d036c31d83337541414cba41cf75fc4d4431ea321c0dd6c8f0c59ed3";
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e48a3384affa57d6a2c5525da24009e0e209c526f9aaa801a5e6685daa727aef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aruco-opencv-msgs, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, python3Packages, roscpp, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-aruco-opencv";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "7aa3964e42462c94d26e3050b9442e70b4423754f1bcd7cedff45bfc91616e32";
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d77b153af83108c26acb37dea319cc3b1afc6d06a83139f30d26a19e69e7ca0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp/default.nix
+++ b/distros/noetic/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ros-environment, roslib, sqlite }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "f96332c54c9baef01333e079b7dbeffd95ec371c6c98faa8e72241da143ad9bc";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "879f1202c11a95f16a36348f212e8092598221ea2f6daba6a6fa15ba57cfe586";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-noetic-eus-assimp";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "0fb75b49127281e801e04d76051da15d7a8c2eac4fbf4505d63b09a99850d865";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "6bca597963ebcd3f77a08289df6812a9bbfafc48a79d96136912a9bb3fed6d8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euscollada/default.nix
+++ b/distros/noetic/euscollada/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-euscollada";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "b5fa910e58ddba38c42ae3063d931e0d4c4793693522cb946e431708ac502dbb";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "4cc47dbe2143b21e17f6d26f40a793b22f8bf204cc3148a12d0a6fc6e014ce58";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, python3Packages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-eusurdf";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "ddc05b743572e8dc8e9ac5ed0b1898030cd1603dcab5483db037d8074f728532";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ad87f0f2c6612ab871b380e767c33ee36d9e17b6e3272a0ccd634e620d29bfff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-noetic-jsk-model-tools";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "01078b70b2d69d83a5a531d05c4f546d557a8281c6376a3e090aa274df68173b";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5606e0d782c584bbf5c7e4744731c8b8eb0e504ed638478022cd4f9399dc3f33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "15f937aa6ab57ea455cf1f139ecab86764bda9d170259008572437f8559f98f6";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "da830d876d68128f6e2754025fa47a8184f9369425b61898cf60437531ea6952";
   };
 
   buildType = "cmake";

--- a/distros/noetic/paho-mqtt-cpp/default.nix
+++ b/distros/noetic/paho-mqtt-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl, paho-mqtt-c }:
 buildRosPackage {
   pname = "ros-noetic-paho-mqtt-cpp";
-  version = "1.2.0-r4";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.cpp-release/archive/release/noetic/paho-mqtt-cpp/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "08cfe92bbf29546b435398dc32db9c53974f2d14151d188dc59113aa595af360";
+    url = "https://github.com/nobleo/paho.mqtt.cpp-release/archive/release/noetic/paho-mqtt-cpp/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "65a0282890c8f752dd1a7a41af0173b0f2256d825fa12e1608a3c1aea5540249";
   };
 
   buildType = "cmake";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.8.0-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "0a9ef8780865c526f9ab48770aa527cb9ec68b846fb535c58110b0e659f2b360";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "38c6f8af1d6d616c675be9bb9b93eac1599e4251ef02b0f9a5ee5b443fc34f05";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-scan-xd/default.nix
+++ b/distros/noetic/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslib, rospy, rviz, sensor-msgs, std-msgs, tf, tf2, tf2-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan-xd";
-  version = "3.0.3-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "e2290874d3c137e0a9ef0a6fea0034034f4dac952599a339857c4a448714d9e1";
+    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "28d3520a82e325983cbc2e4ba39d2463659b2f93348942e46de1491373fb63dc";
   };
 
   buildType = "catkin";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "4c1d8002fb3c969a14f6edfb31903269e88d8e2f2627565bbdd477eab947e63a";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "a589b465440463fd63ebebbd7da876321f731954ba26f72b4642ec9a0764dff0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps";
-  version = "2.11.2-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "1096d672a0afe6c3f8991dd6c8028ca43384229d20b74fe7cf7cdaa7885b1967";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "810166c75a6ececec422e09c1920279505a8b36a4117f2f8715b4b2b5ec1c323";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "f8ca3b535c16d6a393f438869e1e5e6d351be736e8764e23f55c883d76596e80";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "d6c2256c679d1d8882a5356d4eb6e4ae35e47ae529239d50c9328d218abef25a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/plotjuggler/default.nix
+++ b/distros/rolling/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler";
-  version = "3.7.1-r2";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.7.1-2.tar.gz";
-    name = "3.7.1-2.tar.gz";
-    sha256 = "bc5dc27f49d6bf32dfd24cf0ef1aa34bb57d31af9589bfa81dfe642351e45141";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "4b19f2d9b4e2d58cef917d4ca05cd661d8455971311cb29578786d985a5c8aef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-calibration-msgs/default.nix
+++ b/distros/rolling/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration-msgs";
-  version = "0.8.0-r2";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration_msgs/0.8.0-2.tar.gz";
-    name = "0.8.0-2.tar.gz";
-    sha256 = "42c57b0e93106af6e653508f0d866c25b49e0277eaca85bfbccb014db7f5427e";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "675b73eb562e24d0cb58840d14fd6d3fb4413bb66d6b87ddc883c62cdc66dce4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-calibration/default.nix
+++ b/distros/rolling/robot-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration";
-  version = "0.8.0-r2";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration/0.8.0-2.tar.gz";
-    name = "0.8.0-2.tar.gz";
-    sha256 = "023149b5effaa6fe55e609f6d00d46721b67a1212c8496df6b1bdce2ae8da2e9";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "4237e47ab7341d0db5ab1bae62b000772f4942879417f7056f2193d6d8db8a8f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros tinyxml-2 tinyxml2-vendor visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/sick-safevisionary-driver/default.nix
+++ b/distros/rolling/sick-safevisionary-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-sick-safevisionary-driver";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_driver/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b7104ce41ea54b715db4dd8744c86b57924de240acde5028328b4cf11205444e";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_driver/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "1d53498f3e413723315d0898c12a6d376c6670f7c23f1478f9128ed76075807f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sick-safevisionary-interfaces/default.nix
+++ b/distros/rolling/sick-safevisionary-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sick-safevisionary-interfaces";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_interfaces/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "87d8b44cde31dc26c329d0b986759783b8cbe4faa4194e64f4a4c51ef7268351";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_interfaces/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "47ad375a18b5e88315d2ab688af7f3e813b59e3a41e9961d638f079c7891739f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sick-safevisionary-tests/default.nix
+++ b/distros/rolling/sick-safevisionary-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing-ament-cmake, sick-safevisionary-driver }:
 buildRosPackage {
   pname = "ros-rolling-sick-safevisionary-tests";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_tests/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b27f46eec5108c3819f4439c20c95683310c5f89e8afa81ce6818afc33542c89";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_tests/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "0f42abe4d628898f9a3a77d7dd303f1fa2bf4df33ed454aad562f83782d7f375";
   };
 
   buildType = "catkin";

--- a/distros/rolling/topic-tools-interfaces/default.nix
+++ b/distros/rolling/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools-interfaces";
-  version = "1.0.0-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "c18405d7e69e1e8df081606eedbbcbb783426656a449cf33f141286d48dc79ce";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "3712ae9a44b6338554d76b3d86522a9d52c0c6aa16be985237bbdca928a1f09f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools/default.nix
+++ b/distros/rolling/topic-tools/default.nix
@@ -2,25 +2,26 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools";
-  version = "1.0.0-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "9760e2039641c2a27684abf58f87813105c663bdd2fc5c56681147423aa51689";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "e38ccdb246e8a2764c80a366931c5612ec33e0801f6355a354735d05e5e37ef2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Tools for directing, throttling, selecting, and otherwise messing with
+    ROS 2 topics at a meta level.'';
     license = with lib.licenses; [ asl20 ];
   };
 }


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 42cae93f39f0d26134a884a1ec20d1e36dd14f66.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *controller-interface 2.35.0-r1 --> 2.35.1-r1*
* *controller-manager 2.35.0-r1 --> 2.35.1-r1*
* *controller-manager-msgs 2.35.0-r1 --> 2.35.1-r1*
* *etsi-its-cam-coding 1.0.0-r1*
* *etsi-its-cam-conversion 1.0.0-r1*
* *etsi-its-cam-msgs 1.0.0-r1*
* *etsi-its-coding 1.0.0-r1*
* *etsi-its-conversion 1.0.0-r1*
* *etsi-its-denm-coding 1.0.0-r1*
* *etsi-its-denm-conversion 1.0.0-r1*
* *etsi-its-denm-msgs 1.0.0-r1*
* *etsi-its-messages 1.0.0-r1*
* *etsi-its-msgs 1.0.0-r1*
* *etsi-its-primitives-conversion 1.0.0-r1*
* *etsi-its-rviz-plugins 1.0.0-r1*
* *hardware-interface 2.35.0-r1 --> 2.35.1-r1*
* *joint-limits 2.35.0-r1 --> 2.35.1-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *naoqi-driver 2.1.0-r1*
* *naoqi-libqicore 3.0.0-r1*
* *plotjuggler 3.8.0-r1 --> 3.8.2-r1*
* *robot-calibration 0.8.0-r1 --> 0.8.1-r1*
* *robot-calibration-msgs 0.8.0-r1 --> 0.8.1-r1*
* *ros2-control 2.35.0-r1 --> 2.35.1-r1*
* *ros2-control-test-assets 2.35.0-r1 --> 2.35.1-r1*
* *ros2controlcli 2.35.0-r1 --> 2.35.1-r1*
* *rqt-controller-manager 2.35.0-r1 --> 2.35.1-r1*
* *topic-tools 1.0.0-r2 --> 1.1.1-r1*
* *topic-tools-interfaces 1.0.0-r2 --> 1.1.1-r1*
* *transmission-interface 2.35.0-r1 --> 2.35.1-r1*

Iron Changes:
-------------
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *etsi-its-cam-coding 1.0.0-r1*
* *etsi-its-cam-conversion 1.0.0-r1*
* *etsi-its-cam-msgs 1.0.0-r1*
* *etsi-its-coding 1.0.0-r1*
* *etsi-its-conversion 1.0.0-r1*
* *etsi-its-denm-coding 1.0.0-r1*
* *etsi-its-denm-conversion 1.0.0-r1*
* *etsi-its-denm-msgs 1.0.0-r1*
* *etsi-its-messages 1.0.0-r1*
* *etsi-its-msgs 1.0.0-r1*
* *etsi-its-primitives-conversion 1.0.0-r1*
* *etsi-its-rviz-plugins 1.0.0-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *robot-calibration 0.8.0-r3 --> 0.8.1-r1*
* *robot-calibration-msgs 0.8.0-r3 --> 0.8.1-r1*
* *sick-safevisionary-driver 1.0.1-r1 --> 1.0.3-r1*
* *sick-safevisionary-interfaces 1.0.1-r1 --> 1.0.3-r1*
* *sick-safevisionary-tests 1.0.1-r1 --> 1.0.3-r1*
* *topic-tools 1.0.0-r3 --> 1.2.0-r1*
* *topic-tools-interfaces 1.0.0-r3 --> 1.2.0-r1*

Noetic Changes:
---------------
* *aruco-opencv 0.3.1-r1 --> 0.4.0-r1*
* *aruco-opencv-msgs 0.3.1-r1 --> 0.4.0-r1*
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *eus-assimp 0.4.4-r2 --> 0.4.5-r1*
* *euscollada 0.4.4-r2 --> 0.4.5-r1*
* *eusurdf 0.4.4-r2 --> 0.4.5-r1*
* *jsk-model-tools 0.4.4-r2 --> 0.4.5-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *paho-mqtt-cpp 1.2.0-r4 --> 1.3.1-r1*
* *plotjuggler 3.8.0-r1 --> 3.8.2-r1*
* *sick-scan-xd 3.0.3-r1 --> 3.1.1-r1*

Rolling Changes:
----------------
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *fastrtps 2.11.2-r1 --> 2.12.1-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *plotjuggler 3.7.1-r2 --> 3.8.2-r1*
* *robot-calibration 0.8.0-r2 --> 0.8.1-r1*
* *robot-calibration-msgs 0.8.0-r2 --> 0.8.1-r1*
* *sick-safevisionary-driver 1.0.2-r1 --> 1.0.3-r1*
* *sick-safevisionary-interfaces 1.0.2-r1 --> 1.0.3-r1*
* *sick-safevisionary-tests 1.0.2-r1 --> 1.0.3-r1*
* *topic-tools 1.0.0-r2 --> 1.3.0-r1*
* *topic-tools-interfaces 1.0.0-r2 --> 1.3.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] pyqt5-dev-tools
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

