### PR TITLE
rosdistro sync, Fri Dec 15 13:44:09 2023

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "ed946ac225557e5ea704bf4385e731752dcd587e078d7346c790dc5e10a5911c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "90291de09ddb14f84fe827fe7a3db92774d6381d36bed23db4cca440eeb01d08";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "42188175bb8435a8178d11709ae0db8297b892ab67cc9b20605d2f6949404a9e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "f0c166e0ea3b0e28be42edd737c82651ed3048065b38efc78cdd414f21e902e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/aerostack2/default.nix
+++ b/distros/humble/aerostack2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-classic-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-classic-assets, as2-ign-gazebo-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-ign-gazebo, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
 buildRosPackage {
   pname = "ros-humble-aerostack2";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "f9aea9ab9b8cf166b5f2cd9e465389e42027ed40f0154ac3c33c2eefa0e81aea";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "ac40ad62ac1094e0512ebe2b7a3fdf225110f7aa79673d9660c30363f4e435af";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ as2-alphanumeric-viewer as2-behavior as2-behavior-tree as2-behaviors-motion as2-behaviors-perception as2-behaviors-platform as2-behaviors-trajectory-generation as2-cli as2-core as2-gazebo-classic-assets as2-keyboard-teleoperation as2-motion-controller as2-motion-reference-handlers as2-msgs as2-platform-crazyflie as2-platform-tello as2-python-api as2-realsense-interface as2-state-estimator as2-usb-camera-interface ];
