### PR TITLE
buildEnv: Add ROS version environment variables to wrapper

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -10,7 +10,7 @@
 #
 # By default, all binaries in the environment are wrapped, setting the relevant
 # ROS environment variables, allowing use outside of nix-shell.
-{ lib, stdenv, buildPackages, writeText, buildEnv, makeWrapper, python }:
+{ lib, stdenv, buildPackages, writeText, buildEnv, makeWrapper, python, ros-environment }:
 { paths ? [], wrapPrograms ? true, postBuild ? "", passthru ? { }, ... }@args:
 
 with lib;
@@ -63,6 +63,9 @@ let
             --prefix CMAKE_PREFIX_PATH : "$out" \
             --prefix AMENT_PREFIX_PATH : "$out" \
             --prefix ROS_PACKAGE_PATH : "$out/share" \
+            --set ROS_DISTRO '${ros-environment.rosDistro}' \
+            --set ROS_VERSION '${toString ros-environment.rosVersion}' \
+            --set ROS_PYTHON_VERSION '${lib.versions.major python.version}' \
             ''${rosWrapperArgs[@]}
         done
       fi


### PR DESCRIPTION
This PR adds some ROS version environment variables to the `buildEnv` wrapper. These variables are normally included by `nix-shell`, but are left out when building the wrapper.

ROS packages expect these variables to exist, and can fail when they are unset. `foxglove_bridge`, for example, crashes when `ROS_DISTRO` is unset.

See also:
- [REP 123: ROS_ETC_DIR, ROS_DISTRO environment variables and ROS_ROOT changes](https://ros.org/reps/rep-0123.html)
- [REP 149: Package Manifest Format Three Specification](https://ros.org/reps/rep-0149.html#environment-variables)