### PR TITLE
rosdistro sync, Fri Feb 16 13:29:45 2024

### DIFF
--- a/distros/humble/aerostack2/default.nix
+++ b/distros/humble/aerostack2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-assets, as2-gazebo-classic-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-gazebo, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
 buildRosPackage {
   pname = "ros-humble-aerostack2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "306cd86add2f4dc22d15fae1abd5926d959e47fd777fdd946c5a19ff6c4db75c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6c9053d00e2a179c7be6ad81f243e52b188d60d69eb8282f08e4694fe41d0f76";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/apriltag-detector/default.nix
+++ b/distros/humble/apriltag-detector/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-apriltag-detector";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/humble/apriltag_detector/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "38d1d96fbfd1503f80863353af3b203be61b0ef76e173663b81e9f2d96b10325";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS package for apriltag detection'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/as2-alphanumeric-viewer/default.nix
+++ b/distros/humble/as2-alphanumeric-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, ncurses, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-alphanumeric-viewer";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7f8148241ab741ac9a2e6c137cee9b3db73380ad6423d0fe53e80fc9468dc555";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5ea05e948bf00c6e9ac16b41395e2364cafc966b8396c7c4fdb5ef02533f435a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior-tree/default.nix
+++ b/distros/humble/as2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, behaviortree-cpp-v3, geometry-msgs, nav2-behavior-tree, nav2-msgs, rclcpp, rclcpp-action, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior-tree";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b2eb52ca446b92b67e13483ae3e2e5a2642ef949a83fd55ad451be1ea372a121";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d2d418c90a55bf6819664e874a6375ca20407bd90ff8aedb27e70594ae28a418";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior/default.nix
+++ b/distros/humble/as2-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e943e3dc0b141158128b4df558f2f8670ee692190fc15178687ce0a6511afe9c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4ee00a267c0003cd428305b794b60c237f4970188535bb75f79fbf5924697c82";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-motion/default.nix
+++ b/distros/humble/as2-behaviors-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-motion";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7ddff48de616132cfb1fa97bb184e43c842186764708ea5e15d2d7093fccd94d";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8f021b4964be53ba172f8ee8ccaeb1a2ad57b81159f18a2bf064d64f5737e7f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-perception/default.nix
+++ b/distros/humble/as2-behaviors-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-perception";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b1a630b2392e989d7f1d736618c14e18dede558c57ea9872e1ddc67cd7e84c78";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "dcfc2effa8b86b1e63fe618af24be04696313e38f965a0ae3b4ec7f179218dcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-platform/default.nix
+++ b/distros/humble/as2-behaviors-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-platform";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "44dca1f29e6fb5443a56824fc9e9dbe605e6ce80fec3d16ca51ead6b82562325";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9cb381b8e065a95fdf7fa813f2f383ef7d59fac00685b683cbe757dd7b093d77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-trajectory-generation/default.nix
+++ b/distros/humble/as2-behaviors-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-components, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-trajectory-generation";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5136686f1d46046cfa0ac71e0e8b89c88b5836ac34354d26c5031f81f88171f1";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b0ecb8d25e5ee8edf4c7c522776e738be4108aee6809b84870e0a81b4984feb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-cli/default.nix
+++ b/distros/humble/as2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-as2-cli";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5f5f5872dae20287e957f62f4b498ad9f720367b5f78872c8fabe005698bbfb5";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c05a8b768197c2b6becb6665c002aabe37dbe812f96027873565aed8f78fe21a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, pythonPackages, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "78db3266b9d6b249102b6ec6ef6a0226eb9a05931304262d3e72fe058c7c9c1b";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c901d184e468281bb8fd4b225ed74f40a47d903832b8db535d51f30b2ca15e6c";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake as2-msgs cv-bridge eigen geographic-msgs geographiclib geometry-msgs image-transport nav-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ ament-cmake as2-msgs cv-bridge eigen geographic-msgs geographiclib geometry-msgs image-transport nav-msgs pythonPackages.pybind11 rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-gazebo-classic-assets/default.nix
+++ b/distros/humble/as2-gazebo-classic-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, python3Packages, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-gazebo-classic-assets";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e77ebc7ac79b6aa18a27716fc899538e30a812a71b73da0f9d458f5d2db4f385";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6941d8fcf610cf1a40c3a0653f2ed2574344463230dc0d2601e699d0040c317e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-keyboard-teleoperation/default.nix
+++ b/distros/humble/as2-keyboard-teleoperation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-motion-reference-handlers, as2-python-api, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-as2-keyboard-teleoperation";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3ccf2bccbc1ea2810201f8fe45da8e7f093fb930d67216fdbc4d7e760d5f9daf";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4dad4aefdea5724ab2b2c99d4dbfc1c280723a5de40a4abc798b0ebbeed0f29f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "311d7e5b598b8b90a77a74d42ed7be2ba6d1e95523ac099263b7c1c2ce83b5e6";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "2d20b8d998dbfd40c8d2d22dc9bc0a78107dc4603bb5f0d886da20aaed5d8ab4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-motion-reference-handlers/default.nix
+++ b/distros/humble/as2-motion-reference-handlers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-action, rclpy, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-reference-handlers";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "ed8aa041dc28f87773f14cccbb45cdbe25c92c316f7013dd0083c8c5b0f3b195";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "1fcba1242b555ea7865635c8d1879ddddaf213e4a2d659ce774dce6785ebe323";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-msgs/default.nix
+++ b/distros/humble/as2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "32f9c89a2d3bf277f4693c6d25b6c59f742e0c6d8e3adf74886fba793ada9b3d";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d50374751703b58dfb7b72da67f3f24b70398dc78dbabb99ce78c25af904a424";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-crazyflie/default.nix
+++ b/distros/humble/as2-platform-crazyflie/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-crazyflie";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "77be7d322162c176fa152d2c32035590cb5097bea2be39caedd1133cfe26d775";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "1aefef5519b863fb6a29b8398ee441bbd06a9806da68a842cbf8712a9e0994fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-dji-osdk/default.nix
+++ b/distros/humble/as2-platform-dji-osdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, libusb1, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-dji-osdk";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1e9bcd8ad75cc70596d50c09d2806f51129691ff1f73a88ea47b9f4e5d452aed";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "502f3817c6f039873b3c83f0ff4df311301d89e6d41736671ef402482a1a9ca1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-gazebo/default.nix
+++ b/distros/humble/as2-platform-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-gazebo-assets, as2-msgs, geometry-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-gazebo";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "bf174b79d0099fd03c8aea2435cc06e114180c9edad17b0e5082a17444b89113";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d64942c13ac119fe2ee68d17ab0abaff6f2311f7203d0fb9e6fb1dda9131d177";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-tello/default.nix
+++ b/distros/humble/as2-platform-tello/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-tello";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b0dd87f392466a7061bf7976b5e9c83b5d0056e28b51ae6ba9a9efbd4ae54b59";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "701b82dfce32d1966944d9b85ce72c14669f1676ff9fda07185562c6a35725a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-realsense-interface/default.nix
+++ b/distros/humble/as2-realsense-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, geometry-msgs, librealsense2, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-realsense-interface";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "51297532f863f7183521c98914c20e543a99b5cd4d751fa11148db60a80a6819";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f792cdd87ea2a362c140c62185592b2c33dce1d2cf3f1d70e48963f0ec85b094";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-state-estimator/default.nix
+++ b/distros/humble/as2-state-estimator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, geometry-msgs, nav-msgs, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-state-estimator";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "723a7d35264f2670f36ff650b665e35f0af5466d361ce9067ac9dcc0e86bbde9";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "cf9ba8347528a1c39b0d39eb989f2fc8660230e1543daf2df1ab6fc059587903";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-usb-camera-interface/default.nix
+++ b/distros/humble/as2-usb-camera-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-usb-camera-interface";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "fd405021b91312a26c74ac94e9fb9341d7fb67718697fc777b892f2aad956924";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "eb0d62b863ca4f7abd504ecc6829a5611ccaca704f58eb73f0a27151351165ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/caret-msgs/default.nix
+++ b/distros/humble/caret-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-caret-msgs";
-  version = "0.5.0-r2";
+  version = "0.5.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/caret_trace-release/archive/release/humble/caret_msgs/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "a37fdd9b8787a8502aad98b68012fced36f37daec0cffb7a2192c9f16d3c9f6f";
+    url = "https://github.com/ros2-gbp/caret_trace-release/archive/release/humble/caret_msgs/0.5.0-4.tar.gz";
+    name = "0.5.0-4.tar.gz";
+    sha256 = "dd8bdae66cbaf0a7b315e76438dd91d42d9f92bbbd3e6051b656bf8d5011066c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "1b351aefebd321e4687be5afe81c65b00e712103689aea6bebe6370c5a6573b6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "2b3e7771596ffc752a1a1be35e4f3cf6408b8c0e99b04de15d873e0183fa6f58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "965d5c8a1d5c0111d0e61186aa5e22a72d4f851d52fe724e7dcf82b9df94c8c7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "60a6d3e0923802e91528bdee8b4aca9cee9120d99bdc0bf2acf0e4f384fed4e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "6320bec766f514318d5bf940956ae192880b43da95bd6499b65095b9d3a866cb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "712dd6370f04b670f78855ee21090c5459ce190450dec6c15f2c9f6418e9f07f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -188,6 +188,8 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ apriltag-detector = self.callPackage ./apriltag-detector {};
+
  apriltag-msgs = self.callPackage ./apriltag-msgs {};
 
  apriltag-ros = self.callPackage ./apriltag-ros {};

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "68ac90818388e2d40a22609c1ad16af24803b1d31c0cc2b6cde3e796360c6568";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "0ac73c98b0a0e63f78881aeed81ffca79a3da0b6c1f0b58ea853f07d5c2c4e6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "4e1ae10f700f6f7500dd644876e1c7cbd1901a3f47b212f565d3b3f46c9bd89d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "6e670082b5c1765aa5d2350416a6e1a8e549483ca6e94c07d8e8bbc4714683ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.11.8-r1";
+  version = "2.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.8-1.tar.gz";
-    name = "2.11.8-1.tar.gz";
-    sha256 = "4b61c9f5d3092b7a4e8cf2c8de0b4d189f0c9fd6f71cd4dfc8f9dfedd194afb5";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.9-1.tar.gz";
+    name = "2.11.9-1.tar.gz";
+    sha256 = "35731dfb8d189c8024e95e77f71da5e90371f769a9b46cae937f59691b9c7b71";
   };
 
   buildType = "cmake";