+  propagatedBuildInputs = [ as2-alphanumeric-viewer as2-behavior as2-behavior-tree as2-behaviors-motion as2-behaviors-perception as2-behaviors-platform as2-behaviors-trajectory-generation as2-cli as2-core as2-gazebo-classic-assets as2-ign-gazebo-assets as2-keyboard-teleoperation as2-motion-controller as2-motion-reference-handlers as2-msgs as2-platform-crazyflie as2-platform-ign-gazebo as2-platform-tello as2-python-api as2-realsense-interface as2-state-estimator as2-usb-camera-interface ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-alphanumeric-viewer/default.nix
+++ b/distros/humble/as2-alphanumeric-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, ncurses, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-alphanumeric-viewer";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "82b58c4ce27f3d47275bc4574b97c0440869126eaaf1fafcdeab399fe042d813";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "838a642b6cf5388464fbf35708849e4226bd0c46ce85ca4590b120dd24e088b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior-tree/default.nix
+++ b/distros/humble/as2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, behaviortree-cpp-v3, geometry-msgs, nav2-behavior-tree, nav2-msgs, rclcpp, rclcpp-action, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior-tree";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c8e17492362c44bc33b80de4c5940b9023cb44888eb8582db2cda09d08ae5b52";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "7f70f650e245de8478492dd117ec96816c5dc92008cae59b456e4bb2f752fe6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior/default.nix
+++ b/distros/humble/as2-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "aca711d115623b2429912d121a1f4a45feef00c22f661d05b12c95c02dfd061c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "0c1b6e3820191aeb8e763c90b028f7cd24176da4aa4b050fc5f468045427a367";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-motion/default.nix
+++ b/distros/humble/as2-behaviors-motion/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-motion";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "7fe84746625746af69c9da401ad563b6b6dc27f8cddf05cbd452487795b00d39";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "eb9e2390fcb9630de06d40fe01ba7599216a08925ccf56b1f8d34e0e97d2e863";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
-  propagatedBuildInputs = [ as2-behavior as2-core as2-motion-reference-handlers as2-msgs pluginlib rclcpp rclcpp-action std-srvs ];
+  propagatedBuildInputs = [ as2-behavior as2-core as2-motion-reference-handlers as2-msgs pluginlib rclcpp rclcpp-action rclcpp-components std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-behaviors-perception/default.nix
+++ b/distros/humble/as2-behaviors-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-perception";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "effb1aee242b3c53abdf5e8d0732471a2e0e4c35dfdd8724775105f35fe25a4c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a9e6a477319e42c6ea0030b04de34b86fa0b15e209974495e4e057eb892d9164";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-platform/default.nix
+++ b/distros/humble/as2-behaviors-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-platform";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8ea6418de1f9030810bc7d5163ed7457400eb8007a6e37ae58b5c2cd66546639";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "780ae1283d636e78fbe9e6223d979a7348704a80b885c4fa06308f6f30e6d7e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-trajectory-generation/default.nix
+++ b/distros/humble/as2-behaviors-trajectory-generation/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-components, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-trajectory-generation";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "ca9e8d8c000e7987d83b60d9c7ac97450a1bd6178705eb1bb1f704b7473d8d05";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "c7d7f5cb093552cdda51e42422906aeca104eea2ef9e734f269f09821d2b66c4";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-cmake as2-behavior as2-core as2-motion-reference-handlers as2-msgs eigen geometry-msgs rclcpp std-msgs std-srvs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-cmake as2-behavior as2-core as2-motion-reference-handlers as2-msgs eigen geometry-msgs rclcpp rclcpp-components std-msgs std-srvs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Aerostack behaviors colection for trajectory generator'';
+    description = ''Aerostack behaviors collection for trajectory generation'';
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/humble/as2-cli/default.nix
+++ b/distros/humble/as2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-as2-cli";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "278d842c1d536063e670f73a79f7e59b1a2627b162c66cfef9f8df3cd884f939";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "9a8d2f7fa92db2e891d21fa1f3a49e174242c54990a13206cece497a021c5549";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "0ca84d13b256a395ced866e52c5e05f9cc3df5a9c32a4990eec2bc62e9b6bd60";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a1fe13d9801f3ff459e3966353e3dc27b0e5e9947db09341323d42429f73da4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-gazebo-classic-assets/default.nix
+++ b/distros/humble/as2-gazebo-classic-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, python3Packages, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-gazebo-classic-assets";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9d5293f81cbdd0ee8d8dec3f8e5740ba71db68c3b4f5da28d7d1c301594bad47";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "346b24a443f1cdbf1e396f8b934a6f05f8d23c711b6c97bccb542e2048c028c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-keyboard-teleoperation/default.nix
+++ b/distros/humble/as2-keyboard-teleoperation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-motion-reference-handlers, as2-python-api, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-as2-keyboard-teleoperation";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "49b62b7fbb4578940cc5ae0a689654e3ca6a2902e695f6e025da13ce67e475fa";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "6d27f8917b3adcdcf5213fc5ff8cb990e165fbdf74000abb2944fd7f356b1503";
   };
 
   buildType = "ament_python";

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8c9956716bc483195b98420fbb337af4ddaa5a82cc3d8ccae59e7add55af2a7c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "6122f55455c0b4771a7984df0af30a2b489c8925f3a6ada6645e8b91f43e1c34";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-lint-auto ];
   propagatedBuildInputs = [ as2-core as2-motion-reference-handlers as2-msgs eigen gbenchmark geometry-msgs pluginlib rclcpp yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/as2-motion-reference-handlers/default.nix
+++ b/distros/humble/as2-motion-reference-handlers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-action, rclpy, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-reference-handlers";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "54c398eb61847c4165f73ba625fb5414f1c214bce4bb2659bcb7c7f0f20d2d02";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "69d1cdad61617e00051df0f4a023e2b8579088e42fca9f9e77980a4fd2647582";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-msgs/default.nix
+++ b/distros/humble/as2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "7a682a29256a6a53ba3595fb43a636bc8a3d37623ec82b3113f930e76a156ada";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "19873e38f5896e137413f2d81acd5a7000c6015ae87701f6a0699276923d5d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-crazyflie/default.nix
+++ b/distros/humble/as2-platform-crazyflie/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-crazyflie";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "67883ba6e82a9e3e733347c0bacc5fef1a6e6bdd3b38fbf37d98a84f9af451dd";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "99d16f555bd975e66c335ab67553883bdd2495a5e0c578e3c935f7bf6c84ac56";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-dji-osdk/default.nix
+++ b/distros/humble/as2-platform-dji-osdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-dji-osdk";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "de5e2f968f4eeb8b77376990c1a12fbbfacbc41eb04a0988a72b5a02b4111c56";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "cd864b34ae39ea1ffd7896f83992f2a413a7f0cc57315cf25967b6093b29e126";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-ign-gazebo/default.nix
+++ b/distros/humble/as2-platform-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-ign-gazebo-assets, as2-msgs, geometry-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-ign-gazebo";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_ign_gazebo/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "3cf0e921c28d05c2e11cce276dedbc257a910b31c5031ea31f50cabf038c4d8b";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_ign_gazebo/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "7a456919ecefcd3a5684c5a6e63b9cdfa13b859820c904734d75c7f088a190f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-tello/default.nix
+++ b/distros/humble/as2-platform-tello/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-tello";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d96120b0aff26b914ff860504cb7468e41fd5b5acee0a7eb7b579853eebb2000";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "386a89c7bdd531c2a2e1cc275e365f0e5b53854f87da30ec45d5e5f2d4259403";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-realsense-interface/default.nix
+++ b/distros/humble/as2-realsense-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, geometry-msgs, librealsense2, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-realsense-interface";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "ac99c3ea9f6a61c7b1aca9adf34966fe9e4b8b4e012c092e2eee701d36aab29f";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "06f3507ad974667ee2bcfc8d8a83bec0a45eb13ddf4ee8a2fed015af0b131d6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-state-estimator/default.nix
+++ b/distros/humble/as2-state-estimator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, geometry-msgs, nav-msgs, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-state-estimator";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "7628adadf2c6828fa88a7f97498cb2643105f7f43980d0a4183925714fdd07ac";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "bcfa5ca1bc66bddd38a9abf0e20b3302e60bb4f3bd309ae69ff64b7e029bbb57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-usb-camera-interface/default.nix
+++ b/distros/humble/as2-usb-camera-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-usb-camera-interface";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "3a866848c2f5b6a0ef14287e4c394d3a389c61b0bd958d087f113e6448180e9c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "1874e8da2499d698ef54725f6b73af61258f1abe28ff4a87b53a46486b26136c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/behaviortree-cpp/default.nix
+++ b/distros/humble/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-humble-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "c1f18f59f7a55fc8fb8b991b1cd1ab9b7198507963787b7ce8e70f68e2566ddc";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/humble/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "d71643020988f11a82f0876e02afa68c1473fbab5d36149f1170c5b4cb2ca2c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "2b7dbb5f5994e8fbd8a048715f3ff94ec2b5df377d62d0ca67c06dc650936a2b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "661476916a0cdcc0e913ffbcdf96b57fe21d4fb48600993c5fb2e1edf7f18e73";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "4828a9ac823df3ca381c385c68c096990593ed75605a65adedd840e3b71a2975";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "6ce3344de977949f3c2d254cf93091cabe1eadea5f380793655acdb61e730706";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.1.1-r1";
+  version = "0.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "635ba85c7a2bee51e545a262b3088cb97d99c4c87a09b1cc5b7f978440519710";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "d57b8463f3c634796a9d99dae5fd101d34f454331a1a181feaf0f5f683a97f13";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "1880971ca205da73b6bc1d27e68ef0c3caddd46ea134070c7951ef75142d9054";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "fc60f14561ddbed1ea97fc25c26b3da547143000c152db557e10ac803144f90c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "8f47715d546fdf765e0971cc196abd2179aff5ef89bd9a4decec4c8322ebf5a2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "bb3958f0a59ac3fc00103d80e1632071e13d4019c50fd4c881d39fe23ae1e852";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "a5c52ae442ddff243787cdec278a5b17471784f7b11c820c325444bfb193e33d";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "1170e4db4037a2568d268879fd9716c3fbeceb5f78cf7b9f8ea8c5be6e5fb74a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "6bff4cd4a980a0311702d51925bb9feaccb1d2889316cc1cd1bebbc9f1f0caa4";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "84d21e5da421a78a658799320a8bb1170cf54752674612e4b7c7aa75adaab9e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "06bc2252305f5f5c3e4b9eadca92005943cfa032521716758ecc33199d1e8dbd";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "a9ecf4991540e76388df2995ace61c1768049031fe61e54ea49ab8f6e5424ee1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "3dd3df249a6a0ec0013c6f8e68584b19525999ba096d359a250e7c79ffcb9881";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "3abef606a913b4b9e78405469bf349e56eb62f6be0c527b4d3b4008c9c30df32";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-msgs/default.nix
+++ b/distros/humble/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-msgs";
-  version = "0.0.4-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "a55f459d96d9ea0214420798560f041d3290068d5b395a68ce605b5b02f286dc";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "506e283e487c92b5dbe7c7b38fdb9ccbe2123cc28f4447ab24a958df0e07cd66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "9ba561d2bdc3a1bb5aca1070ffd8773255f0c410959148f904bd3a113b998fc0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "ee8f0952077657aa9d946dddd1fcd7758b4c41a953301aacf5855beb6714415e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-msgs/default.nix
+++ b/distros/humble/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-msgs";
-  version = "0.0.4-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "f337f2741b91d275ba709cfe3becb53c933b18ff17cd3c2e06e4e8345ae4b551";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "ef0a5b9cabf444a95e969b31444587f9a3ab00855d5080114c5838b8fdca69f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "4c4d2da316ab6b4988c495be25b716fb1a4aa3907f97019c0ea8be7fb883a92c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "a5eb24db89d5b2ca1c2540a1d4d2f79dd13eb43016c2fcf3ccdc9eb9e2c7fc53";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "fb19e76f81a1f91f2f8aea4833f69481070065fa4e634070c1a2458cc6f9df5e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "53544e83e8375123c0fd714adae13c4c8b91bf62ad0eec81696f4430a8b93248";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "47325ebc27d286931d2c104021e98301baca116b792de46635873a3e8fbf5e2a";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3ad50aa6cda37ad6845700e3584cade1f860ba79239dd625510cd081276a1473";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/control-toolbox/default.nix
+++ b/distros/humble/control-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-control-toolbox";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "b796bc36cf39de0e51077c6338ea0b00f4ee1641d898e01127a11c795b82b55f";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "6209149ad64868e38b82aeda0318ffa316ef9a953c1938b20a1bbfdc2cb4039b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
-  propagatedBuildInputs = [ control-msgs rclcpp rcutils realtime-tools ];
+  propagatedBuildInputs = [ control-msgs filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "33249604146be0857066fd2f156b948879c098902dbb906ca56e237f8a2d5206";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "cc40eb9d6612c8bf7667823384eb3a4a4fa01867cc84630501f8a112a39c102d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "a081b51e6c05e29ab1f696a28a4d65ca27214d6378c8f888a2ecf5b618abfb95";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "ad1ad7ff378afe6bf943b4cbbf604d3b6f1445ce01bb254a79a56ebe13e45255";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "de768403a309e33992e94e143c4a437a2ce60a243e173c45bfdef73614bbe027";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "60a1f87e6f6865b59ccb071201509fe4a48358d4fb0fa4bafba60aba95e952f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "8ac224bedff52371beafc30bf84d66d6840992e4be48c48c4fbde1ae8305e13a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "abd3e7edab8eafdc84f47fb2ce9dd5e30b14d6f45fb3024376d42ea6f54daf7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "a299b566609467948b47044eded2c589264141ba78d13b89bb803123ec09dccd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "216277850633d8a90c3470578fe52a7db58b15b4c9f09545dca1fea96e05cc07";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "2.9.2-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "373191edfcbbe5f151b1fdd09e067167e71893e6b873002598821f0659b73f36";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "3121724c465f51844808e4d191bee7553cfa203eb4784fbd879010eb1d83057c";
   };
 
   buildType = "cmake";

--- a/distros/humble/etsi-its-cam-coding/default.nix
+++ b/distros/humble/etsi-its-cam-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-coding";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b458660a8e6044d0cbcfe940968e95670d0691d609693710d962469a0687473b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS CAMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-cam-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "391ee0f49708862e4bad08372c9b5d05484feab981ba0c5f366cb531c0aaea93";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-cam-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "5212527b31d5dc003e857085750772201587fff5785b05c68af71897336a0725";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS CAM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-coding/default.nix
+++ b/distros/humble/etsi-its-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-coding";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_coding/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "5c1ff6fb1308eb9190205c9fef42c0e7ef673ffd5785c7e33f44dfc7208815cd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-denm-coding ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS messages generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-conversion/default.nix
+++ b/distros/humble/etsi-its-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "75f9817c467e9accb09b41b33d4ebe8be9b941f826eb4d75f4ab952aabaa7f8c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts ROS messages to and from ASN.1-encoded ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-coding/default.nix
+++ b/distros/humble/etsi-its-denm-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-coding";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "487b885d857dd41b7c20a03223925f9de74437c3df0830788b9176cb09f04742";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS DENMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "d7e4e8aa114de99957ddcbe6738b66bed0a6a736a2a445c695707f9bd56d49a6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-coding etsi-its-denm-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "24ba7b0e28f58362f1292e688f6c1566f3360249df1715a3034b75a9e771fbfa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS DENM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-messages/default.nix
+++ b/distros/humble/etsi-its-messages/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-messages";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_messages/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "6769238af374192bbb1b8b1bb324acf3b1e2e760a0c480a927db6a7a0bf4a87d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-coding etsi-its-conversion etsi-its-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS support for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-msgs/default.nix
+++ b/distros/humble/etsi-its-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-denm-msgs, geographiclib, geometry-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b46cbeaa564d50c07eaf6dcb5573e5a9a93dc778a7f1ef99ec96c3bd497ead38";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-denm-msgs geographiclib geometry-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS messages and helper access functions for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-primitives-conversion/default.nix
+++ b/distros/humble/etsi-its-primitives-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-primitives-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "1c89fb86fa530cc7a2894464bca3b6f6425501a48f68406b22a37a1a8d857336";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS primitives to and from ASN.1-encoded primitives'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-rviz-plugins/default.nix
+++ b/distros/humble/etsi-its-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-rviz-plugins";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "ba47cd9281873630feaf82537e7cd880acb0f5ca1a5d2a59b4409363c8fcd939";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-msgs pluginlib qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RViz plugin for ROS 2 messages based on ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/fields2cover/default.nix
+++ b/distros/humble/fields2cover/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3Packages, tbb_2021_8 }:
+buildRosPackage {
+  pname = "ros-humble-fields2cover";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Fields2Cover/fields2cover-release/archive/release/humble/fields2cover/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "b900332945f5b18172d557ea18bf37e08e31a695fdaa5e66f6ca08c8d94983f3";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ gtest lcov ];
+  propagatedBuildInputs = [ eigen gdal git python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Robust and efficient coverage paths for autonomous agricultural vehicles.
+    A modular and extensible Coverage Path Planning library'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.8-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "bd0fa09b67313741f5716c69f680d364cb066b9f20c10e5535ce5992885c73e7";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "e0d683847becc86966e7f27a3b405ca5d8f6e510f27626ca70283fe9600b83e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.8-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "9ae07a4636d36f78304d58b4a36dc0d81e71909273ef7aae9c018556e704be7c";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "f6aabdd3ec4148d71459041bdab2b7617b854017718cf88914095468f3c6c67f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "beaa6924f0fcdd71cd6646a08e49cc373e906641d294d65d7a055bd7e5b1a380";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "fbf454fb0da04a37b76de59105c06177d0515bde7565ea0ff65c99651e232840";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "3cbbe38e667d1e2dc09d10cf35357910df136036c63fdfcd8b7bffe2b2293403";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "843e31cbfa9a1096797a1439f5daf59eece16b4dd5f36f56fafe9b738ced8227";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -574,6 +574,30 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ etsi-its-cam-coding = self.callPackage ./etsi-its-cam-coding {};
+
+ etsi-its-cam-conversion = self.callPackage ./etsi-its-cam-conversion {};
+
+ etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
+
+ etsi-its-coding = self.callPackage ./etsi-its-coding {};
+
+ etsi-its-conversion = self.callPackage ./etsi-its-conversion {};
+
+ etsi-its-denm-coding = self.callPackage ./etsi-its-denm-coding {};
+
+ etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
+
+ etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-messages = self.callPackage ./etsi-its-messages {};
+
+ etsi-its-msgs = self.callPackage ./etsi-its-msgs {};
+
+ etsi-its-primitives-conversion = self.callPackage ./etsi-its-primitives-conversion {};
+
+ etsi-its-rviz-plugins = self.callPackage ./etsi-its-rviz-plugins {};
+
  event-camera-codecs = self.callPackage ./event-camera-codecs {};
 
  event-camera-msgs = self.callPackage ./event-camera-msgs {};
@@ -639,6 +663,8 @@ self: super: {
  fastrtps = self.callPackage ./fastrtps {};
 
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
+
+ fields2cover = self.callPackage ./fields2cover {};
 
  filters = self.callPackage ./filters {};
 
@@ -819,6 +845,8 @@ self: super: {
  iceoryx-binding-c = self.callPackage ./iceoryx-binding-c {};
 
  iceoryx-hoofs = self.callPackage ./iceoryx-hoofs {};
+
+ iceoryx-introspection = self.callPackage ./iceoryx-introspection {};
 
  iceoryx-posh = self.callPackage ./iceoryx-posh {};
 
@@ -1268,7 +1296,11 @@ self: super: {
 
  naoqi-bridge-msgs = self.callPackage ./naoqi-bridge-msgs {};
 
+ naoqi-driver = self.callPackage ./naoqi-driver {};
+
  naoqi-libqi = self.callPackage ./naoqi-libqi {};
+
+ naoqi-libqicore = self.callPackage ./naoqi-libqicore {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
@@ -1428,6 +1460,8 @@ self: super: {
 
  pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
 
+ pal-urdf-utils = self.callPackage ./pal-urdf-utils {};
+
  parameter-traits = self.callPackage ./parameter-traits {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
@@ -1579,6 +1613,8 @@ self: super: {
  position-controllers = self.callPackage ./position-controllers {};
 
  py-trees = self.callPackage ./py-trees {};
+
+ py-trees-js = self.callPackage ./py-trees-js {};
 
  py-trees-ros = self.callPackage ./py-trees-ros {};
 

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "964fdb06bd2bf0a0879138a0dfc5f03c98174aa1958e2cedd5127ca4190cd2ec";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "ef2afaac4daa43d3bcbaa1e3834df721ffc2bf3a23e6f85df24b90e14d7380ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "b100f85f9c1f4d8a490da86aaaf70b0ed5fac70c35ec3efbfc8b34e2d04a7518";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "06d6c19be555973af75908bfc866d10f7f4615387ebb42f73772a8bc9fea66d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-hpp-fcl";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "9ff45aac8b11c44aeee0335c36bb9c948998a808425067dc7f61da4e089a52dc";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "3250388a111510453747c1b23f9556058310f54011638c211b43aaf7133bb220";
   };
 
   buildType = "cmake";

--- a/distros/humble/iceoryx-binding-c/default.nix
+++ b/distros/humble/iceoryx-binding-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh }:
 buildRosPackage {
   pname = "ros-humble-iceoryx-binding-c";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_binding_c/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "4299edb4d8162bde37c309ad40fa6ca5faedb7e17a70b1053ad48bd3186e0ca9";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_binding_c/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "ae235d26cde79de95dc7ea2a835097fbb936687a29a30f1c63a7c0bf68513b04";
   };
 
   buildType = "cmake";

--- a/distros/humble/iceoryx-hoofs/default.nix
+++ b/distros/humble/iceoryx-hoofs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, acl, cmake }:
 buildRosPackage {
   pname = "ros-humble-iceoryx-hoofs";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_hoofs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "4dc71a2368549ff46e18473a3696d5c526f9f6a6951271c9c312641b8c5b3f3c";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_hoofs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "f30ea6dc3e5e319a65083e0cd2aa6d79f011e80c6a3e1e64b797abb4e3ec9b49";
   };
 
   buildType = "cmake";

--- a/distros/humble/iceoryx-introspection/default.nix
+++ b/distros/humble/iceoryx-introspection/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh, ncurses }:
+buildRosPackage {
+  pname = "ros-humble-iceoryx-introspection";
+  version = "2.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_introspection/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "b8ce5d4033e4301bbf7545a07022d90ef41a1479d1034a09860fbb553c3c1762";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ iceoryx-hoofs iceoryx-posh ncurses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Eclipse iceoryx inter-process-communication (IPC) middleware introspection client'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/iceoryx-posh/default.nix
+++ b/distros/humble/iceoryx-posh/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, iceoryx-hoofs }:
 buildRosPackage {
   pname = "ros-humble-iceoryx-posh";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_posh/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "9ffe6b2f8df2d50db187201834bb7dfdbb3f50c717b960fa09a3771b8aa44c36";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/humble/iceoryx_posh/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "04e880e123d61f3ff8610acd0378277716054a9424b61c078e3dc7d5093728b4";
   };
 
   buildType = "cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "e333c10b46f65e7cb58fb08e6ca8c6ca283a5d462c2e564b86c76024226f6e93";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "cb4f774edf5633b9d6e9297a520c9a27740de05235aa2b7c4c4a2ecc1c00a5c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "32f1dc611b3fd25084b88fba6e61cded7fde27c0d15a60788def2d23f11d4f13";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "f315cb17316014bc95c17662292e015bec8363ff9ed6c3591affadfe0000f14c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "953c81dacc5b5018c87869856563b57e63004a4c20a79c56c89a7d1b886c0fa2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "c7f652986fdaf9836383d805d93c4e7d366e7a1fcbe57118d40e25eaf4e8595b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "7bedab252c6f2e85f87f5cbf9aae071cb8290269d33d4b4194612f0b70623bb7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "4a588e05aa8e90ba5c4e519c1f48de09e6821bdb5a98c0de14670586abadaedc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/libphidget22/default.nix
+++ b/distros/humble/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-humble-libphidget22";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/libphidget22/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "b33c2ed88ee8728586da5943d4be8573d8625a92085d8c1c72d3ff24cba2dbf2";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/libphidget22/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "ba9b0efce856d2c750015b277ce27595fdb93e9a9b4a385ee7de77905afcd7b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client-interfaces/default.nix
+++ b/distros/humble/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client-interfaces";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7b94837b0fd5fd9c6398a6eaf243286ce4144e8e9a0c4256619e8bd016a45090";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0c250c21ab149d4801d3ea6c5b43f062a532c70ce793df25d10425d85f44f0e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client/default.nix
+++ b/distros/humble/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "765380fd5d63718c71df863acd54f5218456416f003df8ced20fee714cb1634b";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e737e5a922bf8797cf326b80d00fb39298ed1ec19c6d435320c8e12b5792c794";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "daeab571c665cc2f4797a3bd695843f3bf41ae9ec0f8876b62b4b1b93f81e19e";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "e25bc3b615338f37821f3bc6b9b85f05f5d11e072e6fe3930852d8fd4461a679";
   };
 
   buildType = "cmake";

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "c86c6291ad237224cbe0f2b16278463851c891f919714a0a0e2e7b16aea00819";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "909c30c28abd1aa22bfdb34adfc92e11a1285fd90492084ac5d8add082b27203";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/naoqi-driver/default.nix
+++ b/distros/humble/naoqi-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geometry-msgs, image-transport, kdl-parser, naoqi-bridge-msgs, naoqi-libqi, naoqi-libqicore, rclcpp, rclcpp-action, robot-state-publisher, rosidl-default-generators, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-naoqi-driver";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/naoqi_driver2-release/archive/release/humble/naoqi_driver/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5cef270b3dab4c86abdf8c77f8d4c28fdf1eed89fb1f07926d65b53aa2252421";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake diagnostic-msgs diagnostic-updater geometry-msgs rosidl-default-generators sensor-msgs tf2-geometry-msgs tf2-msgs ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs boost cv-bridge image-transport kdl-parser naoqi-bridge-msgs naoqi-libqi naoqi-libqicore rclcpp rclcpp-action robot-state-publisher tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Driver module between Aldebaran's NAOqiOS and ROS2. It publishes all sensor and actuator data as well as basic diagnostic for battery, temperature. It subscribes also to RVIZ simple goal and cmd_vel for teleop.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/naoqi-libqicore/default.nix
+++ b/distros/humble/naoqi-libqicore/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, naoqi-libqi }:
+buildRosPackage {
+  pname = "ros-humble-naoqi-libqicore";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-naoqi/libqicore-release/archive/release/humble/naoqi_libqicore/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "f830abbbf5fccffc292cdbb19d5393bc1d129f03df5cf5bb7af414e8af005fde";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ naoqi-libqi ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Aldebaran's libqicore: a layer on top of libqi'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/pal-urdf-utils/default.nix
+++ b/distros/humble/pal-urdf-utils/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, xacro }:
+buildRosPackage {
+  pname = "ros-humble-pal-urdf-utils";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_urdf_utils-release/archive/release/humble/pal_urdf_utils/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a8fdee262c55e2a59f4e1f705d7cd7cc5c2bab153a7b90fcd3f93fbdced80195";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ xacro ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''This package contains the color materials of common elements of PAL Robotics' robot.
+      The files in this package are parsed and used by
+      a variety of other components.  Most users will not interact directly
+      with this package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/phidgets-accelerometer/default.nix
+++ b/distros/humble/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-accelerometer";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_accelerometer/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "bc9f595c2f4623964a14128769e982f9e17da771a5013590c06509830aafee78";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_accelerometer/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "f1f7d2924805fb147683a6e7e9b7e0e7867740d767f85211db13a7691f0ae9cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-analog-inputs/default.nix
+++ b/distros/humble/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-analog-inputs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_inputs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "f1b677611caf1dae85883fdf7be39687ac4b42955fadf4799f15d4c73f58bb8c";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_inputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "8f507032c9a18b36742667776af76ef9df3a575c73c3d5ca870fba228f81b4d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-analog-outputs/default.nix
+++ b/distros/humble/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-analog-outputs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_outputs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "811b783343f6adf9e599b32b9fae215e901817009c6f2a00175e2088d5145fb6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_outputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "c2137a2fe32a6f2e1cdf61b3720e82b7b9348bc44ae941fccfec609e41548b0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-api/default.nix
+++ b/distros/humble/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-humble-phidgets-api";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_api/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "1dc6911a781f7df4506a387cdcfad985ec6a5113919b5737fbd9465affa6989e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_api/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "0ed49709613bf3a37b87211b15f148ceb4fc7534222c3a4ba72a94b53f7053cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-digital-inputs/default.nix
+++ b/distros/humble/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-digital-inputs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_inputs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "d503dbde7c6c11df74dd705d3bacc5d9e41676ea96978d14195676799c16a7c7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_inputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "afed4616956fb988b4eba1173d0c6f6a72aaa2ccbb3a9cb14577bd95c36fd419";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-digital-outputs/default.nix
+++ b/distros/humble/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-digital-outputs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_outputs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "5ac1b0732742e3b5773b657d954260ea5fbf52b64303e9c27fe39a9208a12dd8";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_outputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "bcd4824c27bac1d475502097082e4057f7c14fcb214838e3effd5548dc64bd53";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-drivers/default.nix
+++ b/distros/humble/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-humble-phidgets-drivers";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_drivers/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "0998da832b6f854bcde780449c2895d0632bc70c60a9f6a221817e1231ddc164";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_drivers/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "3bd5cf062b90b2c86e5e410b49663ca5af99e9b97149702cb52bdeed6d928752";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-gyroscope/default.nix
+++ b/distros/humble/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-gyroscope";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_gyroscope/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "58f91315a76fe50616e0b1dd68acc02daf82a9702f1b3693f3d40008a36fe83d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_gyroscope/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "e8356d1d23311552eb98aa6bb328794ec6262a1989654ab9d6b1741e0aed2010";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-high-speed-encoder/default.nix
+++ b/distros/humble/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-high-speed-encoder";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_high_speed_encoder/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "fed955d207f03f7a691ba38991891fad208f58e4c404c8df3096f773c325eb83";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "cfdcd43c4ced7fad39c3747196f44357fb690af9746d6ae770b3a6669d8b14d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-ik/default.nix
+++ b/distros/humble/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-ik";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_ik/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "e003e630d4114cbf53e8056140e8f73dbada50548a39d3484ed5bd93334d4f3a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_ik/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "1dd3bb0f53f336108eabc19eba4d837e61e827406d6aaa3dbd22c4f845ad0a06";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-magnetometer/default.nix
+++ b/distros/humble/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-magnetometer";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_magnetometer/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "d3c4629d9a2a324d75f2267a9a07f777307cebf928164ace8b6733339e55df99";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_magnetometer/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "9474645c0d322d980735a496cc94be2e5bf240b89ea5e1129daba24719568651";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-motors/default.nix
+++ b/distros/humble/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-motors";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_motors/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "c9b3f63dc5320ab51fca904db2acd7e5e80e7b149e093d6486697134aa9d245d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_motors/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "2dd8754269be49079f22c907ce288a0592d82104ce0a9f122f6de1baa7316346";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-msgs/default.nix
+++ b/distros/humble/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-msgs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_msgs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "856c9e3efeddf56cf5c8c3e7e3c39bb76ad60eba9891e4f6da6f0a63d0fe98bf";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "15994d6f8f68ce830618ecd5da87102d67877f4fa603478ee14a8b3c9b1ea271";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-spatial/default.nix
+++ b/distros/humble/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-spatial";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_spatial/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "ddea83e94d8233bbbc1c4f0421a630de846dcf072cbcaa0574613fd6475b13dc";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_spatial/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "6b406afeb980aaa4e5e64cfaa2bc21ea2a4390df07002b37ecd8b0a247495c36";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-temperature/default.nix
+++ b/distros/humble/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-temperature";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_temperature/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "3d97ce71359fdaff7c9074ee607d064efd33b24ce99cb2d58e63d168a3bf47ed";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_temperature/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "8301cdc3165351f9221a6a9205d849406c9fd683228ab3a9a9d03ee3744a41ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pinocchio/default.nix
+++ b/distros/humble/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-humble-pinocchio";
-  version = "2.6.17-r1";
+  version = "2.6.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/2.6.17-1.tar.gz";
-    name = "2.6.17-1.tar.gz";
-    sha256 = "7f386fbee3c756c2fca87953eb790278f7ebc0a305563a19705e73061352698f";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/2.6.21-1.tar.gz";
+    name = "2.6.21-1.tar.gz";
+    sha256 = "7952e2dc2cae79dfead37665e2abb30245a6fc3c93769473a88d8c04b765b7a0";
   };
 
   buildType = "cmake";

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.8.0-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "47c93c2ee9cc941ae07c3e08cb3c816dd45f494bb7bc8a92aefa7281daa86e0a";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "4a0106affd5aaf22706c36699d0b0db47de2d89b61c57957ce1248c11e77af4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-interfaces/default.nix
+++ b/distros/humble/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-interfaces";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "55fc2ab4b24bfbbbff862def7757eeb6b75cfa6e1f0fc6db611e15c51bf73646";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "e5ba7db24543bcab04448351993eaf7b8d7019ee06695e2840b29ae192c25737";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-plugins/default.nix
+++ b/distros/humble/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-plugins";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "e85c2307bf4155cecce88eba0d897d5d75f5a43ffe05befdf6b06d1c8da39088";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "ac34d2415b970a2147e5ae09331909feea8af38561753f4d39362457d97355e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-py/default.nix
+++ b/distros/humble/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-py";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "402d950cc31132ffec8eb6f13cd4cf687866692c322041326975592ee8f97701";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "e2907c73fb2ae544f847e7bc694862884ea7e29313e10e18a730c81c49fc8f3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport/default.nix
+++ b/distros/humble/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "9ec263b5dc068e32c9973f2ebbb59b0a45305ab2e23cfcb2376a201e7f8fd52b";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "aed7365081fb48b5f05c6dfdcc4f103a0710debab68b573c48b3e095dd50448f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "0c15b974ba09e8f06a8bfdcbb9f4a144eb6f92d88a1552cc4beb83d5f7899e8a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "e36a7309f2eb0db803013d018f2886b61647fe9b4898d23d3f1f04bc055a4c5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/py-trees-js/default.nix
+++ b/distros/humble/py-trees-js/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, qt5 }:
+buildRosPackage {
+  pname = "ros-humble-py-trees-js";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/humble/py_trees_js/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "1be019e96392b50d374dd207e660b3a1e7fac01b3f8ffeb0d7ca1f192b5a2442";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools qt5.qttools.dev ];
+  propagatedBuildInputs = [ python3Packages.pyqt5 python3Packages.pyqtwebengine ];
+
+  meta = {
+    description = ''Javascript library for visualising behaviour trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "512a53c7270e16107e5784b56f5a93f2ea3c7fd3bb2d48a1f8e17dfea324f7f9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "b9a1c2319485c4cb7c7ab4796f7f6d5ec6335f3e51e559163a87760f98842b8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration-msgs/default.nix
+++ b/distros/humble/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration-msgs";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "416c8562484550974e108e3e7c3adcc48f50e2bbde1bf75a843d57ece74e927d";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "93f34e6c210cb3d68733bbf9ccdb9623672fa88895c010af1b85bc4fbbe7b2fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration/default.nix
+++ b/distros/humble/robot-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "61615283317eda03d7dd8cb7955576b5ff1904f58617c476c82610acfa70822d";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "75d51aa74e27d90f3007b4dcf0e09c5ded1d9dbe4e525bd5c2f21e18edcc7b77";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros tinyxml-2 tinyxml2-vendor visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "1d025d952ebc695dc199b949d04a4f60e758b2417ee3ea16eec7e268531cfa0d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "122fe1dc34fd0a3fe754c2b88fd522e67feac76cb2a90d264c1e88bcaa381c13";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "b057063213b3b88ccbed87bac2c3d39668eb3f139b8e88ae1a10c51e05279183";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "a54e52dc2150f468915eb9872a8c004fc2453d96d3f139b08b6b4ef9c5f6bccb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "2796cd2c3f823243bb57357724f8d9394557ffe63b57b103bbf6e43630ce342b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "a3068cda9c7582ebc99e583f88f115d88e63dafc9177e6d9e207e6fe7fd73efe";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "e966aa6733d4727f2cd12d6fba05211fc8f2282eae9b9ba7bd8ef7bea1632b6e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "f230cc32ada5acf92272e4c23a06da794077ad28ceef0b09106be0bd482fa091";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "7139a307f02bd8cd7742edf9a680db4b7d8ab65cb7efeb94e9bf95288a710bd6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "ed6b77ab3589f5dc1db7b0cda909e1a726e6f17799f8d25940a574595ed846aa";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "bb0a6e0b36f3effd6eebe46a4e982724a62dc6fe112390021371cfd5dc786af3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "d7fc3eac3c353642b3daf4bbe725360b4bb01bdcaac440f36651d1831b433a24";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "f304e70c7721261ff2bfdc8563f3f176d0f4eb59c194a46daab6bdc981325cd7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "8bc809ff943cbbe8e56048eee3657b43b79be4cc04c1d1df25d105f66f947025";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rsl/default.nix
+++ b/distros/humble/rsl/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, clang, doxygen, eigen, fmt, git, range-v3, rclcpp, tcb-span, tl-expected }:
+{ lib, buildRosPackage, fetchurl, clang, doxygen, eigen, fmt, git, range-v3, rclcpp, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-rsl";
-  version = "0.2.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/RSL-release/archive/release/humble/rsl/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "0f8473823bdb6bd92100ecc44827736dc6b51d8038f0785a7157b43abf98989e";
+    url = "https://github.com/ros2-gbp/RSL-release/archive/release/humble/rsl/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f91c02fad94fff759843dc06c1f8de2451c3a1beb18fa46961a1939764ba53a1";
   };
 
-  buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros doxygen git ];
-  checkInputs = [ clang range-v3 ];
+  buildType = "catkin";
+  buildInputs = [ doxygen ];
+  checkInputs = [ clang git range-v3 ];
   propagatedBuildInputs = [ eigen fmt rclcpp tcb-span tl-expected ];
