### PR TITLE
fix cv-bridge: remove cxx output from opencv

### DIFF
--- a/distros/humble/cv-bridge/default.nix
+++ b/distros/humble/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv opencv.cxxdev python3Packages.numpy python3Packages.opencv4 rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/iron/cv-bridge/default.nix
+++ b/distros/iron/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv opencv.cxxdev python3Packages.numpy python3Packages.opencv4 rclcpp rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rclcpp rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/noetic/cv-bridge/default.nix
+++ b/distros/noetic/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ python3Packages.numpy rostest ];
-  propagatedBuildInputs = [ boost opencv opencv.cxxdev python3 python3Packages.opencv4 rosconsole sensor-msgs ];
+  propagatedBuildInputs = [ boost opencv python3 python3Packages.opencv4 rosconsole sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/rolling/cv-bridge/default.nix
+++ b/distros/rolling/cv-bridge/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python boost opencv opencv.cxxdev python3Packages.numpy python3Packages.opencv4 rclcpp rcpputils sensor-msgs ];
+  propagatedBuildInputs = [ ament-index-python boost opencv python3Packages.numpy python3Packages.opencv4 rclcpp rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros python-cmake-module ];
 
   meta = {


### PR DESCRIPTION
Seems like the `opencv.cxxdev` output has been removed from the opencv package and is not necessary anymore for `cv-bridge`. With this change `nix develop github:lopsided98/nix-ros-overlay#example-turtlebot3-gazebo` works again. I also tested to build the `cv-bridge` package for the other distros.