### PR TITLE
Fix plotjuggler-ros for Humble

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -94,6 +94,18 @@ in with lib; {
     };
   };
 
+  plotjuggler-ros = rosSuper.plotjuggler-ros.overrideAttrs ({
+    patches ? [], nativeBuildInputs ? [], ...
+  }: {
+    patches = patches ++ [
+      (self.fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/PlotJuggler/plotjuggler-ros-plugins/pull/82.patch";
+        hash = "sha256-ojZ/ErZZkGIB89O0u2ocU6Gcdu/JhowUqkdsulcArHY=";
+      })
+    ];
+    nativeBuildInputs = nativeBuildInputs ++ [ rosSelf.ros-environment ];
+  });
+
   rcpputils = rosSuper.rcpputils.overrideAttrs ({
     patches ? [], ...
   }: {


### PR DESCRIPTION
Without this, Humble distro is not properly detected and compilation fails.