### PR TITLE
Add packages to  pkgs to distro overlay

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -415,4 +415,5 @@ in self.lib.makeScopeWithSplicing
   ++ self.lib.optional (version == 2) (import ./ros2-overlay.nix self)
   ++ [
     (import (./. + "/${distro}/overrides.nix") self)
+    (import ../pkgs)
   ]) rosSelf {})


### PR DESCRIPTION
Hello, I share my workaround for #150 
I do not know what consequences it has but it  is what I am using to have access to `colcon`.
I have only tested with humble.

closes #150 