--- a/distros/humble/pcl-conversions/default.nix
+++ b/distros/humble/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pcl-conversions";
-  version = "2.4.0-r4";
+  version = "2.4.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.0-4.tar.gz";
-    name = "2.4.0-4.tar.gz";
-    sha256 = "69090c3db0acb73c9ec168210d8e561fa6819e0aefdbfabd6a1cdb91445dbaa0";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.0-5.tar.gz";
+    name = "2.4.0-5.tar.gz";
+    sha256 = "3712ec5d33447d5deb2334a5d2fd8cd9d9cc14770cc0f72c52ef6f015fd610b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pcl-ros/default.nix
+++ b/distros/humble/pcl-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-pcl-ros";
-  version = "2.4.0-r4";
+  version = "2.4.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.0-4.tar.gz";
-    name = "2.4.0-4.tar.gz";
-    sha256 = "1bf600634be4e90bf828217c936e395e2369f9c9e2dd0272013c6d82e200de82";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.0-5.tar.gz";
+    name = "2.4.0-5.tar.gz";
+    sha256 = "8f9b398d650a77006a76f14b2d9d0e164bc9758c54e22ed113a51f8b9e3aa2f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/perception-pcl/default.nix
+++ b/distros/humble/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-humble-perception-pcl";
-  version = "2.4.0-r4";
+  version = "2.4.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.0-4.tar.gz";
-    name = "2.4.0-4.tar.gz";
-    sha256 = "d7510dd5106185979c591097ff990c2604c6b581ded57f6b4fbdb4c34cb1691e";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.0-5.tar.gz";
+    name = "2.4.0-5.tar.gz";
+    sha256 = "e85038742b715f25dcedff5e4215220f21458d4cb058c7dcd3d48f365b03fb01";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "94362204a752df1d08a3ae9030e81cc0b6f78759013c4b6e0ed50e9f6b2a40b1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "9ed4d39ebf1913cce8370f0ff238d72e7be557bfd7ef09a4b5679f2cc8dd86a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "c2d2b099524006e5c077eb3d7c1a465822ac71f0912fada87328b09b2337b5f4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "ddbf654365f692fe187a72103c84f59e3083f080d34099dd314b746ddd7b68f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "e8a3711190e2142a3ec24ec5ca5a9223d6000d030d48a9ab399d0e70cf018fee";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "ea6705c8eb1fd21081ad78987071bab5cb885cf7f59cd6f73db171d0bb7a5bf0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "71328a0fb586fbcdc37553fdcb15b1a12e919495efe5b62fd98296b34fe5b56e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "074ef046c360d327cc44132bb12a128b6b080470e61f3be75e6f6d34d5816e7f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.38.0-r1";
+  version = "2.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.38.0-1.tar.gz";
-    name = "2.38.0-1.tar.gz";
-    sha256 = "51e5d13200128ef26923d475fa162a69a40009228c093a5600b6680e49926622";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.37.0-1.tar.gz";
+    name = "2.37.0-1.tar.gz";
+    sha256 = "a688e1693b714e51850e6776b6fade8d07721edafe5e179bd73925cd898b89f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/vrpn-mocap/default.nix
+++ b/distros/humble/vrpn-mocap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, std-msgs, tf2, vrpn }:
 buildRosPackage {
   pname = "ros-humble-vrpn-mocap";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/humble/vrpn_mocap/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "5278840064c07c052f671a379b50f0bd0112b776ca2e4253f211ba2a30d9dc63";
+    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/humble/vrpn_mocap/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2bb351ad2fabb0b3edf21428abeab744fa79cdea7f5b32b2580286c71ffa5ec3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "d90d41b65adf69db3e0c6579d7f306e936fce7109612210a01783930bbb03bea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "c9532ad6ee8bedb29c36d109c1a2374780b7316e9fa8439674cfdd12fabc74fa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "3fdd07c6b5b4c8704ac6b2b756a70e6174ffe9247344c3adc70d9cac4d8b7710";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "d446345cc174c8773ef89319c72c256889437aebc489066938b00dfef2530b44";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager kinematics-interface-kdl ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/apriltag-detector/default.nix
+++ b/distros/iron/apriltag-detector/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-iron-apriltag-detector";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/iron/apriltag_detector/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2155cc0887ba90782b52853c6d7ff75adb87196f61a713388139066640ec30da";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS package for apriltag detection'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/azure-iot-sdk-c/default.nix
+++ b/distros/iron/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-iron-azure-iot-sdk-c";
-  version = "1.10.1-r4";
+  version = "1.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.10.1-4.tar.gz";
-    name = "1.10.1-4.tar.gz";
-    sha256 = "88eed8b26efaa6213e22be630994bd9aabda0fadce49b142070c6fa0d1eede11";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.12.0-1.tar.gz";
+    name = "1.12.0-1.tar.gz";
+    sha256 = "b35017fcc97c8020d789900557eef5137903e94ced3c3b6c037750b9242cf736";
   };
 
   buildType = "cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "97b03a17529d48a45a05527aae62d251d2ffed2a04827690e2adb99954248937";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "3622a8829e1ce2798dda04aacc2092546a95f26f3a5fadfd8482197c3822ddbf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "a2916cbcbc3d46b951af7aa8c34386bb8198002c646ec212be6a7138318f2f17";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "461a4af32241c2848f7a4bc77605983404c4209ddd10fbd93b920402b33b5fd3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "19cf6cec8abf072d5c81226fdb38b8aca6bdc44ca4db62085a12d405344d507d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "d8a3fd59d541f1be686681fd9796db7c0f7c1f6f248da267a4d2d1483f31031b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "edbff01979931586ef684d92220b759b4b38b2ee005cddc8104f8f214078dd24";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "a15155c25775297b9e8380e97948605fe8354d10ee479d3f020b2a9f8a07cdfa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "976be27867b5638e57cc3bb60c22f5ad0ea77bc6d1a57c21ce246432ccd050cd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "cf8cf306dc18a219be3a20bf8b7aed6c39b21609a2159bcfc21a112a9eb9c10b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -160,6 +160,8 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ apriltag-detector = self.callPackage ./apriltag-detector {};
