### PR TITLE
FIX librealsense2 compile error

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -98,9 +98,13 @@ let
     });
 
     librealsense2 = rosSuper.librealsense2.overrideAttrs ({
-      buildInputs ? [], ...
+      buildInputs ? [], patches ? [], ...
     }: {
       buildInputs = buildInputs ++ [ self.glfw self.libGLU ];
+      patches = patches ++ [(self.fetchpatch {
+        url = "https://github.com/IntelRealSense/librealsense/commit/847b74d3dcade2842ba138f321474159315ab8c2.patch";
+        sha256 = "sha256-zaW8HG8rfsApI5S/3x+x9Fx8xhyTIPNn/fJVFtkmlEA=";
+      })];
     });
 
     libuvc-camera = rosSuper.libuvc-camera.overrideAttrs ({


### PR DESCRIPTION
release packages for librealsense was updated last time at September 2023 while this fix was added on Nov 2023

According to https://github.com/IntelRealSense/librealsense/pull/11917