### PR TITLE
Fix overriding in ignition.fuel-tools4

### DIFF
--- a/pkgs/ignition/fuel-tools/4.nix
+++ b/pkgs/ignition/fuel-tools/4.nix
@@ -1,4 +1,4 @@
-{ callPackage, ignition } @ args :
+{ callPackage, ignition, ... } @ args :
 
 callPackage ./. ({
   majorVersion = "4";


### PR DESCRIPTION
This aligns it to the other ones:

```
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'gazebo-11.14.0'
         whose name attribute is located at /nix/store/rz50qm74nicyhql7wrsibvanlj5kdm78-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'gazebo-11.14.0'

         at /nix/store/rz50qm74nicyhql7wrsibvanlj5kdm78-source/pkgs/stdenv/generic/make-derivation.nix:402:7:

          401|       depsHostHostPropagated      = elemAt (elemAt propagatedDependencies 1) 0;
          402|       propagatedBuildInputs       = elemAt (elemAt propagatedDependencies 1) 1;
             |       ^
          403|       depsTargetTargetPropagated  = elemAt (elemAt propagatedDependencies 2) 0;

       error: function 'anonymous lambda' called with unexpected argument 'ignition-msgs'

       at /nix/store/135xw2s8a4wmi65nzwbfwywc81d9j7x5-source/pkgs/ignition/fuel-tools/4.nix:1:1:

            1| { callPackage, ignition } @ args :
             | ^
            2|
```

For now I'll pass it instead using the `ignition` scope, but it would be nice to have this consistent.