-  nativeBuildInputs = [ ament-cmake-ros doxygen git ];
+  nativeBuildInputs = [ doxygen ];
 
   meta = {
     description = ''ROS Support Library'';

--- a/distros/humble/sick-safevisionary-driver/default.nix
+++ b/distros/humble/sick-safevisionary-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
 buildRosPackage {
   pname = "ros-humble-sick-safevisionary-driver";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/humble/sick_safevisionary_driver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f305dac3e667170c50ce43d26a9b00e5cfd29cf8684be3b0d079f88cfbd92265";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/humble/sick_safevisionary_driver/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2f0340119b80e9dffa0e1e3e46bf2daf00b685edc011e73b37ecec27bf4591df";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge lifecycle-msgs rclcpp rclcpp-lifecycle sensor-msgs sick-safevisionary-base sick-safevisionary-interfaces ];
+  propagatedBuildInputs = [ boost cv-bridge lifecycle-msgs rclcpp rclcpp-lifecycle sensor-msgs sick-safevisionary-base sick-safevisionary-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/sick-safevisionary-interfaces/default.nix
+++ b/distros/humble/sick-safevisionary-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-sick-safevisionary-interfaces";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/humble/sick_safevisionary_interfaces/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f541283b3d78572ecaf2fb231c3de5b2683a74400a4030427ec5db4996faf307";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/humble/sick_safevisionary_interfaces/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "45ba7100f1a4739558fb2b32c44815118259a4f5badb999461a2c1bf658ff163";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sick-safevisionary-tests/default.nix
+++ b/distros/humble/sick-safevisionary-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing-ament-cmake, sick-safevisionary-driver }:
 buildRosPackage {
   pname = "ros-humble-sick-safevisionary-tests";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/humble/sick_safevisionary_tests/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "97b000606e24174581f7518fa9b31d8637755b83b7f66206871a7952134d4887";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/humble/sick_safevisionary_tests/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "730f1d674f7031469c95eefc5d865e1ea12b016feb8b492d81bb694fa909c865";
   };
 
   buildType = "catkin";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.8-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "8cf58b5834df63c0630dc69aca10f4142b6e6da4d90dac560a1706327b1f1867";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "9c7bd829f655b91a08350d3c1a9803ba225453112f640613ec0caabb4147b7a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "e85f01b0bee7b9c17392ba28aa950207a022621e779c90e2e4f5a9ab132a859b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "1842cc971f9e6b7f6f29a5ff6ed629aedc0aa1ff1c2f980218adbd0ad938ad64";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-tools-interfaces/default.nix
+++ b/distros/humble/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-topic-tools-interfaces";
-  version = "1.0.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools_interfaces/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "6e68d8fee9e39482da8aa56ba90086f41f79500ab073bc260216f5b6afb38676";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "28fbf6b17d7ceda9b3f1f0b62d449c82c63d35a5728be9f69bba3bf6939e4ca6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-tools/default.nix
+++ b/distros/humble/topic-tools/default.nix
@@ -2,25 +2,26 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-humble-topic-tools";
-  version = "1.0.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "1b98ac197a1ecd10a6d4209635987fce44a93a3e052d05cd9050a80af43732e9";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/humble/topic_tools/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6b262f27054b6d627f765627eccef88fcfbf25c1dbbd9a56eb26b61f2530e151";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Tools for directing, throttling, selecting, and otherwise messing with
+    ROS 2 topics at a meta level.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.35.0-r1";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.35.0-1.tar.gz";
-    name = "2.35.0-1.tar.gz";
-    sha256 = "36a5930168eb16dd917f159f12e798bd7e5a566322cb0c1c011ab985f5bee3a1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "e9421512faddec344f883d2b548ace85a72b8bbf018072cb4f472a38f5737422";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "555d5c9075d27e1de10ff0acc9d35975302dff0cbd8d181d1dc4baae46f75804";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "49778878a45119f2bf5cec4a724882f9c95aef499165f4195ac916a725ba9916";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "4b3cb87930b9adf9e9d5e6aceb436c7449efb45fcea021a27a17f46645ed6b88";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "77f3ba1d76f56f281bffee00eda39d855aa112a98c388b47c3ea1f31f1897e2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-description/default.nix
+++ b/distros/humble/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-description";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "9bfe422167239b05395148d8098db1383fef260e58d8957001815ef5c16130de";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "e01438a575d04909e9f0ef55cd9fc0013cee02b80a1cfac3c0e4b451de012c79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/usb-cam/default.nix
+++ b/distros/humble/usb-cam/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-humble-usb-cam";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/humble/usb_cam/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "63272f4f6873929dd3eb23bc693bbd7981df81d6a51fe362a5018f0abed9c471";
+    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/humble/usb_cam/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "8f9c20140e37f35d8c7ed19662fdfa6e2cb561775249e423baadc5b622550a8d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  buildInputs = [ ament-cmake-auto ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces camera-info-manager cv-bridge ffmpeg image-transport image-transport-plugins rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {
-    description = ''A ROS 2 Driver for V4L USB Cameras'';
+    description = ''A ROS Driver for V4L USB Cameras'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.27.0-r1";
+  version = "2.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.27.0-1.tar.gz";
-    name = "2.27.0-1.tar.gz";
-    sha256 = "2e846665cb7ccfdadeb2d5132dedc35d120829b403c02fca0d3eab7652037f27";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.29.0-1.tar.gz";
+    name = "2.29.0-1.tar.gz";
+    sha256 = "7a5ace8fdbc09b0b064d1866162c1a91ea1f48addc4431c6912fb573bc0052d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zlib-point-cloud-transport/default.nix
+++ b/distros/humble/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-zlib-point-cloud-transport";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "aac9d44a1542ee247dddfa7c8965f324e8fb4d210f0728ab9f414a9babde1b31";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "1c99a7837760c871e9d4c41c56f35e59416dc87cb6b720c4aa2265ea38b3df16";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zstd-point-cloud-transport/default.nix
+++ b/distros/humble/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-point-cloud-transport";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "cd95f788f3090a2389b0b860629d4cdba5d0748fa6a962d9e0ed0a9bf0f3b49b";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "c286dfaa4f7d39df3848ae4154ccd13980ed23cf6bf0be6b32c49d2678ddfbf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "a4d3e0f828fee2a6ed124a8f702c7c7f7c35343c6fdb9bfbfea87ecdbf126221";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "4b0c6e52283cfa0d538909e392864a81a53f129d0e47554828cc39bbf1539cdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "8ddb4625506cdb704a02eccd340604e6e347231ffbf7f22f2df63061e7fee12d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "e874b2d240a0ec5fbeb15871e86c6ca1fc3a8af7a723698544a194ee5b0b0d0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/behaviortree-cpp/default.nix
+++ b/distros/iron/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-iron-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "45070ae96ea77d7a4e05d3f97f96ff65b0b679a0399fc12d8895c2c9aefe0d37";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/iron/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "6ef2a334645266ad5f3dc96f44f59e15d09069bdbd2a86384a90b24381b0cd20";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "3837dab1d83ad4b4898daef3f8c77c8bf898ce88788d4e030b184c8e2a8fdf40";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "3b9c497f558cb55626a019d1521bfe1d8c5a9ded2c42c0659e49c51ab25dbc2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/control-toolbox/default.nix
+++ b/distros/iron/control-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-iron-control-toolbox";
-  version = "3.0.0-r2";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/iron/control_toolbox/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "22db15abb15757decfd4c51230dc80ebfae2e59e3950f2d73d62cddabb620b06";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/iron/control_toolbox/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "905e58112dbc76281297e100c27c17274b5c5b4f64a6ff50aed2bb4beea233e1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
-  propagatedBuildInputs = [ control-msgs rclcpp rcutils realtime-tools ];
+  propagatedBuildInputs = [ control-msgs filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "68f09fda61e7abc8d70cfc7e6d7c61e1fa173e84c81799e0ed4e71ece01e6769";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "39d768056ed22fc1f2792c5771d1107ed616a3aed4b68dc81f10b8d52c05a09f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "9c224bbc875d0332d8f42d174af5d06ad0818b3b526066f6b6b1ff04b419988d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "737889d6aa324702fc0abdc8f7a84a227df98fb09edd0882147562b5200f8f25";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "215710f3c2723f7dad6c6bda2238d06bc311dc3510d6bb39dc00b7e1b05cc2ae";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "6917c66a233cac7353303991d4c7629c944694f44104e32d7b70dbee0beb1df0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "2db32a57ea3edd7b3e33b2f0105a079c349007451bfca9ff17bd899704bd409b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "b02516678be2e1224f0b03cf08f0fe8f0d460d587cf41d1ef801f30225674059";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "cd3c46e1f7f100b09139c07eb044e5061728d08384b92c8a699c94bad33363cf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "200385a5731490d19850c15bcaf18ab5bdeb1793176908a0d1b6be7fa4dce6fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/eigenpy/default.nix
+++ b/distros/iron/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-eigenpy";
-  version = "2.9.2-r5";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/iron/eigenpy/2.9.2-5.tar.gz";
-    name = "2.9.2-5.tar.gz";
-    sha256 = "89f59bb17b187fd9729c4bdadee13465f618304d4bf024f620694412bc568aab";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/iron/eigenpy/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "b4b16451a9ec960408788073311ccd2cb15b26bdd0ca449adbc64b0d2ac01961";
   };
 
   buildType = "cmake";

--- a/distros/iron/etsi-its-cam-coding/default.nix
+++ b/distros/iron/etsi-its-cam-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-coding";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_coding/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "f852c2e48b730e3609315bcb83e3f1b37c79a08a393974f032cc45ba8ab657b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS CAMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-cam-conversion/default.nix
+++ b/distros/iron/etsi-its-cam-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "9adbff122b2903c425f5a26fc972c2d37e89fff9aa281e6fe1ef8e6ac0a2eb67";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-cam-msgs/default.nix
+++ b/distros/iron/etsi-its-cam-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "e73a010ec5b334490a1ee83904a364a7300930ae034c07f1dcc3341a79bebb4c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS CAM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-coding/default.nix
+++ b/distros/iron/etsi-its-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-coding";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_coding/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "a3d0110d2b7126976142c9a192a71121cb1e07f112913871d7b9d43de8c907d1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-denm-coding ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS messages generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-conversion/default.nix
+++ b/distros/iron/etsi-its-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "f94a774807192582bf96a4b94d038de02d1d99f021b0433179b9f48a12ca11f0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts ROS messages to and from ASN.1-encoded ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-denm-coding/default.nix
+++ b/distros/iron/etsi-its-denm-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-denm-coding";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_coding/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "2a2ce06be97e8de45dd9837bcaa4a7676223494814529a5a06b6dde98a44525e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ compatible C source code for ETSI ITS DENMs generated from ASN.1 using asn1c'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-denm-conversion/default.nix
+++ b/distros/iron/etsi-its-denm-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-denm-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b9508cc2366b3b9a3203662971c736fcb6df4202e95557f7293f1dff49990eb2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-coding etsi-its-denm-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-denm-msgs/default.nix
+++ b/distros/iron/etsi-its-denm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-denm-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "f10c740d228bf449395e4311384f6e7918d80a184dd4217c2f46208d0ca8280f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for ETSI ITS DENM'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-messages/default.nix
+++ b/distros/iron/etsi-its-messages/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-messages";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_messages/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "fa2ec91d8a07a206ef0fe57cbbb2d7e3ea6c3c57eebe143f0df2a9edb59cc690";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-coding etsi-its-conversion etsi-its-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS support for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-msgs/default.nix
+++ b/distros/iron/etsi-its-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-denm-msgs, geographiclib, geometry-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "a29ab416da043ad33c6c68832dc456ad5d27be5ea143e06242f3368f558408f0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-denm-msgs geographiclib geometry-msgs ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS messages and helper access functions for ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-primitives-conversion/default.nix
+++ b/distros/iron/etsi-its-primitives-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-primitives-conversion";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_primitives_conversion/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "d8f55d366b795cf267f1b48e7a27eb4ea5ae2995b414ad1ef682a129a23ab2a5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Conversion functions for converting ROS primitives to and from ASN.1-encoded primitives'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-rviz-plugins/default.nix
+++ b/distros/iron/etsi-its-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-rviz-plugins";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_rviz_plugins/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "066fac539c7b37e4c9534c1833978e3dd702443f35eb4fa9cf9b10fd5e9c8cb0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-msgs pluginlib qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RViz plugin for ROS 2 messages based on ETSI ITS messages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/flir-camera-description/default.nix
+++ b/distros/iron/flir-camera-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-iron-flir-camera-description";
+  version = "2.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "1652cb642467a8946af3f44e25a410880114cc95fcf35b3a30d0a7b4e492f629";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''FLIR camera Description package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/flir-camera-msgs/default.nix
+++ b/distros/iron/flir-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-flir-camera-msgs";
+  version = "2.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "5e34c82fffbe787e4b2860781cb63c6c0a675d09acb12252967187a512fd3b17";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''messages related to flir camera driver'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "8ec3525aa9fd19a053a8b48e6674e15589d6ec34a2b4511bff6162cd9dbba22d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "ac9b71aa0e879f9f7f3fac118a5495f38577c8c90e702d17fb7ebbd805bec2ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "2e72d81f35a41492a2b18c9743ba88f75aabe222a5028e1bae2bfb1cbee4b4f3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "63c7081896439b57faa6b0f600af05832f0050642fe4a2e4493ffe1c38a44b4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -440,6 +440,30 @@ self: super: {
 
  eigenpy = self.callPackage ./eigenpy {};
 
+ etsi-its-cam-coding = self.callPackage ./etsi-its-cam-coding {};
+
+ etsi-its-cam-conversion = self.callPackage ./etsi-its-cam-conversion {};
+
+ etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
+
+ etsi-its-coding = self.callPackage ./etsi-its-coding {};
+
+ etsi-its-conversion = self.callPackage ./etsi-its-conversion {};
+
+ etsi-its-denm-coding = self.callPackage ./etsi-its-denm-coding {};
+
+ etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
+
+ etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-messages = self.callPackage ./etsi-its-messages {};
+
+ etsi-its-msgs = self.callPackage ./etsi-its-msgs {};
+
+ etsi-its-primitives-conversion = self.callPackage ./etsi-its-primitives-conversion {};
+
+ etsi-its-rviz-plugins = self.callPackage ./etsi-its-rviz-plugins {};
+
  event-camera-codecs = self.callPackage ./event-camera-codecs {};
 
  event-camera-msgs = self.callPackage ./event-camera-msgs {};
@@ -523,6 +547,10 @@ self: super: {
  flexbe-testing = self.callPackage ./flexbe-testing {};
 
  flexbe-widget = self.callPackage ./flexbe-widget {};
+
+ flir-camera-description = self.callPackage ./flir-camera-description {};
+
+ flir-camera-msgs = self.callPackage ./flir-camera-msgs {};
 
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
@@ -687,6 +715,8 @@ self: super: {
  iceoryx-binding-c = self.callPackage ./iceoryx-binding-c {};
 
  iceoryx-hoofs = self.callPackage ./iceoryx-hoofs {};
+
+ iceoryx-introspection = self.callPackage ./iceoryx-introspection {};
 
  iceoryx-posh = self.callPackage ./iceoryx-posh {};
 
@@ -1353,6 +1383,8 @@ self: super: {
  proxsuite = self.callPackage ./proxsuite {};
 
  py-trees = self.callPackage ./py-trees {};
+
+ py-trees-js = self.callPackage ./py-trees-js {};
 
  py-trees-ros = self.callPackage ./py-trees-ros {};
 
@@ -2021,6 +2053,8 @@ self: super: {
  spacenav = self.callPackage ./spacenav {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
 
  splsm-7 = self.callPackage ./splsm-7 {};
 

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "af64148c5d421a1bd0ea91f58bd0548d09c7556d45e7bace6a0f5a64037600fa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "8af95bc04d74c9d9f7a9c61b40b3952b784d5c18c0e14493be7236e8e175cb83";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "ff5b7fdbc087b98d39ce35688db6158a023ec74dd40c3ebe107bb48e5acd64da";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "0e97397e83e8a82834f39e3cf0c15b0548c2d2e172eb37665aa3148615eb8783";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hpp-fcl/default.nix
+++ b/distros/iron/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-hpp-fcl";
-  version = "2.3.0-r5";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/iron/hpp-fcl/2.3.0-5.tar.gz";
-    name = "2.3.0-5.tar.gz";
-    sha256 = "a44e6189c4dda6b8eefc7082e487dae74fdbaf31cd659e7c5b8279a49517720a";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/iron/hpp-fcl/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "eca39b56b89fbde81ebf07dbc9f8bde61563684c7a939db88f1f4ec1c3f04483";
   };
 
   buildType = "cmake";

--- a/distros/iron/iceoryx-binding-c/default.nix
+++ b/distros/iron/iceoryx-binding-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh }:
 buildRosPackage {
   pname = "ros-iron-iceoryx-binding-c";
-  version = "2.0.3-r5";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_binding_c/2.0.3-5.tar.gz";
-    name = "2.0.3-5.tar.gz";
-    sha256 = "df344f1dc26afd91c9f577124fe32d465ec5501075d7313ed1224aa29adc4ce3";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_binding_c/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "b5ecd5caf1c8361d0ae5c39f91d8894b4e06f931e7ad824f47ec626c9e645e63";
   };
 
   buildType = "cmake";

--- a/distros/iron/iceoryx-hoofs/default.nix
+++ b/distros/iron/iceoryx-hoofs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, acl, cmake }:
 buildRosPackage {
   pname = "ros-iron-iceoryx-hoofs";
-  version = "2.0.3-r5";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_hoofs/2.0.3-5.tar.gz";
-    name = "2.0.3-5.tar.gz";
-    sha256 = "630dbca759e310dc495f3cc5cb7ae8c49679f07b5f853a914b714f3e0effb9ab";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_hoofs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "547cd7dd9ebe640f7dd55ab87a1ab9fd8f7e89bfe13cbe7e93f06cc69ca189df";
   };
 
   buildType = "cmake";

--- a/distros/iron/iceoryx-introspection/default.nix
+++ b/distros/iron/iceoryx-introspection/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh, ncurses }:
+buildRosPackage {
+  pname = "ros-iron-iceoryx-introspection";
+  version = "2.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_introspection/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "bce2112eed3b6707a327ac6f4b827b39893e4b8897b06865c37aaadd097be4f7";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ iceoryx-hoofs iceoryx-posh ncurses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Eclipse iceoryx inter-process-communication (IPC) middleware introspection client'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/iceoryx-posh/default.nix
+++ b/distros/iron/iceoryx-posh/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, iceoryx-hoofs }:
 buildRosPackage {
   pname = "ros-iron-iceoryx-posh";
-  version = "2.0.3-r5";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_posh/2.0.3-5.tar.gz";
-    name = "2.0.3-5.tar.gz";
-    sha256 = "23822dcae8631737ad868af499c8c7d4413b85fcfcb8da8215b45f537bafc48a";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/iron/iceoryx_posh/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "2678e4eedec58ef154c067927ade7fbe185cb3775c96275b758d9c7de5ceb14c";
   };
 
   buildType = "cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "ebe3b02693dea464de7930c34062b87c1267842d8049cc5bf817b8c950e7dfe6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "e5677b3558fa949e697e45739ed03fbe21068b6fc6f99611beeed5e9265558c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "07c8533ffc6e8f8006d6cbea02ddafed25be35bfa5a79c6c1e50ae8cd9dcc387";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "90561907e1c7955531dee7b278e30814b66f1449f75cf1e947dc421e6587a8dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "9b9aab51f7d99abd67880a75697684d9d8568e5f1d67f70529c2ebbe6d7f3aff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "bf530ddc01262180ff92f077fcd109dc3176c62de87ccae5f6e0eed0da3658fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "85c12492f824a78f9f4171c282528d4923e05f475aee4c361f4c0fcbb91aa646";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "25faa7f715f87621a0a17ffa41fdee117ddc836978abb1d0f3e0fc2a905c1b63";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/libphidget22/default.nix
+++ b/distros/iron/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-iron-libphidget22";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/libphidget22/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "0d21f71d603eab1ac7871ce01d232bf39c06fedf0707b896686c8333a1637963";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/libphidget22/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "d4a3e3f94b0e88d08871bd04a71fb1b8e4fd069109733c50414b113ca9aaa2b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mqtt-client-interfaces/default.nix
+++ b/distros/iron/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mqtt-client-interfaces";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "dee2efa5f9fac0dbae92fa4d18290f717aa86c48e9fb625a3b7a3df0fa298f60";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f2e5e9f011bc2b4219e618818da701c9854effcc9bc7592d7825e0de330b434b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mqtt-client/default.nix
+++ b/distros/iron/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mqtt-client";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0e1e99f900c57944b7a49661873ce7175b84d8872ac6975898f0c736a369b69c";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "55d5a46ba0595cdf74cd67a4f73ee84f8b8251dcfe36dc5f5941c11df5936b74";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "1acb05f82b28f697511b758004100dfa063250b5a05bf99fcee3cb417d94249d";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "481f131354faef95c7d93e59da2300afca010f05bf1894f1898c22a84193ad9e";
   };
 
   buildType = "cmake";

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "e3f8cf189e2f4d04da991b090efda455f78c96d10f83cc7d86436804774719dc";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "2a0d2ea02006bf0f52a411b3ed941d1ad3f16e74a8f76420e4b5d555917add39";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/naoqi-driver/default.nix
+++ b/distros/iron/naoqi-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geometry-msgs, image-transport, kdl-parser, naoqi-bridge-msgs, naoqi-libqi, naoqi-libqicore, rclcpp, rclcpp-action, robot-state-publisher, rosidl-default-generators, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-naoqi-driver";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-naoqi/naoqi_driver2-release/archive/release/iron/naoqi_driver/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "be32391d297f3a8ea3c74c22e55d67b1097b77d2a7e0a1ac3ac7edbc4f8be47b";
+    url = "https://github.com/ros-naoqi/naoqi_driver2-release/archive/release/iron/naoqi_driver/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0a43055a6c3d1337045e191452ae9a5cd469d4f5b8a6792a132bed3f84d2857c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-accelerometer/default.nix
+++ b/distros/iron/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-accelerometer";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_accelerometer/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "35218bfea1720acdc2cd6a8ae7dfad20244ea426506587b1594254a9208c951a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_accelerometer/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "aa6c80a40a8ce930c0896a5cfd83a6ee33f5665c108673d6af0c9f9394bc3334";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-analog-inputs/default.nix
+++ b/distros/iron/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-analog-inputs";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_inputs/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "8e524ee3e2e3e846852213313b58b600d7d9ce3ffbb052e2e43bf93c9389d24c";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_inputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "2a5915ec426069e12d28fde80845fe18d8ab761c292998887abc968f92927600";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-analog-outputs/default.nix
+++ b/distros/iron/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-analog-outputs";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_outputs/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "47153ff2c21c004951aa96dd667731f4f161bc473cc73a7115925d5f33464ef0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_outputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "e45b3d5c258578b0f38c770d32fc5798f86a161d637775761503a9cfce07782a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-api/default.nix
+++ b/distros/iron/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-iron-phidgets-api";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_api/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "60ca50199b6ce96e8c75bc8a29f4c7a0066c32a323b4ff10e8be77008202ee77";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_api/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "136f1c3fa6a5c5f6aeedea8b0215cf76481f2c900558159c45ee69f52b4366b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-digital-inputs/default.nix
+++ b/distros/iron/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-digital-inputs";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_inputs/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "4d2c8a1667f15cad8623cfbc13b7981a1642e1c08e8fd009fd1ea664a4679d7e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_inputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "6d3587788deb7f9a5427dbce84ecf256207ff0ab18af4eef28b36727c9f0c443";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-digital-outputs/default.nix
+++ b/distros/iron/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-digital-outputs";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_outputs/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "feab1e59441dc6da2cc5e4ea6ea9cfc1f783c77a90c6901217d640187a31291b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_outputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "57e1f4216480af21aaf9d5a442fcff6359703aa426e82e3f68a1ec1086f16508";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-drivers/default.nix
+++ b/distros/iron/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-iron-phidgets-drivers";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_drivers/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "25e69d4a4a44b7d188dcf1c5d2a12568f5ec9225838f5d5e71efabfb074b8961";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_drivers/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "d3bc49b5c6a1101ccac4954da7a4f1dc4c2d44bafaddc2f08398d9dae674bee8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-gyroscope/default.nix
+++ b/distros/iron/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-gyroscope";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_gyroscope/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "c67c99be54307517f3dd541759557f793c70e1049e6849800db21f634ff78a20";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_gyroscope/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "f75efc7558ba579a552fb1b4a3914faf4dd84d8903f48b100eac9ac1f40fbed2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-high-speed-encoder/default.nix
+++ b/distros/iron/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-high-speed-encoder";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_high_speed_encoder/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "b84c3bb7b4ce9689983e302c328ec25fd53d4c9885117778ec9317e4033af54b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "02d9e3c5c32d2f763ae47e24b975c740cd742ab8b645d649a342fa4a215e136d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-ik/default.nix
+++ b/distros/iron/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-ik";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_ik/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "dbc4bf694d575640e7d9e48ba73f2f848d25b860b46d2e197bd8648d63d829d0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_ik/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "78e073adfe1adf1d0b90a163c6e05277da9a3889907efb51adc09b18a3988440";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-magnetometer/default.nix
+++ b/distros/iron/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-magnetometer";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_magnetometer/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "6b414cc98eebb9bec6647e6ac7de43fa99b6c95a788007e4864d577d22f6e742";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_magnetometer/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "62acf1e3cf99cc27b2a0ba3472ed3eec26912f9f520e1f433f490dd159af85cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-motors/default.nix
+++ b/distros/iron/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-motors";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_motors/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "b2277859661787ba92eb45634b2d289dda45e9432467f209f3d6cd2a0f124254";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_motors/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "28b56a9db4b195732f6b151084a371be5e961e9e5e5c4b858f939f00757c5fe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-msgs/default.nix
+++ b/distros/iron/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-msgs";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_msgs/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "2fa86a3f9b3d784aa071e75cbc988b1e36212edff0434959f354359c5b59ef83";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "a838f173127f2f123067ca280cb8a68b17d60888f390dc2061014ee477d3fbc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-spatial/default.nix
+++ b/distros/iron/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-spatial";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_spatial/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "69d4a8cc8e79e34e48032a3cfecac31e13e05be3165704c45d38a592b31043d3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_spatial/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "12e7cc27ac1e373401a186653f31fea536596a3a5583b6a0ed7c68c5a825b430";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-temperature/default.nix
+++ b/distros/iron/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-temperature";
-  version = "2.3.1-r3";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_temperature/2.3.1-3.tar.gz";
-    name = "2.3.1-3.tar.gz";
-    sha256 = "ef23a22f84609076e9d515003c11e57342de36db554040057dede9aa48904937";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_temperature/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "f468564c332b2c0183dd49e393822f059ae711f8b3edd8eef7632dbfd746e9d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/pinocchio/default.nix
+++ b/distros/iron/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-iron-pinocchio";
-  version = "2.6.17-r5";
+  version = "2.6.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/iron/pinocchio/2.6.17-5.tar.gz";
-    name = "2.6.17-5.tar.gz";
-    sha256 = "e465b86204b3ad62ccb95bc4e019a15ec633a5e6ab2c492d783713ffe71947ad";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/iron/pinocchio/2.6.21-1.tar.gz";
+    name = "2.6.21-1.tar.gz";
+    sha256 = "6f607d11aa9c767088ad693dc02dc10be9185c39827207efb4bcd30b68644571";
   };
 
   buildType = "cmake";

