### PR TITLE
Move empy override from distros/ to pkgs/

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -4,17 +4,6 @@ let
   pythonOverridesFor = with self.lib; prevPython: prevPython // {
     pkgs = prevPython.pkgs.overrideScope (pyFinal: pyPrev: {
       wxPython = pyFinal.wxPython_4_2;
-
-      # ROS is not compatible with empy 4
-      empy = pyPrev.empy.overrideAttrs ({
-        pname, ...
-      }: rec {
-        version = "3.3.4";
-        src = pyFinal.fetchPypi {
-          inherit pname version;
-          hash = "sha256-c6xJeFtgFHnfTqGKfHm8EwSop8NMArlHLPEgauiPAbM=";
-        };
-      });
     });
   };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -50,6 +50,17 @@ self: super: with self.lib; let
 
       colcon-zsh = pyFinal.callPackage ./colcon/zsh.nix { };
 
+      # ROS is not compatible with empy 4
+      empy = pyPrev.empy.overrideAttrs ({
+        pname, ...
+      }: rec {
+        version = "3.3.4";
+        src = pyFinal.fetchPypi {
+          inherit pname version;
+          hash = "sha256-c6xJeFtgFHnfTqGKfHm8EwSop8NMArlHLPEgauiPAbM=";
+        };
+      });
+
       osrf-pycommon = pyFinal.callPackage ./osrf-pycommon {};
 
       rosdep = pyFinal.callPackage ./rosdep { };


### PR DESCRIPTION
This is needed because colcon also depends on empy and is incompatible with empy 4. Colcon is defined in pkgs/, but distros/ overlay is applied after pkgs/.

Without this change, colcon prints the following errors:

    ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_core.task.build.python': cannot import name 'OVERRIDE_OPT' from 'em' (/nix/store/qbzhivb1f0z53p4xy4203jhy7x6m9ymi-python3.11-empy-4.0.1/lib/python3.11/site-packages/em.py) The Python package 'empy' must be installed and 'em' must not be installed since both packages share the same namespace
    Traceback (most recent call last):
      File "/nix/store/nqwh1ja6x4lm7jancwbjbmhq28d2xm50-python3.11-colcon-core-0.12.1/lib/python3.11/site-packages/colcon_core/entry_point.py", line 120, in load_entry_points
        extension_type = load_entry_point(entry_point)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/nix/store/nqwh1ja6x4lm7jancwbjbmhq28d2xm50-python3.11-colcon-core-0.12.1/lib/python3.11/site-packages/colcon_core/entry_point.py", line 166, in load_entry_point
        return entry_point.load()
               ^^^^^^^^^^^^^^^^^^
      File "/nix/store/dyl7f7v3cfi7j9d4z42pn2ss0bgw0r33-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/pkg_resources/__init__.py", line 2516, in load
        return self.resolve()
               ^^^^^^^^^^^^^^
      File "/nix/store/dyl7f7v3cfi7j9d4z42pn2ss0bgw0r33-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/pkg_resources/__init__.py", line 2522, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/nix/store/nqwh1ja6x4lm7jancwbjbmhq28d2xm50-python3.11-colcon-core-0.12.1/lib/python3.11/site-packages/colcon_core/task/python/build.py", line 25, in <module>
        from colcon_core.task.python.template import expand_template
      File "/nix/store/nqwh1ja6x4lm7jancwbjbmhq28d2xm50-python3.11-colcon-core-0.12.1/lib/python3.11/site-packages/colcon_core/task/python/template/__init__.py", line 4, in <module>
        from colcon_core.shell.template import expand_template  # noqa: F401
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/nix/store/nqwh1ja6x4lm7jancwbjbmhq28d2xm50-python3.11-colcon-core-0.12.1/lib/python3.11/site-packages/colcon_core/shell/template/__init__.py", line 19, in <module>
        raise e from None
      File "/nix/store/nqwh1ja6x4lm7jancwbjbmhq28d2xm50-python3.11-colcon-core-0.12.1/lib/python3.11/site-packages/colcon_core/shell/template/__init__.py", line 10, in <module>
        from em import OVERRIDE_OPT
    ImportError: cannot import name 'OVERRIDE_OPT' from 'em' (/nix/store/qbzhivb1f0z53p4xy4203jhy7x6m9ymi-python3.11-empy-4.0.1/lib/python3.11/site-packages/em.py) The Python package 'empy' must be installed and 'em' must not be installed since both packages share the same namespace