### PR TITLE
Add colcon-clean extension

### DIFF
--- a/pkgs/colcon/clean.nix
+++ b/pkgs/colcon/clean.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core, scantree }:
+
+buildPythonPackage rec {
+  pname = "colcon-clean";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4Xa2WiuckmDtkFBBTb2PUuxXr50tW6ou3Nu2WMQZOxk=";
+  };
+
+  propagatedBuildInputs = [ colcon-core scantree ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to clean package workspaces.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,6 +14,8 @@ self: super: with self.lib; let
 
       colcon-cargo = pyFinal.callPackage ./colcon/cargo.nix { };
 
+      colcon-clean = pyFinal.callPackage ./colcon/clean.nix { };
+
       colcon-cmake = pyFinal.callPackage ./colcon/cmake.nix { };
 
       colcon-core = pyFinal.callPackage ./colcon/core.nix { };
@@ -59,6 +61,8 @@ self: super: with self.lib; let
       rosinstall-generator = pyFinal.callPackage ./rosinstall-generator { };
 
       rospkg = pyFinal.callPackage ./rospkg { };
+
+      scantree = pyFinal.callPackage ./scantree { };
     });
   };
 in {

--- a/pkgs/scantree/default.nix
+++ b/pkgs/scantree/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, attrs, pathspec, six }:
+
+buildPythonPackage rec {
+  pname = "scantree";
+  version = "0.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KosWPeDksvnk83+Mrz8LJlFyu/F0ER4b68eVVYGJWzk=";
+  };
+
+  propagatedBuildInputs = [ attrs pathspec six ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Flexible recursive directory iterator: scandir meets glob(\"**\", recursive=True)";
+    homepage = "https://github.com/andhus/scantree";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}


### PR DESCRIPTION
This adds the [colcon-clean](https://github.com/colcon/colcon-clean) extension that provides a nice command for workspace cleaning. The extension relies on the `scantree` Python package which isn't part of nixpkgs, so that package is specified manually as well. I'm not sure if that's how you'd typically do this or whether the dependency should be specified differently.