--- a/distros/iron/point-cloud-interfaces/default.nix
+++ b/distros/iron/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-interfaces";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "efbab54f34c68b9bb9f3a529bf04df56ecf5d17d0088a82ee87265dd8c45cb12";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "97ff96776d27d52a1f413c712b2de441860fcb50cf03e96baa0e4fdb4db2fe1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport-plugins/default.nix
+++ b/distros/iron/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-plugins";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "3d8d5f8963eef58eee86c41d23f9658df39edcd6a5f0811f379aa2d016b081c4";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f4cad28fe8d9bb0e1a405b391086252945562818a4f703f3b6b7f9bfd3178e4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport-py/default.nix
+++ b/distros/iron/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-py";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "0cd9de660ac96621b7ad1f759a1a673b249f699c66f58eb48bab6680bb514bd5";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "adc014731e370f93e372c811442504a49c454c5a273bd2d35429bc4a13b2e904";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport/default.nix
+++ b/distros/iron/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e4fc94ffb0513e508876da035ffc2685e471e24bf4953c1222d12bc345444c86";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a14e8e645e9e2878ac3cb52bb5d7345c0c41896d4851f27af643edae5c5db47e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "fe8934c2ba2be02ac593ae8be10294929a9056302a7ee6c528ac2513370b3b09";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "914b3d21edd14cb716e217d46b78bb334744b315602f3fe60857a3d0e0c896bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/py-trees-js/default.nix
+++ b/distros/iron/py-trees-js/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, qt5 }:
+buildRosPackage {
+  pname = "ros-iron-py-trees-js";
+  version = "0.6.4-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/iron/py_trees_js/0.6.4-3.tar.gz";
+    name = "0.6.4-3.tar.gz";
+    sha256 = "6bdb4ab4a1f7f0b084bdd04516e76179a473c3fc59815b3acf5164fcec74381a";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools qt5.qttools.dev ];
+  propagatedBuildInputs = [ python3Packages.pyqt5 python3Packages.pyqtwebengine ];
+
+  meta = {
+    description = ''Javascript library for visualising behaviour trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/range-sensor-broadcaster/default.nix
+++ b/distros/iron/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-range-sensor-broadcaster";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "ed61f2752afb038993bd5b2055811adc9f2187b7d981a3f08470f778d485b4c5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "08e2bd8f667dec311878188ed0c9daf519ccdc6b7236f6880648865a6c2308a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robot-calibration-msgs/default.nix
+++ b/distros/iron/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration-msgs";
-  version = "0.8.0-r3";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration_msgs/0.8.0-3.tar.gz";
-    name = "0.8.0-3.tar.gz";
-    sha256 = "4925c656bf34a541871b82f17af2fc8d26f149ddb68513305391e90c764891a2";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "c2b3f063003e105595d0bfa5540ec61fb4e9327ce6857d4641a8c9a458e35ea1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robot-calibration/default.nix
+++ b/distros/iron/robot-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration";
-  version = "0.8.0-r3";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration/0.8.0-3.tar.gz";
-    name = "0.8.0-3.tar.gz";
-    sha256 = "42e5025488c3a5680c8050a1522177cc343ae12141c8b42a8ce380c6c259390a";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "64d1f08611c4db7e99e4d751a683df59d6e0a16c287ccc56fa2027c8dc4f80fd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros tinyxml-2 tinyxml2-vendor visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "525a54a95b24cd3763ec57dd58b3dfabaeb9edc8faa969fae38030269dee6206";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "05541ca2663a6bb80f2556eb7f6b42a76ecf3704554da4629cca930420354cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "a62117119befae9c08209a8f1d7fcfc30ebe4a9c2ec775c655926523e6386f82";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "9f5e788df5b192b0153b641b704e5e7880994e7e0c925b0f5c4cde2d809f0431";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "bd7eea3c1b0b9e8f84c6b41bfb612d7e858cd820dc68c974b8ca75896d298a69";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "fe2ed9589eddbad33fa64d0d765b9d30c570845e40a2641b92c9c93d4a69f972";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "1324cbb58bb66af8b04c069d4e30531e095e6d102e6a73f104c67160af60466b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "30b44ba75420d084c5531b7b2872bdc9dead951df57beb0323d85cae047ddfea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "d4a82ec7c98a635e5d9e01cf872eb54e8a77a6eb44e9b50955b41ed616319f0c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "50cbaf45e27a7fcad176e1d53e7db4ecce41174da366e5c0891a39cba409c41d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "06a4829bace9b0645b29bad794d8bd78ea3cec50104d7ee757c8074400924170";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "8c49f2ccbb5ad1a1112db0b0883bbd7e6227e0544f643a95c249eae7cdd281e3";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "388e342ffab51259e1b734f22fb2169001ac72a9e0c5720eed828d25cc9a439d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "b9237955f9545af89efca8312ca5431fddf7b286ff487cce4ff5d122e72a5ffa";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rsl/default.nix
+++ b/distros/iron/rsl/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, clang, doxygen, eigen, fmt, git, range-v3, rclcpp, tcb-span, tl-expected }:
+{ lib, buildRosPackage, fetchurl, clang, doxygen, eigen, fmt, git, range-v3, rclcpp, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-rsl";
-  version = "0.2.2-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/RSL-release/archive/release/iron/rsl/0.2.2-2.tar.gz";
-    name = "0.2.2-2.tar.gz";
-    sha256 = "b75e089f109ae376e15949e8789cb947591e616c236c379730ea3a20738a3f20";
+    url = "https://github.com/ros2-gbp/RSL-release/archive/release/iron/rsl/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "638007e2ec7405c4cea87cb6a8f1b450d87ee223edb79999dc8e2c6255930f5c";
   };
 
-  buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros doxygen git ];
-  checkInputs = [ clang range-v3 ];
+  buildType = "catkin";
+  buildInputs = [ doxygen ];
+  checkInputs = [ clang git range-v3 ];
   propagatedBuildInputs = [ eigen fmt rclcpp tcb-span tl-expected ];
-  nativeBuildInputs = [ ament-cmake-ros doxygen git ];
+  nativeBuildInputs = [ doxygen ];
 
   meta = {
     description = ''ROS Support Library'';

--- a/distros/iron/sick-safevisionary-driver/default.nix
+++ b/distros/iron/sick-safevisionary-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
 buildRosPackage {
   pname = "ros-iron-sick-safevisionary-driver";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_driver/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "0ea1cd240972637ac20c1075854bf3f545d0509e84f80572f14135dadfe34ae7";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_driver/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "6e88f1e3fa21377f02ac37ed066a275074714d3b4a0b84a6abcaa207c936de3a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ cv-bridge lifecycle-msgs rclcpp rclcpp-lifecycle sensor-msgs sick-safevisionary-base sick-safevisionary-interfaces ];
+  propagatedBuildInputs = [ boost cv-bridge lifecycle-msgs rclcpp rclcpp-lifecycle sensor-msgs sick-safevisionary-base sick-safevisionary-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/sick-safevisionary-interfaces/default.nix
+++ b/distros/iron/sick-safevisionary-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-sick-safevisionary-interfaces";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_interfaces/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "408b47dd875927a06112deaa13939776281f1410b30f3d5f51436b5b8dd30801";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_interfaces/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "675f43ffc28d323f31e63f3d29fa7f291fee707954db17b3758bd27224439d99";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/sick-safevisionary-tests/default.nix
+++ b/distros/iron/sick-safevisionary-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing-ament-cmake, sick-safevisionary-driver }:
 buildRosPackage {
   pname = "ros-iron-sick-safevisionary-tests";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_tests/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "27c814b28fb520ec3812e2c43a9c6f9f6449662254f0ccf3d3a0f4ded7c312e4";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/iron/sick_safevisionary_tests/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "893885426b8cc012213793a5d6ec11edea9a2915ea8a1299d8ddc1378e35dd58";
   };
 
   buildType = "catkin";

--- a/distros/iron/spinnaker-camera-driver/default.nix
+++ b/distros/iron/spinnaker-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-iron-spinnaker-camera-driver";
+  version = "2.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "a0b0ca2fa1e38b01d0e0440962c973a0472e4df95f79faf1b063c4bd99eb91a5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake curl dpkg python3Packages.distro ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver for flir spinnaker sdk'';
+    license = with lib.licenses; [ "Apache-2" bsdOriginal ];
+  };
+}

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "db3aaa4b28f84efbe8f4cb6d1d47978c478bcc1225f550b2722f4641defd2f27";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "f8a2c596fa7f0f92ab7e6eb46155ba2062ffeff112dd3658868fb4bf80e9e4f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/topic-tools-interfaces/default.nix
+++ b/distros/iron/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-topic-tools-interfaces";
-  version = "1.0.0-r3";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools_interfaces/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "a7a4d73fdf60b9d55656500b129f51d579b359d76da9c9646f7f70c48aec8ac5";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools_interfaces/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "86e44b753d2b8e3cf529d0833cfcc7dc1f108c2dedaa89f11f3b9bb877ace4dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/topic-tools/default.nix
+++ b/distros/iron/topic-tools/default.nix
@@ -2,25 +2,26 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-iron-topic-tools";
-  version = "1.0.0-r3";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "900f7bd204ab7b94757cf01ee18fdc3dc2fa84e2bc13cf3e8041d71d8c4bc49e";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/iron/topic_tools/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fa82a964f6cde5f571e72ba730698d0cd28a1d34e17647c947ea94f0fab7a86a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Tools for directing, throttling, selecting, and otherwise messing with
+    ROS 2 topics at a meta level.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.21.1-r1";
+  version = "3.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.21.1-1.tar.gz";
-    name = "3.21.1-1.tar.gz";
-    sha256 = "439b269ce60eb33eb61d95ea5e01643f913ace02a4c41076fadef051388a26db";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.21.2-1.tar.gz";
+    name = "3.21.2-1.tar.gz";
+    sha256 = "d751974c7dd174da7b3a99b7b5c6febd3baaf0d0ee5296574b87b1bdfe05e949";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "2736a592ecab0fe13d55d7470e623604bed2592ec740eebd6c9f16d29314aba1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "9157d4aff0b15afc55d4e4b48f31e2c895c005a8cc0bf15c70ac9946a14dccba";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "2135a143cf2f373bacd97ed19c3568959ea86a632703dccb3d89d0081501d9a6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "6f624e4b91340bd34dc910ddb3000fa36484f46a9e57b0b49b26d3f601999cda";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-calibration/default.nix
+++ b/distros/iron/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-ur-calibration";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "7b8b5d44a5a5f580a54e02d4ec9dcc52117c3ba782cba44a4a2b4ad179c55aef";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "b470e928030f90c05ceec77fab36a38b8cab9d38565e233d27f8ea2e2fbe6dc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-controllers/default.nix
+++ b/distros/iron/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-iron-ur-controllers";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "b4f05d7b296b32ccf7431128d6b66c5ac34f556f250f20cfef71aeeaa254a22c";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "456ca7e78dffa23c0fa0c3de1d25dae38a24c7f9c8e23cfbc84cdbc2892590d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-dashboard-msgs/default.nix
+++ b/distros/iron/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ur-dashboard-msgs";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "95a407902a8b7bae6c8a11da32283f88ac04156617c83ae5b0395db118ffd33b";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "bfdfe6604b1b34d3ea20523ff4a785efdaa0d1987ba0e45e8b6534a016020ba5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-description/default.nix
+++ b/distros/iron/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-description";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/iron/ur_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "f6bdb6093dbc4e7a4e0b69d18df29c81cfdf6d5448f5b545d06f0fd990049a6e";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/iron/ur_description/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "b31b9dfe864c81ecdf3745d5484ffc4b3756b80b392e1681c72777a87fe7fefe";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-moveit-config/default.nix
+++ b/distros/iron/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-moveit-config";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "65d6677c6b19fe2acbf3110c93f61baa7c341a95ee70a9e1de26e82853aec3a9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "b69bc73ec619e201ab0badd0ee8e1561994c1f5cabbec8fa8109472e7a26c6f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur/default.nix
+++ b/distros/iron/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-iron-ur";
-  version = "2.3.4-r1";
+  version = "2.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.4-1.tar.gz";
-    name = "2.3.4-1.tar.gz";
-    sha256 = "f137a5d9b56f19541011db330f394550ea4446b63a8f330dc0519538affd0eb4";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.5-1.tar.gz";
+    name = "2.3.5-1.tar.gz";
+    sha256 = "9f812e3d5a8921e56b48d8cc9e810f060a5938733ab1903dcd4a08f09dcd489a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/usb-cam/default.nix
+++ b/distros/iron/usb-cam/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-iron-usb-cam";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/iron/usb_cam/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "1c8fcacc133ee976ab1a2dd0548d22b705dc7559713004a257ad6c8ff45b4936";
+    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/iron/usb_cam/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "6da595c744ec3625f39eae74d6b12d281000fad66750a7d527522ef86234be97";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  buildInputs = [ ament-cmake-auto ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces camera-info-manager cv-bridge ffmpeg image-transport image-transport-plugins rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {
-    description = ''A ROS 2 Driver for V4L USB Cameras'';
+    description = ''A ROS Driver for V4L USB Cameras'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.18.0-r1";
+  version = "3.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.18.0-1.tar.gz";
-    name = "3.18.0-1.tar.gz";
-    sha256 = "5a663becba48c764ff86c1c99400bb8a1da42e2f393f22a7920e610f05419734";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.19.2-1.tar.gz";
+    name = "3.19.2-1.tar.gz";
+    sha256 = "5efad60dbf6a158d6d0faac8ec7656d77fcc75d361a250080bbac8af2295f21a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zlib-point-cloud-transport/default.nix
+++ b/distros/iron/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-zlib-point-cloud-transport";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "3668dcb35b9082e55c91bcb6a761a7f3c87236fa5cf3f521e12bb711cde3fe44";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "23b9d0a89b2760da78107b7f785a5407f5da0de3a4663786424f81931ccca70c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zstd-point-cloud-transport/default.nix
+++ b/distros/iron/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-iron-zstd-point-cloud-transport";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "6118c1c44d7b86dc02f356387624a50e3770ad9fc473ed4bcf3a575baab024bf";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "9d0f6d22a840c638be548a585c3960d61e6585a3a699caeb9b9487a35fcc2c4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/aruco-opencv-msgs/default.nix
+++ b/distros/noetic/aruco-opencv-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-aruco-opencv-msgs";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "f2ec4432d036c31d83337541414cba41cf75fc4d4431ea321c0dd6c8f0c59ed3";
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e48a3384affa57d6a2c5525da24009e0e209c526f9aaa801a5e6685daa727aef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/aruco-opencv/default.nix
+++ b/distros/noetic/aruco-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aruco-opencv-msgs, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, python3Packages, roscpp, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-aruco-opencv";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "7aa3964e42462c94d26e3050b9442e70b4423754f1bcd7cedff45bfc91616e32";
+    url = "https://github.com/fictionlab-gbp/aruco_opencv-release/archive/release/noetic/aruco_opencv/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d77b153af83108c26acb37dea319cc3b1afc6d06a83139f30d26a19e69e7ca0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp/default.nix
+++ b/distros/noetic/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ros-environment, roslib, sqlite }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "f96332c54c9baef01333e079b7dbeffd95ec371c6c98faa8e72241da143ad9bc";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/noetic/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "879f1202c11a95f16a36348f212e8092598221ea2f6daba6a6fa15ba57cfe586";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.9.2-r1";
+  version = "3.1.4-r5";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "97f080c09f6bd8bd89245fe09e6e64627b4f780a7e443063f9c89e98e55e59a6";
+    url = "https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/3.1.4-5.tar.gz";
+    name = "3.1.4-5.tar.gz";
+    sha256 = "9ae9a2834ca7badd4dfd4e59a76f4b567667ecabc2a9efbf9800f931c4d8ac0e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eiquadprog/default.nix
+++ b/distros/noetic/eiquadprog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-eiquadprog";
-  version = "1.2.5-r1";
+  version = "1.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/noetic/eiquadprog/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "345aec2ab0fb04454100d4d7a75b9e30b91355efe9b8796be2a584a61debae3e";
+    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/noetic/eiquadprog/1.2.8-1.tar.gz";
+    name = "1.2.8-1.tar.gz";
+    sha256 = "7f12972f351a6125c79d8b930091b8c0e3da411ee0e4104352e0210954a5a6ad";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ess-imu-driver/default.nix
+++ b/distros/noetic/ess-imu-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-noetic-ess-imu-driver";
+  version = "1.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/cubicleguy/ess_imu_driver-release/archive/release/noetic/ess_imu_driver/1.0.1-3.tar.gz";
+    name = "1.0.1-3.tar.gz";
+    sha256 = "ae04d77e0518c622a232fb9470b284cd52668129a932bf2bc161d20d249f306f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package for Epson IMU based on C++ wrapper of Linux C driver'';
+    license = with lib.licenses; [ bsd3 publicDomain ];
+  };
+}

