### PR TITLE
Fix rosbag2-compression compile error

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -106,6 +106,19 @@ in with lib; {
     ];
   });
 
+  rosbag2-compression = rosSuper.rosbag2-compression.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      (self.fetchpatch {
+        # Add in a missing cstdint include
+        url = "https://github.com/ros2/rosbag2/commit/65c889e1fa55dd85a148b27b8c27dadc73238e67.patch";
+        hash = "sha256-EzfOqI08roSSqpo3hEUFxoImxKJGi1wUN4ZxwhYszUY=";
+        stripLen = 1;
+      })
+    ];
+  });
+
   rviz-ogre-vendor = patchVendorUrl rosSuper.rviz-ogre-vendor {
     url = "https://github.com/OGRECave/ogre/archive/v1.12.1.zip";
     sha256 = "1iv6k0dwdzg5nnzw2mcgcl663q4f7p2kj7nhs8afnsikrzxxgsi4";


### PR DESCRIPTION
The error messages were as follows:

    In file included from /build/rosbag2-release-release-humble-rosbag2_compression-0.15.9-1/src/rosbag2_compression/compression_options.cpp:18:
    /build/rosbag2-release-release-humble-rosbag2_compression-0.15.9-1/include/rosbag2_compression/compression_options.hpp:29:6: warning: elaborated-type-specifier for a scoped enum must not use the 'class' keyword
       29 | enum class ROSBAG2_COMPRESSION_PUBLIC CompressionMode: uint32_t
          | ~~~~ ^~~~~
          |      -----
    /build/rosbag2-release-release-humble-rosbag2_compression-0.15.9-1/include/rosbag2_compression/compression_options.hpp:29:54: error: found ':' in nested-name-specifier, expected '::'
       29 | enum class ROSBAG2_COMPRESSION_PUBLIC CompressionMode: uint32_t
          |                                                      ^
          |                                                      ::
    /build/rosbag2-release-release-humble-rosbag2_compression-0.15.9-1/include/rosbag2_compression/compression_options.hpp:29:39: error: 'CompressionMode' has not been declared
       29 | enum class ROSBAG2_COMPRESSION_PUBLIC CompressionMode: uint32_t
          |                                       ^~~~~~~~~~~~~~~