+
  apriltag-msgs = self.callPackage ./apriltag-msgs {};
 
  apriltag-ros = self.callPackage ./apriltag-ros {};

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "42ac7167ffff72a736096eacf89362ab8c31ff94519365020c0bfd3b423f91de";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "f6994d4133c1dbe20d12edd9e77da3f4ca2c5d12011d8e6a7960492f8022931e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "8c1f97ae33f72e64a0514f24d2696946ebbbaa30368ab176edeb85571934a31d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "f449eeb0ba9d675e6c9761a97ed7265e8f600580bcb867a2788b63574d4a9ef1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "bb24b842d7079e9e57833083f27911ccf912255a37e2526f5d167f7f42c618f5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "8554025dc9e179529b4cb573d1b79e650b94d83ad62028c584ff0a3ea99b7c63";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface rclcpp ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing rclcpp ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros builtin-interfaces control-msgs controller-interface generate-parameter-library pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "28b7ea265ae975d4cb427b0d8eea89a762047403f76d93e5182ce44c032c5dc2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "b1c433ffe06d175595902eb8d0459ff90f31d1ff06deb133c0e6e08bd1f4763b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl tl-expected trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/leo-description/default.nix
+++ b/distros/iron/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-leo-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d71823d97a81facd16395f8fb69994a815b024fc3cdf9c018eb613cf2e82a766";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "fa09b058802fac99e5733e73b2c84a369d852ed51bf92fb1d096b92dba186e3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-msgs/default.nix
+++ b/distros/iron/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-leo-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "0f399726183b68519d150a1e6ed5460f360b963062c3107f4701e15f2cd4a8d3";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "07c65f513fed477c453485b870ab9aed141d1bf2ea2c29a93560831eb6ec0c2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-teleop/default.nix
+++ b/distros/iron/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-iron-leo-teleop";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_teleop/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "82476720a61f60cc10d58f70aa950e6857fb838cfda3bb7b5bc6f2e15a692e62";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_teleop/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "53e46a9887191510688f8918c5db42ee0c34c6f7fe1579c640ed59cec0cbfef8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo/default.nix
+++ b/distros/iron/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-iron-leo";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "405ca4b6028d273af6fd41d6b8fcc94f2703db2be8a6065d176d3345d81ca5c9";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "19fdb6122c7831d7b8e083c64f2516bcde371700062c8bf376d3e0b750afe883";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0fc380f0e1b2637eb1ab9418234cb2c01c091a6828856a2a1cff132175a180d1";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "debd363e52414bba362169df9eaeccd7e8458102adb487b5afb45d7b922dbbbe";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.11.7-r1";
+  version = "2.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.7-1.tar.gz";
-    name = "2.11.7-1.tar.gz";
-    sha256 = "bcb23231c5cbede1c51a585492d8dcb7f6701178d453e136454f054796bb01a9";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.9-1.tar.gz";
+    name = "2.11.9-1.tar.gz";
+    sha256 = "da90bc624e6efd9038b2d0a9f5f17278bb6e9f311f020fcd1a1b88c7c873419a";
   };
 
   buildType = "cmake";

--- a/distros/iron/multidim-rrt-planner/default.nix
+++ b/distros/iron/multidim-rrt-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, ros2launch, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-multidim-rrt-planner";
-  version = "0.0.6-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/multidim_rrt_planner-release/archive/release/iron/multidim_rrt_planner/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "543682a13c9e1504d481b5b5d9c64ada8994e8152e043ff1bb65315dbcbb8549";
+    url = "https://github.com/ros2-gbp/multidim_rrt_planner-release/archive/release/iron/multidim_rrt_planner/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "9dc967e1cac7c5ed3970eac549db9fd32850a4680d2494a79ed6a9252acaef40";
   };
 
   buildType = "ament_python";

--- a/distros/iron/point-cloud-transport-py/default.nix
+++ b/distros/iron/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-py";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "adc014731e370f93e372c811442504a49c454c5a273bd2d35429bc4a13b2e904";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "b72740f7580f085ea4a5886028edc082656ce2ccf59793ecaf7991d854cc02f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport/default.nix
+++ b/distros/iron/point-cloud-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "a14e8e645e9e2878ac3cb52bb5d7345c0c41896d4851f27af643edae5c5db47e";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "61146c914473da2d67cfaf8d0e3dd0947aa8f62088c006388c97a961ff44244e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
-  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tl-expected ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "5e8ab9550466d7cd817e35a05092157ac40c58784c6caf5d104a6f89183fd8a3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "6454e3399793e8325be0b0d8404c0001f1f1d6133b1b053a2ed499e012855d21";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/range-sensor-broadcaster/default.nix
+++ b/distros/iron/range-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-range-sensor-broadcaster";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "18894be6aeb62b44ac8c2f79e2a2b2780245ff3bb80470b9fca332149c39ffda";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "677926f9b464a26ce93d9f8e052c6e54d8077a94a9c07bd4728f597e856a97e8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/rcpputils/default.nix
+++ b/distros/iron/rcpputils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-iron-rcpputils";
-  version = "2.6.2-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/iron/rcpputils/2.6.2-1.tar.gz";
-    name = "2.6.2-1.tar.gz";
-    sha256 = "ee44666a692192ca3a3c93629b750b13f616c7af78d531dc0334cd311a4915fe";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/iron/rcpputils/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "9099b0cf2d8908ddcb7b63437ac6ca8d6a93e3aa0766219a93552bbada9edc37";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
   propagatedBuildInputs = [ rcutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/iron/robotraconteur/default.nix
+++ b/distros/iron/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-iron-robotraconteur";
-  version = "1.0.0-r1";
+  version = "1.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/iron/robotraconteur/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8e2ed7c0feb6a88bae851139700ff23b12ea2adb473d442ea5a1cec14bd8c730";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/iron/robotraconteur/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b6be3ff8330ae553dce1beeccc482c40ab659587e1e61913d8a4ac1948dabe2d";
   };
 
   buildType = "cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "cd1667cd07ec3aeee6f39b6e07d5a64e443b96e9c5f49ae55e938964c4c8571c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "f407d8f0354da0161819b7fa1de94512591e1169a6341858726492deb43a6ac8";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "776981a988eb2f892e9e65614defd0022cd2eb8497f03c4cd00a60aedd9760ac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "e7675ab333c21575c0358da5c85bd106888fe7db3efae40d533d5e6b20b21712";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-gui-cpp/default.nix