--- a/distros/noetic/eus-assimp/default.nix
+++ b/distros/noetic/eus-assimp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, euslisp, pkg-config, roseus }:
 buildRosPackage {
   pname = "ros-noetic-eus-assimp";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "0fb75b49127281e801e04d76051da15d7a8c2eac4fbf4505d63b09a99850d865";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eus_assimp/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "6bca597963ebcd3f77a08289df6812a9bbfafc48a79d96136912a9bb3fed6d8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/euscollada/default.nix
+++ b/distros/noetic/euscollada/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, catkin, cmake-modules, collada-dom, collada-parser, collada-urdf, mk, openhrp3, pr2-description, qhull, resource-retriever, rosboost-cfg, rosbuild, roscpp, roseus, rospack, rostest, tf, urdf, urdfdom, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-euscollada";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "b5fa910e58ddba38c42ae3063d931e0d4c4793693522cb946e431708ac502dbb";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/euscollada/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "4cc47dbe2143b21e17f6d26f40a793b22f8bf204cc3148a12d0a6fc6e014ce58";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eusurdf/default.nix
+++ b/distros/noetic/eusurdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, collada-urdf-jsk-patch, gazebo-ros, python3Packages, roseus, rostest }:
 buildRosPackage {
   pname = "ros-noetic-eusurdf";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "ddc05b743572e8dc8e9ac5ed0b1898030cd1603dcab5483db037d8074f728532";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/eusurdf/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ad87f0f2c6612ab871b380e767c33ee36d9e17b6e3272a0ccd634e620d29bfff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-msgs/default.nix
+++ b/distros/noetic/foxglove-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-msgs";
-  version = "2.1.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "bc1f40409bf7589dc2d894001df400ffd1d12f40e7b6df34491f711719a4eecd";
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3be5332f073870ea4cc16a10744397e3d151d7608fc9a855adca94700a2dcf38";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -858,6 +858,8 @@ self: super: {
 
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
 
+ ess-imu-driver = self.callPackage ./ess-imu-driver {};
+
  ess-imu-ros1-uart-driver = self.callPackage ./ess-imu-ros1-uart-driver {};
 
  ethercat-grant = self.callPackage ./ethercat-grant {};
@@ -1533,6 +1535,8 @@ self: super: {
  jsk-pcl-ros = self.callPackage ./jsk-pcl-ros {};
 
  jsk-pcl-ros-utils = self.callPackage ./jsk-pcl-ros-utils {};
+
+ jsk-planning = self.callPackage ./jsk-planning {};
 
  jsk-pr2eus = self.callPackage ./jsk-pr2eus {};
 
@@ -2340,6 +2344,12 @@ self: super: {
 
  pcl-ros = self.callPackage ./pcl-ros {};
 
+ pddl-msgs = self.callPackage ./pddl-msgs {};
+
+ pddl-planner = self.callPackage ./pddl-planner {};
+
+ pddl-planner-viewer = self.callPackage ./pddl-planner-viewer {};
+
  people = self.callPackage ./people {};
 
  people-msgs = self.callPackage ./people-msgs {};
@@ -2946,6 +2956,8 @@ self: super: {
 
  rosbag-pandas = self.callPackage ./rosbag-pandas {};
 
+ rosbag-rviz-panel = self.callPackage ./rosbag-rviz-panel {};
+
  rosbag-snapshot = self.callPackage ./rosbag-snapshot {};
 
  rosbag-snapshot-msgs = self.callPackage ./rosbag-snapshot-msgs {};
@@ -3372,6 +3384,8 @@ self: super: {
 
  sick-tim = self.callPackage ./sick-tim {};
 
+ sick-visionary-ros = self.callPackage ./sick-visionary-ros {};
+
  simple-grasping = self.callPackage ./simple-grasping {};
 
  simple-message = self.callPackage ./simple-message {};
@@ -3521,6 +3535,8 @@ self: super: {
  system-fingerprint = self.callPackage ./system-fingerprint {};
 
  tablet-socket-msgs = self.callPackage ./tablet-socket-msgs {};
+
+ task-compiler = self.callPackage ./task-compiler {};
 
  taskflow = self.callPackage ./taskflow {};
 
@@ -3699,6 +3715,8 @@ self: super: {
  ubnt-airos-tools = self.callPackage ./ubnt-airos-tools {};
 
  udp-com = self.callPackage ./udp-com {};
+
+ udp-msgs = self.callPackage ./udp-msgs {};
 
  um6 = self.callPackage ./um6 {};
 

--- a/distros/noetic/hpp-fcl/default.nix
+++ b/distros/noetic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-hpp-fcl";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "6c8603a350d88152a207554f03ca38622e3c686b27975f726fea54e56cad315b";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "261992262b7bc03ee17c6ab1465f77cf3c531c1b4bb43ac18124829921e0fa1c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/jsk-model-tools/default.nix
+++ b/distros/noetic/jsk-model-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eus-assimp, euscollada }:
 buildRosPackage {
   pname = "ros-noetic-jsk-model-tools";
-  version = "0.4.4-r2";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.4-2.tar.gz";
-    name = "0.4.4-2.tar.gz";
-    sha256 = "01078b70b2d69d83a5a531d05c4f546d557a8281c6376a3e090aa274df68173b";
+    url = "https://github.com/tork-a/jsk_model_tools-release/archive/release/noetic/jsk_model_tools/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5606e0d782c584bbf5c7e4744731c8b8eb0e504ed638478022cd4f9399dc3f33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-planning/default.nix
+++ b/distros/noetic/jsk-planning/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pddl-msgs, pddl-planner, pddl-planner-viewer, task-compiler }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-planning";
+  version = "0.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/noetic/jsk_planning/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "64a533802960ec4640626146cb89c273987b6d3e81bf4900507271774408c92b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ pddl-msgs pddl-planner pddl-planner-viewer task-compiler ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains planning package for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e48f54d4b664f349c66cfb3dd8365ae35318aa764c2fb64bcd307b5b03a1a130";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "6f7f6dfe7c964dcc87434885850967cf04e0f73efbb9dd1aed98b3f7cf1c353a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mqtt-client-interfaces/default.nix
+++ b/distros/noetic/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client-interfaces";
-  version = "2.1.0-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "80c9b0430c76f135a292d909b39169260f06df6872f6d9ac09c43ba89e641cd9";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client_interfaces/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "6675f85695f6ea7aaaa39113e986e088bf53b0c9d03379034268bfc7c1c470a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mqtt-client/default.nix
+++ b/distros/noetic/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mqtt-client-interfaces, nodelet, paho-mqtt-cpp, ros-environment, roscpp, rosfmt, std-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client";
-  version = "2.1.0-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b2032fc0f1e2d26f2094b6985b7aa58ec024631728bdf84d03a37d5a87920fc1";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "5434f3f30f25a1434dc28db0efad124fef097437d69331866bc64b7a6684c9c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "15f937aa6ab57ea455cf1f139ecab86764bda9d170259008572437f8559f98f6";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "da830d876d68128f6e2754025fa47a8184f9369425b61898cf60437531ea6952";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, rviz-plugin-tutorials, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "dae2f3f7e815e8d0b7c31ab68a9902503ee551de2c34e01c6681d3581ab52253";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "e3e380560a24df29bdb4e1618f9c4b44d62ebd748cec861f1bfbba1b66945d80";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cmake ros-environment ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ boost cppzmq dynamic-reconfigure mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 roscpp sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
+  propagatedBuildInputs = [ boost cppzmq dynamic-reconfigure mrpt2 nav-msgs protobuf python3 python3Packages.pip python3Packages.protobuf pythonPackages.pybind11 roscpp rviz-plugin-tutorials sensor-msgs tf2 tf2-geometry-msgs unzip visualization-msgs wget ];
   nativeBuildInputs = [ catkin cmake ];
 
   meta = {

--- a/distros/noetic/paho-mqtt-cpp/default.nix
+++ b/distros/noetic/paho-mqtt-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, openssl, paho-mqtt-c }:
 buildRosPackage {
   pname = "ros-noetic-paho-mqtt-cpp";
-  version = "1.2.0-r4";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/paho.mqtt.cpp-release/archive/release/noetic/paho-mqtt-cpp/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "08cfe92bbf29546b435398dc32db9c53974f2d14151d188dc59113aa595af360";
+    url = "https://github.com/nobleo/paho.mqtt.cpp-release/archive/release/noetic/paho-mqtt-cpp/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "65a0282890c8f752dd1a7a41af0173b0f2256d825fa12e1608a3c1aea5540249";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pddl-msgs/default.nix
+++ b/distros/noetic/pddl-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-pddl-msgs";
+  version = "0.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/noetic/pddl_msgs/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "49e500b417f282438e50e47b126c78fc68a0ba9858485645ea4f98bd15e79099";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''message for pddl planner'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pddl-planner-viewer/default.nix
+++ b/distros/noetic/pddl-planner-viewer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pddl-planner }:
+buildRosPackage {
+  pname = "ros-noetic-pddl-planner-viewer";
+  version = "0.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/noetic/pddl_planner_viewer/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "b4f1beaec161cfa11dea92f4f9f4185729470dd4c82f7cce4ced1745c0646135";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ pddl-planner ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''a viewer of pddl_planner.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pddl-planner/default.nix
+++ b/distros/noetic/pddl-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, downward, ff, ffha, lpg-planner, pddl-msgs, rospy, time }:
+buildRosPackage {
+  pname = "ros-noetic-pddl-planner";
+  version = "0.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/noetic/pddl_planner/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "69c76ac33a969f267d3208d16b46717e9aa5b5d5ce7c03c228eb2a8bc9b49a16";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ actionlib downward ff ffha lpg-planner pddl-msgs rospy time ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''pddl planner wrappers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "f1b502a28407596f0f9261c30a2686e717fbd69ff6a6d45d578330ac03f3f04c";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "8085344f3a271328e2ab17eee91c26d5d30271b0025b79b2508ba7b27cdcb160";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "f80086174b1d6a8a9ad72a0be4e2842acb7b8156304db3df00520d0717632ae0";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "47309ebea0e71e9cfe5268a64e1c060ad653d612e7c75ced9f994718e34f0893";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-outputs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1a83d3123875dd400f76c98147c2e5b8be2fb854edc33bc2e5365aadc90c4669";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "9e37ee97d06875556179553175f1c809acfdba9892a24b2efd6c2f5dca00b6aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5a759ef7c8c7a1ad567566e70235648146c789360887db2e536229accb091c70";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "c9253eb517be349ae393958d4713bdf698e8e0cde10de78099c5db5fde34441b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "9f4a4a127262a6c206898a2abb106bcc602e11a10db0c82a49eb7bf9adf4f41f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "fa69386af49d7847e4e7b4a8620415e00a2f3dff28cb16fd42a43fa5e75d28aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "ea2729411e37f4fa6c54437c55ccedf447a223468180bf76124bffadea125511";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "d8d849b2d0ae65eec75080c58e78de5607d1cfbdccc4fbdbeb9a8b2b552ddb9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "78b6ccc5a4eaf9feb8ac081e8d4a7bfcd90b9ff2fc64bed9e421a342f57427c9";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "570610ae7e8377d3c613127797533178d8e34637b7fe5f69c53397081dcf1eff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "17b212f2b7c64e615f3f61890b5a8a53c2e9c509e217b0df3d3cd1f452843f9b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "0ec6b91f3f777277f94b73087cae6671796c4fb5a08ea19d13c72dba7a293bd6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0bd76446f8a718fec75258c31bf5a10df86a3427ea051a303273ce86388d2e01";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "4f39aaf04e9638710a8db22ba2e0ac2ae3a892639aff0c83b6bff81b62da5f3d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0699a8cae0ec2fa1436cc1862dbee1e60d0bb6e1672963a5d713e7b04e492652";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "a1d80e0e81dec854f28245cd2b15484c52c9d11b3dc1ae87ec72751cf5659b94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "bc5ae579c625fb193cc121ccf2771011e5f44b0ab771d5717376b24e720cf3f1";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "472670f7a6fe7c538173873537227c32573528ba96f4cdb8cfde7c887f53f3e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c408b0dcd3d5477faec04533d55a6e8764395e3a2af84c681e006367343a4d51";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "14b6a856bdba644c2f2e475a26c0baf26dd1e3f867e1d074efdd9676fc06342a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5234032d4f29e61cee3587b351a6fa38bbf7bc33ce50683d4a1c18f661b44327";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "c145ac3cd922918f02630e908e794ae4f246f979a2afcd9c7d6c47b87fd26aaf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d4f2d810bf8691a2f469f4f137e2fcc08edd9c5068e0a57fa9ba04b3171390da";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "753bde2f729fe8b93dd41c8098cf4aca73185fcda0ab92888fe911c1d62ffd00";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.7-r1";
+  version = "1.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e2c3523940818f3d1bd682aee170f5662177cba241910847d4f64c838d9783fa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.8-2.tar.gz";
+    name = "1.0.8-2.tar.gz";
+    sha256 = "2fcb7ab02afb1c7781448688d996405200e5742aff2e77ae044022117b3917b9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.17-r1";
+  version = "2.6.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.17-1.tar.gz";
-    name = "2.6.17-1.tar.gz";
-    sha256 = "98e07f341b3610441b36dd0aa1dc6bcf38b4cc381b364682778f999102a77d7b";
+    url = "https://github.com/stack-of-tasks/pinocchio-ros-release/archive/release/noetic/pinocchio/2.6.21-1.tar.gz";
+    name = "2.6.21-1.tar.gz";
+    sha256 = "e80ecb8675edae2f5651c4b722fc9807096042c51b463b1e0381f47261ed6afb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, plotjuggler, qt5, ros-type-introspection, rosbag-storage, roscpp, roscpp-serialization, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "0288b7d6b123ce827873df51c9a0ed519e6c962e92ae960a40fb9048afab98db";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8578f8bb447761bba79ca0a8ed071668e987422402e4b46961a5bc3812dca47a";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler plotjuggler-msgs qt5.qtbase qt5.qtsvg qt5.qtwebsockets rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ binutils boost plotjuggler qt5.qtbase qt5.qtsvg qt5.qtwebsockets ros-type-introspection rosbag-storage roscpp roscpp-serialization tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, qt5, roscpp, roslib, zstd }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, protobuf, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.8.0-r1";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "0a9ef8780865c526f9ab48770aa527cb9ec68b846fb535c58110b0e659f2b360";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "5252e088ebf95df64438c392838763068962275f0900bdd28e111a5dce510479";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ binutils boost cppzmq lz4 qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib zstd ];
+  propagatedBuildInputs = [ binutils boost cppzmq lz4 protobuf qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras roscpp roslib zstd ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
-  version = "2.7.4-r1";
+  version = "2.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.4-1.tar.gz";
-    name = "2.7.4-1.tar.gz";
-    sha256 = "6518a9a73a1c4e5046366b74aa9c0f586089535676b4a644085c633ec6447431";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.5-1.tar.gz";
+    name = "2.7.5-1.tar.gz";
+    sha256 = "d1414c2fe217759515e8ede82d674060aba7a898da82e5bff3cd1268c0fa5714";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-rviz-panel/default.nix
+++ b/distros/noetic/rosbag-rviz-panel/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, rosbag, roscpp, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-rosbag-rviz-panel";
+  version = "0.1.9-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fada-catec/rosbag_rviz_panel-release/archive/release/noetic/rosbag_rviz_panel/0.1.9-2.tar.gz";
+    name = "0.1.9-2.tar.gz";
+    sha256 = "673bfa2317ef103b5f0093cdacf3da62e6f56c912a23c2be1a1f84e60564f333";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ pluginlib qt5.qtbase rosbag roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rosbag_rviz_panel package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/sick-scan-xd/default.nix
+++ b/distros/noetic/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslib, rospy, rviz, sensor-msgs, std-msgs, tf, tf2, tf2-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan-xd";
-  version = "3.0.3-r1";
+  version = "3.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "e2290874d3c137e0a9ef0a6fea0034034f4dac952599a339857c4a448714d9e1";
+    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.1.5-1.tar.gz";
+    name = "3.1.5-1.tar.gz";
+    sha256 = "6eed40eceaa8dc9bda5c547ade68486317d454d51f005a6bacaf379d67023cce";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-visionary-ros/default.nix
+++ b/distros/noetic/sick-visionary-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, pcl, pcl-conversions, pcl-ros, roscpp, roslaunch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sick-visionary-ros";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_visionary_ros-release/archive/release/noetic/sick_visionary_ros/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1f3fe4c97bf170f9121a5814902edb7cd3eb03d931eb07b0e964c75f4de28166";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ cv-bridge image-transport pcl pcl-conversions pcl-ros roscpp roslaunch sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Open source drivers for the SICK Visionary-S 3D camera and Visionary-T Mini 3D-ToF camera.'';
+    license = with lib.licenses; [ "Unlicense" ];
+  };
+}

--- a/distros/noetic/task-compiler/default.nix
+++ b/distros/noetic/task-compiler/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pddl-planner, roseus-smach, rostest, smach-viewer }:
+buildRosPackage {
+  pname = "ros-noetic-task-compiler";
+  version = "0.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/noetic/task_compiler/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "19c4acf423090951fea4b0278a5323073e0cf8eccb95cd7f65cda76cfaba88ec";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pddl-planner roseus-smach smach-viewer ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''task_compiler
+
+     Compiler that translate task description in PDDL (Planning Domain Description Language) to SMACH (state machine based execution and coordination system) description.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/udp-msgs/default.nix
+++ b/distros/noetic/udp-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-udp-msgs";
+  version = "0.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/flynneva/udp_msgs-release/archive/release/noetic/udp_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "39fc480ca735fca400aa241c2cb26e34bc140e01f7228afa36e05bf99a9aca47";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ message-generation message-runtime ros-environment std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS / ROS2 udp_msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "e39c9454a43b615cc951ba7e6dc2c93450a4f5e3a15d6944c00f397d54490bc1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "8c43129364f700b8331becaeaa80bb31b045ac0a51f099fe2cdc506321114543";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "7c3448e0c69e37d53a0ceae43b807be1fb0f58a74913c40249d039e3135e567f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "846e6cca5614ea028a3c1b2ace0c6724ee87cdd5148aad3a31bccb45664c6cba";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/behaviortree-cpp/default.nix
+++ b/distros/rolling/behaviortree-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, cppzmq, rclcpp, ros-environment, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-behaviortree-cpp";
-  version = "4.4.1-r1";
+  version = "4.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.1-1.tar.gz";
-    name = "4.4.1-1.tar.gz";
-    sha256 = "4c1d8002fb3c969a14f6edfb31903269e88d8e2f2627565bbdd477eab947e63a";
+    url = "https://github.com/ros2-gbp/behaviortree_cpp_v4-release/archive/release/rolling/behaviortree_cpp/4.4.2-1.tar.gz";
+    name = "4.4.2-1.tar.gz";
+    sha256 = "a589b465440463fd63ebebbd7da876321f731954ba26f72b4642ec9a0764dff0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "24aa21e922c864e3504ecfcaa4bb6591f2efbe936a70fb05f784e8400c92c613";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "f027c9018dd5814d2a4bf74c4bdb13c515aa9727db732390666eda612fec2912";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "278d67e5f979b74b478130a5d6551b9dadcad01f7a19e246ea7cac9f7317614e";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c9d3dab494187a55e7dc672313833b600bc7acf8907c68157edd8d8a083aed24";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
-  propagatedBuildInputs = [ control-msgs rclcpp rcutils realtime-tools ];
+  propagatedBuildInputs = [ control-msgs filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "74ddf2d68ae35dfd52de561b055a0440809fc5750f3200b8c9ae7ab0ce643471";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "14c47ce10f06d408ce444e95dae69aa8a2e70d022304d1deb4c6ee188fc4362f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "284128a9927cfdea53e0a34dfca39668253819618a11918441e189458af9bd61";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "f51e521e6117a11a308cc40a25244351f7c9ef1ad0718fd7e64e0ad3ffb1b369";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "6ea7cc485e49bb408025898c81e37de7ef90ec0295fd2bd0f0f85f1d0d014ba3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "da24f5ed24aafae60a9bb3cd710b7af01aada900d4d507552dc90d62d00042d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "1b499972745d0f3c03f763eef67683661c6e886daf016b94b1dd04e27dcc695b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "059fb9ce963b5f6c86b435465a47d8f5f2dc61a0648417c890c36bd71f304a82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "89bd60e2e7b65cdbb8cf62082b0815f58d6ec2ff009f75b3b988ddeb6912e16e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "76d131dc59c84bea3f8e906ef7bde21311d40a1aa117bae83ebef883c16e61bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/eigenpy/default.nix
+++ b/distros/rolling/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-eigenpy";
-  version = "2.9.2-r4";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/rolling/eigenpy/2.9.2-4.tar.gz";
-    name = "2.9.2-4.tar.gz";
-    sha256 = "2eaf4de4c158065b9ce0e3e0cd5aaaa8d1015d47592f4029b547d7dd1296a11b";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/rolling/eigenpy/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "6542bf4242ab5b4c41ca3cbf48fd898de31498758d4a3362a0b0bb439f0772d1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps";
-  version = "2.11.2-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "1096d672a0afe6c3f8991dd6c8028ca43384229d20b74fe7cf7cdaa7885b1967";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "810166c75a6ececec422e09c1920279505a8b36a4117f2f8715b4b2b5ec1c323";
   };
 
   buildType = "cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "e68c32991fb6bf7035634854e17acb7c0d1204246f8374ab108352e90937ffc0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "c87926a776c945f702b9012cccd25ce271951b8ba34d386299a8194ab35d4a0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "9f0b8e68be314ad93b32d43c83dcbbecfd492d895b6ee3fc42e15b230a34bb3e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "eff452898b7e938ad50620f7a46e8e48c0ab57f050aa28e0c5a7c3ef409acd35";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -640,6 +640,8 @@ self: super: {
 
  iceoryx-hoofs = self.callPackage ./iceoryx-hoofs {};
 
+ iceoryx-introspection = self.callPackage ./iceoryx-introspection {};
+
  iceoryx-posh = self.callPackage ./iceoryx-posh {};
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
@@ -1038,8 +1040,6 @@ self: super: {
 
  nao-lola-command-msgs = self.callPackage ./nao-lola-command-msgs {};
 
- nao-lola-conversion = self.callPackage ./nao-lola-conversion {};
-
  nao-lola-sensor-msgs = self.callPackage ./nao-lola-sensor-msgs {};
 
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
@@ -1103,6 +1103,10 @@ self: super: {
  osrf-testing-tools-cpp = self.callPackage ./osrf-testing-tools-cpp {};
 
  ouster-msgs = self.callPackage ./ouster-msgs {};
+
+ ouster-ros = self.callPackage ./ouster-ros {};
+
+ ouster-sensor-msgs = self.callPackage ./ouster-sensor-msgs {};
 
  ouxt-common = self.callPackage ./ouxt-common {};
 
@@ -1170,6 +1174,8 @@ self: super: {
 
  picknik-twist-controller = self.callPackage ./picknik-twist-controller {};
 
+ pid-controller = self.callPackage ./pid-controller {};
+
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
@@ -1211,6 +1217,8 @@ self: super: {
  position-controllers = self.callPackage ./position-controllers {};
 
  py-trees = self.callPackage ./py-trees {};
+
+ py-trees-js = self.callPackage ./py-trees-js {};
 
  py-trees-ros = self.callPackage ./py-trees-ros {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "57ba622c58aa180001ceba845d23c6212e08342abba200c4e767e6563ce63fe4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "600843a412b92f83d5a042a01ab170d4af6e1467da0b2b49a5d3fc5d12722f0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "4fd38e06cad1f298bcfe35fdaa06a1a9d1e36aa1ee6a2d52179c6ca4e8568335";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "619f93b5c69955263e3789aaa0baca12456122c9e93f7a8d0bf527f1f4837c02";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hpp-fcl/default.nix
+++ b/distros/rolling/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-hpp-fcl";
-  version = "2.3.0-r4";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.3.0-4.tar.gz";
-    name = "2.3.0-4.tar.gz";
-    sha256 = "5664758636bdb165af79b25c802e2144f09d3628921d2ddab5aa12885633d72e";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e551b0cec7a802bd5797db41241a1f34a9ce0190b74f9c7bb5183f5fac3b577b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-binding-c/default.nix
+++ b/distros/rolling/iceoryx-binding-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-binding-c";
-  version = "2.0.3-r3";
+  version = "2.0.5-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_binding_c/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "5b4ecce5fddaf9c275836ea8f810e7f2179bdf7d4c726831975a54848b804a92";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_binding_c/2.0.5-3.tar.gz";
+    name = "2.0.5-3.tar.gz";
+    sha256 = "54896972fb49094eb9bc1883ab79d5093c585981e911b4f41415ede69eb2ebe9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-hoofs/default.nix
+++ b/distros/rolling/iceoryx-hoofs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, acl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-hoofs";
-  version = "2.0.3-r3";
+  version = "2.0.5-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_hoofs/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "d7660920f45e98be253a7ff9c4ca4e82c5e08cc38bbae9cbc889a86cdad1e573";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_hoofs/2.0.5-3.tar.gz";
+    name = "2.0.5-3.tar.gz";
+    sha256 = "951ad8d2ab600580f5b8fb525cd479ef0b8a2126597576eb34bd87f1cb047935";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-introspection/default.nix
+++ b/distros/rolling/iceoryx-introspection/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh, ncurses }:
+buildRosPackage {
+  pname = "ros-rolling-iceoryx-introspection";
+  version = "2.0.5-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_introspection/2.0.5-3.tar.gz";
+    name = "2.0.5-3.tar.gz";
+    sha256 = "5e5f45a198265d3aa65fcb9eea40ece63ebc75858e04b106a01c941f15ca02ae";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ iceoryx-hoofs iceoryx-posh ncurses ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Eclipse iceoryx inter-process-communication (IPC) middleware introspection client'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/iceoryx-posh/default.nix
+++ b/distros/rolling/iceoryx-posh/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, iceoryx-hoofs }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-posh";
-  version = "2.0.3-r3";
+  version = "2.0.5-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_posh/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "a07b765db17858f483d8b9e529085b50646e4ce55273c15d815c6f055f406339";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_posh/2.0.5-3.tar.gz";
+    name = "2.0.5-3.tar.gz";
+    sha256 = "c7b57846612718ed759c609823a9bf17070798b6d42032a253fa6a0bc9a5b135";
   };
 
   buildType = "cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "0b7df44d9f467abf116558af4b66fae758809874c7e424560b0b93d7fa05a74c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "069954429b08250606a0f94f41aa9df9eb45d58a422fa67df25387c8a7b6df50";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "5af1e7b1e562ed42f89e07283bbab1cd42e979747644733f8d5cf479d9c6e559";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "38613c057d440c4904babb2bab4d1d99beb015f0a0afae1577f2624a70282373";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "8d9a16421033e34cc5248d38ca7bd4ac4f76b9dff43b2ff9c132a9c56fe09fd1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "377e9e9090922f0e4cd0d81b6a6a6e3cfd0599867581507b2811bd8c440ae4c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "8428ed935b8f2418c1a4bd1453d2152254a1419a08d0ed0b63ff72c9de096801";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "0939443816d45a3a8d5039c83ba0501eab6bd7a73af6c5989b52fcb92687d285";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libphidget22/default.nix
+++ b/distros/rolling/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-rolling-libphidget22";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/libphidget22/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "ca439f85a951b0f91ba7e2d4d3b22edcf0e4a4a2ce1dfb45be7ddc0074e91c0f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/libphidget22/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "f03e11f5646c2d9565c946ca6b079a00e1f45f9a943956f4e5814df43f6454a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client-interfaces/default.nix
+++ b/distros/rolling/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client-interfaces";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a09e7743db3e21883c4fc4b3ddb7581a38eb67a34d8c1a1b4dd7e2e2eecbcfd8";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4a700b096cfca0f84891ec9cfa92dba7fec15a4896750aeaf046bda668b71204";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client/default.nix
+++ b/distros/rolling/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f856d8486ffde2d4eeeabfa38f8c5445b7288953492fe638c30b05a4a8a58892";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2a0092ff5b01d6ebcfa279b34d593753c1e114fe15afd385a0c5965869d96ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.11.2-r1";
+  version = "2.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "f8ca3b535c16d6a393f438869e1e5e6d351be736e8764e23f55c883d76596e80";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.3-1.tar.gz";
+    name = "2.11.3-1.tar.gz";
+    sha256 = "d6c2256c679d1d8882a5356d4eb6e4ae35e47ae529239d50c9328d218abef25a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "4dfd8ead9b42262b452fed3441a1f920029109cb83fa631a5feb061ea4008c8b";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "080fecd537d76550bb761798889bff2a4597c4742f510d6772bc9e73b10c6448";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nao-lola-client/default.nix
+++ b/distros/rolling/nao-lola-client/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-lola-command-msgs, nao-lola-sensor-msgs, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-lola-command-msgs, nao-lola-sensor-msgs, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nao-lola-client";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_client/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6b2235348d33557255df3070ffc3efb619ecd4825103b51575f7f0bf2f69680a";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_client/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f43aa630282399906fc7a368e1493922df9419b0af00660f0ed4406db8ea23b1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost nao-lola-command-msgs nao-lola-sensor-msgs rclcpp ];
+  propagatedBuildInputs = [ boost nao-lola-command-msgs nao-lola-sensor-msgs rcl-interfaces rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/nao-lola-command-msgs/default.nix
+++ b/distros/rolling/nao-lola-command-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nao-lola-command-msgs";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_command_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "0d572a7d989cc707837bdfbb04668b5f995bbc0042814c90fc2ef1b59a095f35";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_command_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "c153116b645ac627c94c91637d9a0e123e4443a037bab922ce4ea64a4b34a456";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nao-lola-sensor-msgs/default.nix
+++ b/distros/rolling/nao-lola-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-nao-lola-sensor-msgs";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_sensor_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "82d62a11a1268120cf5d84922e030a59a18e4b5042a3c76384a8fe47ebd16393";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola_sensor_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8b1cec8e1b57a146b23fb877f0a790b4a3ddc28a7c85ccaef3ee53b38cf01a3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nao-lola/default.nix
+++ b/distros/rolling/nao-lola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-nao-lola";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "42397772debdab838c8e4b495327928011d50299230f4d653e8702d9b9ad5a86";
+    url = "https://github.com/ros2-gbp/nao_lola-release/archive/release/rolling/nao_lola/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "14a061bf6eea8b4c673c2034cbacfe454a63c8186e77d3f776c193cb82f4b094";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ouster-ros/default.nix
+++ b/distros/rolling/ouster-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, curl, eigen, geometry-msgs, gtest, jsoncpp, launch, launch-ros, libtins, ouster-sensor-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, spdlog, std-msgs, std-srvs, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-ouster-ros";
+  version = "0.11.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ouster-ros-release/archive/release/rolling/ouster_ros/0.11.1-4.tar.gz";
+    name = "0.11.1-4.tar.gz";
+    sha256 = "9d59c51c89662f2dd2f2968b24fff73fb9286ebd47f0ecdd226daa8fd0d83b88";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen pcl rosidl-default-generators tf2-eigen ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ curl geometry-msgs jsoncpp launch launch-ros libtins ouster-sensor-msgs pcl-conversions pcl-ros rclcpp rclcpp-components rclcpp-lifecycle rosidl-default-runtime sensor-msgs spdlog std-msgs std-srvs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Ouster ROS2 driver'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ouster-sensor-msgs/default.nix
+++ b/distros/rolling/ouster-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-ouster-sensor-msgs";
+  version = "0.11.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ouster-ros-release/archive/release/rolling/ouster_sensor_msgs/0.11.1-4.tar.gz";
+    name = "0.11.1-4.tar.gz";
+    sha256 = "a86f19e5ae511f1bccd5953c41a8a90b327c6043c08802123ad089db9cb7819f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ouster_ros message and service definitions'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/phidgets-accelerometer/default.nix
+++ b/distros/rolling/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-accelerometer";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_accelerometer/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "88c5f3a98178f7e0a44a8e9e09f8e47170b4c74004f5a70bc8ab1e383c6130d6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_accelerometer/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "0e77720ccc06d2fce8347479b25360d147a66b5fbd325d753157b3b7a4026b25";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-analog-inputs/default.nix
+++ b/distros/rolling/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-analog-inputs";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_inputs/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "e7ce88d8f9d5c041c0ca997845724249302c217a0ca5f27358d74adb4d27c421";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_inputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "a0d61be3663cf4dc497882c6216a845e73e45422eff617d1a9f06c88c73250b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-analog-outputs/default.nix
+++ b/distros/rolling/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-analog-outputs";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_outputs/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "e504c915ad3e9fdb0698b191c0f02a9298c15d01052cdb72fa57bbc412fed8c5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_outputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "ac0ea869b95f7ca35a3b86c5ba58d6b74b7ea7146272b1dd7f7cf0451b68a8eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-api/default.nix
+++ b/distros/rolling/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-api";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_api/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "450e6d3a01c8cde62e12c35c5f2e3849a8975a832193689c8985c948430f32c3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_api/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "6050d027aed8c1d5916a667560a095bd0d59549ede1d028b24c8a019189443f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-digital-inputs/default.nix
+++ b/distros/rolling/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-digital-inputs";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_inputs/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "51d05c2c17d0df8847044bbc6ad09fa0abeb1e7a8f0a2aedd68125e64b5a1748";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_inputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "8826a5d7a879e96886f2fd7049f54acc85b50090b357b976ce6f4061f7a45790";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-digital-outputs/default.nix
+++ b/distros/rolling/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-digital-outputs";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_outputs/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "72c323403eba272f35571f40b5289ecbf20b7c86db9abf13b31af12d84902523";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_outputs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "b19da304e73bda049fc479e948eb3181d4fb975e7a9122d3dee998776bd27c56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-drivers/default.nix
+++ b/distros/rolling/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-drivers";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_drivers/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "d59c0b7fc887903827b152e687e4820ba98e782f45b714ce6f1fab6ebc47006d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_drivers/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "7ba320cc4c66f801290b725abc988f182dc7542d62535ffaeccf98c3aa1f3ad2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-gyroscope/default.nix
+++ b/distros/rolling/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-gyroscope";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_gyroscope/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "ea2bfcad352346128fc083956f801809237d430c9db127cc6cc245d6d34a649c";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_gyroscope/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "dee11b7783a61aa3f1fcb0c296b79cd4e5ce268a6681cf14e585b85cd15a7d2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-high-speed-encoder/default.nix
+++ b/distros/rolling/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-high-speed-encoder";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_high_speed_encoder/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "b567b644380d2628746a6610210e7f882da04614158bc5d130bc8cb5b27602a6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "1efa580bc97649eedfa1974a84924acbc7788422b430cc5c90a51d8dc2335205";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-ik/default.nix
+++ b/distros/rolling/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-ik";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_ik/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "642d3bcec98c44d03ce526867e44986bd0b165c8cebe544a6d564ec075440e80";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_ik/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "20b80f92d9007f719fb666c4028accd0e8438bce10c76af48eaf216582feba97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-magnetometer/default.nix
+++ b/distros/rolling/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-magnetometer";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_magnetometer/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "6791e50528f02decd01ae11979c23fea174be55c3ad32243451afb2b8aadfbd5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_magnetometer/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "af7a5e8bc252c91ba8345587a2cd24de54b341ef4db31feb9d7411ad6cf86b53";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-motors/default.nix
+++ b/distros/rolling/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-motors";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_motors/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "ee18f67f6f82511da07e7d20c7e668e08dcf43e374c29c23bc10637cfa7dc14a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_motors/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "fb805b78df8ee958096a7c7fd03f683a1d4f31a1a6aa19f17351e47029e313dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-msgs/default.nix
+++ b/distros/rolling/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-msgs";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_msgs/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "91c86634b71d92d3b3bdf44c171dc66da42ff52ccac591dcf6df9132539507b0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "9638d4a6ec0fc572e5546357d449e8d03e35d91765845265e127bce0087faa2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-spatial/default.nix
+++ b/distros/rolling/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-spatial";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_spatial/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "997299ab1746b32d91fd41d6af719bca88cd88c4453c0ff16447cb6197f93eca";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_spatial/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "ae058058c6561135b7b931eddddd6733e2f44d846cdf9fe8890ac87d5302097a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-temperature/default.nix
+++ b/distros/rolling/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-temperature";
-  version = "2.3.1-r2";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_temperature/2.3.1-2.tar.gz";
-    name = "2.3.1-2.tar.gz";
-    sha256 = "ff6d80b59f7f9e56948bbb5dc12ceef408253f3877229ef9964a1eb09632cc06";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_temperature/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "9203dfe859fc72f266c90449cf8f63cdb40ae1b06775aa4b8abe4786bd79362d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-pid-controller";
+  version = "4.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "dc16726e76c73a6fa75b6f80915ea0993a8df0f90a6de74c31a68f74486f84aa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface hardware-interface parameter-traits pluginlib rclcpp rclcpp-lifecycle realtime-tools std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller based on PID implememenation from control_toolbox package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/pinocchio/default.nix
+++ b/distros/rolling/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-pinocchio";
-  version = "2.6.17-r4";
+  version = "2.6.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/2.6.17-4.tar.gz";
-    name = "2.6.17-4.tar.gz";
-    sha256 = "cbb9d6eefc674eb4bbe25632037c4feb407f30e25cdb88623b016a15e5c281f8";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/2.6.21-1.tar.gz";
+    name = "2.6.21-1.tar.gz";
+    sha256 = "e2619e80fd27a0c178ba22a90047b46ed4ef43a8c813230bb89a196accb46d92";
   };
 
   buildType = "cmake";

--- a/distros/rolling/plotjuggler-ros/default.nix
+++ b/distros/rolling/plotjuggler-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, plotjuggler, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler-ros";
-  version = "1.7.3-r5";
+  version = "2.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/rolling/plotjuggler_ros/1.7.3-5.tar.gz";
-    name = "1.7.3-5.tar.gz";
-    sha256 = "cbbc462d1ad3471ac3a7651c3c6d4df0dcbe7f2e5793c63dde697fdaf8125782";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/rolling/plotjuggler_ros/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "ce540bc291b3bd691c732ade75998a5dfac2a7a1e4beda55ee6bc8ecd50a3b00";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ binutils boost diagnostic-msgs fastcdr geometry-msgs nav-msgs plotjuggler plotjuggler-msgs qt5.qtbase qt5.qtsvg qt5.qtwebsockets rclcpp rcpputils rosbag2 rosbag2-transport sensor-msgs tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ binutils boost plotjuggler qt5.qtbase qt5.qtsvg qt5.qtwebsockets rclcpp rcpputils rosbag2 rosbag2-transport tf2-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/plotjuggler/default.nix
+++ b/distros/rolling/plotjuggler/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, qt5, rclcpp, zstd }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler";
-  version = "3.7.1-r2";
+  version = "3.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.7.1-2.tar.gz";
-    name = "3.7.1-2.tar.gz";
-    sha256 = "bc5dc27f49d6bf32dfd24cf0ef1aa34bb57d31af9589bfa81dfe642351e45141";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.8.3-1.tar.gz";
+    name = "3.8.3-1.tar.gz";
+    sha256 = "fb367e865fc7d3a6fb4da87d773b03692f30d6131b0969f006d80ed792657ac9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq fastcdr lz4 qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq fastcdr lz4 protobuf qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras rclcpp zstd ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/point-cloud-interfaces/default.nix
+++ b/distros/rolling/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-interfaces";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "6cc77668f11090f490fd9818727b1cb9e297770aa9f5b040cc225727a7939622";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "e2d8b54ae4b00561fba791f1fd3e17eeedab9a772547eb765b9dcafc0ffd5740";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-plugins/default.nix
+++ b/distros/rolling/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-plugins";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "ef68183eee7d532e68d6ef69c017ffcd65b62c1805e4ef851efceeac5124fc4d";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "42a900962872e4d393ccb23356e0a60bbce4252274c5580ec18350ee9c4e48c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "4c7fe7010e69ebb90f08409b68814ed7813c5d28b50c018537156a39b6af7c98";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "bb2d4b35a649ba90d92edb38cdef20ab1d20c3f4fa92afa9ab35dad608569bd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "f762d01f3a63c0ce8c933c3a814ea41ceb1d6b663e40d051d05688a2289afffb";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "3554fafcdf11e73ba7c5a3c5b0376e000ab2c1f8c82d7d6650d432e537b59623";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "ea2dcbd9a3770d2bd25d911c7ad44be9e438670c23818ea31895c7e7a80d0616";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "6c64fd876b49ec1eb110695d67e69aa6ba7ee05bf90e49e5494c99b674438ae6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/py-trees-js/default.nix
+++ b/distros/rolling/py-trees-js/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2023 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, qt5 }:
+buildRosPackage {
+  pname = "ros-rolling-py-trees-js";
+  version = "0.6.4-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/rolling/py_trees_js/0.6.4-2.tar.gz";
+    name = "0.6.4-2.tar.gz";
+    sha256 = "38bfaefa608c8252fdff7fb64c37458904f0adc9f6f0ebbe52c7e77452a98f04";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools qt5.qttools.dev ];
+  propagatedBuildInputs = [ python3Packages.pyqt5 python3Packages.pyqtwebengine ];
+
+  meta = {
+    description = ''Javascript library for visualising behaviour trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "ea692b470abfad027f5fb89f78d7271b2c9e1694ae096f5d2638c492a4008d3c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "b3b3058ac1f1c9eb809ccfa21c1bc74fb4e41efc8a436a8dc01199de7127f346";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-calibration-msgs/default.nix
+++ b/distros/rolling/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration-msgs";
-  version = "0.8.0-r2";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration_msgs/0.8.0-2.tar.gz";
-    name = "0.8.0-2.tar.gz";
-    sha256 = "42c57b0e93106af6e653508f0d866c25b49e0277eaca85bfbccb014db7f5427e";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "675b73eb562e24d0cb58840d14fd6d3fb4413bb66d6b87ddc883c62cdc66dce4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-calibration/default.nix
+++ b/distros/rolling/robot-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, visualization-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration";
-  version = "0.8.0-r2";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration/0.8.0-2.tar.gz";
-    name = "0.8.0-2.tar.gz";
-    sha256 = "023149b5effaa6fe55e609f6d00d46721b67a1212c8496df6b1bdce2ae8da2e9";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "4237e47ab7341d0db5ab1bae62b000772f4942879417f7056f2193d6d8db8a8f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake boost eigen ];
   checkInputs = [ ament-cmake-gtest launch launch-ros launch-testing ];
-  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros visualization-msgs yaml-cpp ];
+  propagatedBuildInputs = [ camera-calibration-parsers ceres-solver control-msgs cv-bridge geometric-shapes geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf rclcpp rclcpp-action robot-calibration-msgs rosbag2-cpp sensor-msgs std-msgs suitesparse tf2-geometry-msgs tf2-ros tinyxml-2 tinyxml2-vendor visualization-msgs yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "995bbea4f35fa8948b0f5c69a7363bd39bff72da36cd0c573848a550fd18c2a8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "0a6b1738dffe82d22fbae1f924a20c4779a022682641971a4f94299d45fbdb59";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "1fd2a348f2f35e0220511ea15ab5444d7130ced8d55eac99f618e1c5bb47db6c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "9b7c361b27182362f27449fca7b5d0ea0707e3eb2b505d236715b75e6d688e1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "d897ded997f6b80324a2ddebdeca33152fab688ec9371f7075f318f36860d48a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "22f37a7ce361b178f6ffe7791b7e69b1181c9a1a19f37c1189a00506a098872e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "2c5461f681e54610fc8a5c886a6c4be5104e43fdfd8071bb811bb5b874935c9f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "2d9c65de19652056bda5bba8eac526356acc019495f9870fd4e71933b80288f3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller pid-controller position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "cadaaa3273efd78d950e3c51cc7c312faffc323529d627eba68d183dbb8eeaa1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "80e3ea5f05238b70de4f6e726d53a27e77cc7d3079805b767ee3791d5286de2d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "3c185f0f30d0de929389e4ee6f07daf9986efb67159c60b16bf5234565c4ea0b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "037428d490725282195184bbf4a9a6b8a8d760bd1c83bdfb1616d89bc0147d49";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "9179277263ceccafb6f4df1333a88ee0cf782370599a412ffc8fdbc7cabe4494";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "51117ed617c98a4d423e73d7cc50b0650fc695cc0beb826c3cc91141a49982bf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rsl/default.nix
+++ b/distros/rolling/rsl/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, clang, doxygen, eigen, fmt, git, range-v3, rclcpp, tcb-span, tl-expected }:
+{ lib, buildRosPackage, fetchurl, clang, doxygen, eigen, fmt, git, range-v3, rclcpp, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-rsl";
-  version = "0.2.2-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/RSL-release/archive/release/rolling/rsl/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "9b49ad5f45221c9ff22e97cba92c9238ec694ef218963caeafda19c1b269287e";
+    url = "https://github.com/ros2-gbp/RSL-release/archive/release/rolling/rsl/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a854297851b2e745278cbb1f63409b782cb57d2da3611d787563e0af8fce018f";
   };
 
-  buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros doxygen git ];
-  checkInputs = [ clang range-v3 ];
+  buildType = "catkin";
+  buildInputs = [ doxygen ];
+  checkInputs = [ clang git range-v3 ];
   propagatedBuildInputs = [ eigen fmt rclcpp tcb-span tl-expected ];
-  nativeBuildInputs = [ ament-cmake-ros doxygen git ];
+  nativeBuildInputs = [ doxygen ];
 
   meta = {
     description = ''ROS Support Library'';

--- a/distros/rolling/sick-safevisionary-driver/default.nix
+++ b/distros/rolling/sick-safevisionary-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, lifecycle-msgs, rclcpp, rclcpp-lifecycle, sensor-msgs, sick-safevisionary-base, sick-safevisionary-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-sick-safevisionary-driver";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_driver/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b7104ce41ea54b715db4dd8744c86b57924de240acde5028328b4cf11205444e";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_driver/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "1d53498f3e413723315d0898c12a6d376c6670f7c23f1478f9128ed76075807f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sick-safevisionary-interfaces/default.nix
+++ b/distros/rolling/sick-safevisionary-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sick-safevisionary-interfaces";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_interfaces/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "87d8b44cde31dc26c329d0b986759783b8cbe4faa4194e64f4a4c51ef7268351";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_interfaces/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "47ad375a18b5e88315d2ab688af7f3e813b59e3a41e9961d638f079c7891739f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sick-safevisionary-tests/default.nix
+++ b/distros/rolling/sick-safevisionary-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing-ament-cmake, sick-safevisionary-driver }:
 buildRosPackage {
   pname = "ros-rolling-sick-safevisionary-tests";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_tests/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b27f46eec5108c3819f4439c20c95683310c5f89e8afa81ce6818afc33542c89";
+    url = "https://github.com/ros2-gbp/sick_safevisionary_ros2-release/archive/release/rolling/sick_safevisionary_tests/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "0f42abe4d628898f9a3a77d7dd303f1fa2bf4df33ed454aad562f83782d7f375";
   };
 
   buildType = "catkin";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "5bdb76bff0132f33a1c9bb84ec58ce273d8058b6ccc80a5ab894459613364256";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "4fa900c681a297440d3dba9755a11d54ca963ad26fe9659b6e7a620af9c5f477";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools-interfaces/default.nix
+++ b/distros/rolling/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools-interfaces";
-  version = "1.0.0-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "c18405d7e69e1e8df081606eedbbcbb783426656a449cf33f141286d48dc79ce";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "3712ae9a44b6338554d76b3d86522a9d52c0c6aa16be985237bbdca928a1f09f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools/default.nix
+++ b/distros/rolling/topic-tools/default.nix
@@ -2,25 +2,26 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools";
-  version = "1.0.0-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "9760e2039641c2a27684abf58f87813105c663bdd2fc5c56681147423aa51689";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "e38ccdb246e8a2764c80a366931c5612ec33e0801f6355a354735d05e5e37ef2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Tools for directing, throttling, selecting, and otherwise messing with
+    ROS 2 topics at a meta level.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "414e33768b15c1293ce269a846b2fb966fabd807f3a2f5c868b6d950eae0b3d3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "b15fa520811ce6135ea6c784aa656aaa88b6e7d04e7b197318e430999f95c8bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "b0b3bf14c5491148bad423adae89b49d121b80d8aabd659160eaec36c1244215";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "f3817aab27f36ac47fab6b03b4c5b0101073ba965659904970068bd049b87b6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "59e73a03e6f298c17ece3804efbf5e0a768b3ce8d3ff160eafafba3e79bcb055";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "a49c185375cc258b19e9af1cddaa71c8f0805b0e86a2949e908fe774db4c1d0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/usb-cam/default.nix
+++ b/distros/rolling/usb-cam/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2023 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, cv-bridge, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-rolling-usb-cam";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/rolling/usb_cam/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "f3ebaf94bd5d35d03432c515e13e5d6972db8e0ff83890e28aa6f5c45d090101";
+    url = "https://github.com/ros2-gbp/usb_cam-release/archive/release/rolling/usb_cam/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "24aeccf20fe3bc1c9bb3ffc973181261374e2fc6372e430289dc6d42c5b9cdb7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  buildInputs = [ ament-cmake-auto ros-environment rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces camera-info-manager cv-bridge ffmpeg image-transport image-transport-plugins rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {
-    description = ''A ROS 2 Driver for V4L USB Cameras'';
+    description = ''A ROS Driver for V4L USB Cameras'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.0.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "4c2640ce45f684010091f3428b15319bb7ae8c41ef4a25bde4e1f51f42304417";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "1bde97b9cdff35df665c401a0d737ecdf04cb6ccc40af8bc8858f3fbe1e3a86b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zlib-point-cloud-transport/default.nix
+++ b/distros/rolling/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zlib-point-cloud-transport";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "13944e28d1160e53bb962fc1d06d060aa78fd9833d8c1c8eb24e0ea00dfe35c3";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "666444d708b9b634abecbfa18d1308283eb6b0ff76cdf7a4ae2cc16de55f7bdf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-point-cloud-transport/default.nix
+++ b/distros/rolling/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-point-cloud-transport";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "dc56f67ac74edcc0792ced298b3c064d6b6ade21c1e4a5a898561dad2c0b5189";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "876616645f7f89efda15d264b48c32722b96c4689e40c794ab0f9b15e2659185";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 42cae93f39f0d26134a884a1ec20d1e36dd14f66.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.27.0-r1 --> 2.29.0-r1*
* *admittance-controller 2.27.0-r1 --> 2.29.0-r1*
* *aerostack2 1.0.5-r1 --> 1.0.6-r1*
* *as2-alphanumeric-viewer 1.0.5-r1 --> 1.0.6-r1*
* *as2-behavior 1.0.5-r1 --> 1.0.6-r1*
* *as2-behavior-tree 1.0.5-r1 --> 1.0.6-r1*
* *as2-behaviors-motion 1.0.5-r1 --> 1.0.6-r1*
* *as2-behaviors-perception 1.0.5-r1 --> 1.0.6-r1*
* *as2-behaviors-platform 1.0.5-r1 --> 1.0.6-r1*
* *as2-behaviors-trajectory-generation 1.0.5-r1 --> 1.0.6-r1*
* *as2-cli 1.0.5-r1 --> 1.0.6-r1*
* *as2-core 1.0.5-r1 --> 1.0.6-r1*
* *as2-gazebo-classic-assets 1.0.5-r1 --> 1.0.6-r1*
* *as2-keyboard-teleoperation 1.0.5-r1 --> 1.0.6-r1*
* *as2-motion-controller 1.0.5-r1 --> 1.0.6-r1*
* *as2-motion-reference-handlers 1.0.5-r1 --> 1.0.6-r1*
* *as2-msgs 1.0.5-r1 --> 1.0.6-r1*
* *as2-platform-crazyflie 1.0.5-r1 --> 1.0.6-r1*
* *as2-platform-dji-osdk 1.0.5-r1 --> 1.0.6-r1*
* *as2-platform-ign-gazebo 1.0.5-r1 --> 1.0.6-r1*
* *as2-platform-tello 1.0.5-r1 --> 1.0.6-r1*
* *as2-realsense-interface 1.0.5-r1 --> 1.0.6-r1*
* *as2-state-estimator 1.0.5-r1 --> 1.0.6-r1*
* *as2-usb-camera-interface 1.0.5-r1 --> 1.0.6-r1*
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *bicycle-steering-controller 2.27.0-r1 --> 2.29.0-r1*
* *clearpath-common 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-config 0.1.1-r1 --> 0.2.0-r2*
* *clearpath-control 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-description 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-generator-common 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-generator-gz 0.1.3-r1 --> 0.2.1-r1*
* *clearpath-gz 0.1.3-r1 --> 0.2.1-r1*
* *clearpath-mounts-description 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-msgs 0.0.4-r1 --> 0.2.0-r1*
* *clearpath-platform 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-platform-description 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-platform-msgs 0.0.4-r1 --> 0.2.0-r1*
* *clearpath-sensors-description 0.1.3-r1 --> 0.2.0-r1*
* *clearpath-simulator 0.1.3-r1 --> 0.2.1-r1*
* *control-toolbox 3.1.0-r1 --> 3.2.0-r1*
* *controller-interface 2.35.0-r1 --> 2.36.0-r1*
* *controller-manager 2.35.0-r1 --> 2.36.0-r1*
* *controller-manager-msgs 2.35.0-r1 --> 2.36.0-r1*
* *diff-drive-controller 2.27.0-r1 --> 2.29.0-r1*
* *effort-controllers 2.27.0-r1 --> 2.29.0-r1*
* *eigenpy 2.9.2-r1 --> 3.1.4-r1*
* *etsi-its-cam-coding 1.0.0-r2*
* *etsi-its-cam-conversion 1.0.0-r2*
* *etsi-its-cam-msgs 1.0.0-r2*
* *etsi-its-coding 1.0.0-r2*
* *etsi-its-conversion 1.0.0-r2*
* *etsi-its-denm-coding 1.0.0-r2*
* *etsi-its-denm-conversion 1.0.0-r2*
* *etsi-its-denm-msgs 1.0.0-r2*
* *etsi-its-messages 1.0.0-r2*
* *etsi-its-msgs 1.0.0-r2*
* *etsi-its-primitives-conversion 1.0.0-r2*
* *etsi-its-rviz-plugins 1.0.0-r2*
* *fields2cover 1.2.1-r1*
* *flir-camera-description 2.0.8-r1 --> 2.0.8-r2*
* *flir-camera-msgs 2.0.8-r1 --> 2.0.8-r2*
* *force-torque-sensor-broadcaster 2.27.0-r1 --> 2.29.0-r1*
* *forward-command-controller 2.27.0-r1 --> 2.29.0-r1*
* *gripper-controllers 2.27.0-r1 --> 2.29.0-r1*
* *hardware-interface 2.35.0-r1 --> 2.36.0-r1*
* *hpp-fcl 2.3.0-r1 --> 2.4.0-r1*
* *iceoryx-binding-c 2.0.3-r1 --> 2.0.5-r1*
* *iceoryx-hoofs 2.0.3-r1 --> 2.0.5-r1*
* *iceoryx-introspection 2.0.5-r1*
* *iceoryx-posh 2.0.3-r1 --> 2.0.5-r1*
* *imu-sensor-broadcaster 2.27.0-r1 --> 2.29.0-r1*
* *joint-limits 2.35.0-r1 --> 2.36.0-r1*
* *joint-state-broadcaster 2.27.0-r1 --> 2.29.0-r1*
* *joint-trajectory-controller 2.27.0-r1 --> 2.29.0-r1*
* *libphidget22 2.3.1-r1 --> 2.3.2-r1*
* *mqtt-client 2.1.0-r1 --> 2.2.0-r1*
* *mqtt-client-interfaces 2.1.0-r1 --> 2.2.0-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *mvsim 0.8.2-r1 --> 0.8.3-r1*
* *naoqi-driver 2.1.1-r1*
* *naoqi-libqicore 3.0.0-r1*
* *pal-urdf-utils 2.0.0-r1*
* *phidgets-accelerometer 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-analog-inputs 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-analog-outputs 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-api 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-digital-inputs 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-digital-outputs 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-drivers 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-gyroscope 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-high-speed-encoder 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-ik 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-magnetometer 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-motors 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-msgs 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-spatial 2.3.1-r1 --> 2.3.2-r1*
* *phidgets-temperature 2.3.1-r1 --> 2.3.2-r1*
* *pinocchio 2.6.17-r1 --> 2.6.21-r1*
* *plotjuggler 3.8.0-r1 --> 3.8.2-r1*
* *point-cloud-interfaces 1.0.8-r1 --> 1.0.9-r1*
* *point-cloud-transport 1.0.14-r1 --> 1.0.15-r1*
* *point-cloud-transport-plugins 1.0.8-r1 --> 1.0.9-r1*
* *point-cloud-transport-py 1.0.14-r1 --> 1.0.15-r1*
* *position-controllers 2.27.0-r1 --> 2.29.0-r1*
* *py-trees-js 0.6.4-r1*
* *range-sensor-broadcaster 2.27.0-r1 --> 2.29.0-r1*
* *robot-calibration 0.8.0-r1 --> 0.8.1-r1*
* *robot-calibration-msgs 0.8.0-r1 --> 0.8.1-r1*
* *ros2-control 2.35.0-r1 --> 2.36.0-r1*
* *ros2-control-test-assets 2.35.0-r1 --> 2.36.0-r1*
* *ros2-controllers 2.27.0-r1 --> 2.29.0-r1*
* *ros2-controllers-test-nodes 2.27.0-r1 --> 2.29.0-r1*
* *ros2controlcli 2.35.0-r1 --> 2.36.0-r1*
* *rqt-controller-manager 2.35.0-r1 --> 2.36.0-r1*
* *rqt-joint-trajectory-controller 2.27.0-r1 --> 2.29.0-r1*
* *rsl 0.2.2-r1 --> 1.0.1-r1*
* *sick-safevisionary-driver 1.0.1-r1 --> 1.0.3-r1*
* *sick-safevisionary-interfaces 1.0.1-r1 --> 1.0.3-r1*
* *sick-safevisionary-tests 1.0.1-r1 --> 1.0.3-r1*
* *spinnaker-camera-driver 2.0.8-r1 --> 2.0.8-r2*
* *steering-controllers-library 2.27.0-r1 --> 2.29.0-r1*
* *topic-tools 1.0.0-r2 --> 1.1.1-r1*
* *topic-tools-interfaces 1.0.0-r2 --> 1.1.1-r1*
* *transmission-interface 2.35.0-r1 --> 2.36.0-r1*
* *tricycle-controller 2.27.0-r1 --> 2.29.0-r1*
* *tricycle-steering-controller 2.27.0-r1 --> 2.29.0-r1*
* *ur-description 2.1.1-r1 --> 2.1.2-r1*
* *usb-cam 0.7.0-r1 --> 0.8.0-r1*
* *velocity-controllers 2.27.0-r1 --> 2.29.0-r1*
* *zlib-point-cloud-transport 1.0.8-r1 --> 1.0.9-r1*
* *zstd-point-cloud-transport 1.0.8-r1 --> 1.0.9-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.18.0-r1 --> 3.19.2-r1*
* *admittance-controller 3.18.0-r1 --> 3.19.2-r1*
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *bicycle-steering-controller 3.18.0-r1 --> 3.19.2-r1*
* *control-toolbox 3.0.0-r2 --> 3.2.0-r1*
* *controller-interface 3.21.1-r1 --> 3.21.2-r1*
* *controller-manager 3.21.1-r1 --> 3.21.2-r1*
* *controller-manager-msgs 3.21.1-r1 --> 3.21.2-r1*
* *diff-drive-controller 3.18.0-r1 --> 3.19.2-r1*
* *effort-controllers 3.18.0-r1 --> 3.19.2-r1*
* *eigenpy 2.9.2-r5 --> 3.1.4-r1*
* *etsi-its-cam-coding 1.0.0-r2*
* *etsi-its-cam-conversion 1.0.0-r2*
* *etsi-its-cam-msgs 1.0.0-r2*
* *etsi-its-coding 1.0.0-r2*
* *etsi-its-conversion 1.0.0-r2*
* *etsi-its-denm-coding 1.0.0-r2*
* *etsi-its-denm-conversion 1.0.0-r2*
* *etsi-its-denm-msgs 1.0.0-r2*
* *etsi-its-messages 1.0.0-r2*
* *etsi-its-msgs 1.0.0-r2*
* *etsi-its-primitives-conversion 1.0.0-r2*
* *etsi-its-rviz-plugins 1.0.0-r2*
* *flir-camera-description 2.0.8-r1*
* *flir-camera-msgs 2.0.8-r1*
* *force-torque-sensor-broadcaster 3.18.0-r1 --> 3.19.2-r1*
* *forward-command-controller 3.18.0-r1 --> 3.19.2-r1*
* *gripper-controllers 3.18.0-r1 --> 3.19.2-r1*
* *hardware-interface 3.21.1-r1 --> 3.21.2-r1*
* *hpp-fcl 2.3.0-r5 --> 2.4.0-r1*
* *iceoryx-binding-c 2.0.3-r5 --> 2.0.5-r1*
* *iceoryx-hoofs 2.0.3-r5 --> 2.0.5-r1*
* *iceoryx-introspection 2.0.5-r1*
* *iceoryx-posh 2.0.3-r5 --> 2.0.5-r1*
* *imu-sensor-broadcaster 3.18.0-r1 --> 3.19.2-r1*
* *joint-limits 3.21.1-r1 --> 3.21.2-r1*
* *joint-state-broadcaster 3.18.0-r1 --> 3.19.2-r1*
* *joint-trajectory-controller 3.18.0-r1 --> 3.19.2-r1*
* *libphidget22 2.3.1-r3 --> 2.3.2-r1*
* *mqtt-client 2.1.0-r1 --> 2.2.0-r1*
* *mqtt-client-interfaces 2.1.0-r1 --> 2.2.0-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *mvsim 0.8.2-r1 --> 0.8.3-r1*
* *naoqi-driver 2.1.0-r1 --> 2.1.1-r1*
* *phidgets-accelerometer 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-analog-inputs 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-analog-outputs 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-api 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-digital-inputs 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-digital-outputs 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-drivers 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-gyroscope 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-high-speed-encoder 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-ik 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-magnetometer 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-motors 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-msgs 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-spatial 2.3.1-r3 --> 2.3.2-r1*
* *phidgets-temperature 2.3.1-r3 --> 2.3.2-r1*
* *pinocchio 2.6.17-r5 --> 2.6.21-r1*
* *point-cloud-interfaces 2.0.2-r1 --> 2.0.3-r1*
* *point-cloud-transport 2.0.2-r1 --> 2.0.3-r1*
* *point-cloud-transport-plugins 2.0.2-r1 --> 2.0.3-r1*
* *point-cloud-transport-py 2.0.2-r1 --> 2.0.3-r1*
* *position-controllers 3.18.0-r1 --> 3.19.2-r1*
* *py-trees-js 0.6.4-r3*
* *range-sensor-broadcaster 3.18.0-r1 --> 3.19.2-r1*
* *robot-calibration 0.8.0-r3 --> 0.8.1-r1*
* *robot-calibration-msgs 0.8.0-r3 --> 0.8.1-r1*
* *ros2-control 3.21.1-r1 --> 3.21.2-r1*
* *ros2-control-test-assets 3.21.1-r1 --> 3.21.2-r1*
* *ros2-controllers 3.18.0-r1 --> 3.19.2-r1*
* *ros2-controllers-test-nodes 3.18.0-r1 --> 3.19.2-r1*
* *ros2controlcli 3.21.1-r1 --> 3.21.2-r1*
* *rqt-controller-manager 3.21.1-r1 --> 3.21.2-r1*
* *rqt-joint-trajectory-controller 3.18.0-r1 --> 3.19.2-r1*
* *rsl 0.2.2-r2 --> 1.0.1-r1*
* *sick-safevisionary-driver 1.0.1-r1 --> 1.0.3-r1*
* *sick-safevisionary-interfaces 1.0.1-r1 --> 1.0.3-r1*
* *sick-safevisionary-tests 1.0.1-r1 --> 1.0.3-r1*
* *spinnaker-camera-driver 2.0.8-r1*
* *steering-controllers-library 3.18.0-r1 --> 3.19.2-r1*
* *topic-tools 1.0.0-r3 --> 1.2.0-r1*
* *topic-tools-interfaces 1.0.0-r3 --> 1.2.0-r1*
* *transmission-interface 3.21.1-r1 --> 3.21.2-r1*
* *tricycle-controller 3.18.0-r1 --> 3.19.2-r1*
* *tricycle-steering-controller 3.18.0-r1 --> 3.19.2-r1*
* *ur 2.3.4-r1 --> 2.3.5-r1*
* *ur-calibration 2.3.4-r1 --> 2.3.5-r1*
* *ur-controllers 2.3.4-r1 --> 2.3.5-r1*
* *ur-dashboard-msgs 2.3.4-r1 --> 2.3.5-r1*
* *ur-description 2.1.1-r1 --> 2.1.2-r1*
* *ur-moveit-config 2.3.4-r1 --> 2.3.5-r1*
* *usb-cam 0.7.0-r1 --> 0.8.0-r1*
* *velocity-controllers 3.18.0-r1 --> 3.19.2-r1*
* *zlib-point-cloud-transport 2.0.2-r1 --> 2.0.3-r1*
* *zstd-point-cloud-transport 2.0.2-r1 --> 2.0.3-r1*

Noetic Changes:
---------------
* *aruco-opencv 0.3.1-r1 --> 0.4.0-r1*
* *aruco-opencv-msgs 0.3.1-r1 --> 0.4.0-r1*
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *eigenpy 2.9.2-r1 --> 3.1.4-r5*
* *eiquadprog 1.2.5-r1 --> 1.2.8-r1*
* *ess-imu-driver 1.0.1-r3*
* *eus-assimp 0.4.4-r2 --> 0.4.5-r1*
* *euscollada 0.4.4-r2 --> 0.4.5-r1*
* *eusurdf 0.4.4-r2 --> 0.4.5-r1*
* *foxglove-msgs 2.1.1-r1 --> 2.3.0-r1*
* *hpp-fcl 2.3.0-r1 --> 2.4.0-r1*
* *jsk-model-tools 0.4.4-r2 --> 0.4.5-r1*
* *jsk-planning 0.1.14-r1*
* *libphidget22 1.0.7-r1 --> 1.0.8-r2*
* *mqtt-client 2.1.0-r1 --> 2.2.0-r2*
* *mqtt-client-interfaces 2.1.0-r1 --> 2.2.0-r2*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *mvsim 0.8.2-r1 --> 0.8.3-r1*
* *paho-mqtt-cpp 1.2.0-r4 --> 1.3.1-r1*
* *pddl-msgs 0.1.14-r1*
* *pddl-planner 0.1.14-r1*
* *pddl-planner-viewer 0.1.14-r1*
* *phidgets-accelerometer 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-analog-inputs 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-analog-outputs 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-api 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-digital-inputs 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-digital-outputs 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-drivers 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-gyroscope 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-high-speed-encoder 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-ik 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-magnetometer 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-motors 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-msgs 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-spatial 1.0.7-r1 --> 1.0.8-r2*
* *phidgets-temperature 1.0.7-r1 --> 1.0.8-r2*
* *pinocchio 2.6.17-r1 --> 2.6.21-r1*
* *plotjuggler 3.8.0-r1 --> 3.8.3-r1*
* *plotjuggler-ros 1.7.0-r1 --> 2.0.0-r1*
* *robot-localization 2.7.4-r1 --> 2.7.5-r1*
* *rosbag-rviz-panel 0.1.9-r2*
* *sick-scan-xd 3.0.3-r1 --> 3.1.5-r1*
* *sick-visionary-ros 1.0.0-r1*
* *task-compiler 0.1.14-r1*
* *udp-msgs 0.0.4-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.0.0-r1 --> 4.2.0-r1*
* *admittance-controller 4.0.0-r1 --> 4.2.0-r1*
* *behaviortree-cpp 4.4.1-r1 --> 4.4.2-r1*
* *bicycle-steering-controller 4.0.0-r1 --> 4.2.0-r1*
* *control-toolbox 3.1.0-r1 --> 3.2.0-r1*
* *controller-interface 4.0.0-r1 --> 4.2.0-r1*
* *controller-manager 4.0.0-r1 --> 4.2.0-r1*
* *controller-manager-msgs 4.0.0-r1 --> 4.2.0-r1*
* *diff-drive-controller 4.0.0-r1 --> 4.2.0-r1*
* *effort-controllers 4.0.0-r1 --> 4.2.0-r1*
* *eigenpy 2.9.2-r4 --> 3.1.4-r1*
* *fastrtps 2.11.2-r1 --> 2.12.1-r1*
* *force-torque-sensor-broadcaster 4.0.0-r1 --> 4.2.0-r1*
* *forward-command-controller 4.0.0-r1 --> 4.2.0-r1*
* *gripper-controllers 4.0.0-r1 --> 4.2.0-r1*
* *hardware-interface 4.0.0-r1 --> 4.2.0-r1*
* *hpp-fcl 2.3.0-r4 --> 2.4.0-r1*
* *iceoryx-binding-c 2.0.3-r3 --> 2.0.5-r3*
* *iceoryx-hoofs 2.0.3-r3 --> 2.0.5-r3*
* *iceoryx-introspection 2.0.5-r3*
* *iceoryx-posh 2.0.3-r3 --> 2.0.5-r3*
* *imu-sensor-broadcaster 4.0.0-r1 --> 4.2.0-r1*
* *joint-limits 4.0.0-r1 --> 4.2.0-r1*
* *joint-state-broadcaster 4.0.0-r1 --> 4.2.0-r1*
* *joint-trajectory-controller 4.0.0-r1 --> 4.2.0-r1*
* *libphidget22 2.3.1-r2 --> 2.3.2-r1*
* *mqtt-client 2.1.0-r1 --> 2.2.0-r1*
* *mqtt-client-interfaces 2.1.0-r1 --> 2.2.0-r1*
* *mrpt2 2.11.2-r1 --> 2.11.3-r1*
* *mvsim 0.8.2-r1 --> 0.8.3-r1*
* *nao-lola 1.1.1-r1 --> 1.2.0-r1*
* *nao-lola-client 1.1.1-r1 --> 1.2.0-r1*
* *nao-lola-command-msgs 1.1.1-r1 --> 1.2.0-r1*
* *nao-lola-sensor-msgs 1.1.1-r1 --> 1.2.0-r1*
* *ouster-ros 0.11.1-r4*
* *ouster-sensor-msgs 0.11.1-r4*
* *phidgets-accelerometer 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-analog-inputs 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-analog-outputs 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-api 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-digital-inputs 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-digital-outputs 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-drivers 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-gyroscope 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-high-speed-encoder 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-ik 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-magnetometer 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-motors 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-msgs 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-spatial 2.3.1-r2 --> 2.3.2-r1*
* *phidgets-temperature 2.3.1-r2 --> 2.3.2-r1*
* *pid-controller 4.2.0-r1*
* *pinocchio 2.6.17-r4 --> 2.6.21-r1*
* *plotjuggler 3.7.1-r2 --> 3.8.3-r1*
* *plotjuggler-ros 1.7.3-r5 --> 2.0.0-r2*
* *point-cloud-interfaces 3.0.1-r1 --> 3.0.2-r1*
* *point-cloud-transport 3.0.1-r1 --> 3.0.2-r1*
* *point-cloud-transport-plugins 3.0.1-r1 --> 3.0.2-r1*
* *point-cloud-transport-py 3.0.1-r1 --> 3.0.2-r1*
* *position-controllers 4.0.0-r1 --> 4.2.0-r1*
* *py-trees-js 0.6.4-r2*
* *range-sensor-broadcaster 4.0.0-r1 --> 4.2.0-r1*
* *robot-calibration 0.8.0-r2 --> 0.8.1-r1*
* *robot-calibration-msgs 0.8.0-r2 --> 0.8.1-r1*
* *ros2-control 4.0.0-r1 --> 4.2.0-r1*
* *ros2-control-test-assets 4.0.0-r1 --> 4.2.0-r1*
* *ros2-controllers 4.0.0-r1 --> 4.2.0-r1*
* *ros2-controllers-test-nodes 4.0.0-r1 --> 4.2.0-r1*
* *ros2controlcli 4.0.0-r1 --> 4.2.0-r1*
* *rqt-controller-manager 4.0.0-r1 --> 4.2.0-r1*
* *rqt-joint-trajectory-controller 4.0.0-r1 --> 4.2.0-r1*
* *rsl 0.2.2-r1 --> 1.0.1-r1*
* *sick-safevisionary-driver 1.0.2-r1 --> 1.0.3-r1*
* *sick-safevisionary-interfaces 1.0.2-r1 --> 1.0.3-r1*
* *sick-safevisionary-tests 1.0.2-r1 --> 1.0.3-r1*
* *steering-controllers-library 4.0.0-r1 --> 4.2.0-r1*
* *topic-tools 1.0.0-r2 --> 1.3.0-r1*
* *topic-tools-interfaces 1.0.0-r2 --> 1.3.0-r1*
* *transmission-interface 4.0.0-r1 --> 4.2.0-r1*
* *tricycle-controller 4.0.0-r1 --> 4.2.0-r1*
* *tricycle-steering-controller 4.0.0-r1 --> 4.2.0-r1*
* *usb-cam 0.7.0-r1 --> 0.8.0-r1*
* *velocity-controllers 4.0.0-r1 --> 4.2.0-r1*
* *zlib-point-cloud-transport 3.0.1-r1 --> 3.0.2-r1*
* *zstd-point-cloud-transport 3.0.1-r1 --> 3.0.2-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

