### PR TITLE
rosdistro sync, Fri Feb  9 13:42:10 2024

### DIFF
--- a/distros/humble/aerostack2/default.nix
+++ b/distros/humble/aerostack2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-classic-assets, as2-ign-gazebo-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-ign-gazebo, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-assets, as2-gazebo-classic-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-gazebo, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
 buildRosPackage {
   pname = "ros-humble-aerostack2";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "ac40ad62ac1094e0512ebe2b7a3fdf225110f7aa79673d9660c30363f4e435af";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "306cd86add2f4dc22d15fae1abd5926d959e47fd777fdd946c5a19ff6c4db75c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ as2-alphanumeric-viewer as2-behavior as2-behavior-tree as2-behaviors-motion as2-behaviors-perception as2-behaviors-platform as2-behaviors-trajectory-generation as2-cli as2-core as2-gazebo-classic-assets as2-ign-gazebo-assets as2-keyboard-teleoperation as2-motion-controller as2-motion-reference-handlers as2-msgs as2-platform-crazyflie as2-platform-ign-gazebo as2-platform-tello as2-python-api as2-realsense-interface as2-state-estimator as2-usb-camera-interface ];
+  propagatedBuildInputs = [ as2-alphanumeric-viewer as2-behavior as2-behavior-tree as2-behaviors-motion as2-behaviors-perception as2-behaviors-platform as2-behaviors-trajectory-generation as2-cli as2-core as2-gazebo-assets as2-gazebo-classic-assets as2-keyboard-teleoperation as2-motion-controller as2-motion-reference-handlers as2-msgs as2-platform-crazyflie as2-platform-gazebo as2-platform-tello as2-python-api as2-realsense-interface as2-state-estimator as2-usb-camera-interface ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-alphanumeric-viewer/default.nix
+++ b/distros/humble/as2-alphanumeric-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, ncurses, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-alphanumeric-viewer";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "838a642b6cf5388464fbf35708849e4226bd0c46ce85ca4590b120dd24e088b3";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "7f8148241ab741ac9a2e6c137cee9b3db73380ad6423d0fe53e80fc9468dc555";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior-tree/default.nix
+++ b/distros/humble/as2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, behaviortree-cpp-v3, geometry-msgs, nav2-behavior-tree, nav2-msgs, rclcpp, rclcpp-action, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior-tree";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "7f70f650e245de8478492dd117ec96816c5dc92008cae59b456e4bb2f752fe6d";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b2eb52ca446b92b67e13483ae3e2e5a2642ef949a83fd55ad451be1ea372a121";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior/default.nix
+++ b/distros/humble/as2-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "0c1b6e3820191aeb8e763c90b028f7cd24176da4aa4b050fc5f468045427a367";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "e943e3dc0b141158128b4df558f2f8670ee692190fc15178687ce0a6511afe9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-motion/default.nix
+++ b/distros/humble/as2-behaviors-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-motion";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "eb9e2390fcb9630de06d40fe01ba7599216a08925ccf56b1f8d34e0e97d2e863";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "7ddff48de616132cfb1fa97bb184e43c842186764708ea5e15d2d7093fccd94d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-perception/default.nix
+++ b/distros/humble/as2-behaviors-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-perception";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "a9e6a477319e42c6ea0030b04de34b86fa0b15e209974495e4e057eb892d9164";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b1a630b2392e989d7f1d736618c14e18dede558c57ea9872e1ddc67cd7e84c78";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-platform/default.nix
+++ b/distros/humble/as2-behaviors-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-platform";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "780ae1283d636e78fbe9e6223d979a7348704a80b885c4fa06308f6f30e6d7e7";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "44dca1f29e6fb5443a56824fc9e9dbe605e6ce80fec3d16ca51ead6b82562325";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-trajectory-generation/default.nix
+++ b/distros/humble/as2-behaviors-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-components, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-trajectory-generation";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "c7d7f5cb093552cdda51e42422906aeca104eea2ef9e734f269f09821d2b66c4";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "5136686f1d46046cfa0ac71e0e8b89c88b5836ac34354d26c5031f81f88171f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-cli/default.nix
+++ b/distros/humble/as2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-as2-cli";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "9a8d2f7fa92db2e891d21fa1f3a49e174242c54990a13206cece497a021c5549";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "5f5f5872dae20287e957f62f4b498ad9f720367b5f78872c8fabe005698bbfb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "a1fe13d9801f3ff459e3966353e3dc27b0e5e9947db09341323d42429f73da4d";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "78db3266b9d6b249102b6ec6ef6a0226eb9a05931304262d3e72fe058c7c9c1b";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-cmake as2-msgs cv-bridge eigen geographic-msgs geographiclib geometry-msgs image-transport nav-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/as2-gazebo-classic-assets/default.nix
+++ b/distros/humble/as2-gazebo-classic-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, python3Packages, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-gazebo-classic-assets";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "346b24a443f1cdbf1e396f8b934a6f05f8d23c711b6c97bccb542e2048c028c1";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "e77ebc7ac79b6aa18a27716fc899538e30a812a71b73da0f9d458f5d2db4f385";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-keyboard-teleoperation/default.nix
+++ b/distros/humble/as2-keyboard-teleoperation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-motion-reference-handlers, as2-python-api, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-as2-keyboard-teleoperation";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "6d27f8917b3adcdcf5213fc5ff8cb990e165fbdf74000abb2944fd7f356b1503";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "3ccf2bccbc1ea2810201f8fe45da8e7f093fb930d67216fdbc4d7e760d5f9daf";
   };
 
   buildType = "ament_python";

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "6122f55455c0b4771a7984df0af30a2b489c8925f3a6ada6645e8b91f43e1c34";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "311d7e5b598b8b90a77a74d42ed7be2ba6d1e95523ac099263b7c1c2ce83b5e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-motion-reference-handlers/default.nix
+++ b/distros/humble/as2-motion-reference-handlers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-action, rclpy, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-reference-handlers";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "69d1cdad61617e00051df0f4a023e2b8579088e42fca9f9e77980a4fd2647582";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "ed8aa041dc28f87773f14cccbb45cdbe25c92c316f7013dd0083c8c5b0f3b195";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-msgs/default.nix
+++ b/distros/humble/as2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-msgs";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "19873e38f5896e137413f2d81acd5a7000c6015ae87701f6a0699276923d5d20";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "32f9c89a2d3bf277f4693c6d25b6c59f742e0c6d8e3adf74886fba793ada9b3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-crazyflie/default.nix
+++ b/distros/humble/as2-platform-crazyflie/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-crazyflie";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "99d16f555bd975e66c335ab67553883bdd2495a5e0c578e3c935f7bf6c84ac56";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "77be7d322162c176fa152d2c32035590cb5097bea2be39caedd1133cfe26d775";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-dji-osdk/default.nix
+++ b/distros/humble/as2-platform-dji-osdk/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, libusb1, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-dji-osdk";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "cd864b34ae39ea1ffd7896f83992f2a413a7f0cc57315cf25967b6093b29e126";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "1e9bcd8ad75cc70596d50c09d2806f51129691ff1f73a88ea47b9f4e5d452aed";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ as2-core as2-msgs geometry-msgs nav-msgs rclcpp sensor-msgs std-msgs std-srvs ];
+  propagatedBuildInputs = [ as2-core as2-msgs geometry-msgs libusb1 nav-msgs rclcpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-platform-gazebo/default.nix
+++ b/distros/humble/as2-platform-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-gazebo-assets, as2-msgs, geometry-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-as2-platform-gazebo";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "bf174b79d0099fd03c8aea2435cc06e114180c9edad17b0e5082a17444b89113";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
+  propagatedBuildInputs = [ as2-core as2-gazebo-assets as2-msgs geometry-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package to communicate Gazebo Simulator with Aerostack2 framework'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/as2-platform-tello/default.nix
+++ b/distros/humble/as2-platform-tello/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-tello";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "386a89c7bdd531c2a2e1cc275e365f0e5b53854f87da30ec45d5e5f2d4259403";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b0dd87f392466a7061bf7976b5e9c83b5d0056e28b51ae6ba9a9efbd4ae54b59";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-realsense-interface/default.nix
+++ b/distros/humble/as2-realsense-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, geometry-msgs, librealsense2, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-realsense-interface";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "06f3507ad974667ee2bcfc8d8a83bec0a45eb13ddf4ee8a2fed015af0b131d6d";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "51297532f863f7183521c98914c20e543a99b5cd4d751fa11148db60a80a6819";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-state-estimator/default.nix
+++ b/distros/humble/as2-state-estimator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, geometry-msgs, nav-msgs, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-state-estimator";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "bcfa5ca1bc66bddd38a9abf0e20b3302e60bb4f3bd309ae69ff64b7e029bbb57";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "723a7d35264f2670f36ff650b665e35f0af5466d361ce9067ac9dcc0e86bbde9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-usb-camera-interface/default.nix
+++ b/distros/humble/as2-usb-camera-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-usb-camera-interface";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "1874e8da2499d698ef54725f6b73af61258f1abe28ff4a87b53a46486b26136c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "fd405021b91312a26c74ac94e9fb9341d7fb67718697fc777b892f2aad956924";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/caret-msgs/default.nix
+++ b/distros/humble/caret-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-caret-msgs";
-  version = "0.5.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/caret_trace-release/archive/release/humble/caret_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "3b5c7718f827a30b601ae7bab2fb6e5be6599c575586c4ed6cc31ea167f0c13d";
+    url = "https://github.com/ros2-gbp/caret_trace-release/archive/release/humble/caret_msgs/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "a37fdd9b8787a8502aad98b68012fced36f37daec0cffb7a2192c9f16d3c9f6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/event-camera-codecs/default.nix
+++ b/distros/humble/event-camera-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, class-loader, event-camera-msgs, rclcpp, ros-environment, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-humble-event-camera-codecs";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/humble/event_camera_codecs/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "3728597f320b26add4cd4704fdc358777a73f141790a824172dc15d4f6536581";
+    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/humble/event_camera_codecs/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "135b9f68647df0de262ab398c68ef5545c665cdc9a662343d47c5a7a86fd6c90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/event-camera-py/default.nix
+++ b/distros/humble/event-camera-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-event-camera-py";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/humble/event_camera_py/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a8100b5c6b53b05d21c77e3feb38ce2b959d7254227d23ec26dff006ae310f5e";
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/humble/event_camera_py/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "aff826c96149253e4f3f8d6b5829eea4e221d191f4a97fff89ad30bb4302c50a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/event-camera-renderer/default.nix
+++ b/distros/humble/event-camera-renderer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-event-camera-renderer";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/humble/event_camera_renderer/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "fc127ef4fe320828ff514cb7ac4b1aa843655ac9f1be92088586ca0a7dd96491";
+    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/humble/event_camera_renderer/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "1334ab2b8f062b0a2bf5c6ccf2e3431dc9b392ea9a47e98bb41ce6b9ac97f9e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -234,7 +234,7 @@ self: super: {
 
  as2-platform-dji-osdk = self.callPackage ./as2-platform-dji-osdk {};
 
- as2-platform-ign-gazebo = self.callPackage ./as2-platform-ign-gazebo {};
+ as2-platform-gazebo = self.callPackage ./as2-platform-gazebo {};
 
  as2-platform-tello = self.callPackage ./as2-platform-tello {};
 
@@ -1688,6 +1688,18 @@ self: super: {
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
 
+ qb-softhand-industry = self.callPackage ./qb-softhand-industry {};
+
+ qb-softhand-industry-description = self.callPackage ./qb-softhand-industry-description {};
+
+ qb-softhand-industry-driver = self.callPackage ./qb-softhand-industry-driver {};
+
+ qb-softhand-industry-msgs = self.callPackage ./qb-softhand-industry-msgs {};
+
+ qb-softhand-industry-ros2-control = self.callPackage ./qb-softhand-industry-ros2-control {};
+
+ qb-softhand-industry-srvs = self.callPackage ./qb-softhand-industry-srvs {};
+
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
@@ -1969,6 +1981,8 @@ self: super: {
  ros2action = self.callPackage ./ros2action {};
 
  ros2bag = self.callPackage ./ros2bag {};
+
+ ros2caret = self.callPackage ./ros2caret {};
 
  ros2cli = self.callPackage ./ros2cli {};
 

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "5e82c04d029cfbe313658030c7db791a6beb898f72a735da330a5770d6677466";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "679136fcc2bd3607bc33c4390500e4cb246981f1a7a33d15ff7b2e42d04663ec";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.11.7-r1";
+  version = "2.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.7-1.tar.gz";
-    name = "2.11.7-1.tar.gz";
-    sha256 = "c2727d2a676f36ddf4c2060f3fa8353fd09d0736b71fe21a27df4ddb9514d0da";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.8-1.tar.gz";
+    name = "2.11.8-1.tar.gz";
+    sha256 = "4b61c9f5d3092b7a4e8cf2c8de0b4d189f0c9fd6f71cd4dfc8f9dfedd194afb5";
   };
 
   buildType = "cmake";

--- a/distros/humble/plotjuggler-ros/default.nix
+++ b/distros/humble/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, plotjuggler, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler-ros";
-  version = "2.0.0-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/humble/plotjuggler_ros/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "145b5496c6a4e317fc35ac2c44703cea344af9fa3ed8492f836e7017c325c43a";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/humble/plotjuggler_ros/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "9aeb4ad6c9dd8f93bceb8d9734e664ebc4f20a9c2210290dd00fc28422bfea4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.8.10-r2";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.8.10-2.tar.gz";
-    name = "3.8.10-2.tar.gz";
-    sha256 = "d9c38fea7d2ee82ee4087bfbe162eb0279c0cf880cba7b20f24e4e9211ecfd19";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "737a6357d24c07791f3695abcee345bb659588d637d11a71eacd80e662b6bf63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/psdk-interfaces/default.nix
+++ b/distros/humble/psdk-interfaces/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-psdk-interfaces";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_interfaces/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "faffdb25758983beb77c0f3cb9e8e7d2ba8c5898903bd903d833e0e3488dff12";
+    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_interfaces/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "70b4146d19b9a48951ddada7fb02a2286b9cb2ac404b364a89fded553884bb9e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/psdk-wrapper/default.nix
+++ b/distros/humble/psdk-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ffmpeg, geometry-msgs, libopus, libusb1, nav-msgs, psdk-interfaces, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-psdk-wrapper";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_wrapper/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "81712e25985c4f127ab3a540e691b4ce9a86e93e875fca40a22b7d012714c08c";
+    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_wrapper/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "65e25751aadfdc523aa605c3b6602172d624432aba31f630f8b17ba47a9d328f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qb-softhand-industry-description/default.nix
+++ b/distros/humble/qb-softhand-industry-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-qb-softhand-industry-description";
+  version = "2.1.2-r4";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros2-release/get/release/humble/qb_softhand_industry_description/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "fb78d854c4e40b9851ded76e91f86d6174911051fd84dc6f24e72f7d9661488b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the ROS description for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/qb-softhand-industry-driver/default.nix
+++ b/distros/humble/qb-softhand-industry-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, qb-softhand-industry-srvs, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-qb-softhand-industry-driver";
+  version = "2.1.2-r4";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros2-release/get/release/humble/qb_softhand_industry_driver/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "85c73614e76c5f6ef50600c295724702febee448d7d1065d7172e9aad3fcbea0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ qb-softhand-industry-srvs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains communication interface for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/qb-softhand-industry-msgs/default.nix
+++ b/distros/humble/qb-softhand-industry-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-qb-softhand-industry-msgs";
+  version = "2.1.2-r4";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros2-release/get/release/humble/qb_softhand_industry_msgs/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "a2027bd50f5f59f7b4618a068ff6c0a91805711a6aeb5415bf84db63cb7d957c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains the ROS messages for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/qb-softhand-industry-ros2-control/default.nix
+++ b/distros/humble/qb-softhand-industry-ros2-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, controller-manager, forward-command-controller, hardware-interface, joint-state-broadcaster, joint-state-publisher-gui, joint-trajectory-controller, pluginlib, qb-softhand-industry-msgs, qb-softhand-industry-srvs, rclcpp, rclcpp-lifecycle, robot-state-publisher, ros2-controllers-test-nodes, ros2controlcli, ros2launch, rviz2, transmission-interface, xacro }:
+buildRosPackage {
+  pname = "ros-humble-qb-softhand-industry-ros2-control";
+  version = "2.1.2-r4";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros2-release/get/release/humble/qb_softhand_industry_ros2_control/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "e93d568703062b21700a82ba59b64c93c2fa127ff1d5c5d9b8845e6a987c4a59";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller hardware-interface joint-state-broadcaster joint-state-publisher-gui joint-trajectory-controller pluginlib qb-softhand-industry-msgs qb-softhand-industry-srvs rclcpp rclcpp-lifecycle robot-state-publisher ros2-controllers-test-nodes ros2controlcli ros2launch rviz2 transmission-interface xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package of `ros2_control` hardware for qbSoftHand Industry with transmission interface.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/qb-softhand-industry-srvs/default.nix
+++ b/distros/humble/qb-softhand-industry-srvs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, qb-softhand-industry-msgs, rosidl-default-generators, rosidl-default-runtime, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-qb-softhand-industry-srvs";
+  version = "2.1.2-r4";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros2-release/get/release/humble/qb_softhand_industry_srvs/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "39e84b17adfd7eeecbf65908bfa02dca31ac56c37522dc741ed2426737367b2e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ qb-softhand-industry-msgs rosidl-default-runtime std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains the ROS services for qbrobotics® SoftHand Industry.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/qb-softhand-industry/default.nix
+++ b/distros/humble/qb-softhand-industry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, qb-softhand-industry-description, qb-softhand-industry-driver, qb-softhand-industry-ros2-control }:
+buildRosPackage {
+  pname = "ros-humble-qb-softhand-industry";
+  version = "2.1.2-r4";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros2-release/get/release/humble/qb_softhand_industry/2.1.2-4.tar.gz";
+    name = "2.1.2-4.tar.gz";
+    sha256 = "4752fcc6103ddf95badea1d1a33d57f2055419393dc24090c2030ee2b21a955a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ qb-softhand-industry-description qb-softhand-industry-driver qb-softhand-industry-ros2-control ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the ROS interface for qbrobotics® SoftHand INdustry device.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/ros2caret/default.nix
+++ b/distros/humble/ros2caret/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, caret-analyze, caret-msgs, python3Packages, pythonPackages, ros2cli, tracetools-trace }:
+buildRosPackage {
+  pname = "ros-humble-ros2caret";
+  version = "0.5.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2caret-release/archive/release/humble/ros2caret/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "41bc5103018749665db80182249d8fd56e94bb41977ad94faca5ea0ace470a7a";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 python3Packages.pytest-mock pythonPackages.pytest ];
+  propagatedBuildInputs = [ caret-analyze caret-msgs python3Packages.tabulate ros2cli tracetools-trace ];
+
+  meta = {
+    description = ''ROS 2 CLI package for caret'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/ament-clang-format/default.nix
+++ b/distros/iron/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-clang-format";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_clang_format/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "2bfae69d2090f4c803313769130e76203c7c358b767c305aab37ae33ca923588";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_clang_format/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "37a65cc22b49912f6314557a59e4d691adc785edeff044b5ccc92ab08a95328b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-clang-tidy/default.nix
+++ b/distros/iron/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-clang-tidy";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_clang_tidy/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "079cd244d7ea38e0064fa227f47850d48e77352c27e0223672f927d7fb9d1734";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_clang_tidy/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "27b6cbab456fb912bc1396364c4e2190142aa76cf196f95b8cff260df8615416";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-cmake-auto/default.nix
+++ b/distros/iron/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-auto";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f2412dd4cecdbe9d1a1f10bd11c4a0691faeac16d4fd70cdafeebce744c501b1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "19b698c8e0aed80996375c952bc0428c057ad703458ebdf4740f80f6f94fad66";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-clang-format/default.nix
+++ b/distros/iron/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-clang-format";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_clang_format/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "714954675a8274eb75550d0aea689ca8eb8769134a5b48c96fab1e05900035f1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_clang_format/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "3fe611b1c8ac0305fda984d8880f0c99a03f7b320127406e90f57c2ef0aad5ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-clang-tidy/default.nix
+++ b/distros/iron/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-clang-tidy";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_clang_tidy/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "c4d1c5e154dd9736d620b93a3ee93cea628175a7ae4a777a2c77462f8013943b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_clang_tidy/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "60702d1d61cab72d5d653e503b297f6ecde509cef49162a123ade325f4a759aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-copyright/default.nix
+++ b/distros/iron/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-copyright";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_copyright/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "796d2ee886b8334507bc96e78e48e50a1eee0ceec2bedd99ebba3bd7a7c97ef6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_copyright/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "a25b292eb2b651fc5667ff99b5a143621ac94ff75dbca0662ccabb95fdd1e3db";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-core/default.nix
+++ b/distros/iron/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-core";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "7a9de8482aff77d0194a52364d7e97540af85edefac22e88bda5dbd3b1111bb7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "aec721bcf55a9ee8ec605a6f1b45a0be57e041c0ac8431578031e94dcb801d97";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-cppcheck/default.nix
+++ b/distros/iron/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-cppcheck";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_cppcheck/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "fc0af62119f869c4f3dca8130d0dc54f747e3927590ded9f5b0b7bffd7ddbc3c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_cppcheck/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "b2a39c7348344502cfc5cafbf7ea094fa8171d8c0fff1ff1faeb5e6db3639791";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-cpplint/default.nix
+++ b/distros/iron/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-cpplint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_cpplint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "31acb712ce2c4737774b2e703b68bb08d31e23b02142058aef2ce1c6d314b04d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_cpplint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "e86afe5ffd5522e4b272f0f55ba5275ba4849666b4ba1beacb69c3373e43081b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-definitions/default.nix
+++ b/distros/iron/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-definitions";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "282d5de031937b5282f4783042742fa6ba12d20da006736746c62fca3dbc359f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "692962915f07e6684f93f6f8a067685a1b86e62ec2fd5b8d6806b8f5638ac85f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-dependencies/default.nix
+++ b/distros/iron/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-dependencies";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "2e81dfdd5df113ee47f3b2d127821b507ac006407999317d5fe338903c5e1269";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "339dc41ddb2a368e617c9631e8a2c39f1802863d28540bcfcd5deb7b1ee8a490";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-include-directories/default.nix
+++ b/distros/iron/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-include-directories";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "a1db6ecae340f695e58641ec537cf673712c47965ea84b96acda3468d3c7a007";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "1239fe0c2a1218f6db578d997d5b5b50869584e06a99ccde910392a93437f04f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-interfaces/default.nix
+++ b/distros/iron/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-interfaces";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "08a5c80213905983de9cf7d8325332837c36617d935d667c1d3fdc2b3e4125be";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "3832dbfe77e5ae8240e531b49985806bd0b059e638141a71a5d81313b4647740";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-libraries/default.nix
+++ b/distros/iron/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-libraries";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "b8a391cd7d8e9e4dd6f6b3b9c4348cd32543ce27997d4be0701182dfbb990446";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "a49c99a57d64c6f2377b8e21dda40a2874e9c81cfe601d5f2ba36e7bfb12c54e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-link-flags/default.nix
+++ b/distros/iron/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-link-flags";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "baf68dcb21a84e3ed209b92f8674b4df3f36b4c33aefd3443b859bba6617638d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "3c5e1cc6df3d4e75b50420e8c5d834c5b9f93190251db7db748f42578498988d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-targets/default.nix
+++ b/distros/iron/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-targets";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "91710a34ca5865df1ce8151e4f46167b86081577d4ea2158399f0502ffada859";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "8abd5957a0de57fb6be0350f3d1aca186b885de8a64c0e57f3bf34edb0bc5b7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-flake8/default.nix
+++ b/distros/iron/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-flake8";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_flake8/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "828ad22ac1ba794cc960e02ba708a6a06e9b837e497e7f46a140a314b6144118";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_flake8/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "71198ce1ed18a4f823ab23142a316e30c59761d0bca9a280869e536f39d9e79c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gen-version-h/default.nix
+++ b/distros/iron/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gen-version-h";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f947b05e180a613609d58702fad526c7d4e1d76b6c165cb61c80437472ba252e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "bbc5ee13241661361e416bcb68145ae49746bd40182aa714fd6a9e1c58cb51ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gmock/default.nix
+++ b/distros/iron/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gmock";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "4aa77161e81a4378eaaa73c203825d9fafda11cf13466657b7d967c160746d15";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "7394843555e2ce379a5b2cb427224775878d6e70ab8070a568cb8f2cc3bf4608";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-google-benchmark/default.nix
+++ b/distros/iron/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-google-benchmark";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "8ac453a1aa03cc3b095286d0f0d3ae3da8750c68f280a27fafccfbeebb50c0ad";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "967c4c118b5849ce2787ed172971cf1401f609337d18d793c3246cecfbcd417e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gtest/default.nix
+++ b/distros/iron/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gtest";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "a713c488c550f795b972d357a574bf7470044d29f53d1b6b56f2efa7cc270771";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "dcc6aad4664e4b19a5b8f67c44a5a9e6677d8ebc3136c16f2dedde8d3b3aa9e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-include-directories/default.nix
+++ b/distros/iron/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-include-directories";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "fc1844dd5cc25b47a8cf789578dace16fdf6d5e83c8b53315ff7739fc308d3cf";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "6a18304a0a6b0425d74b8e9754320cb5af8afa9253e51b50b04e41d129566f87";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-libraries/default.nix
+++ b/distros/iron/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-libraries";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "08b9475583e805630930e7d46fa6d25ff79022b658bb75f48c94c1571f9af304";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "fc91131f6b47006b44a361f1cfa4d5718f591ff88bc33b252672c15a7321ce6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-lint-cmake/default.nix
+++ b/distros/iron/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-lint-cmake";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_lint_cmake/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "51ea08dc742096d2c7a0d46ef6013ddf7d70eca8e0c7671d68037ec668608c4a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_lint_cmake/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "c7dd9574e0e77a140218307634734a0106bf0b4eff10483c06238bdc015468a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-mypy/default.nix
+++ b/distros/iron/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-mypy";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_mypy/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "be53d19a4d166175f09794b4c9a32996ef475805ebfe4a5b5aaa7c6665ca91d7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_mypy/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "60ea68f687278cb7d9c8ea5551ba1166050b9ff4629ac2369051ed8081ae81fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pclint/default.nix
+++ b/distros/iron/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pclint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pclint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "890dd36741a1307b11b8df857a5842b42111b1c2ec6ce9b0c0ac8bc2c85ab3c6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pclint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "136eac2177f78e88bc501d4f86945f814894eb7baa3ba6203d98ae1f5c23c983";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pep257/default.nix
+++ b/distros/iron/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pep257";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pep257/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "2360693b364bbe7981cd29f1be1faf30191f94f4d2cfec0690aaeae4083b6434";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pep257/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "48a342ce98f5ad5cdadf7901f4a9fdf578e604b4fcf21cb35ba6fe8b93f208d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pycodestyle/default.nix
+++ b/distros/iron/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pycodestyle";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pycodestyle/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "b6186becefc329bc19a48b119006d9f1c12cdac63b5b87fd9c86242112678401";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pycodestyle/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "9311a267772c82c5564b0420251efcf293d33aa648f8d069d08e5e229fe1ba9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pyflakes/default.nix
+++ b/distros/iron/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pyflakes";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pyflakes/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "1e3c777c05de6724c7b8557e2149ff1574e6137be88b59e5313f040da3140d94";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_pyflakes/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "7e92900dfb74822f23ed70d086aee97a60b988d95f756e6dcae3b4bbe7f8e4e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pytest/default.nix
+++ b/distros/iron/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pytest";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "6d5c99756c9d212b62bb63bbfecb51a9b7b3025819a4b626d874063b11395d59";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "c45eca3f3f38d8d8818292645481d1642a524a5023ca9348cc2646e882f61607";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-python/default.nix
+++ b/distros/iron/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-python";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "5e8d912a66e82b4f56a9b23995d98574f6c02ba4ca62a8e082ce9284cddc168d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "0dcbaac8d68dc473fdd05c3e6e97f4d701402b7d2bf0da2bf4688f417c3d50eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-target-dependencies/default.nix
+++ b/distros/iron/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-target-dependencies";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f26815d7d79bd0e8d9999ec879b80f90115ec72b64ed73899afd213c2f27d572";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "bd682317de446e358146326ea80c919e2fa483a681c3a5f447ee14481d1ba2e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-test/default.nix
+++ b/distros/iron/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-test";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "ee30a27078e3448e72be82f2d91d956277a0f1410212f7fafa8074c116b368a6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "ae60646aba357d694f9934863eb111965581ea8400fb57dea41120f8d17f44bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-uncrustify/default.nix
+++ b/distros/iron/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-uncrustify";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_uncrustify/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "16c590005300fd691b555007ebbc3257449180675dcebc61d174e334b10b2b0d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_uncrustify/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "ee5acfa5d1fd19f5d5aa3074566a9e89ab51e9c47a94029d1cbdaff390a3c766";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-vendor-package/default.nix
+++ b/distros/iron/ament-cmake-vendor-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-vendor-package";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_vendor_package/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e3a0039ca358d245e6021bbb91e7261c793a93533142b12c2f6a16b7046cda42";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_vendor_package/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "018bfac29dc36ff874a6c64f47edd524217db83f3fcfb1bbf8b108ba38de25b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-version/default.nix
+++ b/distros/iron/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-version";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "04fb4886abdd06619c2da88bfcc37b7790739f89181b062c4dae17211df09388";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "4e382d49557095eac99231d3c3fb34556ca0fa25643161f141f95f3a32b0ab85";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-xmllint/default.nix
+++ b/distros/iron/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-xmllint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_xmllint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "a925c7fd15d0f5c943f159e6abab2fb1bb60172401f9408784aae5a9fb412a8c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cmake_xmllint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "89470933ce3269cc8ecd0532665615276a38bc14ea8d85a239538bbea0874df0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake/default.nix
+++ b/distros/iron/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "ddae13dce739f826668ee72cf092c396211037d8e2cd22cda9e343bcb4006ccf";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "828ecb19e1a89f5b2521d43bd5a9657310e9049a2033d352abb098f48788d21e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-copyright/default.nix
+++ b/distros/iron/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-copyright";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_copyright/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "4650c963be6c43b1fb0a49f30ad1366e55a07c721dd32c992ec24cbebe7d70d1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_copyright/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "cb431d4c511fea8650d2c4953e113de93c373b22fe63a5b4c513fd7f267c2cd5";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-cppcheck/default.nix
+++ b/distros/iron/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-iron-ament-cppcheck";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cppcheck/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "e27208fe1531fb7c0452af810b32ecf8e1ef661030a61145f54240337a65c8e2";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cppcheck/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "fcf0b309f4afed0cd52909f9b6012538619af5d97dbaeca2f1e432b6cac09c6e";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-cpplint/default.nix
+++ b/distros/iron/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-cpplint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cpplint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "b08c20c41e96af8eaafe3cce95ffb94bc34488df46f488625feae3ec284d71db";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_cpplint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "3c7f9df67947e611e150390cc3ff20b04dba05ed9346a3fa97ff2bfe8e843d65";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-flake8/default.nix
+++ b/distros/iron/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-ament-flake8";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_flake8/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "a14af59be3111bbc66efb20267b34c11f4a34c4d590631c8a4a5e4fa2fad6b16";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_flake8/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "c2aa3c88b450074c642d3152f0b2128dab136359130a36d3725c1ab480a7c615";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-lint-auto/default.nix
+++ b/distros/iron/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-iron-ament-lint-auto";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint_auto/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "d5aa8ede1c866b7d4670484cb820d3cb7875138332ff2de2dfa75a1108badbd6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint_auto/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "2d55c39fcb65a042f634e49c0f655fa2ff89d44481e0ea9c5f9871d9eb544194";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-lint-cmake/default.nix
+++ b/distros/iron/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-lint-cmake";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint_cmake/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "5352ae19e6448638f863d7ee312951a6dc8648a40a4e7b0486fb024e0ee5d9c1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint_cmake/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "28f753bedec1f60dee81ad91cc88aaf217cec8bd35d52e87bc21cf58bd13d954";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-lint-common/default.nix
+++ b/distros/iron/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-iron-ament-lint-common";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint_common/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "e2178f1752693a4605ab1ff2c6099a857c07f2eb8073e4115f07aa4c6cc2bb97";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint_common/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "6853a69ad08625f8b05de97c95bf26a35d2b21116a74b2d11d79ab560e09115d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-lint/default.nix
+++ b/distros/iron/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-iron-ament-lint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "060df712efb5301170c3ca005872423636d0ab2dd948abf2a4362f8404a14f82";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_lint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "8c5cea55ac0c61fde8e5ca7d5eb091f7d1f907473f4afa65fbc9d37e05a05d9a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-mypy/default.nix
+++ b/distros/iron/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-mypy";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_mypy/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "992f5f96c279cc99c6bdf80d3897158c172b0bba43d2e0beb41b816fa0e1577d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_mypy/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "99b289bb9028d4ff975441ce5081feb2e36e598aa117225ee81ed6b9254c5a4b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-pclint/default.nix
+++ b/distros/iron/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-pclint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pclint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "3f6f8e450e61beef10c343e7ebb8e3c8174d04464e4865815ff162d7c11ded06";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pclint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "66bd8c0753a70df3855a6c92ae1cf19468b097d7eb5f4683846a9b1314b53efb";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-pep257/default.nix
+++ b/distros/iron/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-pep257";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pep257/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "315b281b600aeb38abf9721c029a1ac241c53a94e19e45a76e146726755741d6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pep257/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "bd6f25067880b3f79e3022469c43d84d30a7abd16a2a64e6aa0af27a7fa16794";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-pycodestyle/default.nix
+++ b/distros/iron/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-ament-pycodestyle";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pycodestyle/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "02af425dbc6727a57714da406e18e02431693c3bd86b549000ed16f073922c0e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pycodestyle/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "815030ac797fd292bdcfe37c953e4860795dbab4c452dea30b2483748ca86a5d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-pyflakes/default.nix
+++ b/distros/iron/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-pyflakes";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pyflakes/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "7a5dbd6c1088afdd56d9a0d6b8a76cd412a82be8078ab64db58fd40e66e3ab35";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_pyflakes/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "b969c79ec18f352214c26cbab67f2c9a1f99b7292d79c990a2f0ab56c43e095a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-uncrustify/default.nix
+++ b/distros/iron/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-uncrustify";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_uncrustify/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "ab93b4ab42db68992dee2250b6523b57df25026ddf216772b516b405ce9bd0f5";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_uncrustify/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "a07d60674da485181110706872dd712cb78dbc9e2ae2318fc38ef726409d813b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-xmllint/default.nix
+++ b/distros/iron/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-xmllint";
-  version = "0.14.2-r1";
+  version = "0.14.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_xmllint/0.14.2-1.tar.gz";
-    name = "0.14.2-1.tar.gz";
-    sha256 = "865311296b69b9ea7c1c3e1d8a341cacde03d7e41859c5e234340ae9cbed9a16";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/iron/ament_xmllint/0.14.3-1.tar.gz";
+    name = "0.14.3-1.tar.gz";
+    sha256 = "a0a6295b0ab60f26f2a1e201ed890f022c7e6b1f4f810e8ac7ecda1f580e1905";
   };
 
   buildType = "ament_python";

--- a/distros/iron/camera-calibration-parsers/default.nix
+++ b/distros/iron/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-camera-calibration-parsers";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "b43efff4061ddb17efd96ef35fd9e9898d7baa76937ed179f5294f60935df7f4";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "26bbe270df87c4a314f76441747756762892101ac3d1a04a2c6e2f2cbfd217fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/camera-info-manager/default.nix
+++ b/distros/iron/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-camera-info-manager";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "4a08d3e0bc3cc438afe56174d26def4ca66af38146f7fb29ab61a05c1187bf2d";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "8654605dc1dbbb7df2c5c473f43735c11b0db38a0cac6413a626799139adee14";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cyclonedds/default.nix
+++ b/distros/iron/cyclonedds/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, cunit, iceoryx-binding-c, iceoryx-hoofs, iceoryx-posh, openssl }:
+{ lib, buildRosPackage, fetchurl, cmake, iceoryx-binding-c, iceoryx-hoofs, iceoryx-posh, openssl }:
 buildRosPackage {
   pname = "ros-iron-cyclonedds";
-  version = "0.10.3-r2";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/iron/cyclonedds/0.10.3-2.tar.gz";
-    name = "0.10.3-2.tar.gz";
-    sha256 = "b31b45605acd66f911b88eac80a28d2e22282e0ba4ac6d383826a5c7d6a14a6e";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/iron/cyclonedds/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "cb30b275eb184596db2c25904c5dd15488a760fb390b688ebf0a510a7f3c07d1";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  checkInputs = [ cunit ];
   propagatedBuildInputs = [ iceoryx-binding-c iceoryx-hoofs iceoryx-posh openssl ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/iron/event-camera-codecs/default.nix
+++ b/distros/iron/event-camera-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, class-loader, event-camera-msgs, rclcpp, ros-environment, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-iron-event-camera-codecs";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/iron/event_camera_codecs/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "31b4840818a52347763704d209a76d6addeb33b32701439d6907576cc1137b68";
+    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/iron/event_camera_codecs/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "9c5102e31369dd9dbaed2ab8ddd1dbe657d311c5ce26d8c30c01fd2f8cc8a025";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/event-camera-py/default.nix
+++ b/distros/iron/event-camera-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
+buildRosPackage {
+  pname = "ros-iron-event-camera-py";
+  version = "1.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/iron/event_camera_py/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "26e1438be4284ff454f6a6f5d3cf46de08ac090c398a1b44aeca1083ad6a3150";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy rclpy rosbag2-py rosbag2-storage-default-plugins rosidl-runtime-py ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
+
+  meta = {
+    description = ''Python access for event_camera_msgs.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/event-camera-renderer/default.nix
+++ b/distros/iron/event-camera-renderer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-event-camera-renderer";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/iron/event_camera_renderer/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "41a506fb7895f233d65ee996976df6581967946e23867d79f696db8fd26237bf";
+    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/iron/event_camera_renderer/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "7695c124046c64e7a79ccb7f112f68ba6ac1bc9e36332283698547971cfa422c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -472,6 +472,8 @@ self: super: {
 
  event-camera-msgs = self.callPackage ./event-camera-msgs {};
 
+ event-camera-py = self.callPackage ./event-camera-py {};
+
  event-camera-renderer = self.callPackage ./event-camera-renderer {};
 
  example-interfaces = self.callPackage ./example-interfaces {};

--- a/distros/iron/image-common/default.nix
+++ b/distros/iron/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-iron-image-common";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "fc7ec16630f5349c9bcc8a290ccc2d378f8878efd82fe12da3dfdc9dab3a4a1b";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "e95fca874ae1b2cbe4aa573222c90a276b0ddb2233cb8662d6300099c7c58d95";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-transport/default.nix
+++ b/distros/iron/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-image-transport";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "700d51e00158168ffaeab55729290a769a0a0d317de1a690d5b956f0256e4839";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "096bb06528635bbcb2b405c06ed2dc322a5acb022ef7c8524118c1d29253e575";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/launch-ros/default.nix
+++ b/distros/iron/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-launch-ros";
-  version = "0.24.0-r2";
+  version = "0.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_ros/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "e46ada520a840a8cedc2dd805b031904388539753e203a744aef386faec105b7";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_ros/0.24.1-1.tar.gz";
+    name = "0.24.1-1.tar.gz";
+    sha256 = "e89f2ea9e688f59a6653cbcfab598d6da3b0e79c49da9a4599c880a7c6462e44";
   };
 
   buildType = "ament_python";

--- a/distros/iron/launch-testing-ros/default.nix
+++ b/distros/iron/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-launch-testing-ros";
-  version = "0.24.0-r2";
+  version = "0.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_testing_ros/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "e2b615f0cf5c8067bada40c82240c482149292663af6ac8d9dda04a1613694cc";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_testing_ros/0.24.1-1.tar.gz";
+    name = "0.24.1-1.tar.gz";
+    sha256 = "56f17cb60f87fd9d407906c2138708ef2e36fa19a1a94294c9d17102c035b977";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mcap-vendor/default.nix
+++ b/distros/iron/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-mcap-vendor";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/mcap_vendor/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "966a40be1de8e0eb5df7f0eee48935553bf4bf9d127df79d0e0d2023eaa75d17";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/mcap_vendor/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "61adc6c3e3696084434838a88dad348e1f1be0fc420a5cf23033f8aa32c8c919";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plotjuggler-ros/default.nix
+++ b/distros/iron/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, plotjuggler, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-plotjuggler-ros";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/iron/plotjuggler_ros/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "011e71b277e14135d6b8cba4bbd47d10d2e9a31eab8f5773bc7fdf8b6bf1c6df";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/iron/plotjuggler_ros/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "7949c6415af2a009e4753783ee8e9f010b9afffd201f6b609e3715f8d8cbb464";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/plotjuggler/default.nix
+++ b/distros/iron/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-iron-plotjuggler";
-  version = "3.8.10-r2";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/iron/plotjuggler/3.8.10-2.tar.gz";
-    name = "3.8.10-2.tar.gz";
-    sha256 = "c4bf4b101ded27818274c6ff8a66d03982684bea6700469ec5733acc0d5d88f0";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/iron/plotjuggler/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "d8ffae331afa4491428eaacecdcf19120ca4f1f676f5422bb84361b6688e038d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/python-qt-binding/default.nix
+++ b/distros/iron/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-iron-python-qt-binding";
-  version = "1.2.3-r2";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/iron/python_qt_binding/1.2.3-2.tar.gz";
-    name = "1.2.3-2.tar.gz";
-    sha256 = "1ac1ea94776932a0e296c01d83d930871f4f97bc48b0874415ba2876686609d3";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/iron/python_qt_binding/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "7008088523c480e0a59c2d4f91116c0640c483b458e33f2b7056a336159b3f1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/qt-dotgraph/default.nix
+++ b/distros/iron/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-qt-dotgraph";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_dotgraph/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "96abf3d10094073fb47fcb1cfdafb93d7c98d60233da6aedf1c8af89f441cd60";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_dotgraph/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "e708fa300e8f363ab4a39a1638fddf499ff07fd8c7eed317bb6d03eac4602852";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/qt-gui-app/default.nix
+++ b/distros/iron/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-iron-qt-gui-app";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_app/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "e532661f5e30e23daa08d0f51deb3fd399265c1bcbdf853c18e5320ce6a12fa4";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_app/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "1caf4ffefba4e7ab29cd5e03825e672de0c75f56fbc8bdc42a54c24d65fde70f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/qt-gui-core/default.nix
+++ b/distros/iron/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-iron-qt-gui-core";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_core/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "fb241f30caccbeca35ccf86c0840950582bfb52e76fb069ef646528621ccdb16";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_core/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "4a2569bd3c76ba9dec69a1375f9b20a5ee19deb0896e9d028e97fb8b4fc83fac";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/qt-gui-cpp/default.nix
+++ b/distros/iron/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, rcpputils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-qt-gui-cpp";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_cpp/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "47e4f1082be9569109981ca5b194f923b2ec32fc9ae36b176fc5cf0e795a529d";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_cpp/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "dbc5965153b1c65be8372fb6b725e94c1c4042ca95bc35fd46ee6647d7b931c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/qt-gui-py-common/default.nix
+++ b/distros/iron/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-iron-qt-gui-py-common";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_py_common/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "3c194517bd9cb1e1cd8a5b67d6141c1514b8d4bac3c4665d01670931c11f2040";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui_py_common/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "9fe71215dbcd019c490196c2fbda38339d575c786a31859b907cd0871131dbb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/qt-gui/default.nix
+++ b/distros/iron/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-iron-qt-gui";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "f4034dee118d2ff7c9bf1c1f4ac5aec42b8069c45f7736f6a9cc2f28a51d1c05";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/iron/qt_gui/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "0f3fc26019c2a71dea1808c16adeb1bf706c1f71b0de15a1c1d16de36d3eb17d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-action/default.nix
+++ b/distros/iron/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rcl-action";
-  version = "6.0.4-r1";
+  version = "6.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_action/6.0.4-1.tar.gz";
-    name = "6.0.4-1.tar.gz";
-    sha256 = "3e286aba073091865ce5dde7e11aeba3eebbf51eed7bd03c2c14506cd28436b5";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_action/6.0.5-1.tar.gz";
+    name = "6.0.5-1.tar.gz";
+    sha256 = "e0f19c3880af687ad30512be53ef1d50039b6924f0e8b0c560f8f42cdd80c3a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-lifecycle/default.nix
+++ b/distros/iron/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rcl-lifecycle";
-  version = "6.0.4-r1";
+  version = "6.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_lifecycle/6.0.4-1.tar.gz";
-    name = "6.0.4-1.tar.gz";
-    sha256 = "0f7781e08592705505593d5acb6182c29b13fbcc5ed77b2d33d1cb2120bade38";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_lifecycle/6.0.5-1.tar.gz";
+    name = "6.0.5-1.tar.gz";
+    sha256 = "0c3126d7d6a1e0c736e9131426af4c5cbb1c7bc697b8c6c6055626fc4a5979a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-yaml-param-parser/default.nix
+++ b/distros/iron/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-iron-rcl-yaml-param-parser";
-  version = "6.0.4-r1";
+  version = "6.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_yaml_param_parser/6.0.4-1.tar.gz";
-    name = "6.0.4-1.tar.gz";
-    sha256 = "bf62fb9a0a9e41f820daf7acf67d6d3d32e0a19467ddd647d9cd414dc04e9d39";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_yaml_param_parser/6.0.5-1.tar.gz";
+    name = "6.0.5-1.tar.gz";
+    sha256 = "93b14b0f97b2cc53544c41c7a0bec6604e077345c4f83f6f6541204ec7f4c637";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl/default.nix
+++ b/distros/iron/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-iron-rcl";
-  version = "6.0.4-r1";
+  version = "6.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl/6.0.4-1.tar.gz";
-    name = "6.0.4-1.tar.gz";
-    sha256 = "eb2635f14661f39a73641c8d9fa4c13d9a6d28408ec7ecff526f9a046d1fe64e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl/6.0.5-1.tar.gz";
+    name = "6.0.5-1.tar.gz";
+    sha256 = "bbdb033919af146ab39bc69d5b4e3dc9f554f522a164241f9f35c82ebdfa7bcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-action/default.nix
+++ b/distros/iron/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-action";
-  version = "21.0.4-r1";
+  version = "21.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_action/21.0.4-1.tar.gz";
-    name = "21.0.4-1.tar.gz";
-    sha256 = "bd2dea03f58fc3ac81ef7d73bd6ac5d83a9cb40549aacd7ecce5b5a0ce3a107c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_action/21.0.5-1.tar.gz";
+    name = "21.0.5-1.tar.gz";
+    sha256 = "dc37354726b0f11da36d2555a23273a68207c6beeb361929e606174248d76485";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-components/default.nix
+++ b/distros/iron/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-components";
-  version = "21.0.4-r1";
+  version = "21.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_components/21.0.4-1.tar.gz";
-    name = "21.0.4-1.tar.gz";
-    sha256 = "4bdb7b9966ad9348303c59d21bee01f553d7d561937657d76cea780eed01fd61";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_components/21.0.5-1.tar.gz";
+    name = "21.0.5-1.tar.gz";
+    sha256 = "28f29fe3412f89a41bb4a069387e2c3fd2767bd83bd5e110f75b661828466ac4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-lifecycle/default.nix
+++ b/distros/iron/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-lifecycle";
-  version = "21.0.4-r1";
+  version = "21.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_lifecycle/21.0.4-1.tar.gz";
-    name = "21.0.4-1.tar.gz";
-    sha256 = "dae71348e6226c3c7790cd7ce8278b30cccd192549201959e9ef30627fa97bc6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_lifecycle/21.0.5-1.tar.gz";
+    name = "21.0.5-1.tar.gz";
+    sha256 = "8ecf54ebb36a529ba4bdf88595129ae979636a6b2d616a541f56c4178f378a6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp/default.nix
+++ b/distros/iron/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rclcpp";
-  version = "21.0.4-r1";
+  version = "21.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp/21.0.4-1.tar.gz";
-    name = "21.0.4-1.tar.gz";
-    sha256 = "dec56f861e44cf7ab949f4f4f1ba002467bf3c04c004738754a546f23354a071";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp/21.0.5-1.tar.gz";
+    name = "21.0.5-1.tar.gz";
+    sha256 = "a3d86aefa94632ac981d2dd0f9f6730658ef821758b3ec0534d481dd5d6e001a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmw-fastrtps-cpp/default.nix
+++ b/distros/iron/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rmw-fastrtps-cpp";
-  version = "7.1.2-r1";
+  version = "7.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_cpp/7.1.2-1.tar.gz";
-    name = "7.1.2-1.tar.gz";
-    sha256 = "75cbc1333e20ca207b79f459b5724afb1c73c341fe83eee17cfabda1bdedb6ce";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_cpp/7.1.3-1.tar.gz";
+    name = "7.1.3-1.tar.gz";
+    sha256 = "70e6ee3bc55e30461875c928f02c54fee457768b400be260d374dd54aca1daf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/iron/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rmw-fastrtps-dynamic-cpp";
-  version = "7.1.2-r1";
+  version = "7.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_dynamic_cpp/7.1.2-1.tar.gz";
-    name = "7.1.2-1.tar.gz";
-    sha256 = "d8919146e21768d87f8a8ba00884131bed2ac3fa2f6009957505af813c448391";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_dynamic_cpp/7.1.3-1.tar.gz";
+    name = "7.1.3-1.tar.gz";
+    sha256 = "41181c350b4c873bffa30524754676280408649f43167c856465d7a4ecb30ea2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/iron/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rmw-fastrtps-shared-cpp";
-  version = "7.1.2-r1";
+  version = "7.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_shared_cpp/7.1.2-1.tar.gz";
-    name = "7.1.2-1.tar.gz";
-    sha256 = "205addb95860d06c1cff35b5fa9215caf04566b9eb0691dd8b12ab91e21d1ae7";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/iron/rmw_fastrtps_shared_cpp/7.1.3-1.tar.gz";
+    name = "7.1.3-1.tar.gz";
+    sha256 = "33c7f596d86bbea2f31843d59979e1e0e9af9ced279d0245c84abd741462d9b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robot-state-publisher/default.nix
+++ b/distros/iron/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl-vendor, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-iron-robot-state-publisher";
-  version = "3.2.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/iron/robot_state_publisher/3.2.0-2.tar.gz";
-    name = "3.2.0-2.tar.gz";
-    sha256 = "2a0f1b6735d9c43f25fdba637f16165a193a30602ed8ea021e0a47a11f35d574";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/iron/robot_state_publisher/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "201c2417014a8e2395b7b5a904cf43c9ef16b56ee49b301843adbb7487b8fbac";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2action/default.nix
+++ b/distros/iron/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2action";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2action/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "e5231d987a960badbb8473f384471799bfd9b6942a111975c371f19a68d098e8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2action/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "d7fd33c789c0cfea316afa0ed92d3082cba4e53914866811b021ba37e2f05ac7";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2bag/default.nix
+++ b/distros/iron/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-iron-ros2bag";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/ros2bag/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "8c88a02d5a7770ecea2e0697159e8243fa11d6289d81d88c54d20c8c5c5f7a26";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/ros2bag/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "3cba79783be0a01f66305083b7e2b1bdc064f45a840ba924c2247787e202a182";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2cli-test-interfaces/default.nix
+++ b/distros/iron/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ros2cli-test-interfaces";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli_test_interfaces/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "a461ddb4b7f435e1c8d97ceaae01fae7cdd9067c791d955fe0ecc2bd071e5944";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli_test_interfaces/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "ee44359ed3800707fbee79f233c99f22176fbeabdc51aad7b2a83312ca8f3bdb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2cli/default.nix
+++ b/distros/iron/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2cli";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "2687f0234f06e38361ed959e74f4452c16251548347de54c4ebc8cd565e0a5da";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "4fbdc0555ff94c472b6fe9e9e779e5c75d85fc6dc9b10bfc66823a574eb8ca1d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2component/default.nix
+++ b/distros/iron/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2component";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2component/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "520c16777146fba5a05af9ab57abb81bac43280e2cdfd1d028c4d1d9a8444d04";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2component/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "f005316fc530a2b9bd4527f89b7fdad1ef8ee76cb575882f3645fd002c4328eb";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2doctor/default.nix
+++ b/distros/iron/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2doctor";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2doctor/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "72ee59127a8d9a163eb1ddf954f68fe05da4889658e07e2b75bcdd33e75f91fa";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2doctor/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "db7d026b98ebc44899a33f4ab0eecb87e39698893fc4eaf30ad38103456a3e4f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2interface/default.nix
+++ b/distros/iron/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2interface";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2interface/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "2b0fa21076b4ac789bf03ad98a60c11d123e4485c796b62efa6158e8263dddbf";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2interface/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "5e7d6d44997487ce356bf5819edbacc45dc8485f7facbd0f96e6e8cb1e1c0c7c";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2launch/default.nix
+++ b/distros/iron/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2launch";
-  version = "0.24.0-r2";
+  version = "0.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/ros2launch/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "fad1448105969210ef33120d06f86c046024e2d8e1c0d2714be439a3ad41bb5c";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/ros2launch/0.24.1-1.tar.gz";
+    name = "0.24.1-1.tar.gz";
+    sha256 = "b37ce20d56d12ecd44af9cbd615c1d0cde013ccab0a938e71df343a434c31b9f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/iron/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-ros2lifecycle-test-fixtures";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle_test_fixtures/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "76cc49e533b046df75020eba2eb1be618017b91f0078629038ad68b3c8447876";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle_test_fixtures/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "71d16641a90ec20e5a9560d7bef2952d85197ad157633f48f7506eb9a2b100b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2lifecycle/default.nix
+++ b/distros/iron/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-iron-ros2lifecycle";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "6c1faa460f5a695bd8a1ea11a3be758614f9e1a0bdc47012a8230474d5f50914";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "0660c8746b43e7840a9d5b66d1076e5feca4ddd96da8f5eae4c1b24d0f8307d2";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2multicast/default.nix
+++ b/distros/iron/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-iron-ros2multicast";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2multicast/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "e2d793ae8307bc8da4a7b05f767ffb9e556335ce5cb2ef0de606a8a909735190";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2multicast/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "e159928d81a105ae11d927cf4e694a9708ab055702d5fad6c58a9d4cff85cfe7";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2node/default.nix
+++ b/distros/iron/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2node";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2node/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "32263c81461cb106d8daa833f17a04dd51a55bc2b2d4a293f56b335bcb5f8267";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2node/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "703c1989d7ac93e378e39b563c6c5a2226a68eb14420d604ac1d63c2d225153a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2param/default.nix
+++ b/distros/iron/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-iron-ros2param";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2param/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "d8c2f3f6711efcca5cbb96e066ba19cd53bd1a3a571e3af633999a6593447712";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2param/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "fcc23b7bb59d910747e19a4856ad71596712d97ddd269284f4e0ab3fb3d9f7ff";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2pkg/default.nix
+++ b/distros/iron/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-iron-ros2pkg";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2pkg/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "81b1381c88b0f823765c57d436d1c415c1294821e1bbb558d0ec77669aca4f25";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2pkg/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "4e3d8c5a21cf32f3d8aa350d311a861b6082c7926b13da9818f625dcded7b2f7";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2run/default.nix
+++ b/distros/iron/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2run";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2run/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "ebbdc09d65fde28449712ac017f21a73064c0a2fb7c43d4e995530f5b6de2ea4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2run/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "269d72616671a64430b3e59324d651fa71ba7c92bc2b5743befbd8bf9500c184";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2service/default.nix
+++ b/distros/iron/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2service";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2service/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "f79363170d61a930405f099de44830abd390cc5676588dbab38a5bdebda38c51";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2service/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "1330ec91834ed7a3bda532d398fc762f1d24bef7b4403ba115be6b0e0bdaa163";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2topic/default.nix
+++ b/distros/iron/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2topic";
-  version = "0.25.4-r1";
+  version = "0.25.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2topic/0.25.4-1.tar.gz";
-    name = "0.25.4-1.tar.gz";
-    sha256 = "367ba13be56aea197044f3c9e850f0457c36a7b8bff6827ab4bacd667aa361f9";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2topic/0.25.5-1.tar.gz";
+    name = "0.25.5-1.tar.gz";
+    sha256 = "0bcac5f88355d6a4ca3fde0da7576c60cb9780c0920eb85a98c2a9e1187c1118";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosbag2-compression-zstd/default.nix
+++ b/distros/iron/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-compression-zstd";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression_zstd/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "5a8f05bcdbbe6e46ee552301538666dd703ed0b3ab86168d3bb95a989d68d5f4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression_zstd/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "48aea7e36fb78e8e5d8a57866b4af28ce70d96acf364ba31e0c067c589bc82b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-compression/default.nix
+++ b/distros/iron/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-compression";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "70905f34b81a9441140e7f43d8e080f0466f6dd3ec46bb8a510481828a0a457c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "b3dbe817cfd49211640a4e49562d40a275ccdd94116c1995144e4750861c05ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-cpp/default.nix
+++ b/distros/iron/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-cpp";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_cpp/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "ed47c1f6d96ffcf8ae2e5320146851f6f1fc69396a9c9f682212a996092b15e0";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_cpp/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "abc60608df8d3a36b97d85071d9d8b558674dfa7c39e04ba9395fad4e8e45565";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-examples-cpp/default.nix
+++ b/distros/iron/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-examples-cpp";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_cpp/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "57719d22373a1e831674dd7375996d6a1bdd1db7669fff755a46d15ce7eefd9d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_cpp/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "12e9608fae192c04c390bcda608666b97de0eaa9917608227139c3a3ebdc8f80";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-examples-py/default.nix
+++ b/distros/iron/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-examples-py";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_py/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "63969165882f7679370fc22896215fadbbd02bf0e9b5eb8ad21418dd8977dcb0";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_py/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "5043637846a2c17a3b8ad684786e814423faa0ba2f840f7a335dd3dd793f3f95";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosbag2-interfaces/default.nix
+++ b/distros/iron/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-interfaces";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_interfaces/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "62dff7d6e05f5e87f6c3cd7e02699f026702be896200db07454276e2622f0b59";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_interfaces/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "b96800ab6b2ddec9a7ddc6b970de63b438fdf33050e69f68a2192909601a426d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/iron/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-performance-benchmarking-msgs";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking_msgs/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "c50fa460f774b9922ef16112d07964af52f668d075c9c5e9d54a31393aaf7324";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking_msgs/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "b386f8a9c81f05b3c8c388732233d2f9d258af374ea15c02d668e593d38b1605";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-performance-benchmarking/default.nix
+++ b/distros/iron/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-performance-benchmarking";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "a8e4dcafb5c16f06767837a5abcf5712d3fa06dc628587a9b47925bb4d54e630";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "a8e2305f68c04fb3ba6c83974e715c68c3b4158d01b44b41f72c3ab60fc4bad7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-py/default.nix
+++ b/distros/iron/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-py";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_py/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "f981e4e0c548cc00f6b683ed0382246f0a6b5643eeccb7a40ef4163ed27abc0d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_py/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "f3541d69858323d72538f795d7c4f98c0531c2b1cadd8dced2abe21a27a50ece";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-default-plugins/default.nix
+++ b/distros/iron/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-default-plugins";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_default_plugins/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "e9593e741d9c98554e26fa12f2b8874009eae809065f8617f018d7491a6f429c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_default_plugins/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "025f47f4763b32dc1cb4676cfb60d7ea6561eefad15ef0eaf31990f887414d4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-mcap/default.nix
+++ b/distros/iron/rosbag2-storage-mcap/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-mcap";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_mcap/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "430dfd2aac0d0a9e369187e99e223994294c359d71c3a189f7f74d19fbe4aa9c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_mcap/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "5b06aa0c4fd531deab2d6d9c6cd2471fffef9a2afdd1fb1f05c3c474c5360027";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rcpputils rosbag2-test-common std-msgs ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-test-common std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/iron/rosbag2-storage-sqlite3/default.nix
+++ b/distros/iron/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-sqlite3";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_sqlite3/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "5eb9025245ccd0978f47305ae0dac1195fe9213a9bc9c46105fb700c051f074d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_sqlite3/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "e7b580fed3b008495bf3a4c7d658792f3d9ea316ab49e9d34e85e2738271b0e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage/default.nix
+++ b/distros/iron/rosbag2-storage/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "f30045c2ecb4ad89842f97c2b3dbbbd9e663f31bf5f6d26e17596be5e5ddb7cb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "684541c861f8f36aea8698671122f82f267f03f74bd49f96f7bce593e0d2b9db";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common rosbag2-test-common ];
-  propagatedBuildInputs = [ pluginlib rcpputils rcutils yaml-cpp-vendor ];
+  propagatedBuildInputs = [ pluginlib rcutils yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/rosbag2-test-common/default.nix
+++ b/distros/iron/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-test-common";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_common/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "fd6ff976f3fe9e37404a9f22352e296e10dacac13d837b291180b0f6c23ee0e6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_common/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "91b06c001211edaabfe30ae23fa2557af3cb8768e2c7579dfef6d7753faf495e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-test-msgdefs/default.nix
+++ b/distros/iron/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-test-msgdefs";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_msgdefs/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "df25c75169aba3e3f3dd255c3d27d507a3b6f41dfabf0f5771a60eca82485815";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_msgdefs/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "8b2303425a162a168af98e2433551c741bffe6ebc323abc8055c4107e5e3520d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-tests/default.nix
+++ b/distros/iron/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-tests";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_tests/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "ae530fa78d2839585d0c13c4f02f605050f3d68fbc7f1ba47d8f6d581f5a569a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_tests/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "710dfb4f1a93c224ded00bd4cd7522fe5a7af7728b521e2a954502191a3b271f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-transport/default.nix
+++ b/distros/iron/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-transport";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_transport/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "90a31b050a83bec0fb20342c323618625f4b7d3db379b6fd90ca22c036694b5b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_transport/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "348d0159205256fa36e871407440337ba79ea9c57a908286de6915b2b0788965";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2/default.nix
+++ b/distros/iron/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "91b98a59e046bcd31f0519383437f9cc13670218adf294473d4795f2280385c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "aba9148def798c3cd00da579741ca125337b3cfe8fd3f04d011b28da44ea5541";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-assimp-vendor/default.nix
+++ b/distros/iron/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-iron-rviz-assimp-vendor";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "2dc730fd57bd0ab535bb919b9c25849e04eadc729f1b6649cad37498316f0190";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "44ab8d261ee236133e75d29b3427de7f17cc9ea84ecb854e1cb2a6aefed311c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-common/default.nix
+++ b/distros/iron/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-common";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "14cd0cb542e280aa0656cb15711b2242fdda4d0f08f7e22773f70dfc75432861";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "549ff1d26355d451c9136a30533351d01817fe9df7815ba1941b9c97fdfc24a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-default-plugins/default.nix
+++ b/distros/iron/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz-default-plugins";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "885aa6312eaae5b1f20d09098afdcdd9daac097da261bf7187312be158568ed0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "0b709e75bae929946cece04b0e51f916ff465071848bbd2bd68fc1afd158618b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-ogre-vendor/default.nix
+++ b/distros/iron/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-iron-rviz-ogre-vendor";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "42e24cd7122269a900b32685f79a0a2ca8d0daaeb915c9b7c7b6926f0cd359ae";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "bff5ab6d14bf7af5375cdd1f0edeb5ed984ddcd1cb75606c3f8c568599a3925f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering-tests/default.nix
+++ b/distros/iron/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering-tests";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "eedf08d96692dd21d57c94cefefd32615ddbf1f40d79d260b26bf38c79b4326a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "d7f88aa1e581ba4f06569ffa37fe5a03bbcd3e86162954d51f1a6d82181c8b42";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering/default.nix
+++ b/distros/iron/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "de82e800b2d22c525cb6843f0e403758191ae36819436a852f3b86b2d48f8f20";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "0c9095e5e04bb5d9c3e3bc5d88629fc018f11e39d45780a90ce3ed5d3bff1e95";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-visual-testing-framework/default.nix
+++ b/distros/iron/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rviz-visual-testing-framework";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "1b4f6a7a79734121884fa1b3db78cbc316bf9ec141be249ce5352caad9e05aef";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "b52e3ef6d901e788d3b3cb6961e59965323af834a26bdc2dad5e3536cf2542be";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz2/default.nix
+++ b/distros/iron/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz2";
-  version = "12.4.5-r2";
+  version = "12.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.5-2.tar.gz";
-    name = "12.4.5-2.tar.gz";
-    sha256 = "78b8e840f3b18aff9231dfdc1dce8d446dc69ef4e6902a36964f3593ca249cbd";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.6-1.tar.gz";
+    name = "12.4.6-1.tar.gz";
+    sha256 = "13696f45cdcbcee2138532d06de16c27ca81a7258215f95f7365d2affd3e30c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/shared-queues-vendor/default.nix
+++ b/distros/iron/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-shared-queues-vendor";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/shared_queues_vendor/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "4cde69e15c44ca744423c6869d7494eb12ece2a5f47055b7034f1a910a5a4bb7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/shared_queues_vendor/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "500336a44e108a880cbe2453b6e6d6f361db051827101e1849aa3926e9e8ad40";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/sqlite3-vendor/default.nix
+++ b/distros/iron/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-iron-sqlite3-vendor";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/sqlite3_vendor/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "754346895b80fdedff1ff82be428e632ca9544ce41c290b497e2b200a185c680";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/sqlite3_vendor/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "b846f86171ff7579a3ce2bdadfe4dd5bcce938ccfc4287b43f33a0f9fa0463bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zstd-vendor/default.nix
+++ b/distros/iron/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-iron-zstd-vendor";
-  version = "0.22.5-r1";
+  version = "0.22.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/zstd_vendor/0.22.5-1.tar.gz";
-    name = "0.22.5-1.tar.gz";
-    sha256 = "ec0d7a1958dd40748b797b76d49512715b6e0083088b6885c47bc76f9f0992c8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/zstd_vendor/0.22.6-1.tar.gz";
+    name = "0.22.6-1.tar.gz";
+    sha256 = "8aecc16d117ff11a1ca356336d963f18682d7b7af1fa1271df1bb569fbeeb2ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/novatel-oem7-driver/default.nix
+++ b/distros/noetic/novatel-oem7-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nav-msgs, nmea-msgs, nodelet, novatel-oem7-msgs, rosbag, roscpp, rostest, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-novatel-oem7-driver";
-  version = "4.2.0-r1";
+  version = "4.3.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "20d0ac5e4194f7bd4300c8e13ae4025b8351591d38e9c3e058596bc4a454cecb";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/4.3.0-5.tar.gz";
+    name = "4.3.0-5.tar.gz";
+    sha256 = "48efcf44d44fbf2180b71540df4a19d5c281b609338f24d1aceb73891acde982";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-oem7-msgs/default.nix
+++ b/distros/noetic/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-novatel-oem7-msgs";
-  version = "4.2.0-r1";
+  version = "4.3.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "5dbe82e5b86347391fa237432cc1969df985613f41d39c37e644cab1f6bd86b4";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/4.3.0-5.tar.gz";
+    name = "4.3.0-5.tar.gz";
+    sha256 = "8b752bce7c179dccc5c0e97d743f7c947c1b1125242857d55aa717f5b56ad712";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, plotjuggler, qt5, ros-type-introspection, rosbag-storage, roscpp, roscpp-serialization, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8578f8bb447761bba79ca0a8ed071668e987422402e4b46961a5bc3812dca47a";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0dbcb7e1d14592a367ae3884ef828db6d3bb794850d5280136b0e25662de8575";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, protobuf, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.8.10-r2";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.8.10-2.tar.gz";
-    name = "3.8.10-2.tar.gz";
-    sha256 = "37a34873040c11fc9d5bce115cec66553d7aad8d3e8b7e6a9c4415bfeb7aeef6";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "8c29aadbde72634b1d5341b84f3fc6e5bea630439f21572b1b590568f9d8b8c3";
   };
 
   buildType = "catkin";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "ed1ce139e711be2c0854ea56e030a7a074cc1b38ba7029466f7d07ca262aa109";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "ecd1cf065d8cb7766c654eafc7b37eb689c90deb2d86826f1987976105912618";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-interfaces/default.nix
+++ b/distros/rolling/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-interfaces";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "21ef830feb84de8f212bc3a8e393de6d4877c643cae634bb59f4dd54e0ba53dc";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "edd6d93dc5dc703c4fc9fa4c081b5cb2770636bcd736ce453b932785fba510ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-lint-auto, ament-lint-common, rclpy }:
+{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "4b10ffb1dc32fa00104589464e2dfa952e14e3a6cdb306968d981c29ef3afa49";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "f81d727e048acff048029a09fccf5096f5b8f91ad6ca815f79c92359586bc265";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
   propagatedBuildInputs = [ action-tutorials-interfaces rclpy ];
 
   meta = {

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "b25b084d4a29c595faed8b876fdca28c0cf11341472d452e6fee622ce6b3b139";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "4a5a20a76ed3f15a06975e5a90a02855fd764d05fe0b6c85eb3ab2e6159665da";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "4264e3b0d8b96e123b35d4e203f62e969ff54e288b8f232b34a2d5c097ec97d7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "5bc0485a25343694a345bae2bb5f9979d1b92c26d2a3a75c8c9f61b2e3158ce5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "348650f4a5705691e48778bed718dcd07efd0bd3385463575e3cddbfcf52bd79";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "49957ce445beb27a89f4bbfeb0456ca274b9f984f14add01a0a137695bc1b70b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "f5d1f2c7e7dba2c6f8b11f6c5949988375b8521390a72570e5b9cd2e9761291b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "60324463691497b1ced2e878b2ee880f8f5d454619fac15ae1cbb16f39b4996d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "2e78ba0fd3d74b2bfb73e91388af248b25e3c2b925dc48fb27d2843c89e669bd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "cb19538caf358c9f6ceec4dd29211e7529d1218a3f79a10e91c2a9b22e92b067";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "7b92303d8a78e314e7a9d499cdcba3a4addca815b1bc1f159751af504181d7e0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "fb64682de8b30ac9b147b6a71948311c63fbfd6e944153adff94890e8049fd7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "1d188c64a9fb27a3e1e1f6bf91e655b0bed50fbf362a2583197066be4be6096e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "bb95edf6c24c40ed0d88963607141e150bcb26fdab431edd239584d1ae3a1f56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "cc6187656905ed7e81b91da60008e1f377b1edacdb234f5d22dacae04cc8121c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "1eafc3bcabaf3feaa6ba18f2a314ba97571f8d7b154f1c4af0d969a2d20de092";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "64dc2272698076550588a2463e9e7951cf8489e6b9169895d005b3281d3d89ec";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "47528b8fb425c58769c0880f25223e80ff7ab47985ebc34bdf8c18a9182ac718";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "5fbd325c3e877722899a22d429fcc4ef02e0e599b657e64ce512917b2abb0b90";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "22a161d552702f85582ea0ff9f1814a06bfbc0265039a30f7c6519d98f04bfc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "26c9a106940dd77c95a9e1f52c19fac8c38b8b2d21d71a62dd68005823c2595b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "0cedc879682440c2986e14c4504a5f1621267452cd9ceba4d415e2ca13f8ba9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "226dd64322257d033bb4100b9308a07c2301930b1b2429ffc6de5ba497d218fa";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "e3afa2d9fc7ea3704b67b54e74159431aaa06349f369de0d3d97964a373cb20b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "5f50cc04e67a82002036ae4fe6d5934374d83823ad53c8903d8d95b8df9e369d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "979d397f31f7dc502262ff1e462da3d5e60006f5a063b4264468e94fddde8e3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "d2a2dfe67ba2fc922dbe9b36249876a5ec397914ad2c52d490181b869e6559c3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "f66dd865805fbaf0bf8dbc367bdd074388121beedd35ad927c7cb9daa6ddf1c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "4b0323eb54d3ab7891a583d9838c2ae7e23b27bc82150a425d34bf96bbaa24a9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "81097e9e1e1586ae119ead43a9a07bfb8ebaaf1e41e1858139741a7d2acba576";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "5888c23656de0cfcf8fc8d362ffa986b8dac3e4dd41605ecf4f16ff93aca579d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "ae21aa4bc1865d391b40fe15fd4cca0059bea89542cced349be28ac40ae49dfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "55144ab4db5bc89c41f37bbf68224c52008c8c93ff08c9ff3d92bf2ef3092b13";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "3572839a302c55668f70e7e76277c0588d9d2bca69ad00fe73bbda48a9f9a997";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cppcheck }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, cppcheck, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "737b80f578c8d21f85c436784614941f968fe7b33f7e68430e369557e486d890";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "5414263b8174a0e349c769d6901587640df8178eb06d2149da622be5910bf741";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-pycodestyle pythonPackages.pytest ];
   propagatedBuildInputs = [ cppcheck ];
 
   meta = {

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "565ab1651eee10a754cdaca12f164aff20407259f4d79d72c1da64d9437c44c3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "f1ecf327961c6c4e4c3e55fdc08031917c6bb62fa95bd105c34110ddd67d3767";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "fbb74c4c89bc7b6ee226579c87f28ddc25e5dc28ef7f5281fbc12946bdb1d684";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "f43dcd7b0117790a1daf53af6298aa407c1036e3c385db85d2d54128c8918155";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "b54b11e8e72c9a71a37927eb9222730e130c3675d437bcf88ce87a74cb64b67e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "d60cddff17ae5461ebe145b0b9fa1b2ed69433086a8fbe77bda82a2aae77511b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "783a37fc6277f2fd2d906867b4b3fd6b159c50dcf9c8bc0a1ddc2943a46fc1ef";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "fc500c03f0735d8565e68a464fbebc52018ce85cbc14dbe62fe4599f1191b6e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl,  }:
+{ lib, buildRosPackage, fetchurl, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "018317be2583f7e6fea851b2bca83eede04dcabc72f3e4c6d3b16427a1935d0a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "f615c28f2950a07a743d56b1c2ae1d7238b6bd3abf4c3a1298401ce6a61780a4";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
 
   meta = {
     description = ''Providing common API for ament linter packages.'';

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "065b473f2afa2d29768d02f04625b5d30b9062438699cd4fe652911aa0169cd4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "daf5b2d5ccf6049016a276e99ef1e9c114f6d42c3456cd00d86e4469066ba2ab";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "85b4f49e6710834152d86287533e0f2a95d1f01aeb1ca2c610a952a9d7a7a487";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "cf8d1fe485a76d09a3f955d6560c63991c62e18022eea7e297e8e56a804fb913";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "9c565e399793072902df3ada770a79ded242bc2ee6a9fd3de95e215628674aab";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "2722c4e3d04429687b73a2020542971424891477c19acea7635ed493b8b9603f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "73f8fd732334be1555eb5451130972536856a60bc13d88555ca052b884938a90";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "d9d4e55d8eff4d98eb60dd021f8ed08676da160fa42399a363867dcd332e5ef5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "3703533139e1c5e2ccb6659c77c629702193cc865333334d466c9aefbf147374";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "1a7da8b0853aac9457beb4e4899e4ade7daacb002c93b2f55257f21c29839ade";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "aacea183f86914de5be1abdcd355c3ecbabc5bea31481400cc4ec2843fee68c6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "95073a3cea8de340334e4843b4adb4be253c2ee40eb04fb96ab9c581eae48063";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.16.2-r1";
+  version = "0.16.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.2-1.tar.gz";
-    name = "0.16.2-1.tar.gz";
-    sha256 = "8a455cbc6c5106311a06bce268e0e05acbe95680aabdae185a40460af83be27f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.3-1.tar.gz";
+    name = "0.16.3-1.tar.gz";
+    sha256 = "633ae2fd4c7ab651ac6eb031e8630ca1660771c4d5e32bbbc03bd729cbc1d7e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "772d4ce691ce0a43f667fe435787e18ba15a8d5cc167e3cb86676ff0292fcd32";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "eb0413920564a829a182b4f7062c07c2e0c2dbdb7777004907a8c594ba4426d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "058939b1a9d2e5bb6e99d283752b60971af63db2fe3a0e36ca1f26ca235e867f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "bb598f6cb3d07f326d405a24f5075a771aa6510007cfab9871ff18cb85a1e06a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "51135f826768e7f4a4623ab740cde7dd1fba4cf823efb5d56a0e81c331d6b33f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "67f12b6044bc7078085ab2aef44e33af9e9f7ea8d65b394dd41dd98c57618689";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "64984e86d8f8d47e77f0e9e561bde4ae89189532250271277dccf588911ee458";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "541f8f058f56d9d0850a77634e81fe664b38c2093375424df755516df896068f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "edc9ccb37c097bb6943f3b79b22e98655232187302daa91feba602c66d0a0155";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "16c3f2c0b12ff7ca2b99fb4943a52d8ec378ee7df8dee82849e7a36586a1c577";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "571c4631b8445a40fc7a20f2c1d8932bac16984a51b05681e13c58f80349fe0e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "8c4fd8dd8571663211c1b93083cea4d3b2e7165dbac9c41509e4849de5b7e96a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "35179b053073b167130488a9cadd154c075277e0b37650c5c12129316861af88";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "327121a834e80484291384c37d29f44545f0871b42fd462fba99cbd0a597112f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-codecs/default.nix
+++ b/distros/rolling/event-camera-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, class-loader, event-camera-msgs, rclcpp, ros-environment, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-rolling-event-camera-codecs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/rolling/event_camera_codecs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "c0a6514250036d4a24966f26248e29a4c2045dab0f51ad3f44054868e331d33f";
+    url = "https://github.com/ros2-gbp/event_camera_codecs-release/archive/release/rolling/event_camera_codecs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "9dff5198de83ca75b2622e901af8a937a1bee863b48d32ae9416d51fac178007";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-py/default.nix
+++ b/distros/rolling/event-camera-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-event-camera-py";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/rolling/event_camera_py/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "2765ea79f241210ff730833bd04378095e76262dacf3ae0d1acbdfcf28570fc9";
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/rolling/event_camera_py/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "ea28d086d2a365d3f7aaeb76a128adf104338004054937ab78fe3a2071d6d078";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/event-camera-renderer/default.nix
+++ b/distros/rolling/event-camera-renderer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, image-transport, rclcpp, rclcpp-components, ros-environment, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-event-camera-renderer";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/rolling/event_camera_renderer/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "82d4d1a4d192c030b10fb9796986dc4e4c21e6dd3568d2261948c0889a2df2bd";
+    url = "https://github.com/ros2-gbp/event_camera_renderer-release/archive/release/rolling/event_camera_renderer/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "78f73634e902653e35c41d357af69b5a1d7adbb5d32f3a5860b257a6e8b1664f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "fbc9808210fe9d4a080e69d27cbb4193da0a44106c0d9d8302f357cde02292e4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "66b96390546e53d98c78e6e4039535cc52451a73445296361acbccc3517d2116";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "ddd28665242901e478d602cb35b06c22949a4f4f4e068f59e565e4a06a9c1c00";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "73cecdc41cd37c451d612700d91bb2be55a6b747ec7ad8bba4ca7e02ddf3658c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "7b6139e869dcbedea00673e708c6c6e9c7f6e34840ac11adf9bf1f430f2d7a7f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "d3defe4aa2a941af069f5bebeeda04fadd6a669f832b50d4e67fea750c02b7d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "d7eaf726e426f5ada0833f376f3909f98f7ef3b441bec789d1f6fc6d65b3a9bc";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "36535641d57c990532ad027037f9938f3dc188dba6549b5363c06d9cadb71544";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "d9b9f3a0d79084aee3888f9eb879811e29018a036ec8583c29bfc625da7ef057";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "719db23da9a1b3ffba8218b1883620d1474e31f8d6305083f480d1bbdb766b8b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "be98377b482a9629162f0fb5916ff941ca33adef735ecceb91508c26b2a5d86b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "acf1aeba40e3db6288e7bb4baaac2120c1938b890b3bc0e93fa700fddec7f612";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "7c1fe8a784d153401c8783cbcf4cd262ed792eb3e9ad3f128bace6361d457906";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "db455162ce6b8fe23757a6d5a9f04e535bebb4c11120673968ab828d99fb26bf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "1a178dc243684e03032ef09ff4a3fae2b7517e7801680db5118673c4ecdd2cf1";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "dc5b1635d806fcb3d6114493e42d2e9deea8c39c99179dc18e3a24d8e239505e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "b350db81dc52ea6303baf4e22c889fdd1894d5c842e4f3af838238ef65d6ddef";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "6ec00079f4554a1dad0987a7b1a0a6e9c762413ae1222eb03688e9df0d16708b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "5fe988ed47a5121ee116a5f599d04eb052f29d681a74318265ac2affc6e98b6c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "7ba61ffaec82fc3353aea92e8662d2f57c1350a2e774c02e9179c6269994bb15";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "19797cbc95fccf3a5734fbe4e4a89735ac9b09766f392b92adc8e279c3ba362b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "1cb56d04e92304514eaa8c130c5826d7e452db8e18c81d53ae0ac84a6fe183d1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "19a7e6fb96a3a06ca22ff5a5ee9313d7c705887e2ba4415ea8bb072783594bbc";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "03735239bd74aba88afc1d44937b4010578422783c4d32d8f5aace52bd6a2ea2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "1a9802b45461b28703cfa541a92bfc9baa792aa367eb102fd8891a1d4abc8a98";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "86ef9c2385712dccb3c956f86ef90c5a65555d4a5ee8cef0cf7aea92744764b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6b957dd36f0432ef106b54c2826af9ea11efe522766a226a16f3e58d6e8b9de1";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "97c31b759e071cf6765982e953b6c9c02ac17cf8ecd9f320c4a6353fe8ab4445";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.11.7-r1";
+  version = "2.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.7-1.tar.gz";
-    name = "2.11.7-1.tar.gz";
-    sha256 = "6d142d09b03488446610fbb8c3fd362d74927cbf5ba7535e6831f6cdb2bd2db4";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.8-1.tar.gz";
+    name = "2.11.8-1.tar.gz";
+    sha256 = "801e14d7a86d406199de7c7a66ace472e1f20846c434bc4171e1bee566fff0dd";
   };
 
   buildType = "cmake";

--- a/distros/rolling/osrf-testing-tools-cpp/default.nix
+++ b/distros/rolling/osrf-testing-tools-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-osrf-testing-tools-cpp";
-  version = "1.7.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_testing_tools_cpp-release/archive/release/rolling/osrf_testing_tools_cpp/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "13bc9926c3d325fb4d149e37e56aed193e142b16b34b5779e223e9bc043558e1";
+    url = "https://github.com/ros2-gbp/osrf_testing_tools_cpp-release/archive/release/rolling/osrf_testing_tools_cpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "df484a4a0c0d6d5b13e72271bd146485c7b0a470191e69acb54199813cd2be0f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "12c1ada97306457258988dbc1beaf10c633c80fb757a6462aebbcfc3be05d05b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "c2f8f20092def20bbd8c09ed0f432ee0f088968b534dea9b75b166227508c4c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "5f68fb4155a3d15021f643c7422a78835120ce227dc8170d266ca5166d428308";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "3a85377ca8b95bf06fd672e590b50e0d02dc0ac4989ad8059c19570c724c2073";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/plotjuggler-ros/default.nix
+++ b/distros/rolling/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, plotjuggler, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler-ros";
-  version = "2.0.0-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/rolling/plotjuggler_ros/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "ce540bc291b3bd691c732ade75998a5dfac2a7a1e4beda55ee6bc8ecd50a3b00";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/rolling/plotjuggler_ros/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "bd1a536f67aaae1050e79814017381acadc4f37ea84376a85f02bf92c2bdb8f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/plotjuggler/default.nix
+++ b/distros/rolling/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-plotjuggler";
-  version = "3.8.4-r1";
+  version = "3.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.8.4-1.tar.gz";
-    name = "3.8.4-1.tar.gz";
-    sha256 = "7139d0e031dd3d447ea5a5115e1f5b43bd1d68ffc8f944cb2733fdf192c39aec";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/rolling/plotjuggler/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "8f3a44253071da03fe935a1e140785aa23b711dc903c4a8391c790d3518539fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-qt-binding/default.nix
+++ b/distros/rolling/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-rolling-python-qt-binding";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/rolling/python_qt_binding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a74418286d2c7b4d878d673e3ab6454db851d860ffc28c1e8cf2522e894d63fc";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/rolling/python_qt_binding/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3c1ceb82aa762be959a563da4f9f922a76d659eb566799f9c31c9451005973f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-dotgraph/default.nix
+++ b/distros/rolling/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-qt-dotgraph";
-  version = "2.7.1-r2";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/2.7.1-2.tar.gz";
-    name = "2.7.1-2.tar.gz";
-    sha256 = "1bcecd4a19ea1fc4602b57defab8aa008c4eefe0baa3f5bc021c63ca2cb35e2a";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "cea4a06de168cf6955ab5c2966fd8dfd04d012f2cc3e2b292fd5371bb78510fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-app/default.nix
+++ b/distros/rolling/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-app";
-  version = "2.7.1-r2";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/2.7.1-2.tar.gz";
-    name = "2.7.1-2.tar.gz";
-    sha256 = "dee9107c8ef53074ff74a421f727faf84c0c541653c14b8adfd33d105a204d3b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "de21b6cc7d41c3c838347c998fce0d986fd208177dcde081d5d2ada89d5d5cb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-core/default.nix
+++ b/distros/rolling/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-core";
-  version = "2.7.1-r2";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/2.7.1-2.tar.gz";
-    name = "2.7.1-2.tar.gz";
-    sha256 = "a468428dc068155b9514bd13adb3a799fed50aacda9b13c3f7a2788dbfeb1385";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "0c195e5fa77563c4ce20e8a7c7a604e5c2b837b387000b8c6d4599aa28085130";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-cpp/default.nix
+++ b/distros/rolling/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, rcpputils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-cpp";
-  version = "2.7.1-r2";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/2.7.1-2.tar.gz";
-    name = "2.7.1-2.tar.gz";
-    sha256 = "88379273acfa350b4a07d45b3538ec1dc07f977022bcf08401825b1c446f2535";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "b5000db0577e6aacd0cf3510d25150446de2896acbb607fd89cb7de2a6ba0f0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-py-common/default.nix
+++ b/distros/rolling/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-py-common";
-  version = "2.7.1-r2";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/2.7.1-2.tar.gz";
-    name = "2.7.1-2.tar.gz";
-    sha256 = "f8c9a4696fb8eee93651038f05e3a8c52ac4781d079fcf4715fe06e204940d57";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "db97bb2a906ba1865e0ec44a127d7df42879925625f8836232e3e6f8c096d702";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui/default.nix
+++ b/distros/rolling/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui";
-  version = "2.7.1-r2";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/2.7.1-2.tar.gz";
-    name = "2.7.1-2.tar.gz";
-    sha256 = "5f55584cd2298b5a7911e2d0d7ee1649944f594bffa231686db84a1ea68f817d";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "b5e3256a08ee4325ad5c54783915e18e272b1c93e35a584e6d1c6f2094053a3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "4e55f987c6437f5e9f781542ac0da340e22f263a35f81086b9473a69a7e0a1d0";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "ab97b8bc06cfcd3539d85b748e7ac63435b1e2d1c057573a45dcbd7b29449760";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "29619a7d269bac38fc89688697047c4fce7888509e32efc71c4b337fb12a1be4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "b95fa7bf1bcaa38d4da45845d6212d74f6dc12e3aff3c373f31d5febcc55bbd5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "26.0.0-r1";
+  version = "27.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/26.0.0-1.tar.gz";
-    name = "26.0.0-1.tar.gz";
-    sha256 = "50f61e3b0131b55c2344cd6f9af5e06c463da1f8dddd4616b2607410720d26f2";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/27.0.0-1.tar.gz";
+    name = "27.0.0-1.tar.gz";
+    sha256 = "7dd185d6266476fa6237f1b88df6866828c4e82db2e68c6b9080f173be11f32c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "26.0.0-r1";
+  version = "27.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/26.0.0-1.tar.gz";
-    name = "26.0.0-1.tar.gz";
-    sha256 = "33c7e9f520fb448f7971c427ba33cc2923120fcd2d01d76c8d377e04659fe642";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/27.0.0-1.tar.gz";
+    name = "27.0.0-1.tar.gz";
+    sha256 = "3b5adb1d97210210c20865f52d678b95debb92a483c7081eaa90378b277f1fb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "26.0.0-r1";
+  version = "27.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/26.0.0-1.tar.gz";
-    name = "26.0.0-1.tar.gz";
-    sha256 = "1f02d09936d1a313cf1e8c92ba00e758f2e7ade159693d4780e8f1dbcfe042e3";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/27.0.0-1.tar.gz";
+    name = "27.0.0-1.tar.gz";
+    sha256 = "89c343cb0979f161aaaec846ee3e32c0aa0bd3393bf3d63de53e7b3626537208";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "26.0.0-r1";
+  version = "27.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/26.0.0-1.tar.gz";
-    name = "26.0.0-1.tar.gz";
-    sha256 = "5edb37d9185730e56e94da1d25f7107b51004fbab19b3083cd7c4225f43d76f5";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/27.0.0-1.tar.gz";
+    name = "27.0.0-1.tar.gz";
+    sha256 = "d2ededdc04746108bd374374b7a780071812a716e1b9b2d7402d85b6c301ffd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "c72b6006fa9e3b249d2946f6d4863eb6598a20e4646ea058ac4a1a2f84d6d6c9";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "4a7ec58a5b010cc0b386384dea5522cd59a85eec6075a133ee8676134845791b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.9.0-r1";
+  version = "2.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.9.0-1.tar.gz";
-    name = "2.9.0-1.tar.gz";
-    sha256 = "ce5db4ccaccc678efa0ea1029920d16d209e8a594add6151308badf90311db2e";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.10.0-1.tar.gz";
+    name = "2.10.0-1.tar.gz";
+    sha256 = "407b184d8a423a62d5eaaacb2f64e9d64bd1c424e6ddd0a290cf91333f7ee1c2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
   propagatedBuildInputs = [ rcutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.5.1-r1";
+  version = "6.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.5.1-1.tar.gz";
-    name = "6.5.1-1.tar.gz";
-    sha256 = "189724b1d723d05a14d03e7a8c75bbfe874727188a1c3f50ca8cbcbc80dd9a2e";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.5.2-1.tar.gz";
+    name = "6.5.2-1.tar.gz";
+    sha256 = "6571cce7867f3df671397a06aaff38cc254c95d8b5743385f77235227e9803e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "6169329339a1c366f328afd8ff0a5e4e65649559980b38bccb674bccd903c718";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "f3dff643a380741fea2e8180d2f532bd9432ed6e59692a7fd8d1e48c9dea7876";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "04c0678ab6b464b8527ef0de06d6e3e3c22150d59168565f16c4a8847e676938";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "da0de9c62f108a683313a027dfc12b3488825845bcee0e3ea4dd407928a45ef7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "548931c1f6241e9e9232f7a6d8db58fca154bbd284d3745eb7128e7b6c03b7a8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "c6ddcf307b73058e81d4bf8e337a9e9c7f3f06b4fda0e5eee57bf54c603c834e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "23e6e07c93e7fd3f9340318048a36357c7b2e4e0d4950b20a2d7205b4bd84935";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "e70a53ce225f375594c22ffe1b3749945d248dfebc47b6cff94788deb426a582";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "f98403216eaa291cbd74fd350f2a27feb828dbf2cbd38fd91fdae73e591bce48";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "25889202fdd8a6dd7b711c983bae9310e7c90391aa3e04943e8d4c71cce6bf3e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "a601aa9469838995bb95c091d081cb78205e397da26ffa9ad59e4db78e27f9b8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "c92b76150cc6e3befceafa614e9eb7c02d7a13cd8c6a7537d9c089bcbf4ef641";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "a600578e6e5caec0e234e52e7b0282cce1c00ba152bc59363cabb12310037efe";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "fd9217d3f72c1e12595c39485de9e14d06c17ee96a26c57d76a55c4650e9d92b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "12e04163e1f15ae751698e0452c18509743421af99dbb558fe4f15e81f992e31";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "071d8b9a16dcb35a4aa16ffa7d0afaac0c89479a2bc60ae5cc172aa07095f897";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "54e8fd9bf93547e7c7d8e8017ab60eeb715995d66711418b11ae756cc3200240";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "6948b0894f9b4c04c45134dceef2a2ebc05ed3030ebde05a16ea12042c903bab";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "34f56439fa35fa00486e229a318cb4a98ad3ab1930c67c03521d7405d194d2ee";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "17d3bce820f001ea4b57afb3e6adab84fd1be8f2899c5d22d71a9b88e9b3d400";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "2dafa40b7bb8c6f8f724fa1eede3e3cfc314b6ca9dc4deca15d5a7ae359e6f65";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "b18ae65498fbfe4ba15ccfb58828a0d78c30af6b3505e88fabb44acd452cb0d5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "2c0fcb108c1e7fb4bccdea0076037418f8ea8fa0130694783ad8a3d56a17b825";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "0571dd314a148dcf59d4b32372ab879b4794e85720ad59e6508af3f73b9898b6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "e000c983aa9f2df21957e01f31aa099e02ffb1cc7cf4863e2d94dc7ac6639a1a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "00bcdbbf96cdc23be73dd5b19f117972a5c89bfc19c5f93e251d09b56ea4a4b0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "8db70bc25e81c2449ea1077ea4df674ab15139ab3f5a852607c4474195dcc401";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "24794a9818758a98afc92ad0f08d4e7cc23b7ccc7e7daceacf5b09282b0a781e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.31.0-r1";
+  version = "0.31.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.31.0-1.tar.gz";
-    name = "0.31.0-1.tar.gz";
-    sha256 = "f8bc0a76d6e03c4e8b0671af8676a5be3980798402b26f711d6e70fa754d02ab";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.31.1-1.tar.gz";
+    name = "0.31.1-1.tar.gz";
+    sha256 = "6b57cb4fdb6486e973c2e0d8009e04d19d897d296cb8358c7bdc3a277754d2b4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "850b5dd3c4bf13293c50405a5b6539c84324c1b0ad068fa300bbd491466fecab";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "4319aa53734fa03948a223e619886bc9a6b2c8914d4cf98898ad5da0a7f335b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "b2eeb4e129d8d61e1f4904f6f072ed77fabaff8fbcdd9d670b1d5f7c0745a4ac";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "8fd68aea9650533bb48a945823d6863ae677acaaf9fe07d251ecf26f4d1dc8b5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "5772428d96638fc765034283235a2247ccddf40d6aa73a47011a1bf0d56f30c4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "5356b52a06e3484b9aee62c2610874f397c655a79e91a75ef33c8cfd7c0f3c17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "1d2a77d7e045bc6f38b21babcb2f2cf3325388803a4a0205293ff596c955dd13";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "c617f8100dd13d410e52298e2bbc5ecf532163ae8545d68eedf51e42a2eb14a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "ed2a640e6f1b3176d439f402b957d573944c17f1998154ff0d18de638b884ff9";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "e5c2cffc1af2f399829db2ea6084a92fc51eba80294db0ddc44c3f84f3df5e1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-dds-idl/default.nix
+++ b/distros/rolling/rosidl-generator-dds-idl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, rosidl-cli, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-dds-idl";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dds-release/archive/release/rolling/rosidl_generator_dds_idl/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "c95bcdf7eed85b9ef525e346b79d1458772c545e8b7cd15ef881fb0c3a2c99f9";
+    url = "https://github.com/ros2-gbp/rosidl_dds-release/archive/release/rolling/rosidl_generator_dds_idl/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "954efe2fb2437bda7d89e5e40b5002b69cba2eb4be9f11700f4afbbb25fb58e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-py/default.nix
+++ b/distros/rolling/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-pytest, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-py";
-  version = "0.21.0-r1";
+  version = "0.21.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "318d6a7fbb9f3ac53970a2968c3cf05a9b31b17d2c9dc80ad359dadabb314272";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.21.1-1.tar.gz";
+    name = "0.21.1-1.tar.gz";
+    sha256 = "d0e0b3fd519155f880b582312b745554b5627250acad14dad460b5569bce56e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "8848a044cb19eaf94c53235a186fb73cb485d029bee1fd9b231b421f6c0d44a2";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "3029a5e513e1682791c12b39b977b3235301b65c1ed70700e3ce37ec1ea5338d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "45c5a56b6c36e3b7927faf83e3d599d1b0a344864dbf754d344b472b81306224";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "b6ed2ab2f1039dd8c52ae7d6ee6cc42eea271015193c07e47dea40eda09c5fc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "c20511690a1f379ec2a3fde05b25dc0203fb4655f8296c0defeb4951b0226e95";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "b202be18827878888d7b0fc342881848740bf00ea328aac17851cd45546da2b6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "4a3b686595d8fef44a25af381d6f900f9c1502c44d2e394910eba68010e13453";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "cc49995febae752e7ea55aa21630010b06740733b749c3b1615bfca515a77d34";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "27fb2621521ba1e6dade0087e2c85fbc95aa3f8fefefc2ccdfbcc6970aae938b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "d0da4b45f9ccacab6acc846375a6d88d209f9e8c3612e17ee492bcc290212401";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "92c90b6a91bb2becd62eb81de0b23db1f1b2f19e5a523ff90915ee9cc5182536";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "3c472802cc82aa461c0cb9993c8086a923b0b7d6d2e0f22a85a3b0a721224638";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "ea3739c91bd48824b3f2a9aacce7929e4693b77b34425e2ca86e6bdeb503a790";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "49047413a355c0e5fc83eb8d2e6fa82650ff168e3ea6aeede61ba3c6ddeab7b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.5.0-r1";
+  version = "4.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "feb0da32a45665940f679b0f183a37e0411cf70136c73ff378262605406953dd";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.5.1-1.tar.gz";
+    name = "4.5.1-1.tar.gz";
+    sha256 = "9ae55c8b580fcc9b522d0769d8740d946eadb250a1c841206eae8184dc7f08d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-bag-plugins/default.nix
+++ b/distros/rolling/rqt-bag-plugins/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, pythonPackages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag-plugins";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "c3a40b916317e3afbf2ef0097f8a0940919a64d01f715b2ecfa3b79a9a4c716b";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "3e38af2a585419f175ef38e471eafac7419a39ba1de0b19dd56f64bb85e42e6b";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ geometry-msgs python3Packages.pillow python3Packages.pycairo rclpy rosbag2 rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
 
   meta = {

--- a/distros/rolling/rqt-bag/default.nix
+++ b/distros/rolling/rqt-bag/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, pythonPackages, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "41c74c839e2f7e517528041e77ab0241fb8fb581c0e88ee166de69c9376b6985";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "538faf3ca21bb495d08387690531bda0c83e931c0ef6f90063c04e87b0eb615b";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ python-qt-binding rclpy rosbag2-py rqt-gui rqt-gui-py ];
 
   meta = {

--- a/distros/rolling/rqt-console/default.nix
+++ b/distros/rolling/rqt-console/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, pythonPackages, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-console";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/rolling/rqt_console/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d892e2d1bfd9463576128452d171c00531d24e7c4d10ea21a492dc5319b26ffa";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/rolling/rqt_console/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "17590ab8b0317cb5a9330efaeeaacb1632d8d57dc97f835f631b11ca72332169";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding rcl-interfaces rclpy rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rqt-graph/default.nix
+++ b/distros/rolling/rqt-graph/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-dotgraph, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, pythonPackages, qt-dotgraph, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-graph";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/rolling/rqt_graph/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "7abf7fb251aea08ee8b3d8106db41869a283b790a0a6dfa9c91d49568c5ddfa7";
+    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/rolling/rqt_graph/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "caf59c52316ec9c4236c445faacfea96c974be6b474c7e7a1f125235dd9920fb";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding qt-dotgraph rqt-gui rqt-gui-py ];
 
   meta = {

--- a/distros/rolling/rqt-msg/default.nix
+++ b/distros/rolling/rqt-msg/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, rclpy, rosidl-runtime-py, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, pythonPackages, rclpy, rosidl-runtime-py, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-msg";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/rolling/rqt_msg/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "034dd256f67aee69220c30ae5455eb6b2433542e943bb8044d0c740c40aca13a";
+    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/rolling/rqt_msg/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "ae986c8092d4b4dd6a5505f35815caa2829ef8fffe5990578db8cf5ca908455b";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-flake8 ament-xmllint ];
+  checkInputs = [ ament-flake8 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding rclpy rosidl-runtime-py rqt-console rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rqt-plot/default.nix
+++ b/distros/rolling/rqt-plot/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, pythonPackages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-plot";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/rolling/rqt_plot/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "815546a9a6ac19043de3a24ca9a0f215cc9c4e8f7ec9c4532dc0b287757e42ed";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/rolling/rqt_plot/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "6039d06496cbad98c251b89bc1c471bb68b8aa65b266c81ac122384060759315";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg python3Packages.matplotlib python3Packages.numpy qt-gui-py-common rclpy rqt-gui rqt-gui-py rqt-py-common std-msgs ];
 
   meta = {

--- a/distros/rolling/rqt-publisher/default.nix
+++ b/distros/rolling/rqt-publisher/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rosidl-runtime-py, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, python3Packages, pythonPackages, qt-gui-py-common, rclpy, rosidl-runtime-py, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-publisher";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/rolling/rqt_publisher/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "f89df5393044f2039b0d019b1f18ae68696d41106755dbd3ec74c929fdf9ccc4";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/rolling/rqt_publisher/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "78681d97625f253b66ca87b124a49ac0ccb1c251591f1f0e31f63fe9e44b0df2";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.numpy qt-gui-py-common rclpy rosidl-runtime-py rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rqt-py-console/default.nix
+++ b/distros/rolling/rqt-py-console/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, pythonPackages, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-console";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/rolling/rqt_py_console/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "5d2ec9dfb4507042d3d606c556e51859bd12507f6aca228c31684ceb6338a5c8";
+    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/rolling/rqt_py_console/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "905f4f3f4ae3a6ab51cc70dacccd9bf5a195f164e6dc3bd899b98a957548978c";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding qt-gui qt-gui-py-common rclpy rqt-gui rqt-gui-py ];
 
   meta = {

--- a/distros/rolling/rqt-reconfigure/default.nix
+++ b/distros/rolling/rqt-reconfigure/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, pythonPackages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-reconfigure";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "7ef228cbfe216c319f182aa87ae4fd40dc6ff6a3a99658d9bc6dded5af2e4a6d";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/rolling/rqt_reconfigure/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "829ecceb05348afe7d4408d9be8c35dc2ac097fe32d953c62adcb85337d023a2";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-xmllint ];
+  checkInputs = [ ament-copyright ament-flake8 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.pyyaml qt-gui-py-common rclpy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rqt-service-caller/default.nix
+++ b/distros/rolling/rqt-service-caller/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, pythonPackages, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-service-caller";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/rolling/rqt_service_caller/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "254919afd5e8733ac87c15aebe130dc7f7746e90b7000377c270baad8c919019";
+    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/rolling/rqt_service_caller/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "dcc8ca52c9c76c34ff1aa0fecdd248c7e5ea41e004635e14bd863defb5d7534d";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rqt-shell/default.nix
+++ b/distros/rolling/rqt-shell/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, pythonPackages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-shell";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/rolling/rqt_shell/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "092ef9c1498b0909918ea024d085dbdb726baf081f667b1a3ca68cff89363256";
+    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/rolling/rqt_shell/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "dda320255d68b1fe7cffbb553ac21b31803bee373dd4c7630fe13d36bbec1bd2";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg qt-gui qt-gui-py-common rqt-gui rqt-gui-py ];
 
   meta = {

--- a/distros/rolling/rqt-srv/default.nix
+++ b/distros/rolling/rqt-srv/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, rqt-gui, rqt-gui-py, rqt-msg }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, pythonPackages, rqt-gui, rqt-gui-py, rqt-msg }:
 buildRosPackage {
   pname = "ros-rolling-rqt-srv";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/rolling/rqt_srv/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "878fe4e1ef812f8f2239e0dae597e209da17210bafed8f5fe8efede2a3a1f7d4";
+    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/rolling/rqt_srv/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "e100358e82bc5f3d6d5c74f08720c48330546fbb545aad6253471f506055e8fc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-flake8 ament-xmllint ];
+  checkInputs = [ ament-flake8 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rqt-gui rqt-gui-py rqt-msg ];
 
   meta = {

--- a/distros/rolling/rqt-topic/default.nix
+++ b/distros/rolling/rqt-topic/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python-qt-binding, rclpy, ros2topic, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python-qt-binding, pythonPackages, rclpy, ros2topic, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-topic";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/rolling/rqt_topic/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "de88ed7540880aa6b1ad77647bc3783a6b8b01f47479a974c36cb224f0a996b5";
+    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/rolling/rqt_topic/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "302cc958c1b2c2961731f0e489d9adb477911ece6ab848fbf094a4739df14ff8";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-flake8 ament-xmllint ];
+  checkInputs = [ ament-flake8 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ python-qt-binding rclpy ros2topic rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/sros2-cmake/default.nix
+++ b/distros/rolling/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-rolling-sros2-cmake";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2_cmake/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "a214de05697ce0df49699fb8e112f891ea56a06bfed7e56b1e671f841dd73216";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2_cmake/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "8ece57544a7a24df10e903865934e6f51ecc79c29e615f8a44303ae6ed48a4c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sros2/default.nix
+++ b/distros/rolling/sros2/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sros2";
-  version = "0.12.1-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2/0.12.1-1.tar.gz";
-    name = "0.12.1-1.tar.gz";
-    sha256 = "6889bfae6041e4e0065adb8270a17c7aa9be62d19c1d7074a3dbdcf3799bcbf8";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "9b67b88186f059ddd745439ebd9d16bea6c3cbe9f90c971366c97f7a0b3a9913";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ros-testing test-msgs ];
-  propagatedBuildInputs = [ ament-index-python python3Packages.cryptography python3Packages.importlib-resources python3Packages.lxml rclpy ros2cli ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.argcomplete python3Packages.cryptography python3Packages.importlib-resources python3Packages.lxml rclpy ros2cli ];
 
   meta = {
     description = ''Command line tools for managing SROS2 keys'';

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "e07dfb1282d8be9d3da8bcab7c9b9d5dfdfb4447a46349281c5fcf8934185a0c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "9e4270c51664c5d4fc56743d42b88cc39e9de0ffa1cc3650cb33458b99f21333";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "6549007b49f60d3917714adecedb91ba2bcbf8c190ca4accb2b070e6a82add01";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "b64ef86cd072252557eb57476b3ce94c885c71e40a519640c526768b8aa13370";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "bfce9e7358e482f9a2e6ae9f31a4f137a5a4a24de007339001055622e601039d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "54391bbaa68d4da784d136f458bc740b8e210eb0e30c0541cda1ccb10bc88b96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "24ccab60388e8108c4773bfb13d4fda5d2f58ab0e0ef513a4d168f500b17134a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "066d754ab7486cf164c5f907d9501bb5dd11e1ea7e79c4151faab698a546e3bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "cf04536b999974a0f00a32798cb3cf6a1587a0034e72bcdcbfe6ba8f5fb58ff5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "c9f7a33b2e2241ef9f550b4f25d5584a6266404e90ac62ad645c7c34a6cbc823";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "b93239a049fc1b58693f505be87c9fbd9c06552e145066d6f88e45b5b9173aaa";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "2fbbfa5839bfd07262289a491ae3bef1ef4f807bea7e7874a4749decef1c26df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "38b23d5db3db10bc45fb4310b3940b61c11881e99e3177b80a3f4e9f396a9c83";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "fe11158e193659b4ff69f5436eac88acf0fcf4a1861d92b03381e3bfc39c8341";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "b0d19167314b691d23e8c79ae56ed2c0f1763939240b729582da0ab96029d7e5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "b62a65fd79d8868ed44df4072a1b79be3200e664689dbfa73f57a56946e64dcc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "cd5ae201ef9af377bf7e673f6e9a25bdcac6cf75491f2548707b256d090cb767";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "51fff7b584cdda7ae4166951821fa06d6e4a130adee5a1a9f918019f5a5851ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "0f8bdd7a945727dc73d257d84c389286ab735db8f9258a74f6934926fce40192";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "5c1ffb93fd889caf62d30294d833e9667f2900dffbf49832e5c911a40e40299b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "66ae0671a03842b7858ed6491df8e911b09dbbb296159a0612bf250cb469becb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "58189b009eb43d99361ecb8eb5c4fd8a9ca724b31f4bd1443cec3ab0ff048fbb";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
   propagatedBuildInputs = [ graphviz python3Packages.pyyaml rclpy tf2-msgs tf2-py tf2-ros-py ];
 
   meta = {

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.35.1-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.35.1-1.tar.gz";
-    name = "0.35.1-1.tar.gz";
-    sha256 = "2c354143e6d26021ac19f420dbe82f2f6159ceacf87576014d06710485086582";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "effc6e29fc3b626996dee6b3bcb7a89dc2147eff997051b259723136a5dc89e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "621b942f59ae2a8fede630cc74022214923781ed212bcb349f9d9262d44af1b7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "fff21da900f0503894b327ff59f54fb28f716886d636b263a9204977b331ad58";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.33.0-r1";
+  version = "0.33.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.33.0-1.tar.gz";
-    name = "0.33.0-1.tar.gz";
-    sha256 = "d79d6bc65e2934b2d570150fd820cf5d6dd96bf175feb2edc914ac0d5b59998d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.33.1-1.tar.gz";
+    name = "0.33.1-1.tar.gz";
+    sha256 = "d48c35965fdf60b2108274d26584d0fbd883fc45d242192b564f1085789ca487";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "28ef2304ff1c65b3f6c15b1dfef87f271995fcdca5f6c572ea7f90b3722fbeb0";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "c0b59e3b9d94822775e1bf8378832b4e0cdd38d3be11c18b38ee9068d1bf2eee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "8f6ed573712d279fcef73fd084aa565d01f500ab15a67358f2cfa6538d0d3f4d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "7a5ea95c8184f7569360c216652c660710ed8d1e9b07e7c9a6ac9efa6aa2fe4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "25666f59f58b321af50c83f192870a66c01eb1ef7ba993499eb9efbd60b64835";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "040247afcacfb6723cad2a8658dfcccc3942f705682c2df52fc1b9490e995cae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "378cfce9f19ae3eea8678fc3b0062917ce7243c0da93948b6049011b40f8b103";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "5a9fd7c09d8191c3d9a56ae14ab3c622b1e776773b6b08a6eb5565fef5448a39";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "f1187fb68ef1ed7986786266947645cc6bd7acdf938210e17fccc20c72f3b2be";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "e2aaf59d9f497a62605002b6d9686eebef60793d1da2664b3c278436118033e4";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit d0ed0ee3399a109c2e7027f0c8c16f2b629fad9e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aerostack2 1.0.6-r1 --> 1.0.7-r1*
* *as2-alphanumeric-viewer 1.0.6-r1 --> 1.0.7-r1*
* *as2-behavior 1.0.6-r1 --> 1.0.7-r1*
* *as2-behavior-tree 1.0.6-r1 --> 1.0.7-r1*
* *as2-behaviors-motion 1.0.6-r1 --> 1.0.7-r1*
* *as2-behaviors-perception 1.0.6-r1 --> 1.0.7-r1*
* *as2-behaviors-platform 1.0.6-r1 --> 1.0.7-r1*
* *as2-behaviors-trajectory-generation 1.0.6-r1 --> 1.0.7-r1*
* *as2-cli 1.0.6-r1 --> 1.0.7-r1*
* *as2-core 1.0.6-r1 --> 1.0.7-r1*
* *as2-gazebo-classic-assets 1.0.6-r1 --> 1.0.7-r1*
* *as2-keyboard-teleoperation 1.0.6-r1 --> 1.0.7-r1*
* *as2-motion-controller 1.0.6-r1 --> 1.0.7-r1*
* *as2-motion-reference-handlers 1.0.6-r1 --> 1.0.7-r1*
* *as2-msgs 1.0.6-r1 --> 1.0.7-r1*
* *as2-platform-crazyflie 1.0.6-r1 --> 1.0.7-r1*
* *as2-platform-dji-osdk 1.0.6-r1 --> 1.0.7-r1*
* *as2-platform-gazebo 1.0.7-r1*
* *as2-platform-tello 1.0.6-r1 --> 1.0.7-r1*
* *as2-realsense-interface 1.0.6-r1 --> 1.0.7-r1*
* *as2-state-estimator 1.0.6-r1 --> 1.0.7-r1*
* *as2-usb-camera-interface 1.0.6-r1 --> 1.0.7-r1*
* *caret-msgs 0.5.0-r1 --> 0.5.0-r2*
* *event-camera-codecs 1.1.2-r1 --> 1.1.3-r1*
* *event-camera-py 1.1.3-r1 --> 1.1.4-r1*
* *event-camera-renderer 1.1.2-r1 --> 1.1.3-r1*
* *mp2p-icp 1.1.0-r1 --> 1.1.1-r1*
* *mrpt2 2.11.7-r1 --> 2.11.8-r1*
* *plotjuggler 3.8.10-r2 --> 3.9.0-r1*
* *plotjuggler-ros 2.0.0-r3 --> 2.1.0-r1*
* *psdk-interfaces 0.0.4-r1 --> 0.0.5-r1*
* *psdk-wrapper 0.0.4-r1 --> 0.0.5-r1*
* *qb-softhand-industry 2.1.2-r4*
* *qb-softhand-industry-description 2.1.2-r4*
* *qb-softhand-industry-driver 2.1.2-r4*
* *qb-softhand-industry-msgs 2.1.2-r4*
* *qb-softhand-industry-ros2-control 2.1.2-r4*
* *qb-softhand-industry-srvs 2.1.2-r4*
* *ros2caret 0.5.0-r2*

Iron Changes:
-------------
* *ament-clang-format 0.14.2-r1 --> 0.14.3-r1*
* *ament-clang-tidy 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-auto 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-clang-format 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-clang-tidy 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-copyright 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-core 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-cppcheck 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-cpplint 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-export-definitions 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-export-dependencies 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-export-include-directories 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-export-interfaces 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-export-libraries 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-export-link-flags 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-export-targets 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-flake8 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-gen-version-h 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-gmock 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-google-benchmark 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-gtest 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-include-directories 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-libraries 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-lint-cmake 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-mypy 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-pclint 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-pep257 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-pycodestyle 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-pyflakes 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-pytest 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-python 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-target-dependencies 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-test 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-uncrustify 0.14.2-r1 --> 0.14.3-r1*
* *ament-cmake-vendor-package 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-version 2.0.3-r1 --> 2.0.4-r1*
* *ament-cmake-xmllint 0.14.2-r1 --> 0.14.3-r1*
* *ament-copyright 0.14.2-r1 --> 0.14.3-r1*
* *ament-cppcheck 0.14.2-r1 --> 0.14.3-r1*
* *ament-cpplint 0.14.2-r1 --> 0.14.3-r1*
* *ament-flake8 0.14.2-r1 --> 0.14.3-r1*
* *ament-lint 0.14.2-r1 --> 0.14.3-r1*
* *ament-lint-auto 0.14.2-r1 --> 0.14.3-r1*
* *ament-lint-cmake 0.14.2-r1 --> 0.14.3-r1*
* *ament-lint-common 0.14.2-r1 --> 0.14.3-r1*
* *ament-mypy 0.14.2-r1 --> 0.14.3-r1*
* *ament-pclint 0.14.2-r1 --> 0.14.3-r1*
* *ament-pep257 0.14.2-r1 --> 0.14.3-r1*
* *ament-pycodestyle 0.14.2-r1 --> 0.14.3-r1*
* *ament-pyflakes 0.14.2-r1 --> 0.14.3-r1*
* *ament-uncrustify 0.14.2-r1 --> 0.14.3-r1*
* *ament-xmllint 0.14.2-r1 --> 0.14.3-r1*
* *camera-calibration-parsers 4.2.2-r1 --> 4.2.3-r1*
* *camera-info-manager 4.2.2-r1 --> 4.2.3-r1*
* *cyclonedds 0.10.3-r2 --> 0.10.4-r1*
* *event-camera-codecs 1.2.3-r1 --> 1.2.4-r1*
* *event-camera-py 1.2.4-r1*
* *event-camera-renderer 1.2.2-r1 --> 1.2.3-r1*
* *image-common 4.2.2-r1 --> 4.2.3-r1*
* *image-transport 4.2.2-r1 --> 4.2.3-r1*
* *launch-ros 0.24.0-r2 --> 0.24.1-r1*
* *launch-testing-ros 0.24.0-r2 --> 0.24.1-r1*
* *mcap-vendor 0.22.5-r1 --> 0.22.6-r1*
* *plotjuggler 3.8.10-r2 --> 3.9.0-r1*
* *plotjuggler-ros 2.0.0-r1 --> 2.1.0-r1*
* *python-qt-binding 1.2.3-r2 --> 1.2.4-r1*
* *qt-dotgraph 2.4.2-r2 --> 2.4.3-r1*
* *qt-gui 2.4.2-r2 --> 2.4.3-r1*
* *qt-gui-app 2.4.2-r2 --> 2.4.3-r1*
* *qt-gui-core 2.4.2-r2 --> 2.4.3-r1*
* *qt-gui-cpp 2.4.2-r2 --> 2.4.3-r1*
* *qt-gui-py-common 2.4.2-r2 --> 2.4.3-r1*
* *rcl 6.0.4-r1 --> 6.0.5-r1*
* *rcl-action 6.0.4-r1 --> 6.0.5-r1*
* *rcl-lifecycle 6.0.4-r1 --> 6.0.5-r1*
* *rcl-yaml-param-parser 6.0.4-r1 --> 6.0.5-r1*
* *rclcpp 21.0.4-r1 --> 21.0.5-r1*
* *rclcpp-action 21.0.4-r1 --> 21.0.5-r1*
* *rclcpp-components 21.0.4-r1 --> 21.0.5-r1*
* *rclcpp-lifecycle 21.0.4-r1 --> 21.0.5-r1*
* *rmw-fastrtps-cpp 7.1.2-r1 --> 7.1.3-r1*
* *rmw-fastrtps-dynamic-cpp 7.1.2-r1 --> 7.1.3-r1*
* *rmw-fastrtps-shared-cpp 7.1.2-r1 --> 7.1.3-r1*
* *robot-state-publisher 3.2.0-r2 --> 3.2.1-r1*
* *ros2action 0.25.4-r1 --> 0.25.5-r1*
* *ros2bag 0.22.5-r1 --> 0.22.6-r1*
* *ros2cli 0.25.4-r1 --> 0.25.5-r1*
* *ros2cli-test-interfaces 0.25.4-r1 --> 0.25.5-r1*
* *ros2component 0.25.4-r1 --> 0.25.5-r1*
* *ros2doctor 0.25.4-r1 --> 0.25.5-r1*
* *ros2interface 0.25.4-r1 --> 0.25.5-r1*
* *ros2launch 0.24.0-r2 --> 0.24.1-r1*
* *ros2lifecycle 0.25.4-r1 --> 0.25.5-r1*
* *ros2lifecycle-test-fixtures 0.25.4-r1 --> 0.25.5-r1*
* *ros2multicast 0.25.4-r1 --> 0.25.5-r1*
* *ros2node 0.25.4-r1 --> 0.25.5-r1*
* *ros2param 0.25.4-r1 --> 0.25.5-r1*
* *ros2pkg 0.25.4-r1 --> 0.25.5-r1*
* *ros2run 0.25.4-r1 --> 0.25.5-r1*
* *ros2service 0.25.4-r1 --> 0.25.5-r1*
* *ros2topic 0.25.4-r1 --> 0.25.5-r1*
* *rosbag2 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-compression 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-compression-zstd 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-cpp 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-examples-cpp 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-examples-py 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-interfaces 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-performance-benchmarking 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-performance-benchmarking-msgs 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-py 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-storage 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-storage-default-plugins 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-storage-mcap 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-storage-sqlite3 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-test-common 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-test-msgdefs 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-tests 0.22.5-r1 --> 0.22.6-r1*
* *rosbag2-transport 0.22.5-r1 --> 0.22.6-r1*
* *rviz-assimp-vendor 12.4.5-r2 --> 12.4.6-r1*
* *rviz-common 12.4.5-r2 --> 12.4.6-r1*
* *rviz-default-plugins 12.4.5-r2 --> 12.4.6-r1*
* *rviz-ogre-vendor 12.4.5-r2 --> 12.4.6-r1*
* *rviz-rendering 12.4.5-r2 --> 12.4.6-r1*
* *rviz-rendering-tests 12.4.5-r2 --> 12.4.6-r1*
* *rviz-visual-testing-framework 12.4.5-r2 --> 12.4.6-r1*
* *rviz2 12.4.5-r2 --> 12.4.6-r1*
* *shared-queues-vendor 0.22.5-r1 --> 0.22.6-r1*
* *sqlite3-vendor 0.22.5-r1 --> 0.22.6-r1*
* *zstd-vendor 0.22.5-r1 --> 0.22.6-r1*

Noetic Changes:
---------------
* *novatel-oem7-driver 4.2.0-r1 --> 4.3.0-r5*
* *novatel-oem7-msgs 4.2.0-r1 --> 4.3.0-r5*
* *plotjuggler 3.8.10-r2 --> 3.9.0-r1*
* *plotjuggler-ros 2.0.0-r1 --> 2.1.0-r1*

Rolling Changes:
----------------
* *action-tutorials-cpp 0.33.0-r1 --> 0.33.1-r1*
* *action-tutorials-interfaces 0.33.0-r1 --> 0.33.1-r1*
* *action-tutorials-py 0.33.0-r1 --> 0.33.1-r1*
* *ament-clang-format 0.16.2-r1 --> 0.16.3-r1*
* *ament-clang-tidy 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-clang-format 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-clang-tidy 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-copyright 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-cppcheck 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-cpplint 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-flake8 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-lint-cmake 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-mypy 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-pclint 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-pep257 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-pycodestyle 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-pyflakes 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-uncrustify 0.16.2-r1 --> 0.16.3-r1*
* *ament-cmake-xmllint 0.16.2-r1 --> 0.16.3-r1*
* *ament-copyright 0.16.2-r1 --> 0.16.3-r1*
* *ament-cppcheck 0.16.2-r1 --> 0.16.3-r1*
* *ament-cpplint 0.16.2-r1 --> 0.16.3-r1*
* *ament-lint 0.16.2-r1 --> 0.16.3-r1*
* *ament-lint-auto 0.16.2-r1 --> 0.16.3-r1*
* *ament-lint-cmake 0.16.2-r1 --> 0.16.3-r1*
* *ament-lint-common 0.16.2-r1 --> 0.16.3-r1*
* *ament-mypy 0.16.2-r1 --> 0.16.3-r1*
* *ament-pclint 0.16.2-r1 --> 0.16.3-r1*
* *ament-pep257 0.16.2-r1 --> 0.16.3-r1*
* *ament-pycodestyle 0.16.2-r1 --> 0.16.3-r1*
* *ament-pyflakes 0.16.2-r1 --> 0.16.3-r1*
* *ament-uncrustify 0.16.2-r1 --> 0.16.3-r1*
* *ament-xmllint 0.16.2-r1 --> 0.16.3-r1*
* *composition 0.33.0-r1 --> 0.33.1-r1*
* *demo-nodes-cpp 0.33.0-r1 --> 0.33.1-r1*
* *demo-nodes-cpp-native 0.33.0-r1 --> 0.33.1-r1*
* *demo-nodes-py 0.33.0-r1 --> 0.33.1-r1*
* *dummy-map-server 0.33.0-r1 --> 0.33.1-r1*
* *dummy-robot-bringup 0.33.0-r1 --> 0.33.1-r1*
* *dummy-sensors 0.33.0-r1 --> 0.33.1-r1*
* *event-camera-codecs 1.0.3-r1 --> 1.0.4-r1*
* *event-camera-py 1.0.3-r1 --> 1.0.4-r1*
* *event-camera-renderer 1.0.2-r1 --> 1.0.3-r1*
* *examples-tf2-py 0.35.1-r1 --> 0.36.0-r1*
* *geometry2 0.35.1-r1 --> 0.36.0-r1*
* *image-tools 0.33.0-r1 --> 0.33.1-r1*
* *intra-process-demo 0.33.0-r1 --> 0.33.1-r1*
* *launch 3.3.0-r1 --> 3.4.0-r1*
* *launch-pytest 3.3.0-r1 --> 3.4.0-r1*
* *launch-testing 3.3.0-r1 --> 3.4.0-r1*
* *launch-testing-ament-cmake 3.3.0-r1 --> 3.4.0-r1*
* *launch-xml 3.3.0-r1 --> 3.4.0-r1*
* *launch-yaml 3.3.0-r1 --> 3.4.0-r1*
* *lifecycle 0.33.0-r1 --> 0.33.1-r1*
* *lifecycle-py 0.33.0-r1 --> 0.33.1-r1*
* *logging-demo 0.33.0-r1 --> 0.33.1-r1*
* *mp2p-icp 1.1.0-r1 --> 1.1.1-r1*
* *mrpt2 2.11.7-r1 --> 2.11.8-r1*
* *osrf-testing-tools-cpp 1.7.0-r1 --> 2.0.0-r1*
* *pendulum-control 0.33.0-r1 --> 0.33.1-r1*
* *pendulum-msgs 0.33.0-r1 --> 0.33.1-r1*
* *plotjuggler 3.8.4-r1 --> 3.9.0-r1*
* *plotjuggler-ros 2.0.0-r2 --> 2.1.0-r1*
* *python-qt-binding 2.1.0-r1 --> 2.1.1-r1*
* *qt-dotgraph 2.7.1-r2 --> 2.7.2-r1*
* *qt-gui 2.7.1-r2 --> 2.7.2-r1*
* *qt-gui-app 2.7.1-r2 --> 2.7.2-r1*
* *qt-gui-core 2.7.1-r2 --> 2.7.2-r1*
* *qt-gui-cpp 2.7.1-r2 --> 2.7.2-r1*
* *qt-gui-py-common 2.7.1-r2 --> 2.7.2-r1*
* *quality-of-service-demo-cpp 0.33.0-r1 --> 0.33.1-r1*
* *quality-of-service-demo-py 0.33.0-r1 --> 0.33.1-r1*
* *rclcpp 26.0.0-r1 --> 27.0.0-r1*
* *rclcpp-action 26.0.0-r1 --> 27.0.0-r1*
* *rclcpp-components 26.0.0-r1 --> 27.0.0-r1*
* *rclcpp-lifecycle 26.0.0-r1 --> 27.0.0-r1*
* *rclpy 7.0.0-r1 --> 7.0.1-r1*
* *rcpputils 2.9.0-r1 --> 2.10.0-r1*
* *rcutils 6.5.1-r1 --> 6.5.2-r1*
* *ros2action 0.31.0-r1 --> 0.31.1-r1*
* *ros2cli 0.31.0-r1 --> 0.31.1-r1*
* *ros2cli-test-interfaces 0.31.0-r1 --> 0.31.1-r1*
* *ros2component 0.31.0-r1 --> 0.31.1-r1*
* *ros2doctor 0.31.0-r1 --> 0.31.1-r1*
* *ros2interface 0.31.0-r1 --> 0.31.1-r1*
* *ros2lifecycle 0.31.0-r1 --> 0.31.1-r1*
* *ros2lifecycle-test-fixtures 0.31.0-r1 --> 0.31.1-r1*
* *ros2multicast 0.31.0-r1 --> 0.31.1-r1*
* *ros2node 0.31.0-r1 --> 0.31.1-r1*
* *ros2param 0.31.0-r1 --> 0.31.1-r1*
* *ros2pkg 0.31.0-r1 --> 0.31.1-r1*
* *ros2run 0.31.0-r1 --> 0.31.1-r1*
* *ros2service 0.31.0-r1 --> 0.31.1-r1*
* *ros2topic 0.31.0-r1 --> 0.31.1-r1*
* *rosidl-adapter 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-cli 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-cmake 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-generator-c 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-generator-cpp 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-generator-dds-idl 0.11.0-r1 --> 0.11.1-r1*
* *rosidl-generator-py 0.21.0-r1 --> 0.21.1-r1*
* *rosidl-generator-type-description 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-parser 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-pycommon 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-runtime-c 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-runtime-cpp 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-typesupport-interface 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-typesupport-introspection-c 4.5.0-r1 --> 4.5.1-r1*
* *rosidl-typesupport-introspection-cpp 4.5.0-r1 --> 4.5.1-r1*
* *rqt-bag 1.5.0-r1 --> 1.5.1-r1*
* *rqt-bag-plugins 1.5.0-r1 --> 1.5.1-r1*
* *rqt-console 2.2.0-r1 --> 2.2.1-r1*
* *rqt-graph 1.5.1-r1 --> 1.5.2-r1*
* *rqt-msg 1.5.0-r1 --> 1.5.1-r1*
* *rqt-plot 1.3.1-r1 --> 1.3.2-r1*
* *rqt-publisher 1.7.0-r1 --> 1.7.1-r1*
* *rqt-py-console 1.2.1-r1 --> 1.2.2-r1*
* *rqt-reconfigure 1.6.1-r1 --> 1.6.2-r1*
* *rqt-service-caller 1.2.0-r1 --> 1.2.1-r1*
* *rqt-shell 1.2.0-r1 --> 1.2.1-r1*
* *rqt-srv 1.2.1-r1 --> 1.2.2-r1*
* *rqt-topic 1.7.0-r1 --> 1.7.1-r1*
* *sros2 0.12.1-r1 --> 0.13.0-r1*
* *sros2-cmake 0.12.1-r1 --> 0.13.0-r1*
* *tf2 0.35.1-r1 --> 0.36.0-r1*
* *tf2-bullet 0.35.1-r1 --> 0.36.0-r1*
* *tf2-eigen 0.35.1-r1 --> 0.36.0-r1*
* *tf2-eigen-kdl 0.35.1-r1 --> 0.36.0-r1*
* *tf2-geometry-msgs 0.35.1-r1 --> 0.36.0-r1*
* *tf2-kdl 0.35.1-r1 --> 0.36.0-r1*
* *tf2-msgs 0.35.1-r1 --> 0.36.0-r1*
* *tf2-py 0.35.1-r1 --> 0.36.0-r1*
* *tf2-ros 0.35.1-r1 --> 0.36.0-r1*
* *tf2-ros-py 0.35.1-r1 --> 0.36.0-r1*
* *tf2-sensor-msgs 0.35.1-r1 --> 0.36.0-r1*
* *tf2-tools 0.35.1-r1 --> 0.36.0-r1*
* *topic-monitor 0.33.0-r1 --> 0.33.1-r1*
* *topic-statistics-demo 0.33.0-r1 --> 0.33.1-r1*
* *ur 2.4.2-r1 --> 2.4.3-r1*
* *ur-calibration 2.4.2-r1 --> 2.4.3-r1*
* *ur-controllers 2.4.2-r1 --> 2.4.3-r1*
* *ur-dashboard-msgs 2.4.2-r1 --> 2.4.3-r1*
* *ur-moveit-config 2.4.2-r1 --> 2.4.3-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libxkbcommon-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