+++ b/distros/iron/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pluginlib, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-rqt-gui-cpp";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_gui_cpp/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "e12a988de9c81c3bc5c975436f07ad3c76c53220a5ce9a1ec36f0180441260a6";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_gui_cpp/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "2e012a92faa646f2b67f1e2c87cd3ba19da983b53ff5205ee63099ddb6e8f1ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-gui-py/default.nix
+++ b/distros/iron/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-iron-rqt-gui-py";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_gui_py/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "e7a1ae861376de73cb8d01371abf5f88c2dcb979429d998eb97460edb77d064d";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_gui_py/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "8e3f8839696376d5c5741f13b0b6d34593535e08e7e1dfd2fe12d3dd82c51b28";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-gui/default.nix
+++ b/distros/iron/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-iron-rqt-gui";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_gui/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "2f6cdf32990891df8c368dbbc8e1183fd09fdff585eccbdd17bbbdf563b5acd5";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_gui/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "fffbab10d3915288ac488106fba771494c07d15a191b6df18d20fab8ad28be9d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "aba072c8f3bfd6c658f48477133cc09ce32c1699bac32f6cae70508f6f11a1e7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "65cf61b017e115ee1653788eb8e5274ae6cac135a27cc24aa43d3b609b155915";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-py-common/default.nix
+++ b/distros/iron/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rqt-py-common";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_py_common/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "5042639e094b2dd9d5eb6f1566d1c44f8601d33f91a4b835cd6c3b62e2600e8f";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt_py_common/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "ca12bfb5047d461685529012ae9d8f9c8625f35f2f1aa4a4d7b1195340e5d018";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt/default.nix
+++ b/distros/iron/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-iron-rqt";
-  version = "1.3.3-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "05fe1ec5c8b9f690fc25df8a4784b96e900fc770904117c5d258f546014c5c06";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/iron/rqt/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "13694810d1129b6dc2ae49335bb7a9ad51b8226fc676dde92542f9644f21755d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "5c8af72ebfd07bca70990453cfcdc53d61c1a76e63bb755589704ccf4c36c348";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "d56274c30a1184c32bb9c4077d3d6c8127a1c2eb7d44512ade9bb7a56f57b1dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "722d173cfb92e1d5da3a92feecfb052e8abf2cc3f9e330bcb69a1dd8cb62821f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "8cbe28e301acd28319ecd581436d2389e44ab54d8004334d9a3ff11c7f7d3cb9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ackermann-msgs backward-ros builtin-interfaces controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "038415855d0dc174fbc9e4cb8b321e721b90379e3200380bff23ea0c5893cb21";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "39dae544882a5428a6ddf398410fd6c68d8e1b97287cb0eaeffceabb117e654f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.21.0-r1";
+  version = "3.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.21.0-1.tar.gz";
-    name = "3.21.0-1.tar.gz";
-    sha256 = "4508b445e4b5d0d8f2e97480324040992b2a75bcc35701c0cc6b8037d5c9c58f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.22.0-1.tar.gz";
+    name = "3.22.0-1.tar.gz";
+    sha256 = "9bbd82417e8c5904e3828d82eb3249e62dca42ac83f42922498442604b69d96f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/vrpn-mocap/default.nix
+++ b/distros/iron/vrpn-mocap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, std-msgs, tf2, vrpn }:
 buildRosPackage {
   pname = "ros-iron-vrpn-mocap";
-  version = "1.0.3-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/iron/vrpn_mocap/1.0.3-3.tar.gz";
-    name = "1.0.3-3.tar.gz";
-    sha256 = "610e521c809c68840794f8ecf0e26fd4711395e0592ca97650893fb7d10986e6";
+    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/iron/vrpn_mocap/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "17c1defc0ebfa4bc40860772ffffe95cf62f48118f8368a361c0c276302b70d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/jackal-control/default.nix
+++ b/distros/noetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-jackal-control";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "7f1c7ab4f5df6621b8b2cbb79dc46ed78a87ee016eab6350248f14d5e398a633";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "3243b47691b1cff5dfd351127b65749b1a096c85fe9a01728fc44ff784778c62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-description/default.nix
+++ b/distros/noetic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpr-onav-description, flir-camera-description, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, sick-tim, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-description";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "6fa3359a243f8edd42ab22894f811f9e1e7c6f83caf50e67304fdabd7cfd317d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "f89b1ecb0af66f78d4b2569fbca1659e1362dbbca12ce1dd571dd26b51c49bc9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-msgs/default.nix
+++ b/distros/noetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-jackal-msgs";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "8cad3196eaf5b7acadae4692af5aaf25fd4f7fcb7ef16636896ac7683f6b177d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "d77b5d39e26c042ef2f7094a84ea3f533bbe3194aa948297a371a29bc975d534";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-navigation/default.nix
+++ b/distros/noetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-jackal-navigation";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "f7e85b966700c6dd002f35bf1f169d68be37de3d8b2d401c54fa6a49a20db77b";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "5ccf994f98877d83337dab323c949f13954772e2d4afc155308a1ea98160ab10";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jackal-tutorials/default.nix
+++ b/distros/noetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-noetic-jackal-tutorials";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "d0f92cd2a56f8303d97a5737c462c1590b0ca3ab463e12c72d7b15e1ec1aa523";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "0cf6efeb1136865e22b20ff27bdbecf874ee4a3c2948d6502ca333860e82f33e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-geometry-msgs, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.11.7-r1";
+  version = "2.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.7-1.tar.gz";
-    name = "2.11.7-1.tar.gz";
-    sha256 = "de9c7e3b8be83d9c591bb5e393d508bd122f1242c753cf6d0c9030727237a259";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.9-1.tar.gz";
+    name = "2.11.9-1.tar.gz";
+    sha256 = "18f7cdc1a6d2a850956824846e2cdb22ee5764de817c7c596d75001e5691966f";
   };
 
   buildType = "cmake";
   buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv opencv.cxxdev rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv opencv.cxxdev rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-geometry-msgs tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/qb-softhand-industry-bringup/default.nix
+++ b/distros/noetic/qb-softhand-industry-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-bringup";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_bringup/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "571efd14b1ee6c8c6f7169a11a9d32f5e99504fecdda94db166f7bcf1f0bb8b2";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_bringup/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "7971ab21eb260341df7280bd83560ca9d9e7743d2ebf25acccdafdad884022fe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-control/default.nix
+++ b/distros/noetic/qb-softhand-industry-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-control";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_control/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1323b8d15588b11ce536eae55e6fd8debff33a286d584a0a8cfc1b4b7c733010";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_control/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "becb93808886acc18d163aa1146169413ddeb6d7b3dff5ae3101afde3f3c319c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-description/default.nix
+++ b/distros/noetic/qb-softhand-industry-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-description";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_description/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "d60108e783fd9a0583721b4989c91c400b29c65919344575b83e814225f22a3c";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_description/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "47ad38e51722395dfd78603bacf298f9befa532445eb39baabd2e76c070cd9dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-driver/default.nix
+++ b/distros/noetic/qb-softhand-industry-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-srvs, qb-softhand-industry-utils, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-driver";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_driver/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "bc92b13e95b8d3f01836c40a1efc545b2d2d157e88040ed2b8aac625b378fca4";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_driver/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "8dae1b85530da06b1e3212ff6ccccb3398cc57222b78fdd5edc36931533efbd0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-hardware-interface/default.nix
+++ b/distros/noetic/qb-softhand-industry-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-manager, hardware-interface, joint-limits-interface, qb-softhand-industry-msgs, qb-softhand-industry-srvs, roscpp, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-hardware-interface";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_hardware_interface/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "521fb29de835669dd478e60ba39bede92993e2987cd906c486440a5bfc397a57";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_hardware_interface/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "97d585e8d6ee8a5d0868f2c647826271a9f0ef06bf708c9db60574a9bb51877e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-msgs/default.nix
+++ b/distros/noetic/qb-softhand-industry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-msgs";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "9ee66ddf0c23b6f30d3714a9c31ad0dc510f7a9a354ee7c1b2b27d7c570635d9";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_msgs/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "16083c6a447b1729d335ab760c5504528717bf0b57a9b8b4ed5f18e25b09a245";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-srvs/default.nix
+++ b/distros/noetic/qb-softhand-industry-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-softhand-industry-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-srvs";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_srvs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "9ba47ff27cf74620b5f20d16bbb6e9a304920735237c14a20582e73686668b7d";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_srvs/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "0ae96f0defe477ecdc683a717ebb354f7d56feab20349a8cfb6c804b2b094231";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry-utils/default.nix
+++ b/distros/noetic/qb-softhand-industry-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry-utils";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_utils/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "f4c7cff988737ad1f9869cc9ccb6616ec5131395580f2a2d90d398c70a4d2878";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry_utils/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "7392f212dbae522465f74ccac40402901a56f7d186b51855a63c6efe28464c12";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-softhand-industry/default.nix
+++ b/distros/noetic/qb-softhand-industry/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-control, qb-softhand-industry-description, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-softhand-industry-bringup, qb-softhand-industry-control, qb-softhand-industry-description, qb-softhand-industry-driver, qb-softhand-industry-hardware-interface, qb-softhand-industry-utils }:
 buildRosPackage {
   pname = "ros-noetic-qb-softhand-industry";
-  version = "1.0.9-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a23fa40e605cbf4c71a7b24ce43568a5809f3d4d0be21fa2191317f96bec56be";
+    url = "https://bitbucket.org/qbrobotics/qbshin-ros-release/get/release/noetic/qb_softhand_industry/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "634a8fe5e99b52cd7a49b8a7674ac41ff5a47aa3370742c997a379d8c5bbe420";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ qb-softhand-industry-control qb-softhand-industry-description qb-softhand-industry-hardware-interface qb-softhand-industry-utils ];
+  propagatedBuildInputs = [ qb-softhand-industry-bringup qb-softhand-industry-control qb-softhand-industry-description qb-softhand-industry-driver qb-softhand-industry-hardware-interface qb-softhand-industry-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sick-visionary-ros/default.nix
+++ b/distros/noetic/sick-visionary-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, diagnostic-updater, image-transport, pcl, pcl-conversions, pcl-ros, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sick-visionary-ros";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_visionary_ros-release/archive/release/noetic/sick_visionary_ros/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "61e2b6539448525998f4aa119b8c41c42f0dea810c2977833d708fbeae264b4f";
+    url = "https://github.com/SICKAG/sick_visionary_ros-release/archive/release/noetic/sick_visionary_ros/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "bb13c6c6f1d7c277c733624ea4f504ef464416cfe38f46db70b25eb06a5524e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.17-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.17-1.tar.gz";
-    name = "0.0.17-1.tar.gz";
-    sha256 = "e5c49b35f3d72dc3dbd4bd171bad8f27c56689d29a221786a80f6857f8e37967";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "457bd32788d830b1d0164f553786191767cc149b06fec8827b956cc9d6a936d2";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "2d9e108274ea082643fa23d4205f693aac28a6d8c4f2f1844782c2e40af2e8c2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "4ebf328459dd4ddcf6108a454a2859c6d28f9e9e89636f75762db7e163ad326a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "8dde03d921f9f8e566b56df8315c0e3f1ec7227c001171ebb6ecae1919321947";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "97e320d879abbb0507965d4d404917597958db64bcd481a650b0df0a916a4e53";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager kinematics-interface-kdl ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/apriltag-detector/default.nix
+++ b/distros/rolling/apriltag-detector/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, apriltag, apriltag-msgs, cv-bridge, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-apriltag-detector";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/apriltag_detector-release/archive/release/rolling/apriltag_detector/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ac6dddbb8b51542dd67a1557052028913273d74a5672c1e1084d631c70ab91ed";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ apriltag apriltag-msgs cv-bridge image-transport rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS package for apriltag detection'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "1a32f0d56648dfa64ef57596c11ddde21dd4224e3bcd6d0303e7d4e48be9be5f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "7891c19218191b0d9322afb8f4e939bc1d58ef302d0d7bd785ef6f41330c5d55";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "a45df7b105665a02e163b022a1c10b1610b294c9fe3a48b59a38999027f07892";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "54910b5891982b0ba9078c13975327fa448cdf9507fac575443df38fe32152b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "96c68c724ee1ceac0abf70be92f02fe639f8adb31e6ac02de10bd73c22913fc1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "7c709aed7f4b6ab8d74a59741f40f4edb023b88afef70ed8d98718f08b34db64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "3cc2ee5f42c4d59669f80adcddeec24d7e78f20e1a252797bf8989cfb8e0dedd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "7ca2f97526bff3388187462a5e1feae6182e995885c1f78e59b2e7b9a558656f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "2b374c76ea66d64d0a1197a14fcadf52bf921f31898df7853dee092c72022075";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "b2933e7e4ac302730823cd7bf3026dc4944dd22e3a0b7d14818206c8b1f40571";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "7abf0edfad4b755e20097651ccfc76064cf52ce89716d1a69edc0a231037fc5b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "32bf93d49a7d4bcc347f23d121ef599b1cc40b0b77848b1bb5478cbae0097875";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "5b8e70749dd9924ccfed443b9ca3c6ed175c7cf584d4b427e9513de9c984e8b7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "dc28e671d63ddcb5131e8fbd56c07a6f8aa959867196ebcfde5dc2fc94996f40";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "4ba11507894b02e283aebf8380810212f9e270d6266b95eb375a7cc028f70514";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "38393cb15577df41068a7c87465f73c14e7c18ff18f365d3ecccb921121c8032";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -158,6 +158,8 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ apriltag-detector = self.callPackage ./apriltag-detector {};
+
  apriltag-msgs = self.callPackage ./apriltag-msgs {};
 
  apriltag-ros = self.callPackage ./apriltag-ros {};

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "834bc1619674c3722d9c6f651f9b763706b6ac68060bc9786c13aaf4013b148b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "1972b6645bd79822ed493f01174dfc870e660d87bdf40c6083e6e83dc0233755";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "2f6a8d3b646dec8860edb180e1c00abdebed558ab5ef729d672db18c9c054528";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "db940a3dbaa5b321a0374374bdaf4d1d7bba766f19dadce1a28a473a39b30251";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "eb39379974648f573e4bf35411752cfdd1f173aa3ba5de6285a611ae26b5e478";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "6d7e349226297dd2d5b6fa34b864a1e4f43432d57872c606ca63e0702ef86fb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-pipeline/default.nix
+++ b/distros/rolling/imu-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-processors, imu-transformer }:
 buildRosPackage {
   pname = "ros-rolling-imu-pipeline";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_pipeline-release/archive/release/rolling/imu_pipeline/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "84c4a59456594452cea9c7046c1eb5824d1857e83cb730867e32b050bcb6c4c6";
+    url = "https://github.com/ros2-gbp/imu_pipeline-release/archive/release/rolling/imu_pipeline/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "ec06d302db033b28b0a78e49d178f633c624bf7006392a556eb1c5af51cbe7fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-processors/default.nix
+++ b/distros/rolling/imu-processors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, geometry-msgs, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-imu-processors";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_pipeline-release/archive/release/rolling/imu_processors/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0629b6717d6979da46b464de073f5384741956ec473c723fa9d929a6ada3984d";
+    url = "https://github.com/ros2-gbp/imu_pipeline-release/archive/release/rolling/imu_processors/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "4f8de223e13b7aba6f5ac75ef6178ea1652c42b9d95461dc605a61a13bdfe43d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "ef3c174f5f79bfb4a4cf6ebd003d3c02b1bdf2749267821f66c79836f5f7a9e9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "0350c9a794f2148555032d5582547246a4521f2051c015d9107563cf6a353b10";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/imu-transformer/default.nix
+++ b/distros/rolling/imu-transformer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, message-filters, rclcpp, rclcpp-components, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-transformer";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/imu_pipeline-release/archive/release/rolling/imu_transformer/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "9252d8228d3fb60b14f9c6625f2d6b8ac730ea8bae5ac7e255ba60b6282d6d0a";
+    url = "https://github.com/ros2-gbp/imu_pipeline-release/archive/release/rolling/imu_transformer/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "571bf04cc2221074d4c0b34dc7d3f9520b1be55451b12ca3df1fce49f67c2059";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "3b68e97fb3157c3caab14bc138965e75ace2b9c3737284ddedcaa572eeebfe47";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "8fd51313c47603f9022fcdf08db269df74cedf867410f75c161f8d1cde23839e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "4a94025ec0018aaa6c946997857111f6c14a271df5a0f2df7afa351c50b708eb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "9123078f28381d1c2c468db2bd3c049788941e45a95be39e1307fafc5f6b0465";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface rclcpp ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing rclcpp ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros builtin-interfaces control-msgs controller-interface generate-parameter-library pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "e241fc926c51fb1cc7da5152d5e64dd9e7604ce2235632e2a671add8a430d202";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "5e59cebee7dca49e8a079ada72ed56e19e258c30716031e40ec267ef6831f29c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl tl-expected trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/leo-description/default.nix
+++ b/distros/rolling/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-rolling-leo-description";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_description/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ca3044aa4dae62289786a5e27ffa42b97cb8246206d9d47a6f3e4c84619df7e3";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_description/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "cc503a68a47e7112c25b95fa12edf185b1e3f875ad1c886a5e8d7c097c26e532";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo-msgs/default.nix
+++ b/distros/rolling/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-leo-msgs";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ed4faaf97efd41a4469f7524c77efa8833b6a9a17adfd4b9fb285885c7b66e7c";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "00ace67f110b3bec943d7b68293851e1b1c9a1355ec03b3a15ebec045bec622c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo-teleop/default.nix
+++ b/distros/rolling/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-rolling-leo-teleop";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_teleop/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "c29d644c1612b61d7e55e6a40894c0ef040b1663157bc27dc1360af77a8b49fd";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo_teleop/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "a60f40d21927812461561da5a718c4636d71c88f1276a70e4180f25db175e912";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo/default.nix
+++ b/distros/rolling/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-rolling-leo";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "144b10b51dae20d66f7d571271f0e803952c5ecc3c84ff525044b13c4a7749ce";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/rolling/leo/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "55e396fa7b0b95b8dbd55e04c0d39351385d9cde4db1a2bb2c8f4f19c1f2ea5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.11.8-r1";
+  version = "2.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.8-1.tar.gz";
-    name = "2.11.8-1.tar.gz";
-    sha256 = "801e14d7a86d406199de7c7a66ace472e1f20846c434bc4171e1bee566fff0dd";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.9-1.tar.gz";
+    name = "2.11.9-1.tar.gz";
+    sha256 = "7eec1a89e9e99c6e78249ed20c3e66e2e39d8870214436b5db49835e1cd1a204";
   };
 
   buildType = "cmake";

--- a/distros/rolling/openni2-camera/default.nix
+++ b/distros/rolling/openni2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, camera-info-manager, depth-image-proc, image-transport, openni2, pkg-config, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-openni2-camera";
-  version = "2.0.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openni2_camera-release/archive/release/rolling/openni2_camera/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "8dab263f33fea27d27a013276dc5ac9afd6f8819e769f85d84db48a021b7c2d2";
+    url = "https://github.com/ros2-gbp/openni2_camera-release/archive/release/rolling/openni2_camera/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d66114af708badde63d263b4a99b3e9793eddd5c32b5111c86a3261c33284025";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "656e505d91745a5f3e937c0cbec00618f7c69cdeca7852493d004def74888b9d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "1c819cb73d83f22805dbc9b8e9b8ceaadd89f54de6c6b0fd689ae9baea92d3b8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface hardware-interface parameter-traits pluginlib rclcpp rclcpp-lifecycle realtime-tools std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "bb2d4b35a649ba90d92edb38cdef20ab1d20c3f4fa92afa9ab35dad608569bd4";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "4c979915bfa8843b5b2ceb01435acc16d77bc3e7c24d87563bc063b74fc8a778";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "3554fafcdf11e73ba7c5a3c5b0376e000ab2c1f8c82d7d6650d432e537b59623";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "488e7807cdbfcfbe025b0d60b904c948da38139ccaff5846a721c034bb8d69e0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
-  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tl-expected ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "820de812be4a68cfe5e6cd21297ac0d568b06956ab53741bc47757aa70ab9bf7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "5d1a47401b9deddcc9bc429abdca6891344212a71d21846e7a1ad422ec05f625";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "fb60568ad7f5742deac9dfa27ecec44f489986047d2f0509c988f58a59689cf4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "2ab1d109a7a544f25cbbdd5d3f75cfeae8cfd2b6546dd27b6891d7e041953d4a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "dfb24f0dce402968550be34ecae98ecdb950e2a19e4a507e83b530f92f131c6c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "df95dee8cfb55674981f96a0718e60e79702807e027088cd3ecc44eab6c93f8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "4919a3e1ce5c0e3fe12be05307782f86093c185ceb97287a9e275648f2e12012";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "2663f4d2d442db863027a5c0f99411f4a229a2442d3daf9896b3720149c85ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "3324c2ff256d6677f9a332c80feb4d520e8305e3baf479e63431d7fe3f0f9409";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "0f562b1b02fd6a53101e8d2ce407cc6847509a2784d14b2efe61b9796f6cde8c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "55e8aa18eb0ef81c7d2d952ecd0beff4974a5830aa6c3efdc29e3fa3aef67ab4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "431fdce5e5659f0168e0aaebfd9cbe863892f3f84cb051815da3df15562a26ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "11c4d53d20bc2adf0905715724f97f8ddd5ac9762b315a6e8ce74134510d0f53";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "2f451b6db62dd112a2c82502a38c362dc6b69fb9169fe71e99a9e5cfd832100d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "54bc41d96b1de44983b156b60b48a8107a88b09165982b52884b061111cb39ce";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "6d9fd6c773a9cc0ce58d25892e24a02fcfd110988e93d6b82610a5842a1c5215";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "b397e99e5399c8f74fd3d9592ee06fa38c4bca4bd420e551f475a62ea778bcd9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "8c67e54c61d8d0f9a30af124ba2d4d6bdf12b5be2d9731903f1fb436f16729b4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "084656429ee77c02d0fde0fb0cecf47173695d93f95f85baf183519130518544";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "a49b72cce843ea5938f34a81845f0ef6e9e4c95be52583f67245389d63b1ce05";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.4.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.4.0-1.tar.gz";
-    name = "4.4.0-1.tar.gz";
-    sha256 = "bdb0a237ad70bdec62b972eea77debc2bca5c3151b36a846e298009f4d65beed";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "8fa393dc10d0ad7193bf9b427d0f41991d1724eda3cea83cf60dd761a590b747";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "3d5f55d2bf5afa7a7a986f5cff6bb4aceca8979d0c032e1b4baa25b1bddab674";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "08daf006a22e47697881335997df6b9e26c8ace832c8b140ec2b8c2e98fb1f74";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ackermann-msgs backward-ros builtin-interfaces controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "96f4c26a885b8f4ea5af264bca6031d861ac41d314f9ccd0780dd893e1a1d4df";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "a4b90fc7a760444239d82f18883b5e4efc077937cea1d9a9079bb7948ace0821";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.5.0-r1";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.5.0-1.tar.gz";
-    name = "4.5.0-1.tar.gz";
-    sha256 = "259b53a9396531a46645092339aa5c5e7dbae83fe6c96311d777d5682f95a273";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "b2140db1c0f0c98b3780132de607052926c1809ab80d2d82005b04bb7a20769e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/vrpn-mocap/default.nix
+++ b/distros/rolling/vrpn-mocap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, std-msgs, tf2, vrpn }:
 buildRosPackage {
   pname = "ros-rolling-vrpn-mocap";
-  version = "1.0.4-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/rolling/vrpn_mocap/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "19d45945ef5437b560fd7081f4a5f931bf0ca359e1d7fd08262c668042bbf382";
+    url = "https://github.com/ros2-gbp/vrpn_mocap-release/archive/release/rolling/vrpn_mocap/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e7257a4f5547979033439305c09d197533c6faa90c649edc6bf011493883d90f";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 9f53d85d2a20447f67048a85e5e79e8753dce327.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aerostack2 1.0.7-r1 --> 1.0.8-r1*
* *apriltag-detector 1.1.0-r1*
* *as2-alphanumeric-viewer 1.0.7-r1 --> 1.0.8-r1*
* *as2-behavior 1.0.7-r1 --> 1.0.8-r1*
* *as2-behavior-tree 1.0.7-r1 --> 1.0.8-r1*
* *as2-behaviors-motion 1.0.7-r1 --> 1.0.8-r1*
* *as2-behaviors-perception 1.0.7-r1 --> 1.0.8-r1*
* *as2-behaviors-platform 1.0.7-r1 --> 1.0.8-r1*
* *as2-behaviors-trajectory-generation 1.0.7-r1 --> 1.0.8-r1*
* *as2-cli 1.0.7-r1 --> 1.0.8-r1*
* *as2-core 1.0.7-r1 --> 1.0.8-r1*
* *as2-gazebo-classic-assets 1.0.7-r1 --> 1.0.8-r1*
* *as2-keyboard-teleoperation 1.0.7-r1 --> 1.0.8-r1*
* *as2-motion-controller 1.0.7-r1 --> 1.0.8-r1*
* *as2-motion-reference-handlers 1.0.7-r1 --> 1.0.8-r1*
* *as2-msgs 1.0.7-r1 --> 1.0.8-r1*
* *as2-platform-crazyflie 1.0.7-r1 --> 1.0.8-r1*
* *as2-platform-dji-osdk 1.0.7-r1 --> 1.0.8-r1*
* *as2-platform-gazebo 1.0.7-r1 --> 1.0.8-r1*
* *as2-platform-tello 1.0.7-r1 --> 1.0.8-r1*
* *as2-realsense-interface 1.0.7-r1 --> 1.0.8-r1*
* *as2-state-estimator 1.0.7-r1 --> 1.0.8-r1*
* *as2-usb-camera-interface 1.0.7-r1 --> 1.0.8-r1*
* *caret-msgs 0.5.0-r2 --> 0.5.0-r4*
* *controller-interface 2.38.0-r1 --> 2.37.0-r1*
* *controller-manager 2.38.0-r1 --> 2.37.0-r1*
* *controller-manager-msgs 2.38.0-r1 --> 2.37.0-r1*
* *hardware-interface 2.38.0-r1 --> 2.37.0-r1*
* *joint-limits 2.38.0-r1 --> 2.37.0-r1*
* *mrpt2 2.11.8-r1 --> 2.11.9-r1*
* *pcl-conversions 2.4.0-r4 --> 2.4.0-r5*
* *pcl-ros 2.4.0-r4 --> 2.4.0-r5*
* *perception-pcl 2.4.0-r4 --> 2.4.0-r5*
* *ros2-control 2.38.0-r1 --> 2.37.0-r1*
* *ros2-control-test-assets 2.38.0-r1 --> 2.37.0-r1*
* *ros2controlcli 2.38.0-r1 --> 2.37.0-r1*
* *rqt-controller-manager 2.38.0-r1 --> 2.37.0-r1*
* *transmission-interface 2.38.0-r1 --> 2.37.0-r1*
* *vrpn-mocap 1.0.4-r1 --> 1.1.0-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.21.0-r1 --> 3.22.0-r1*
* *admittance-controller 3.21.0-r1 --> 3.22.0-r1*
* *apriltag-detector 1.2.0-r1*
* *azure-iot-sdk-c 1.10.1-r4 --> 1.12.0-r1*
* *bicycle-steering-controller 3.21.0-r1 --> 3.22.0-r1*
* *diff-drive-controller 3.21.0-r1 --> 3.22.0-r1*
* *effort-controllers 3.21.0-r1 --> 3.22.0-r1*
* *force-torque-sensor-broadcaster 3.21.0-r1 --> 3.22.0-r1*
* *forward-command-controller 3.21.0-r1 --> 3.22.0-r1*
* *gripper-controllers 3.21.0-r1 --> 3.22.0-r1*
* *imu-sensor-broadcaster 3.21.0-r1 --> 3.22.0-r1*
* *joint-state-broadcaster 3.21.0-r1 --> 3.22.0-r1*
* *joint-trajectory-controller 3.21.0-r1 --> 3.22.0-r1*
* *leo 2.0.0-r1 --> 2.0.1-r1*
* *leo-description 2.0.0-r1 --> 2.0.1-r1*
* *leo-msgs 2.0.0-r1 --> 2.0.1-r1*
* *leo-teleop 2.0.0-r1 --> 2.0.1-r1*
* *mp2p-icp 1.1.0-r1 --> 1.1.1-r1*
* *mrpt2 2.11.7-r1 --> 2.11.9-r1*
* *multidim-rrt-planner 0.0.6-r1 --> 0.0.8-r1*
* *point-cloud-transport 2.0.3-r1 --> 2.0.4-r1*
* *point-cloud-transport-py 2.0.3-r1 --> 2.0.4-r1*
* *position-controllers 3.21.0-r1 --> 3.22.0-r1*
* *range-sensor-broadcaster 3.21.0-r1 --> 3.22.0-r1*
* *rcpputils 2.6.2-r1 --> 2.6.3-r1*
* *robotraconteur 1.0.0-r1 --> 1.0.0-r2*
* *ros2-controllers 3.21.0-r1 --> 3.22.0-r1*
* *ros2-controllers-test-nodes 3.21.0-r1 --> 3.22.0-r1*
* *rqt 1.3.3-r1 --> 1.3.4-r1*
* *rqt-gui 1.3.3-r1 --> 1.3.4-r1*
* *rqt-gui-cpp 1.3.3-r1 --> 1.3.4-r1*
* *rqt-gui-py 1.3.3-r1 --> 1.3.4-r1*
* *rqt-joint-trajectory-controller 3.21.0-r1 --> 3.22.0-r1*
* *rqt-py-common 1.3.3-r1 --> 1.3.4-r1*
* *steering-controllers-library 3.21.0-r1 --> 3.22.0-r1*
* *tricycle-controller 3.21.0-r1 --> 3.22.0-r1*
* *tricycle-steering-controller 3.21.0-r1 --> 3.22.0-r1*
* *velocity-controllers 3.21.0-r1 --> 3.22.0-r1*
* *vrpn-mocap 1.0.3-r3 --> 1.1.0-r1*

Noetic Changes:
---------------
* *jackal-control 0.8.8-r1 --> 0.8.9-r1*
* *jackal-description 0.8.8-r1 --> 0.8.9-r1*
* *jackal-msgs 0.8.8-r1 --> 0.8.9-r1*
* *jackal-navigation 0.8.8-r1 --> 0.8.9-r1*
* *jackal-tutorials 0.8.8-r1 --> 0.8.9-r1*
* *mrpt2 2.11.7-r1 --> 2.11.9-r1*
* *qb-softhand-industry 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-bringup 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-control 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-description 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-driver 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-hardware-interface 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-msgs 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-srvs 1.0.9-r1 --> 1.2.5-r1*
* *qb-softhand-industry-utils 1.0.9-r1 --> 1.2.5-r1*
* *sick-visionary-ros 1.1.1-r1 --> 1.1.2-r1*
* *urg-stamped 0.0.17-r1 --> 0.1.0-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.5.0-r1 --> 4.6.0-r1*
* *admittance-controller 4.5.0-r1 --> 4.6.0-r1*
* *apriltag-detector 1.0.0-r1*
* *bicycle-steering-controller 4.5.0-r1 --> 4.6.0-r1*
* *controller-interface 4.4.0-r1 --> 4.5.0-r1*
* *controller-manager 4.4.0-r1 --> 4.5.0-r1*
* *controller-manager-msgs 4.4.0-r1 --> 4.5.0-r1*
* *diff-drive-controller 4.5.0-r1 --> 4.6.0-r1*
* *effort-controllers 4.5.0-r1 --> 4.6.0-r1*
* *force-torque-sensor-broadcaster 4.5.0-r1 --> 4.6.0-r1*
* *forward-command-controller 4.5.0-r1 --> 4.6.0-r1*
* *gripper-controllers 4.5.0-r1 --> 4.6.0-r1*
* *hardware-interface 4.4.0-r1 --> 4.5.0-r1*
* *hardware-interface-testing 4.4.0-r1 --> 4.5.0-r1*
* *imu-pipeline 0.4.1-r1 --> 0.5.0-r1*
* *imu-processors 0.4.1-r1 --> 0.5.0-r1*
* *imu-sensor-broadcaster 4.5.0-r1 --> 4.6.0-r1*
* *imu-transformer 0.4.1-r1 --> 0.5.0-r1*
* *joint-limits 4.4.0-r1 --> 4.5.0-r1*
* *joint-state-broadcaster 4.5.0-r1 --> 4.6.0-r1*
* *joint-trajectory-controller 4.5.0-r1 --> 4.6.0-r1*
* *leo 3.0.0-r1 --> 3.0.1-r1*
* *leo-description 3.0.0-r1 --> 3.0.1-r1*
* *leo-msgs 3.0.0-r1 --> 3.0.1-r1*
* *leo-teleop 3.0.0-r1 --> 3.0.1-r1*
* *mrpt2 2.11.8-r1 --> 2.11.9-r1*
* *openni2-camera 2.0.2-r1 --> 2.1.0-r1*
* *pid-controller 4.5.0-r1 --> 4.6.0-r1*
* *point-cloud-transport 3.0.2-r1 --> 3.0.3-r1*
* *point-cloud-transport-py 3.0.2-r1 --> 3.0.3-r1*
* *position-controllers 4.5.0-r1 --> 4.6.0-r1*
* *range-sensor-broadcaster 4.5.0-r1 --> 4.6.0-r1*
* *ros2-control 4.4.0-r1 --> 4.5.0-r1*
* *ros2-control-test-assets 4.4.0-r1 --> 4.5.0-r1*
* *ros2-controllers 4.5.0-r1 --> 4.6.0-r1*
* *ros2-controllers-test-nodes 4.5.0-r1 --> 4.6.0-r1*
* *ros2controlcli 4.4.0-r1 --> 4.5.0-r1*
* *rqt-controller-manager 4.4.0-r1 --> 4.5.0-r1*
* *rqt-joint-trajectory-controller 4.5.0-r1 --> 4.6.0-r1*
* *steering-controllers-library 4.5.0-r1 --> 4.6.0-r1*
* *transmission-interface 4.4.0-r1 --> 4.5.0-r1*
* *tricycle-controller 4.5.0-r1 --> 4.6.0-r1*
* *tricycle-steering-controller 4.5.0-r1 --> 4.6.0-r1*
* *velocity-controllers 4.5.0-r1 --> 4.6.0-r1*
* *vrpn-mocap 1.0.4-r1 --> 1.1.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libxkbcommon-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-lttng
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

