### PR TITLE
rosdistro sync, Fri Mar  1 13:05:07 2024

### DIFF
--- a/distros/humble/ament-cmake-auto/default.nix
+++ b/distros/humble/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-auto";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "b26d2e35cc22ec96800b27e047c9ba27fd236b619c0fb5d15213cb921d91aefc";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "f504e5a93a2535998abd90b1c9d803bcce4e51e8dca9ccd9fd45ad3d538e9190";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-core/default.nix
+++ b/distros/humble/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-core";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "e648062c6ba6f79d1ed65dfedb2ee3fa14d02840edb9a6f86c9ddc88ba036139";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "35b3be6197fcd6e563fba95b48197fdf5b48621ebe15775789e36e1fd62afe85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-definitions/default.nix
+++ b/distros/humble/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-definitions";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "b1b9553c19405bafed3d902f4d51b32711a6076299316bd46c05a96c979df8ab";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "58c6793fc9e2396d04555861974541a558174c30feff0e76df080fbb49b38ae0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-dependencies/default.nix
+++ b/distros/humble/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-dependencies";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "c4ae1bef9b2d31c59585092582b6f39b640c3391d089e26ea6c699a8b3a9fdfb";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "e79e2d0d1fefcf7dd7156ec51425e7b752ab7c06912819c44466b8c78e32f8b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-include-directories/default.nix
+++ b/distros/humble/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-include-directories";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "5ce7766aa116da82713c410b82d1cbae2006eb283fcb8288a95050ed418afb70";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "e5599b4f536bf18e2364a4e2f4479165208c1db8267870260213f587f824daff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-interfaces/default.nix
+++ b/distros/humble/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-interfaces";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "f8d32355c8afabeb13068e376deb3035c57cfe4f6c3cb1de0dba9ddae7b82cc2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "c36384afa21203004c19b599e02476cc642ee099ece55e9d22192c3f5c10b91f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-libraries/default.nix
+++ b/distros/humble/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-libraries";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "c52fb632be947252d685226c127a93ccadd78a3a13be68a03774e696480e9d0d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "4521a17677ad8d3cf0cef9624e01e0965128b97a12271964bac843c334b21ba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-link-flags/default.nix
+++ b/distros/humble/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-link-flags";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "f5c16fe78adacb2348a1fb9c4861c0b2308882225bc18744173b473a5ed25613";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "e34efbe1916765eb354a1e5a54d5ffddc0e83a0bab69624d4eb324a822327eab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-targets/default.nix
+++ b/distros/humble/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-targets";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "7695ec84cdcfbe30ff798c69722269da8a53a79c2db64e3c18e2a1353238e4a8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "4011001edeccfb08598075864bc66bd2ce9f01ebac5fbd605a1ca6cfe79f55c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gen-version-h/default.nix
+++ b/distros/humble/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gen-version-h";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "abd83f1422295f35f8dabd0b3041700b0a40e088470e5c916737d34acc18e563";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "d7dd19094f5c123f55058bd4365bd9d32d7cf8fc317d697eb27553ab3379c8b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gmock/default.nix
+++ b/distros/humble/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gmock";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "182545aff59448db5c3d8675a6542b5d0f0ed04ee4200b0e05c1fa35acec995d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "e0215d815946d163b578f6e3cc1e4537e5771f24ec67802571868813b0e3bf43";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-google-benchmark/default.nix
+++ b/distros/humble/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-google-benchmark";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "5b0f3500832633f580f264f7e15402d72800a07ef18e95c68b06acc65a73237d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "aa8427b43f2d80fa71482a1a8254db498aa433263df0585553b6a940be0a2943";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gtest/default.nix
+++ b/distros/humble/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gtest";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "2cb2f7bd899b93d35edcfd3da7e547f8e431a873bc217c337de8bb774c17718a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "6b914f72839660d8ac8512f54c56601e2d7e8d97063c66500b7cae66a1a8a7be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-include-directories/default.nix
+++ b/distros/humble/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-include-directories";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "cd8c0a71256a27fec524d9f549e387f9738182745794b6195dbc36e5cfc09af9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "49cb2c73b0c988b1700692e808b0ca22fdf007f1a621f3b170a29797939c8892";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-libraries/default.nix
+++ b/distros/humble/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-libraries";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "28e898b04334c03f3e1ab3939d2ccacbb70179b2fe03f6fd182764e951e894d1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "c3b257e168e9489f30cec8adbeaf79e8e81d6f925e38c8a7a4e068522ea949e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-nose/default.nix
+++ b/distros/humble/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-nose";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "e9d142d06885078730e4b60f3790fa8fe826c8e9522f7932cf8c5c3b7ae9277e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "2134fb63b0a98644419080c1e7eeabcbee798128a12a8148cdca4efccea1dbf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pytest/default.nix
+++ b/distros/humble/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pytest";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "3b3ad5728499a9f57ebd15da71bf258d3daef3b1f733395a99c0e2d3b3bb97ab";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "c8dfbfe4629efa72c2947ba38bed3552b76957b6b9bb43b7ec528380afe3d353";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-python/default.nix
+++ b/distros/humble/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-python";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "b0864f5e511c6be343ca80384d9dabaa77d62a63155cd43586c9ae0fc960165d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "b111a21c2d2cb8dbe54ff3a8dd005da2610531c86503bfdd93066c460f8cd7b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-target-dependencies/default.nix
+++ b/distros/humble/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-target-dependencies";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "168fc4f608270cee497ddd4d7b859a1482dde77ce17836a9bfcd48fe35db1557";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "89eb3f64cf8d6a1c3443468de61d8849b439a36e1fe8cf790284d2d88d636853";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-test/default.nix
+++ b/distros/humble/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-test";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "ba28151c58d7a3bab86748c534ec22c133550e4b32a2e5e8485edd71535f21f9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "7563f3d15237b6096ea4b0727a98f9dac2ff34a927905b607dd2114fc7a3f029";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-vendor-package/default.nix
+++ b/distros/humble/ament-cmake-vendor-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-vendor-package";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "30e117088f8029029bc9a461eaf988fcf0a29d8248ac7205e5cef781f592cd11";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "bb58b7b45d306e95b681f308554e89c4854054c1cbbf05b9ae7ac6e84adb2ca5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-version/default.nix
+++ b/distros/humble/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-version";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "8c4170f1dd6e6cc951a8284ffd6068d2768d43d6acde9e75e042461010aab600";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "b6663819f31b229c036f22b52de1db85eed02c53256a4d7b4521746a764f254f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake/default.nix
+++ b/distros/humble/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake";
-  version = "1.3.7-r1";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.7-1.tar.gz";
-    name = "1.3.7-1.tar.gz";
-    sha256 = "d6e2caf6b93751b1930862a0e42459ab5d5f219cba74987a9447dd8c6a7b6f86";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "494dfb65eff68181ce4438a2b4e339bc13f672b2991784972741cbf7e8e72cf1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/caret-analyze-cpp-impl/default.nix
+++ b/distros/humble/caret-analyze-cpp-impl/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pybind11-vendor, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-caret-analyze-cpp-impl";
-  version = "0.5.0-r1";
+  version = "0.5.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/caret_analyze_cpp_impl-release/archive/release/humble/caret_analyze_cpp_impl/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "0729584419c01938f12c5b8b4547a42bfe0dcbcf1e2fb148190687e1b68f3cb7";
+    url = "https://github.com/ros2-gbp/caret_analyze_cpp_impl-release/archive/release/humble/caret_analyze_cpp_impl/0.5.0-5.tar.gz";
+    name = "0.5.0-5.tar.gz";
+    sha256 = "5c5003de6c5513668e60e0ed633864b5e528fbe7e0e4b8371339b9c7dc08a5a9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake python-cmake-module ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ pybind11-vendor yaml-cpp-vendor ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake python-cmake-module ];
 
   meta = {
     description = ''c++ implementation of caret_analyze'';

--- a/distros/humble/caret-msgs/default.nix
+++ b/distros/humble/caret-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-caret-msgs";
-  version = "0.5.0-r4";
+  version = "0.5.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/caret_trace-release/archive/release/humble/caret_msgs/0.5.0-4.tar.gz";
-    name = "0.5.0-4.tar.gz";
-    sha256 = "dd8bdae66cbaf0a7b315e76438dd91d42d9f92bbbd3e6051b656bf8d5011066c";
+    url = "https://github.com/ros2-gbp/caret_trace-release/archive/release/humble/caret_msgs/0.5.0-6.tar.gz";
+    name = "0.5.0-6.tar.gz";
+    sha256 = "5c360218822c58a4a1db3a3b07356619825ebb45dc6c785c17b80b91a11ebdf0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ];
   propagatedBuildInputs = [ rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/humble/cob-actions/default.nix
+++ b/distros/humble/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, actionlib-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-cob-actions";
-  version = "2.7.9-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/humble/cob_actions/2.7.9-1.tar.gz";
-    name = "2.7.9-1.tar.gz";
-    sha256 = "2f15e4d75a5e8ea045adc811825f20d0dee6da82e3fbee342eebbda6fafe990c";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/humble/cob_actions/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "763ce6e7920075c5d7b25c4565bcbaaef97323508f2898543953f643b1028da4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cob-msgs/default.nix
+++ b/distros/humble/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-cob-msgs";
-  version = "2.7.9-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/humble/cob_msgs/2.7.9-1.tar.gz";
-    name = "2.7.9-1.tar.gz";
-    sha256 = "48f582be55db8b0083101a1ddd19e80376a6ec39bf3594552dfa1695cf613fcd";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/humble/cob_msgs/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "64db2279563e07ef0ab3ec8d2f677781db979df4b1832876d1e277d11150d065";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cob-srvs/default.nix
+++ b/distros/humble/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-cob-srvs";
-  version = "2.7.9-r1";
+  version = "2.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/humble/cob_srvs/2.7.9-1.tar.gz";
-    name = "2.7.9-1.tar.gz";
-    sha256 = "80f9372180b3d1bca14f9d1ddc175a6e02e7181774b37468acdac33ae43995d8";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/humble/cob_srvs/2.7.10-1.tar.gz";
+    name = "2.7.10-1.tar.gz";
+    sha256 = "c0783cbe62d7d71d7d2e7ab870271cfe5c84d62bfb7deba3291de595aaf4c14d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/color-util/default.nix
+++ b/distros/humble/color-util/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/color_util-release/archive/release/humble/color_util/1.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/color_util-release/archive/release/humble/color_util/1.0.0-1.tar.gz";
     name = "1.0.0-1.tar.gz";
     sha256 = "ad88e72db74ed89e5ea85d0c4ecfe934ae1b990321de7927742260d02ad380b2";
   };

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "2b3e7771596ffc752a1a1be35e4f3cf6408b8c0e99b04de15d873e0183fa6f58";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "b4abb4b0b62ed80bada26aee40005e300ca2e4eb9debe3a72618907e35a70120";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "60a6d3e0923802e91528bdee8b4aca9cee9120d99bdc0bf2acf0e4f384fed4e0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "3d63ff00e4c5cfbad22f6e8dfbefe48a43a35c64ad64fd93a51640650d200e51";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "712dd6370f04b670f78855ee21090c5459ce190450dec6c15f2c9f6418e9f07f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "73ed711bce028298f34f52149c7abffed8e5f40a00b77b56e39b33b652678e95";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-gmock ];
+  checkInputs = [ ament-cmake-gmock hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/dataspeed-dbw-common/default.nix
+++ b/distros/humble/dataspeed-dbw-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, rclcpp, ros2-socketcan }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-dbw-common";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_common/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "18b702547eae717be609c555ebc5017ec2e2455474384578d60622df05511b13";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_dbw_common/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "ded56f8bc4ddc646f6261bfc0d8e7265c2abffb1ecfd262bd1aeae6b649f4345";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc-can/default.nix
+++ b/distros/humble/dataspeed-ulc-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-dbw-common, dataspeed-ulc-msgs, geometry-msgs, rclcpp, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc-can";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_can/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "b1563c9998bdabb57d54a3243950ee69b60c6406ee7a95549ab287c690bbff57";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_can/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "aba3ebbaaef837303f4c0fe7323dbadd181e621c8ee9f3591eb5e1f89a5bfd9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc-msgs/default.nix
+++ b/distros/humble/dataspeed-ulc-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc-msgs";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_msgs/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "fe170ec9f49205322c78edf08eb68ff62d18dfcee3958d72e11a7371401f1be7";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc_msgs/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "29314a477ed9d5c7ab58f7381dabf6b66679a79616cd385e7b414c3d934ca709";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-ulc/default.nix
+++ b/distros/humble/dataspeed-ulc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-ulc-can, dataspeed-ulc-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-ulc";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "bc52fe40d8f9049585ed8e2129f5e991f320f1495aa61b2279eebdff137cc957";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dataspeed_ulc/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "a6afdde59a7e17f14bd6180ebe18c3415348b6feb5477b27c6b63b1f1263c3d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-can/default.nix
+++ b/distros/humble/dbw-fca-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-can";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_can/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "30ef91eb69d973a1ce28039d0f3302fb29c7d699bbbb5ee7976a8f47f9b5569d";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_can/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "3a2b3925cf5da1597a6226ebf6bc7bf63d124a73ff8f2c9ed0e01bd5469d56ec";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake dataspeed-can-msg-filters ];
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-dbw-common dataspeed-dbw-gateway dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-dbw-common dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/dbw-fca-description/default.nix
+++ b/distros/humble/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-description";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_description/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "48d5260311f0af86902faf74be90672936a9ad9d35ac6531c24fecccbaeda9db";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_description/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "920bcd4e6a23e7066f665122db9eb819472b74a1876e92bd69975848b8cda0fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca-joystick-demo/default.nix
+++ b/distros/humble/dbw-fca-joystick-demo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-fca-can, dbw-fca-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-fca-can, dbw-fca-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-joystick-demo";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_joystick_demo/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "57b77dde2c49ea3d0b8423615e6d370b3449c538d11575a2df0df1458f4bf9e8";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_joystick_demo/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "834f634706b0c173e411aae29abaebbbcb8a98d12430aa6f71d7f64ce5323aa6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ dataspeed-dbw-common dbw-fca-can dbw-fca-msgs joy rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ dataspeed-dbw-common dbw-fca-can dbw-fca-msgs joy rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/dbw-fca-msgs/default.nix
+++ b/distros/humble/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca-msgs";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_msgs/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "63c9085654fac36703d82f30ebdf58fb54d29c65df332320a63fef277b2083cc";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca_msgs/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "5a4be8aef4236d9f0e57f68127f4fc2e2b1ec3b056cc20fd8e7936ffcfba0823";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-fca/default.nix
+++ b/distros/humble/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-fca";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "47b4ce1b73ca5b391ca105ce974bec3d85a5ab017c1962cadea99b082e8074d2";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_fca/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "280fe467e3b13f9d22db7a61420685328c1377149d1797d65eb5e678b4d52503";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-can/default.nix
+++ b/distros/humble/dbw-ford-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-ford-description, dbw-ford-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-ulc-can, dbw-ford-description, dbw-ford-msgs, geometry-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-can";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_can/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a7547971f4a42e53f5a6926247bb0555d565cc315d67e1a47d6f83ac554310fc";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_can/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "825cc869efdb77aa88d749a014169dfed75e934b1a8e642499ff443f75852107";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake dataspeed-can-msg-filters ];
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-dbw-common dataspeed-dbw-gateway dataspeed-ulc-can dbw-ford-description dbw-ford-msgs geometry-msgs rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-dbw-common dataspeed-ulc-can dbw-ford-description dbw-ford-msgs geometry-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/dbw-ford-description/default.nix
+++ b/distros/humble/dbw-ford-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-description";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_description/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "62424e4ae5b3eae5f595171a9157cce34204e4222a28677a3c93bc784079505e";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_description/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "4c2dff41a355d3fcccc2cccf8fe1bbdf783db3238a7f9a9984dcb264f769acb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford-joystick-demo/default.nix
+++ b/distros/humble/dbw-ford-joystick-demo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-ford-can, dbw-ford-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-ford-can, dbw-ford-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-joystick-demo";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_joystick_demo/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "233015c3ffbe0b646379f9c1d38490bf6f2cba138dbce872cc1c53cd4c8b814b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_joystick_demo/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "3adf804e66132f71226be03170f0629c7b9d4b891ab72376980100556417375c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ dataspeed-dbw-common dbw-ford-can dbw-ford-msgs joy rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ dataspeed-dbw-common dbw-ford-can dbw-ford-msgs joy rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/dbw-ford-msgs/default.nix
+++ b/distros/humble/dbw-ford-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford-msgs";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_msgs/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "cf4b4304a7998228eed60388525d7f87ae8f5fb97d693963726cee798d6059fb";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford_msgs/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "8d7d718b4a605b9934bd7a00eda797fb8b80cb4daece817e097d931fad1ec146";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-ford/default.nix
+++ b/distros/humble/dbw-ford/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-ford-can, dbw-ford-description, dbw-ford-joystick-demo, dbw-ford-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-ford";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "87de75e12f2f16cfc4e8c82f746f864dc957732157f72e3f2ad0e910f67de620";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_ford/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "8fb1bbf97d354ca29b5a411f068b9eb946c016735a01ea915718f1b7ea7b07b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-can/default.nix
+++ b/distros/humble/dbw-polaris-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-dbw-gateway, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-dbw-common, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-can";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_can/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "7433eb88680cf23c48848becce11ea26d8b278ce2cc4d0240d5752107f078a64";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_can/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "b9b7a9f44e3d9a06f8c5267bd12010c324f73e2534a644f131a6bdc0caf30ecd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake dataspeed-can-msg-filters ];
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-dbw-common dataspeed-dbw-gateway dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-dbw-common dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/dbw-polaris-description/default.nix
+++ b/distros/humble/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-description";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_description/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "55d6a73595115281713fbdfb4a47e2a802ed953bc76e8e8323ae24709d44950d";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_description/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "41534d5389669b65d1c6fa858bd103aa91e54262e092d612c01c16e95e89593f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris-joystick-demo/default.nix
+++ b/distros/humble/dbw-polaris-joystick-demo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-polaris-can, dbw-polaris-msgs, joy, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-dbw-common, dbw-polaris-can, dbw-polaris-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-joystick-demo";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_joystick_demo/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "9fdfdeab9df0111d7ee730e83426c90895988f78fc5c8c89fcd21fecc4ad5fa7";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_joystick_demo/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "ccd8ced3fbd38bcae4170c32cb4743608c0466c85313ae24c5b547522810382f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ dataspeed-dbw-common dbw-polaris-can dbw-polaris-msgs joy rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ dataspeed-dbw-common dbw-polaris-can dbw-polaris-msgs joy rclcpp rclcpp-components sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/dbw-polaris-msgs/default.nix
+++ b/distros/humble/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris-msgs";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_msgs/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "10de28cf5a43298fe95e0c389d03032ee423899e2b9486bda9b7d840fddade7d";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris_msgs/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "cede355bd0569f48e60fbff7a7484af56dd92f309af842c832f0b495d8a4c778";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dbw-polaris/default.nix
+++ b/distros/humble/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-humble-dbw-polaris";
-  version = "2.1.3-r1";
+  version = "2.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a301cbf2a3aec9e3da64bb2c0a201acf61dd96a5557e579e3e6d682e8c14795d";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/dbw_polaris/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "b705fd19952bbf393dc421269cd2572895b2689bc298efa3673bf9a4445e430e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ds-dbw-can/default.nix
+++ b/distros/humble/ds-dbw-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, ds-dbw-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ds-dbw-can";
+  version = "2.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/ds_dbw_can/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "53e4d056fa7abf129b09a61bfe671f70c00c13d0075477f75ced968bf673bbee";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake dataspeed-can-msg-filters ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb ds-dbw-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interface to the Dataspeed Inc. Drive-By-Wire kit'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ds-dbw-joystick-demo/default.nix
+++ b/distros/humble/ds-dbw-joystick-demo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ds-dbw-joystick-demo";
+  version = "2.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/ds_dbw_joystick_demo/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "bd402f457c5453d0f766662e3a629be9ca2ce8788a7b46aba73870d7553a015e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ds-dbw-can ds-dbw-msgs joy rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demonstration of drive-by-wire with joystick'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ds-dbw-msgs/default.nix
+++ b/distros/humble/ds-dbw-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ds-dbw-msgs";
+  version = "2.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/ds_dbw_msgs/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "8c871e83ca7d60072e289ec114b53c8bbcf0b5dd9f0b374de22562f1441b6f7c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Drive-by-wire messages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ds-dbw/default.nix
+++ b/distros/humble/ds-dbw/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-joystick-demo, ds-dbw-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ds-dbw";
+  version = "2.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/humble/ds_dbw/2.1.10-1.tar.gz";
+    name = "2.1.10-1.tar.gz";
+    sha256 = "ae1d357e89cb024d70a5658a019897f6a4024b6ddeeb7510547d3d2d5f76eb05";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ds-dbw-can ds-dbw-joystick-demo ds-dbw-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interface to the Dataspeed Inc. Drive-By-Wire kits'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/etsi-its-cam-coding/default.nix
+++ b/distros/humble/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "caa2ae720df6fd05b23c18c7702a7076b65e2cb9dc131c8456bfbd9ac4b29dd0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "265e2588131c3b725edf0bf7305f442dad35d045cb9134700e62ca0d52a057ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "cc62fc589eaba0d34b8edded6fc69df6e583f374b32c8b4296e39e99ccc7785e";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "34dd764687d23919c5c97d3a217d8046901c6742c764281a3f98b51f4eb7ad61";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "924c16116ff331a5d62f6a75052c6217f1d93687ebb29d8e58d90706201382d6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b644d1ce650440b843000c9176a8c7f7a7ec53f68853ed6a3250a3c0859ff370";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-coding/default.nix
+++ b/distros/humble/etsi-its-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "7da5fbab5f5b95486dcb5965f1ee3fbf8884528f52f1097d28a2373b55909edb";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c3e8110356da27066f7d2b47eaa8df06c87765fc40ea00fd77af41c6805a3f6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-conversion/default.nix
+++ b/distros/humble/etsi-its-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "a59ecb6acf2d31f81d9526f418ff49a1e8aef1a073f4420286f7f4e67e30ccc0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "df82966ca39886626605261e620666819ae3645555601e13699fa8a418956f52";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-coding/default.nix
+++ b/distros/humble/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "64a1b927b061a955b74cad146b4bfc31348c57d7b210d0b7f87fb87a1aef6ca6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e6774aa21daa57b1fd47c8dedb52e21fc9bb166d09afcfc1a1486cf9eb863ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "6a7b7d54f5a1ef80b175781fc77fdc67e9904e12ccc7c9ce5096c2c338641aa6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "1f4b6f6e29f1a556ee8e73b4bf5753a1161d859d0e61905c126a700c78d4a625";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "51955f697bebac16626288ae5405ccac68790db9e0a78148b51f9bd6d0ae384e";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "dbd8114e56ad21e9d481198b7e1cefe8256fe21a33d4fe1972ca790f03b4c568";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-messages/default.nix
+++ b/distros/humble/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-messages";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_messages/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "820e59abd81a64244e645b8518ba3b79d9a52228934fafc5854a9cf989015141";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_messages/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a2450778ea667dfa397408a0a7d7c901a2a03d7d38b08c321939caef9956609c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs-utils/default.nix
+++ b/distros/humble/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs-utils";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "a0598452aae44187351d12be0b311292beb2dc4b5aa9a217112f0f360cb802b6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "31650c8e148315444985a5a2372fb0f1e5b06cb4f2ae0b72bb395ea55ab5fe0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs/default.nix
+++ b/distros/humble/etsi-its-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "02896672798e7e7066396c6c7928f35258b511828eb2f9ff8a72943d14e8f1d7";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c6f715db108f5c64c52a1cad2ea5f5785171f8e9432e265cc7d76f76f970aac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-primitives-conversion/default.nix
+++ b/distros/humble/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-primitives-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "f993d9d279f92246c43f5bf4e040aed8122c98e58e424cf6ecbb5eb925bed954";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "255aa13ea03113fef1c9d3d78b4ca24fb8f7cdbc0f671a83780342111194514f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-rviz-plugins/default.nix
+++ b/distros/humble/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-rviz-plugins";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "f3cfe1fd1971090c0b6c85cbcdd8503924fa986028d265c29e948a50046a2217";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "255ce7f9f20095053ddb90639a759171c46961bb06fba0fa4a5add1a2714d705";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "37d1db1a386eac3d54409b2b8d1802abb93cea5a5e2cf8058154ac0a6901e418";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "4d0483dbff3791a5f0cd4a7e314e28782206ffa3d31dd0d960a00570b71b1747";
   };
 
   buildType = "ament_python";

--- a/distros/humble/fields2cover/default.nix
+++ b/distros/humble/fields2cover/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/Fields2Cover/fields2cover-release/archive/release/humble/fields2cover/1.2.1-2.tar.gz";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/1.2.1-2.tar.gz";
     name = "1.2.1-2.tar.gz";
     sha256 = "e88e84ed14b66ef8ec9a3dfcc7d60b5e63e193c9003254882766a4b4587a1a67";
   };

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.8-r2";
+  version = "2.0.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "e0d683847becc86966e7f27a3b405ca5d8f6e510f27626ca70283fe9600b83e0";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.8-3.tar.gz";
+    name = "2.0.8-3.tar.gz";
+    sha256 = "36db1c9a8e803c8dabf3fd221a1477dad144e81b7d1acde0c956b9f0737b3d7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.8-r2";
+  version = "2.0.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "f6aabdd3ec4148d71459041bdab2b7617b854017718cf88914095468f3c6c67f";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.8-3.tar.gz";
+    name = "2.0.8-3.tar.gz";
+    sha256 = "bbd0f118cc69b2f3dd87ddcb0354dbbec4210780ef00146e4a9c7f8518e4234b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-no-physics-plugin/default.nix
+++ b/distros/humble/gazebo-no-physics-plugin/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gazebo-ros, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-gazebo-no-physics-plugin";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_no_physics_plugin-release/archive/release/humble/gazebo_no_physics_plugin/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "3ebc897424e1655fc64a68c72131eb2370ac45645d8604012b174311b17bd840";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gazebo-ros rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Disables physics in gazebo'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -280,8 +280,6 @@ self: super: {
 
  bicycle-steering-controller = self.callPackage ./bicycle-steering-controller {};
 
- bno055 = self.callPackage ./bno055 {};
-
  bond = self.callPackage ./bond {};
 
  bond-core = self.callPackage ./bond-core {};
@@ -442,10 +440,6 @@ self: super: {
 
  dataspeed-dbw-common = self.callPackage ./dataspeed-dbw-common {};
 
- dataspeed-dbw-gateway = self.callPackage ./dataspeed-dbw-gateway {};
-
- dataspeed-dbw-msgs = self.callPackage ./dataspeed-dbw-msgs {};
-
  dataspeed-ulc = self.callPackage ./dataspeed-ulc {};
 
  dataspeed-ulc-can = self.callPackage ./dataspeed-ulc-can {};
@@ -543,6 +537,14 @@ self: super: {
  domain-bridge = self.callPackage ./domain-bridge {};
 
  domain-coordinator = self.callPackage ./domain-coordinator {};
+
+ ds-dbw = self.callPackage ./ds-dbw {};
+
+ ds-dbw-can = self.callPackage ./ds-dbw-can {};
+
+ ds-dbw-joystick-demo = self.callPackage ./ds-dbw-joystick-demo {};
+
+ ds-dbw-msgs = self.callPackage ./ds-dbw-msgs {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -756,6 +758,8 @@ self: super: {
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
 
+ gazebo-no-physics-plugin = self.callPackage ./gazebo-no-physics-plugin {};
+
  gazebo-plugins = self.callPackage ./gazebo-plugins {};
 
  gazebo-ros = self.callPackage ./gazebo-ros {};
@@ -857,6 +861,8 @@ self: super: {
  gtsam = self.callPackage ./gtsam {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
+
+ hardware-interface-testing = self.callPackage ./hardware-interface-testing {};
 
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
 
@@ -2553,6 +2559,8 @@ self: super: {
  tracetools-launch = self.callPackage ./tracetools-launch {};
 
  tracetools-test = self.callPackage ./tracetools-test {};
+
+ tracetools-trace = self.callPackage ./tracetools-trace {};
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "2c789a8fe7f97d822289111eb471141e641949d902cc653e9d4c821791a76ca6";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "91b7a73e06bd3fc1cd0252afbdcd81594e88055724eee527a4b0244b59780662";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface-testing/default.nix
+++ b/distros/humble/hardware-interface-testing/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-humble-hardware-interface-testing";
+  version = "2.39.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "0000a473dd854c6ab313d3cda6cda14c3c464c5c04d34e6e55c87a5863ba14c9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ];
+  propagatedBuildInputs = [ control-msgs hardware-interface lifecycle-msgs pluginlib rclcpp-lifecycle ros2-control-test-assets ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2_control hardware interface testing'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "0ac73c98b0a0e63f78881aeed81ffca79a3da0b6c1f0b58ea853f07d5c2c4e6e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "d0fd95ff9c211dda40f5738077fa8150ce833f506bc524f9125f4a7e78b96963";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "6e670082b5c1765aa5d2350416a6e1a8e549483ca6e94c07d8e8bbc4714683ab";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "f970537aec3e5103383f28840cde19d89645e561d014984382fd3ffff8ac0f99";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinematics-interface-kdl/default.nix
+++ b/distros/humble/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-humble-kinematics-interface-kdl";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface_kdl/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "7956421c5855e0bc56e7ca29aa9806831e02cd8a653b684f33158c14cd44df13";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface_kdl/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3af9c1804e8789458320e758477f0eba3831840558051a69fa676c3bc0af746d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinematics-interface/default.nix
+++ b/distros/humble/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-kinematics-interface";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "eee2f00cca92e0748c0a9eff451d4e839748ebaa9f9fce5e6a5596ad5b38f5dc";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/humble/kinematics_interface/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "0dfa527ba88ad9f6d300430c563aa8a273f5edd9f244639a99a2d048f2822f69";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-pytest/default.nix
+++ b/distros/humble/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-pytest";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_pytest/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "263d00cd5f42992a47ff1a86dc46f069c3579ed6ae07690547db28b53192c452";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_pytest/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "6c387917a2d6d0216906e7552a812ebbf3288aea5050943f4d2b4d3bc3c37af0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing-ament-cmake/default.nix
+++ b/distros/humble/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ament-cmake";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing_ament_cmake/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "aaf0021bd29c15c19fbaa2db73e20a2ec144b814fe24474dcef0d5f1f769ae98";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing_ament_cmake/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9b62dd1aebc3e7e274254105ec20e1254ce3388f1118211d97b84c2bfef4e9e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-testing/default.nix
+++ b/distros/humble/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-testing";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "4bb7991f65d09395c2150843168a2e204d538c9de9e30e8cdfe3b81a3838c063";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9019247880ee41f6828ed180c53dbdc3d40fc0c5a9d51c3dc06414a811eb814a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-xml/default.nix
+++ b/distros/humble/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-xml";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_xml/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "e880764cf45a1b4156a1a035ce295b1250feffb592c03c03e12fa35c9fc5f9b7";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_xml/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "da99ffd975c7b35e27190d8f752f6e3cc85b01da709766cc1b714f699de0a916";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-yaml/default.nix
+++ b/distros/humble/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-yaml";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_yaml/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7045e03a8047d3f64091564d1208d3625ecd341811857496744b750cbe30e15c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_yaml/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f437b578a408f718685565bc411c5e2867b1210261ff1120d33e82b3ab726027";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch/default.nix
+++ b/distros/humble/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "f9aaf08f51e1dd5859f9143902633f11b24e43698dc4015674b1b772849e0f86";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "73c1d94e1a2c2ba6f3b61bb00ed65b1f9cd26288539e9c3c2f12d173ddd1681d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/leo-description/default.nix
+++ b/distros/humble/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-description";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "df2cc9de1f06023544339d6d2d4b76768979792990f88a2a6da3367a562ae4ab";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "8e07665ebaaf07bf3f648ce8c0f022b6d266f6e93a230d8d92fe389260e6b3b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-msgs/default.nix
+++ b/distros/humble/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-leo-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a308f218b698b153faad0905c031f52a6147d52b88ca6d8da367817ac0995e92";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "911273d1ac7dcf9bd3d89a7064be0a078beadf36afeb76db08498e81ffc4b8f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-teleop/default.nix
+++ b/distros/humble/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-leo-teleop";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ea75ec89a0880cecec7b01f0c16fa219184c0f1285c97208844ec1f9360ea2a2";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "b678d0fe9f497f7d279634d6db6d4fb983a80081e349868a00b435198415d182";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo/default.nix
+++ b/distros/humble/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-humble-leo";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2466f7670b18809c81b1a2e6feb6924b8acc98535395c79c00276e6f75e4de55";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "08c0214787b9d0018eeb512db91fef13a996d068d5b14efab6c381d86f53f08c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/magic-enum/default.nix
+++ b/distros/humble/magic-enum/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/humble/magic_enum/0.9.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/magic_enum-release/archive/release/humble/magic_enum/0.9.5-1.tar.gz";
     name = "0.9.5-1.tar.gz";
     sha256 = "23f6ed6e8c6eb3d3c0620768297150d5a385dce187a243f6159d4b73a2610cb6";
   };

--- a/distros/humble/message-tf-frame-transformer/default.nix
+++ b/distros/humble/message-tf-frame-transformer/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release/archive/release/humble/message_tf_frame_transformer/1.1.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/humble/message_tf_frame_transformer/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
     sha256 = "51bf95fac905e0ea0f9119ee44795a449662b0ddf7693dfd211421e34ed18f34";
   };

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "679136fcc2bd3607bc33c4390500e4cb246981f1a7a33d15ff7b2e42d04663ec";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "89ed6b444a9c2aadc0f5b0db472d7cd67a0d30b9a8c8df40d8dac393c80a53fb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mqtt-client-interfaces/default.nix
+++ b/distros/humble/mqtt-client-interfaces/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "0c250c21ab149d4801d3ea6c5b43f062a532c70ce793df25d10425d85f44f0e9";
   };

--- a/distros/humble/mqtt-client/default.nix
+++ b/distros/humble/mqtt-client/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/humble/mqtt_client/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "e737e5a922bf8797cf326b80d00fb39298ed1ec19c6d435320c8e12b5792c794";
   };

--- a/distros/humble/ntrip-client/default.nix
+++ b/distros/humble/ntrip-client/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, nmea-msgs, rclpy, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ntrip-client";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/humble/ntrip_client/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "7516989ca6c25bdc5db576845a4156554a32076b2ca71f0455e22502eedd2232";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/humble/ntrip_client/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "eb301449af47f021d6635c603c72f615fe5a6f42318b882410b783bec1cd3c9f";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ mavros-msgs nmea-msgs rclpy std-msgs ];
+  propagatedBuildInputs = [ nmea-msgs rclpy rtcm-msgs std-msgs ];
 
   meta = {
     description = ''NTRIP client that will publish RTCM corrections to a ROS topic, and optionally subscribe to NMEA messages to send to an NTRIP server'';

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.2.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.2.3-1.tar.gz";
     name = "2.2.3-1.tar.gz";
     sha256 = "feb621751a41b1cbe76482b7880339b1cb0a8c548f1ff67729c99b2d1eddefaa";
   };

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.2.3-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.2.3-1.tar.gz";
     name = "2.2.3-1.tar.gz";
     sha256 = "1e832180ad7b52b2bff9780a66a660de748caedbe6b0edb26e230ac38ffaa788";
   };

--- a/distros/humble/pcl-conversions/default.nix
+++ b/distros/humble/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pcl-conversions";
-  version = "2.4.0-r5";
+  version = "2.4.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "3712ec5d33447d5deb2334a5d2fd8cd9d9cc14770cc0f72c52ef6f015fd610b1";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.0-6.tar.gz";
+    name = "2.4.0-6.tar.gz";
+    sha256 = "dee51fc73a0875ced007e7bcab00eea6b5240327bc6bf5179a51b3aa70b1d87c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pcl-ros/default.nix
+++ b/distros/humble/pcl-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-pcl-ros";
-  version = "2.4.0-r5";
+  version = "2.4.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "8f9b398d650a77006a76f14b2d9d0e164bc9758c54e22ed113a51f8b9e3aa2f2";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.0-6.tar.gz";
+    name = "2.4.0-6.tar.gz";
+    sha256 = "c05c0597712030197c8b1c5266e6587038c86694823565e8aaa89c275c2565dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/perception-pcl/default.nix
+++ b/distros/humble/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-humble-perception-pcl";
-  version = "2.4.0-r5";
+  version = "2.4.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "e85038742b715f25dcedff5e4215220f21458d4cb058c7dcd3d48f365b03fb01";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.0-6.tar.gz";
+    name = "2.4.0-6.tar.gz";
+    sha256 = "665287fc0bdf50f3f21d77ba6b5633a43fee2da6d0e0d334bd7f9f6dac380eb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/plotjuggler/default.nix
+++ b/distros/humble/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, fastcdr, lz4, protobuf, qt5, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-plotjuggler";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "737a6357d24c07791f3695abcee345bb659588d637d11a71eacd80e662b6bf63";
+    url = "https://github.com/ros2-gbp/plotjuggler-release/archive/release/humble/plotjuggler/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "393a70dbc9841b891fb777ee6df9e9bf1849ac8ee77e61371bafe75561efc247";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-interfaces/default.nix
+++ b/distros/humble/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-interfaces";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "e5ba7db24543bcab04448351993eaf7b8d7019ee06695e2840b29ae192c25737";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_interfaces/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "ad8509b58b8725f9a7671bd81ea6cb3215d9b1c73eca3d08e944fe78fa85c316";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-plugins/default.nix
+++ b/distros/humble/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-plugins";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "ac34d2415b970a2147e5ae09331909feea8af38561753f4d39362457d97355e9";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/point_cloud_transport_plugins/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "0ea55704fc2a2fe52690a8d61fa6eeed44ac2f26741a40b80d0d990c51d592b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-py/default.nix
+++ b/distros/humble/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-py";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "e2907c73fb2ae544f847e7bc694862884ea7e29313e10e18a730c81c49fc8f3c";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "48407a44a3d0e76d5a8377dce199f4004d2701b7306ec23079c517121047a774";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport/default.nix
+++ b/distros/humble/point-cloud-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs, tl-expected }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "aed7365081fb48b5f05c6dfdcc4f103a0710debab68b573c48b3e095dd50448f";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "71de8d112a99b55af2fc5307717f8ca50dbbc6006d358082e5f22e5d6ee59a4d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
-  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs tl-expected ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components rcpputils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/humble/polygon-demos/default.nix
+++ b/distros/humble/polygon-demos/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/humble/polygon_demos/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_demos/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "f21943b9241a4738e01055587cefc767ecfbe5df3322f2a437645d7282b06127";
   };

--- a/distros/humble/polygon-msgs/default.nix
+++ b/distros/humble/polygon-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/humble/polygon_msgs/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_msgs/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "0c25d241f9a001906a4d59d62f94fbe132fdf97feda4a749c601349667957002";
   };

--- a/distros/humble/polygon-rviz-plugins/default.nix
+++ b/distros/humble/polygon-rviz-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/humble/polygon_rviz_plugins/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_rviz_plugins/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "f66f9b02b0abddfd0f7d251b7c9af425530f781bc20dfc69621f07a785abf257";
   };

--- a/distros/humble/polygon-utils/default.nix
+++ b/distros/humble/polygon-utils/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/humble/polygon_utils/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_utils/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "b54f35d9f5ffaf46684c6621270b5ae0f796b9298152bb8be3b4b7172a575cab";
   };

--- a/distros/humble/psdk-interfaces/default.nix
+++ b/distros/humble/psdk-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-psdk-interfaces";
-  version = "0.0.5-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_interfaces/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "70b4146d19b9a48951ddada7fb02a2286b9cb2ac404b364a89fded553884bb9e";
+    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_interfaces/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ddc90f3d3639fea9c3e1ee61f3eaafc4963603daaeceb2f03137db27d52ecf09";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/psdk-wrapper/default.nix
+++ b/distros/humble/psdk-wrapper/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ffmpeg, geometry-msgs, libopus, libusb1, nav-msgs, psdk-interfaces, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ffmpeg, geometry-msgs, libopus, libusb1, nav-msgs, nlohmann_json, psdk-interfaces, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-psdk-wrapper";
-  version = "0.0.5-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_wrapper/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "65e25751aadfdc523aa605c3b6602172d624432aba31f630f8b17ba47a9d328f";
+    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_wrapper/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "973899fe94f925c57d3a4db7c78ce4208c9966681c09b901efbc358dd73daff9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ffmpeg geometry-msgs libopus libusb1 nav-msgs psdk-interfaces rclcpp rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  propagatedBuildInputs = [ ffmpeg geometry-msgs libopus libusb1 nav-msgs nlohmann_json psdk-interfaces rclcpp rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rclpy/default.nix
+++ b/distros/humble/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclpy";
-  version = "3.3.11-r1";
+  version = "3.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.11-1.tar.gz";
-    name = "3.3.11-1.tar.gz";
-    sha256 = "184061975480a269e8167463133552854b94b3f90ee403445471561c785aeed9";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.12-1.tar.gz";
+    name = "3.3.12-1.tar.gz";
+    sha256 = "47d269dc92eee068b7abc3eb5434e42030268dbafeb19f61a76ee66b3bc006c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcpputils/default.nix
+++ b/distros/humble/rcpputils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rcpputils";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "9e1052a636cd97726d00d3a71d37360083e77167ec95263646f504c2c9e39a5a";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "9327305e552d3158e5ba1920bf3bae855ffa99f6b15a8261b368d2ae59038607";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ];
   propagatedBuildInputs = [ rcutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/humble/rcutils/default.nix
+++ b/distros/humble/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-rcutils";
-  version = "5.1.4-r1";
+  version = "5.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/humble/rcutils/5.1.4-1.tar.gz";
-    name = "5.1.4-1.tar.gz";
-    sha256 = "727057c12716581c51cdc0a35d62e4b213a0f4edcd034f0538719ebd6e655800";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/humble/rcutils/5.1.5-1.tar.gz";
+    name = "5.1.5-1.tar.gz";
+    sha256 = "71f53db60bfb3af5adcce039f931fb371b47261d407dc84cf793ef8cddd0750c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robotraconteur/default.nix
+++ b/distros/humble/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-humble-robotraconteur";
-  version = "1.0.0-r1";
+  version = "1.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f6c46e599caec298dddadf58ba207493c38a2999f25d70fe954121d6264e610d";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "289563494bbd6d49daca9a7b348732c440a3dd103a02b7a388c8a9327f53d961";
   };
 
   buildType = "cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "9ed4d39ebf1913cce8370f0ff238d72e7be557bfd7ef09a4b5679f2cc8dd86a7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "aa26c903abc1a99c83eade7643310b5555ff4d993c5f7e29009a94b2981efbc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "ddbf654365f692fe187a72103c84f59e3083f080d34099dd314b746ddd7b68f6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "1dbe7a2a6bfd2b4361fcc455b0eba629bc05e420474ea64c880813d58de9f6c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2action/default.nix
+++ b/distros/humble/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2action";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "7df9ed6bc8c6063b80b56709a00ef4d0c0c32db63913f48ad41838454f3c0fd0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "1e9359518818283a70db9ae80b10715b4693134ed5a0697187785428f6d61d11";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2caret/default.nix
+++ b/distros/humble/ros2caret/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, caret-analyze, caret-msgs, python3Packages, pythonPackages, ros2cli, tracetools-trace }:
 buildRosPackage {
   pname = "ros-humble-ros2caret";
-  version = "0.5.0-r2";
+  version = "0.5.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2caret-release/archive/release/humble/ros2caret/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "41bc5103018749665db80182249d8fd56e94bb41977ad94faca5ea0ace470a7a";
+    url = "https://github.com/ros2-gbp/ros2caret-release/archive/release/humble/ros2caret/0.5.0-6.tar.gz";
+    name = "0.5.0-6.tar.gz";
+    sha256 = "2902914f68a199160d89197fd79676105840912ba1768680f35518d6bd933d7c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2cli-test-interfaces/default.nix
+++ b/distros/humble/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2cli-test-interfaces";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "47ad7be107dff88264fe9c0cfbe0b0a35a92babcae3b82f2380f5381a2f85aad";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "024106731e02f52ff5503f4221ffdce06d91bcf52198f56e211da9bfeb34d1ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2cli";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "1609d7a0c3e628662c340cbeb3675dfa132031bf79591086fee1d37c9926bddf";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "235d4c32e6bb15cbc8839713df5efd742d4e49c243da257de077896befbd393a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2component/default.nix
+++ b/distros/humble/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2component";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "ebf68c9e7c32b6c158defcc638da2bb7dd8a4481439b07661c6d14a35bc7cad5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "9da35ebe454370b6a1d4a8bda2d1c89d14859271b1f17dc3444bb50b4a82b3cc";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "ea6705c8eb1fd21081ad78987071bab5cb885cf7f59cd6f73db171d0bb7a5bf0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "4ce7e04d8ed26a335ad48fcdbec4335dda0da0e6f8ed155822131df27643b150";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2doctor/default.nix
+++ b/distros/humble/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2doctor";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "ff41d7fc61137e52625879da7011b2ac093808ea81abaab24c8e84846113d907";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "733ffbf34c8846ebccd82307a3480a54695d55beb2a088416c01086499e5ea04";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2interface/default.nix
+++ b/distros/humble/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2interface";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "17d4db7e0d37cd4e97f9fdb1efec07425ac37323a20f959633761c6221acd1b5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "3780a02760d241c214b55b3973a4cd52f18c592addacfa873441a2e940631d99";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/humble/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle-test-fixtures";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "4d8117e7169357cefc6039eb341d6f6e4188aec2b7a3b834d8c58a4340861d84";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "df5255632be4013f3acd5f246181a75aba7d7d52af6fbc6f780d0857bcc0e099";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2lifecycle/default.nix
+++ b/distros/humble/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "e543ed5fb4b632cd17f630cfba75d09f29bd240c6378415b08fb7a664b575035";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "b93cf1f840c791821c5150e00aecdd8f062bbeae46c2c33125380ff1d90191cd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2multicast/default.nix
+++ b/distros/humble/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2multicast";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "e34d785f8a44925147e1d45b122bf807cc2949fc0fec227c2bb2c5e586a1d897";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "1a98081682b169f6eb1a0e422f08eb751c4da12f030f567f94b341471d247946";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2node/default.nix
+++ b/distros/humble/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2node";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "4622801617cdf21c4cde244cf3e63bd52f8febbad6631aeec860b6175cf9b508";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "922f72277ecf54dcf6ed2998c0550d1486a1275a42a091f769037aa1e680dd9a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2param/default.nix
+++ b/distros/humble/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2param";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "ea86719e5c4266f7ac533353b89401080b9b9022e2365ff734e9182b7eed7f73";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "b14e37a91abd677d16e471d7d9621f8ded16c02ca83abed41b1df3505be8cfd4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2pkg";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "20b69455ac85d5a17236edba21c852616e013717b9ac3dd6bc9ef14746f3d12a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "04432de7df5a4bd2531f52a3d467a4f0993bfc2f59bf98ca54eec8cca3aaa57b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2run";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "cb4c959abcbf112ce3cdc80abd7f7913ad60ae67bb1cf77eaec53b1fb98edc2a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "7c5b768e013a23b94d4059a9d63c50edda883e9ca45d6bd6d546216d37992c13";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2service/default.nix
+++ b/distros/humble/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2service";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "a974448f628c410a0a7f53c4545bb399884bf2bb33b2038ac592aa12053b4e8c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "d08e8e06d174e75ba269416bca29d8831d89d299de20f03c50cd2490b7f9e04f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2topic/default.nix
+++ b/distros/humble/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2topic";
-  version = "0.18.8-r1";
+  version = "0.18.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.8-1.tar.gz";
-    name = "0.18.8-1.tar.gz";
-    sha256 = "b64a23d70d1de9d9ddf4a18c527d823fe2023c067672478e6bb4345e06c28ee8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.9-1.tar.gz";
+    name = "0.18.9-1.tar.gz";
+    sha256 = "49286c63b140d6b2f0d866b7abb5951ad17e9681a3efbac1add5ed89d9615bb8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-console/default.nix
+++ b/distros/humble/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-humble-rqt-console";
-  version = "2.0.2-r3";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/humble/rqt_console/2.0.2-3.tar.gz";
-    name = "2.0.2-3.tar.gz";
-    sha256 = "06759f530a897cb663e7d7648843466bfb775dc8bdd2f86adf727c1b46b6c760";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/humble/rqt_console/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f330714fa12a6896a6696d20db3d34c1963f1309e66d1679bb043fc45ad22270";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "074ef046c360d327cc44132bb12a128b6b080470e61f3be75e6f6d34d5816e7f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "6ee69977f2562eb6212b51fb91e33cb27ef99910fcfd4959f4f6ca82ead2b4e2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-gauges/default.nix
+++ b/distros/humble/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-gauges";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/humble/rqt_gauges/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "871aafc465d5f4a8f2b57ec41452bf5ab40083e201854efe96778b21813e515f";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/humble/rqt_gauges/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "43b9cb3e99359ead65731c49f5d2402afa06a8ecffe7d2839e68e0f677fd7b58";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-gui-cpp/default.nix
+++ b/distros/humble/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pluginlib, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-rqt-gui-cpp";
-  version = "1.1.6-r2";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui_cpp/1.1.6-2.tar.gz";
-    name = "1.1.6-2.tar.gz";
-    sha256 = "40cbdecfcdd59237b03f13e34ab2dc98ca4c6edb08752be3bff8c4594f012e13";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui_cpp/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "830388c57fc2b8cd90b2e76673e311bfdc369705f26b345b90154c72725a26e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-gui-py/default.nix
+++ b/distros/humble/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-humble-rqt-gui-py";
-  version = "1.1.6-r2";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui_py/1.1.6-2.tar.gz";
-    name = "1.1.6-2.tar.gz";
-    sha256 = "f22005ac77b32a7d26aacfed1a144732ed69689d4890155fb8e7e9b38529fbfe";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui_py/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "b148417e4d12c6efbb05b8148a48773d84686f676d408df736f9e3832438407f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-gui/default.nix
+++ b/distros/humble/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-humble-rqt-gui";
-  version = "1.1.6-r2";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui/1.1.6-2.tar.gz";
-    name = "1.1.6-2.tar.gz";
-    sha256 = "9fe8dc9675fdf82eeeabc2bb214f16c5981a8925bef8e2089c9527e9922b6629";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "aa99f15e7b90e0a7b271b3be81c014a1f1ea01e7e03c655e835b58bca17c5ca6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-py-common/default.nix
+++ b/distros/humble/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rqt-py-common";
-  version = "1.1.6-r2";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_py_common/1.1.6-2.tar.gz";
-    name = "1.1.6-2.tar.gz";
-    sha256 = "bbab700336f1275611fa08ddb5028553b36de0f334c22d8a1fa9d4f93739c785";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_py_common/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "3e3abc0d8f553acb5128ce7ebe47710672a280b7e8642e38a66cb0331f9c07a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt/default.nix
+++ b/distros/humble/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-humble-rqt";
-  version = "1.1.6-r2";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt/1.1.6-2.tar.gz";
-    name = "1.1.6-2.tar.gz";
-    sha256 = "09477dd2d94fb6e875416de05e6fb9afbc6dcb50305f2dc8e6928b1392c79e82";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "b789db680cc123e67116ef3cd78978292b740ce163f34d28017d52e1891ae995";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rtabmap-conversions/default.nix
+++ b/distros/humble/rtabmap-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-conversions";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_conversions/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "5a656ebed957a6d609b4a1d8958e424675658a00abb8b1f10bf3cb7d6a3a4ad1";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_conversions/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "d620493b25d9da89e64ba786a2e1421cf7cf9e296b381f8d344a2144bcdb19f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-demos/default.nix
+++ b/distros/humble/rtabmap-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, turtlebot3-gazebo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-demos";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_demos/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "f639712b66d69c3bd4f2fee80ed3fe303fb34132818c49bfde8bb7de84f9b12a";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_demos/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "2d32635fee4c7f89f9bf126d622308ac9eb8a71dc50d6e260fb48ecfa0dd7671";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ nav2-bringup rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz turtlebot3-gazebo ];
+  propagatedBuildInputs = [ nav2-bringup rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rtabmap-examples/default.nix
+++ b/distros/humble/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, realsense2-camera, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-examples";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_examples/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "e23b9fcacfb33aa6a37ae18cd6cb4aab597e505da71cb5baf21642410106638b";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_examples/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "0829bf2ef1ce9a37287c09da6e1e1ef1096cce3a44251d9a456f22a9675d21bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-launch/default.nix
+++ b/distros/humble/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-launch";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_launch/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "fb61d5b512d12f71b15842bc3a950b5d98939464c86b4dce427a2b2e11adf4bb";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_launch/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "e61e36cc903483ddec4cec3b957f51f9143def0890d4aa4c6cf40f8c8737b4af";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-msgs/default.nix
+++ b/distros/humble/rtabmap-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-msgs";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_msgs/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "f42a5d27f6678d484593f3fb0a333b0fb075149e567abf4544d87cc445c6d396";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_msgs/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "1f90cf6fa975b65b7e0005c12a42dfd2c31068fa8b1f8f5efbf57daaf63e18d1";
   };
 
-  buildType = "catkin";
+  buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''RTAB-Map's msgs package.'';

--- a/distros/humble/rtabmap-odom/default.nix
+++ b/distros/humble/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-odom";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_odom/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "3faba24aa3233953876357a24702bd28c18f2d0fef3da4307ebe49752b57639f";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_odom/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "508977de6462f339205a507ed61fdd28db8a93a9f96cac0f8f7431b21614d824";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-python/default.nix
+++ b/distros/humble/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-python";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_python/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "66e58bf52879b517c88d1fcb60df29a00188745fcc249cdb6b622ded168b66fa";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_python/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "027c9cb797609a5e04adbe64282cdb841434535360c9ef95002b6d4f37d07154";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rtabmap-ros/default.nix
+++ b/distros/humble/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-ros";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "5620a200f48a19b9281f5237d8ed2acf366f9c26314de006359a8284f21682d9";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "be91fb32c5ec967fae98e3e3194257ba2e30b6bdf82273cd7dfa1d756aa6b864";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-rviz-plugins/default.nix
+++ b/distros/humble/rtabmap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-rviz-plugins";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_rviz_plugins/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "7e6eb54ce190524cd080aca070aa95ed2b804fe68b05fdb6c728fccd6d9d4a33";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_rviz_plugins/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "b3b0dea3f8959d9d92d0739fa68528f9247d9d6b6c104d5ee4baa7b52da4baf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-slam/default.nix
+++ b/distros/humble/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-slam";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_slam/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "746c1dcf8cd677731ad1c0a62baff9ef9003e2da947e1275f12b5ec71813e935";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_slam/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "5d6e2b77c8e1d496da909f31b1479989a786fd3eb2acc658b57424600a351123";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-sync/default.nix
+++ b/distros/humble/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-sync";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_sync/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "d4de4ea580fdf82d2d90df4fe55079cd4223083b9c36ecc358e45fa3fb802874";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_sync/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "b3bc8905a34fbbd21ebd15323f2b3c32e42fcfb740f2209dc1b8443058ae3589";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-util/default.nix
+++ b/distros/humble/rtabmap-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-util";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_util/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "7f956be970a2cce34f1c2cc4d37c3e6d89568200dc8cc1b2353d0ee2a1a3e532";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_util/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "f9693343bd8b5d86abfe93a62ccf932766d4dfafce8f11e033a814fbdfdd0ba6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-viz/default.nix
+++ b/distros/humble/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-viz";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_viz/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "a7ae33de5a17dfa641f23582775e9cd1a9d822229c3158c33d01ff44cab8a430";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_viz/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "ce057822e38175e53e1648b0fb49a90f0562e1224de2dae03ecd4d427a375532";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap/default.nix
+++ b/distros/humble/rtabmap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, grid-map-core, gtsam, libg2o, libpointmatcher, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-humble-rtabmap";
-  version = "0.21.3-r1";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/humble/rtabmap/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "75f972436b092af01db3aa14e1a9e53525bec138a95b9b3ca85cbf2da1f0f800";
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/humble/rtabmap/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "253aee183b22386bc414456d184b4fa722f22801ab716153eec8315ea35e36a7";
   };
 
   buildType = "cmake";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "a53f8167f04f5aaee30f1d10d4204ac418b2e0d832a1e06dcddcef2b38d23521";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "698b33537a6436ca22c96bea35c5e6f1736bcddf0705e0bd60e23d2e7baaff79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "0fc02141c08abee1a5200100f1115adf668c684182b7da2a56a236e16b0cfc90";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "1ce81946eb284578e380a12dd1dd99e285ea14798cbe5e279ed025d5accf1652";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "7cb9e1550088aa6954a3e531cef97bcd2ab51d33397f55b5f893ab85021a59de";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "9a22f60cf1430eba6185f6b28e1968651a4669fcc64465271c44aca23b1e6fcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "0240d405fb6073d4af4c398c1e7beb2009ef3ba6cc2861c08dc2a6a18935cbeb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "2e2bef887817e6b6b2c1e062b48412cbe9d4e4800d5f3ee97b29d90273144100";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "9e076973d242780173c4b86b5bc11beb2010ea22bba4a4173fc304c3be9b50da";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "bcbe4cca0af775f94c69472edb48ccd3976879288c48c33720c6f132dfb1a26d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "8ad821ed08ed1cd9b9f7828fa837a9ae3ed23b0720a967a90b7b040a96fb8e8f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "1f195eaaf76556df11e65881b792403c03cc091df81411b0dfe4778586fd9783";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "2da201e60bfbf7571f20b32ead69e038e4ea8dfa98d412679dd805965fd6e2d8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "6c1b2e2ef6657fae4c2b76753af1c39fca832ad869ca41495b5b6d23d5d4b295";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.10-r1";
+  version = "11.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.10-1.tar.gz";
-    name = "11.2.10-1.tar.gz";
-    sha256 = "552617b4d6bfe8f4345e4e839a42fdeedbc743f2fe35c14a11d2d089e51de70b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.11-1.tar.gz";
+    name = "11.2.11-1.tar.gz";
+    sha256 = "efd56ec1caf7c5fb61d9dd854f5b28219f69c36d5f691ee51e716771edb8201f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sick-scan-xd/default.nix
+++ b/distros/humble/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-sick-scan-xd";
-  version = "3.1.11-r1";
+  version = "3.1.11-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_scan_xd-release/archive/release/humble/sick_scan_xd/3.1.11-1.tar.gz";
-    name = "3.1.11-1.tar.gz";
-    sha256 = "a3db248e8eb87ed6c7bbdddeb7986248da68e3e29ec5ebb1abf8b0e69edb1743";
+    url = "https://github.com/ros2-gbp/sick_scan_xd-release/archive/release/humble/sick_scan_xd/3.1.11-3.tar.gz";
+    name = "3.1.11-3.tar.gz";
+    sha256 = "6fa1966620d69c090a7e28defea775aaa6724dcbb2f881d36138d08de51aa92a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.9.0-r1";
+  version = "1.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "6a377c03b67c8e076ca6b6df1646abd3dbda63647898efa92951f19bd10c9c6b";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.9.1-1.tar.gz";
+    name = "1.9.1-1.tar.gz";
+    sha256 = "f82181fd0d7bf5705921eeb3601e23f46063e0b7f85869ee7fe84bd9c6a7c88c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.8-r2";
+  version = "2.0.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "9c7bd829f655b91a08350d3c1a9803ba225453112f640613ec0caabb4147b7a7";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.8-3.tar.gz";
+    name = "2.0.8-3.tar.gz";
+    sha256 = "db632c142b60bc0df147152dee60ed79c5a394f0851fa7ed6546d5739df5f541";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "325a8bb0851404c88b2a1813e1f89bb46b8b0c445c264e1b761e9b824b26da68";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "4f84369e1cb86a2255de8d9c768887b2921244bd2d0999b488c1587c5995ca9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "d7702e06b500199562947fe48ef92b65f581b0a60052ec596b4a0b96834216cf";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "91491efecf0a3f1cdbe210f27f071dafaca04dba46f2de1055561443b71d08e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "859ae104198db3388141b71352476488d5718757ae9259830399fb4a62024533";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "86afe8a05c50fdd27f867d0ffa0e42bbdc74d3879f1fa24cc387c6dbc6232c7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "923d761ebeceef80a8fe01b542c49f813a0b5270d13cf5a2313d265adb3a7a63";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "5c1a4c0571bfe54b013355bbe463608d6e96b458dbb0c99ed4efaf2c505a59d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "bed12a26511a4d0da8e452f3a3cc478a20cf61242455a041994ffd733841dc00";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "d60c4516997494ca3d7c6f2044de2112ca70b34f2697b3e0326a631437c9cb55";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "05a9b8aea730e18ff7f53fb73a58554838a90b2e96ccd58d930bfe27d7025e78";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "8597d94d5cdf972e698c3d28e7e6206c1f6dfa265c5b4b22de298a4404473f46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "cdf8f8e4796d3e8c7d4d298d02f5f8d50933e223709fabcaf7e5b51f942fef26";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "1077f50f8b49a08cbb957d9f1401d308284483ee3f26a945237c341738c5bbd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "5da99f69d48c627ee5f4259d27066d2a0e14f33cd7b61a38f954803882ee9a2d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "4c442465c9e4374a7a9c81e4af78b47f0774750f942b933ba5b7cac56d1a4177";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "467d4f76edbbcc69f7b2fec79b8e746eda679fae3e76a98dfd5fad7ed1c13057";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "ef495e32558764c89fc2cb22d18937ee29247f08249f055085d35397e3306fbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "320f3ba25456eec0a47d2e1958b020f8a54e1e6c6359fe5f9d1f1d972112a56e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "eb9d35da2862611ce27c5e3a578089b387fd7a5a17e711b37a79b78f91cb287c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "b840ad6151f7c17f5efce1e1735188555c2060ab14843a51e27a3978c0699522";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "826023df93140aa4edc5bdaed449b62d544d4e76d9eb6f6e78081b0abe7d443b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.5-r1";
+  version = "0.25.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.5-1.tar.gz";
-    name = "0.25.5-1.tar.gz";
-    sha256 = "59c7062c027b5568e8caf5322eec2279543c90ffec3f7c4899ecba5ac57e6510";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.6-1.tar.gz";
+    name = "0.25.6-1.tar.gz";
+    sha256 = "339e0d87dbdd19bf2103dee9709f33c10c4ffe150289f6238b98b2f4d1cf6901";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-based-ros2-control/default.nix
+++ b/distros/humble/topic-based-ros2-control/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/humble/topic_based_ros2_control/0.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/topic_based_ros2_control-release/archive/release/humble/topic_based_ros2_control/0.2.0-1.tar.gz";
     name = "0.2.0-1.tar.gz";
     sha256 = "102d8ff9d1aa0537f6986d2e9d65e0464a49f6e117bf0767209de7ff0fbe21a9";
   };

--- a/distros/humble/tracetools-trace/default.nix
+++ b/distros/humble/tracetools-trace/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-humble-tracetools-trace";
+  version = "4.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/humble/tracetools_trace/4.1.1-1.tar.gz";
+    name = "4.1.1-1.tar.gz";
+    sha256 = "69f8705139952ddba4a7d2a0e1af92f1146f59c10865c997886d7e18df12432c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.lttng ];
+
+  meta = {
+    description = ''Tools for setting up tracing sessions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.37.0-r1";
+  version = "2.39.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.37.0-1.tar.gz";
-    name = "2.37.0-1.tar.gz";
-    sha256 = "a688e1693b714e51850e6776b6fade8d07721edafe5e179bd73925cd898b89f8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.39.1-1.tar.gz";
+    name = "2.39.1-1.tar.gz";
+    sha256 = "2d4c4f95d1d78497df21cdac13b030398dd0573ff04cb7bcb417d19b19e27e21";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tuw-geometry/default.nix
+++ b/distros/humble/tuw-geometry/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_geometry-release/archive/release/humble/tuw_geometry/0.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/tuw_geometry-release/archive/release/humble/tuw_geometry/0.1.1-1.tar.gz";
     name = "0.1.1-1.tar.gz";
     sha256 = "ead05b67d7d43c49d5bcfef73f5db67b4a81389db907feef1c64670d231e6faa";
   };

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.3.4-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.4-1.tar.gz";
-    name = "1.3.4-1.tar.gz";
-    sha256 = "e0e2c457247ea7e9a8345947efa05f31d3e58cc766c2631fd365b66bf10868df";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "394de316eb48762148dec817eebeebde09f38b493c5936b29466f05ce763b9fd";
   };
 
   buildType = "cmake";

--- a/distros/humble/zlib-point-cloud-transport/default.nix
+++ b/distros/humble/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-zlib-point-cloud-transport";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1c99a7837760c871e9d4c41c56f35e59416dc87cb6b720c4aa2265ea38b3df16";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zlib_point_cloud_transport/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "6bf2d3bb12d2c5033feaf94c0860e5a41a77888f0fddfebeff4d8b2fe1ca7f73";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zstd-point-cloud-transport/default.nix
+++ b/distros/humble/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-point-cloud-transport";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "c286dfaa4f7d39df3848ae4154ccd13980ed23cf6bf0be6b32c49d2678ddfbf7";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/humble/zstd_point_cloud_transport/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "4b34333c13e7d4355d8d276bb9c7e2b213876adb9413b98c1b2f74b8a7a3810a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-coding/default.nix
+++ b/distros/iron/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cam-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "2d55cf74e2da4933162eec1b2cd4c9c827399b4061b6101e3dd993cf50a573be";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "74afcafccc483ebe6dcf9738898a71bd682e114ebec2c3d0096f779fde2b31ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-conversion/default.nix
+++ b/distros/iron/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cam-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "e27c85deea703a4157b029912edea15da480bbc40d9383a2ed719cf09388f14e";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "84fa7ce461af8c7d7334659f89c1ce89c1c476c194ebe0d3764c7a0febe72399";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-msgs/default.nix
+++ b/distros/iron/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cam-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "5bd385e3076f7a82721fbc51be3a8ba0b54f195b0081153c1ff67b23fcbfc572";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_cam_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "72c884d190ee0d8da07b615f1f701b332851d4c3ae324b1f263b645c3b71f374";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-coding/default.nix
+++ b/distros/iron/etsi-its-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "57a7b68d2a337aefdeaf9b4b419af6f5a88f4e84c762f56a51ce8fb354170bf0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e09436ff47b52758096a06567ce313e6c2539850ab42507da0cabd4042b6e65f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-conversion/default.nix
+++ b/distros/iron/etsi-its-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4a6a241501b735fa15492f54c1ef47f2c0eb0a4aeb414093d9d7ede9cf41f406";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5bef46a9ec7c56a2e7564d0b0f4196731fa05e81747966a810b8a16f486a94b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-denm-coding/default.nix
+++ b/distros/iron/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-denm-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "146221e501bddf1313be171b5626cb0fa51efd20db94024146363b74bcb1569c";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "117d0089411b2e2fce49f3a2e3de9c567fcad0166909d2fbedc5d3ec44555679";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-denm-conversion/default.nix
+++ b/distros/iron/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-denm-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8254ae51c86a35f0958a145c68444dd9a35b64ed252251c59e98d23a5ed8e8a2";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "6bc540a786cf2ca589d4d272b0d5f5e26f3d2ff67ea53a4916f8af8ee252902c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-denm-msgs/default.nix
+++ b/distros/iron/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-denm-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "06d196fcdb5d2b41b2f5a6226b3dc2515dea7fa72bca6e8b1baf2f369acd4574";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_denm_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "542afac8fecd431432e58a1e8b3330a96ef7661f44bb8afd182a4ac2a69b97d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-messages/default.nix
+++ b/distros/iron/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-messages";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_messages/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "afcd1715bfc29d83469671f1a0821dbf370988c80fd95818578465069963eee0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_messages/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f8188e1850c6db1210e766b63db9b6107ce900a4b990d1de154e42fb2b1974f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-msgs-utils/default.nix
+++ b/distros/iron/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-msgs-utils";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_msgs_utils/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "cae5ce6dcd0e8ac7d9ce43030ee30e8ce0ede1b878cb867b7dc4ef151512e286";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_msgs_utils/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "10bffc3f0c348f8bdfc08d015f9d7d6c50e4ceb1c70825400bafe35b946ae227";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-msgs/default.nix
+++ b/distros/iron/etsi-its-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "be79b5ef5d93392e86dcb6b4a76dc1a1bc0fb26fe8b5d44da00d2ad31cfd0c6c";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "934e977f244e7cfc7cd72144e23980704ed29d6c6c3d7da368ab5658702ae77d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-primitives-conversion/default.nix
+++ b/distros/iron/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-primitives-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_primitives_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "da8214d82c8a73d90e60d71ce3e02ac4a9a5af7b482abe704d6c01ac86589f2c";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_primitives_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "dd2379a87c4359749473a60861523919e5ec1cea35083bdeca66180ae983e62b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-rviz-plugins/default.nix
+++ b/distros/iron/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-rviz-plugins";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_rviz_plugins/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "145da32f90c7f425ff58086a34b47d2141787a2d7b841ef8a05934870000f41b";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/iron/etsi_its_rviz_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e28861f67e7e15c357e6ae966a6650b80a41f2abd47892e02d14420f3afa0cfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/fields2cover/default.nix
+++ b/distros/iron/fields2cover/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/Fields2Cover/fields2cover-release/archive/release/iron/fields2cover/1.2.1-2.tar.gz";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/1.2.1-2.tar.gz";
     name = "1.2.1-2.tar.gz";
     sha256 = "c2e956c725c499fafd36d03ca150ec49ff2f34ed7e4cc371a3639d0f51911314";
   };

--- a/distros/iron/flir-camera-description/default.nix
+++ b/distros/iron/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-description";
-  version = "2.0.8-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "1652cb642467a8946af3f44e25a410880114cc95fcf35b3a30d0a7b4e492f629";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "c28fdb71a7c4a82b6befe799881c635a7e9e360a7629da25a7c7909b54de09cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/flir-camera-msgs/default.nix
+++ b/distros/iron/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-msgs";
-  version = "2.0.8-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "5e34c82fffbe787e4b2860781cb63c6c0a675d09acb12252967187a512fd3b17";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "40a71402d01d7dd098c211fa413c2a732ce05632e53deda81769ec6403ea3cd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -200,8 +200,6 @@ self: super: {
 
  bicycle-steering-controller = self.callPackage ./bicycle-steering-controller {};
 
- bno055 = self.callPackage ./bno055 {};
-
  bond = self.callPackage ./bond {};
 
  bond-core = self.callPackage ./bond-core {};
@@ -2241,6 +2239,8 @@ self: super: {
  tracetools-launch = self.callPackage ./tracetools-launch {};
 
  tracetools-test = self.callPackage ./tracetools-test {};
+
+ tracetools-trace = self.callPackage ./tracetools-trace {};
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 

--- a/distros/iron/magic-enum/default.nix
+++ b/distros/iron/magic-enum/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/iron/magic_enum/0.9.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/magic_enum-release/archive/release/iron/magic_enum/0.9.5-1.tar.gz";
     name = "0.9.5-1.tar.gz";
     sha256 = "4813a17e7ab18c13c1d8be6aa0f7db33137d1de36ff45ea319f1d70f964c01a2";
   };

--- a/distros/iron/message-tf-frame-transformer/default.nix
+++ b/distros/iron/message-tf-frame-transformer/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release/archive/release/iron/message_tf_frame_transformer/1.1.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/iron/message_tf_frame_transformer/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
     sha256 = "deee91f888bc5747e4176a3092e1c20a5c04ef6c641958e57a34b41d234b948f";
   };

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "debd363e52414bba362169df9eaeccd7e8458102adb487b5afb45d7b922dbbbe";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "013a16649971f3e386f3a795b26882591c79aeec25608542c5620769ff73c657";
   };
 
   buildType = "cmake";

--- a/distros/iron/mqtt-client-interfaces/default.nix
+++ b/distros/iron/mqtt-client-interfaces/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "f2e5e9f011bc2b4219e618818da701c9854effcc9bc7592d7825e0de330b434b";
   };

--- a/distros/iron/mqtt-client/default.nix
+++ b/distros/iron/mqtt-client/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/iron/mqtt_client/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/iron/mqtt_client/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "55d5a46ba0595cdf74cd67a4f73ee84f8b8251dcfe36dc5f5941c11df5936b74";
   };

--- a/distros/iron/ntrip-client/default.nix
+++ b/distros/iron/ntrip-client/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, nmea-msgs, rclpy, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ntrip-client";
-  version = "1.2.0-r3";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/iron/ntrip_client/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "32677b4e3a128907d37e8b46c168fa133be10b871dd7bb1985729c59c418101a";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/iron/ntrip_client/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "4dafdea6fda2a3c0e1a037e8059f00de2e80c0dd314bc63d340ee9087e5365fb";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ mavros-msgs nmea-msgs rclpy std-msgs ];
+  propagatedBuildInputs = [ nmea-msgs rclpy rtcm-msgs std-msgs ];
 
   meta = {
     description = ''NTRIP client that will publish RTCM corrections to a ROS topic, and optionally subscribe to NMEA messages to send to an NTRIP server'';

--- a/distros/iron/plotjuggler-ros/default.nix
+++ b/distros/iron/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, plotjuggler, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-plotjuggler-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/iron/plotjuggler_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7949c6415af2a009e4753783ee8e9f010b9afffd201f6b609e3715f8d8cbb464";
+    url = "https://github.com/ros2-gbp/plotjuggler-ros-plugins-release/archive/release/iron/plotjuggler_ros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ba2fa70f1cbe9a2bd1daab56d67cc2fe916b7fbdb5dc93ea8a8d99acce8dff84";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-interfaces/default.nix
+++ b/distros/iron/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-interfaces";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "97ff96776d27d52a1f413c712b2de441860fcb50cf03e96baa0e4fdb4db2fe1c";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_interfaces/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "249d8b348cc96d4cd1306b5c25337e10de4e88fb7717d06b1d17b583de86847f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport-plugins/default.nix
+++ b/distros/iron/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-plugins";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f4cad28fe8d9bb0e1a405b391086252945562818a4f703f3b6b7f9bfd3178e4f";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/point_cloud_transport_plugins/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "4f0d10cbd44297d3b8bcd1a7bf0f68847adcef100b2807a418967a524930d965";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-gauges/default.nix
+++ b/distros/iron/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-gauges";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/iron/rqt_gauges/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "c46108db0c92aaf911917a9c76ef90568693ba330f56d661ab10a5d666336c03";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/iron/rqt_gauges/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "b2104eac32117f2da319023316c8f0b73af6637f503017530d6d51641d6801e3";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rtabmap-conversions/default.nix
+++ b/distros/iron/rtabmap-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-conversions";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_conversions/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "5a13a36693bd777cfe3c2432fa0c865f39416b569cbc7c8960ff677dea64142b";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_conversions/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "1c691506c24c76b75c48d4729267eec2e573b1942bf1c42cb63a54ecf863d810";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-demos/default.nix
+++ b/distros/iron/rtabmap-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, turtlebot3-gazebo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-demos";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_demos/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "f545bd8073132dfb042af14547a2d6fbc96914f5b443a838bc9f00b6561610b3";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_demos/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "7f5fcdcdc9948a54170dff59af10c485caf6a9571480699e84f270d75106c5f9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ nav2-bringup rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz turtlebot3-gazebo ];
+  propagatedBuildInputs = [ nav2-bringup rtabmap-odom rtabmap-rviz-plugins rtabmap-slam rtabmap-util rtabmap-viz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/rtabmap-examples/default.nix
+++ b/distros/iron/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, realsense2-camera, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-examples";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_examples/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "2ebe5bf4cd5d969456d89dd8bae744360aea0204d68b59e408a605a042ad2552";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_examples/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "e27e6f19a3f7ebb8b0cc5a54e5afddbcd636b41f20cc564ffdfe19971790221e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-launch/default.nix
+++ b/distros/iron/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-launch";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_launch/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "d2f48a9673e0491364fc5669c6a9505f7ed5d5ca8f175adae21822c57d9d0e3e";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_launch/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "abfb464219877e6c571f34eb380e677629ea82b19f71b87de20084c14e9c15d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-msgs/default.nix
+++ b/distros/iron/rtabmap-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-msgs";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_msgs/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "44c2579cc0fca863b01aadc31b0a4e2e311610e4fdd0949de2b616ab442e2a00";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_msgs/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "c063638ea24b245ab4cfa40b1b76ee7d6d7b2a2c6b25c1b21e4a43d02bc0f1ca";
   };
 
-  buildType = "catkin";
+  buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''RTAB-Map's msgs package.'';

--- a/distros/iron/rtabmap-odom/default.nix
+++ b/distros/iron/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-odom";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_odom/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "16c289929aa15683bc2fa31bb6a37fc9c71d3302b31fac534eaf23a6649895d6";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_odom/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "e6217c10de4a470fbe9cc2ebad43e798d30bb36a3fc4a6b2754aa9e399db70f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-python/default.nix
+++ b/distros/iron/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-python";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_python/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "5912505929d1fae9400aa96a03ae7da478ef44dd0ca62493fa516c9dd4ffcca1";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_python/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "c65edf345c44b67cd2a9d4ab01aaf4433c624d0bcbebaaee8bcb1e1a0ace074a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rtabmap-ros/default.nix
+++ b/distros/iron/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-ros";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_ros/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "8ea9071454b9b32e68e3ac5fffa6c5abbf8b57f9df58dc3874018f12b5226cc2";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_ros/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "6aa6c6f92657ea2894a7c88ef1ecbe03511147381c2a93acdbd8f849b1b310e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-rviz-plugins/default.nix
+++ b/distros/iron/rtabmap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-rviz-plugins";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_rviz_plugins/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "324d648d5c8580346a630d2f17c70c3b6085436a2fe93a2a7908bc1a6a17f2ee";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_rviz_plugins/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "5b52e022cbf23c6b56a0dd7428a209d07c6b5f2794d5190c4f7c0b733d9adbf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-slam/default.nix
+++ b/distros/iron/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-slam";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_slam/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "9e3d64ae43eb8c9f76b7bbb5b6663a10bda51cb0ff00dfa241f54de4b3f4f5b3";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_slam/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "662b7a04b118a43a8b984284d2cf9751ae517f214bd885f124058192e8bf9e9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-sync/default.nix
+++ b/distros/iron/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-sync";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_sync/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "a7f689257b0269252b11f43370e10f359cdfb86cdb997f01013e240c7876da7a";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_sync/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "8232cc92c17f8908c515247e0bbc0e0ce3490e1006d91cae9262572d66c1face";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-util/default.nix
+++ b/distros/iron/rtabmap-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-util";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_util/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "ac9796deffaf7202968d6fd7c0241bdaef02df6adcd01a637e31a149ffa2e644";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_util/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "ce0845b2ba7e5ea1b9e9ce8f6656dbd29c49fe62ee40d14d40f2f2b3a73ecc57";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap-viz/default.nix
+++ b/distros/iron/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
 buildRosPackage {
   pname = "ros-iron-rtabmap-viz";
-  version = "0.21.3-r1";
+  version = "0.21.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_viz/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "efac12b78907d279ef9bfc43bfe284a58d2f19c599e12b37cdcb24c844817c20";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/iron/rtabmap_viz/0.21.4-2.tar.gz";
+    name = "0.21.4-2.tar.gz";
+    sha256 = "5cb2adc9a5abf913ebe5a9c58761b556bc60b974f329a7f2db53c559cc824f23";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rtabmap/default.nix
+++ b/distros/iron/rtabmap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, grid-map-core, gtsam, libg2o, libpointmatcher, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-iron-rtabmap";
-  version = "0.21.3-r1";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/iron/rtabmap/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "0fb6717aadc2f6e31618af30c62f776dfa2bbd48a461b3f98457ea9e846189d7";
+    url = "https://github.com/ros2-gbp/rtabmap-release/archive/release/iron/rtabmap/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "dffc7ce0e7b719eda612f943a06f4239774bd325f38e09cc80807f27627d4741";
   };
 
   buildType = "cmake";

--- a/distros/iron/simple-launch/default.nix
+++ b/distros/iron/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-iron-simple-launch";
-  version = "1.9.0-r1";
+  version = "1.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "1f7391303f8b363b8ff7b672e66c2df7dc31f69e527314555b7f0986439f0958";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.9.1-1.tar.gz";
+    name = "1.9.1-1.tar.gz";
+    sha256 = "d614e6f671bb2d71eab3236fb47d77a775e8d18886fe321740e0829ee143b54c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/spinnaker-camera-driver/default.nix
+++ b/distros/iron/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-spinnaker-camera-driver";
-  version = "2.0.8-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "a0b0ca2fa1e38b01d0e0440962c973a0472e4df95f79faf1b063c4bd99eb91a5";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "313d78fb103ef26ff3b85905902386d71393097d464e2e9e48cd0b4d1f947118";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/topic-based-ros2-control/default.nix
+++ b/distros/iron/topic-based-ros2-control/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/iron/topic_based_ros2_control/0.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/topic_based_ros2_control-release/archive/release/iron/topic_based_ros2_control/0.2.0-1.tar.gz";
     name = "0.2.0-1.tar.gz";
     sha256 = "957ef4c6fbb5d18a103619c0ed28962539a75e98fb01982f04847a8bde57b041";
   };

--- a/distros/iron/tracetools-trace/default.nix
+++ b/distros/iron/tracetools-trace/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, lttng-tools, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-iron-tracetools-trace";
+  version = "6.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_trace/6.3.1-1.tar.gz";
+    name = "6.3.1-1.tar.gz";
+    sha256 = "0ba9920f1640dd102a27d8dd514850d7a8414f4c7b5acbfb08f4d1f3764cecd9";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ lttng-tools python3Packages.lttng ];
+
+  meta = {
+    description = ''Tools for setting up tracing sessions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/ur-client-library/default.nix
+++ b/distros/iron/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-iron-ur-client-library";
-  version = "1.3.4-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.4-1.tar.gz";
-    name = "1.3.4-1.tar.gz";
-    sha256 = "c7461f5a5f2c0158423d146358c4002b096551cf273b706b53219355d1830de8";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "962cc2773eaa3038bd8124e2e5be06021dfccef42dd2babbae88a19617fd9539";
   };
 
   buildType = "cmake";

--- a/distros/iron/zlib-point-cloud-transport/default.nix
+++ b/distros/iron/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-zlib-point-cloud-transport";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "23b9d0a89b2760da78107b7f785a5407f5da0de3a4663786424f81931ccca70c";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zlib_point_cloud_transport/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "80e956cea9653c006b3a7c0322caff55ce6c09c0c4a46c18d582547854d1ce1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zstd-point-cloud-transport/default.nix
+++ b/distros/iron/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-iron-zstd-point-cloud-transport";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "9d0f6d22a840c638be548a585c3960d61e6585a3a699caeb9b9487a35fcc2c4a";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/iron/zstd_point_cloud_transport/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "ff650b495d61a46f9e6f3fe7dd564afb9f3ab6f5cfaa9d276190f75790deec9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/care-o-bot-robot/default.nix
+++ b/distros/noetic/care-o-bot-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-manipulation, cob-navigation }:
 buildRosPackage {
   pname = "ros-noetic-care-o-bot-robot";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/care-o-bot-release/archive/release/noetic/care_o_bot_robot/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "ea4c33f96d677d3b57906b0c6d26d78a53b4ff017380db85a2d71ad48cfc4afc";
+    url = "https://github.com/ipa320/care-o-bot-release/archive/release/noetic/care_o_bot_robot/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "755c8da4b557dfaaa5562cf26728a289ca4a092ddc0dc12fff428f27e1f2be4b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/care-o-bot-simulation/default.nix
+++ b/distros/noetic/care-o-bot-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup-sim, cob-manipulation, cob-navigation }:
 buildRosPackage {
   pname = "ros-noetic-care-o-bot-simulation";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/care-o-bot-release/archive/release/noetic/care_o_bot_simulation/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "06e11bc56166899096de43204abc2963f7d87f70eac332eb904679324892f511";
+    url = "https://github.com/ipa320/care-o-bot-release/archive/release/noetic/care_o_bot_simulation/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "3170c350ff0f188c5dded6aea4e64cd0e3e27d4cef7c2fc3de4119d79151d6b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/care-o-bot/default.nix
+++ b/distros/noetic/care-o-bot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, care-o-bot-robot, care-o-bot-simulation, catkin, cob-manipulation, cob-navigation }:
 buildRosPackage {
   pname = "ros-noetic-care-o-bot";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/care-o-bot-release/archive/release/noetic/care_o_bot/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "3ad322ea442e98494b3f780a42850c527ab030814a83af8fcc3550176870f3db";
+    url = "https://github.com/ipa320/care-o-bot-release/archive/release/noetic/care_o_bot/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "16fdee4ffb54d5d53be7ce975ef5961403dd1be803709ffaf31f352cbe2fecac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-3d-mapping-msgs/default.nix
+++ b/distros/noetic/cob-3d-mapping-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-object-detection-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-3d-mapping-msgs";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_3d_mapping_msgs/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "8b92297cbf0b9b29fe7ab6ab41dec0971d2982eafaf994131d64a23d760b81e2";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_3d_mapping_msgs/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "01b50f3d33dc844900db710f9e80d3bfc110e0a0a7f9f05edb34f26d82f133c9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-actions/default.nix
+++ b/distros/noetic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-actions";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "222453e0319f0829005ed9d613f7af7ce9de9e223fab5b98845e27ac4984a8d3";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/noetic/cob_actions/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "657504a0b9053de1023694df3c1c6b515cb57199bf082413500d3063f37d3fd5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-msgs/default.nix
+++ b/distros/noetic/cob-android-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-msgs";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_msgs/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "aaf0b59312ca1282c2344fc7ed2f338d55e7711d2f03e90b14f2985d924ddb75";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_msgs/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "0f25995d748603d805781839b2676dd7dcac02f32a71a8550cb6e0d072122d09";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-resource-server/default.nix
+++ b/distros/noetic/cob-android-resource-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-resource-server";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_resource_server/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "259bfab83811916e28ae201e2bb4aeb2961509844c722584b375203ebb8c5697";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_resource_server/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "8eeb703192d3797253e9274cd320826d7e271a7cb28cd8a49955c0e07bf9ef25";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-script-server/default.nix
+++ b/distros/noetic/cob-android-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-android-msgs, cob-script-server, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-script-server";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_script_server/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "ce3448c78c5d5239a142baed1c050904d157b5f60823ddc7cc23c7ee49fd86ee";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_script_server/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "c8be67caad73a545e52cf58ad435ea60c16c7929dc8e458a77076fcbb7323644";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android-settings/default.nix
+++ b/distros/noetic/cob-android-settings/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-android-settings";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_settings/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "e4038140c231cf067a0de76b46b2d902bf15f4aad761bd4b03422c0acd2b9214";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android_settings/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "ccc13eeb823cc8f7f0489ad11f44edc756ad1982ac820be9c8743a0f50a82660";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-android/default.nix
+++ b/distros/noetic/cob-android/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-android-msgs, cob-android-resource-server, cob-android-script-server, cob-android-settings }:
 buildRosPackage {
   pname = "ros-noetic-cob-android";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "99c030bef5a2dda143c534296504d8e7badb84353c2cb83aac676b0e93fa42e6";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/noetic/cob_android/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "e3743c5fd25917330d868aef75376c5bf56a600679a65356cba881ad8dd21ee1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-controller-utils/default.nix
+++ b/distros/noetic/cob-base-controller-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-controller-utils";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "b3d759b9dbf0890df1b0c1b0f2f76a688dd4a76ebbebf6b314063fb22058a51d";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_base_controller_utils/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "aff4c20df99aa85d1b389ef6a8aeec732d98347378bc882f3d1d5138cfe541f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-drive-chain/default.nix
+++ b/distros/noetic/cob-base-drive-chain/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-canopen-motor, cob-generic-can, cob-utilities, control-msgs, diagnostic-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-drive-chain";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "39a6faa136253910301a986ad33e4edc807e34aa07bb49d565e465164109e205";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_base_drive_chain/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "ca0c8ccd2605670b866c4f377a3f1d95a74fcbcaeb1759d0ae535665ac18d736";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-base-velocity-smoother/default.nix
+++ b/distros/noetic/cob-base-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-base-velocity-smoother";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "71345480830b5bb49db4e1450f8e0ff5cc19eb58342553ec50d7dca15295d916";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_base_velocity_smoother/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "16ff0313294d31701994ca16b0b43972dbc5462ff00894ed6e9e8953fecb3b02";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bms-driver/default.nix
+++ b/distros/noetic/cob-bms-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-srvs, diagnostic-msgs, diagnostic-updater, python3Packages, roscpp, rospy, sensor-msgs, socketcan-interface, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-bms-driver";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "52d53b4709e7c48b987bf98ddcf390b50ea5be2cb6df520dfa429e5a76b09a30";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_bms_driver/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "ccf2bef78ef0b3b93ffba1788e49e847cde1f010064e21e1a773e39d817a5d35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bringup-sim/default.nix
+++ b/distros/noetic/cob-bringup-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, cob-default-robot-config, cob-gazebo, cob-gazebo-worlds, cob-supported-robots, gazebo-ros, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-bringup-sim";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_bringup_sim/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "f1a63615fe869afaf3b0c360bc88e3b7c15e2612cda27689ec54069bf5b70237";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_bringup_sim/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "e8ada0a116dc59e96e778dadfb9d4d451c52f456fe65e4d574424255f672c668";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-bringup/default.nix
+++ b/distros/noetic/cob-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cob-android-script-server, cob-base-controller-utils, cob-base-velocity-smoother, cob-bms-driver, cob-calibration-data, cob-cam3d-throttle, cob-collision-monitor, cob-collision-velocity-filter, cob-command-gui, cob-control-mode-adapter, cob-dashboard, cob-default-env-config, cob-default-robot-behavior, cob-default-robot-config, cob-docker-control, cob-frame-tracker, cob-hand-bridge, cob-hardware-config, cob-helper-tools, cob-image-flip, cob-light, cob-linear-nav, cob-mecanum-controller, cob-mimic, cob-monitoring, cob-moveit-config, cob-obstacle-distance, cob-omni-drive-controller, cob-phidget-em-state, cob-phidget-power-state, cob-phidgets, cob-reflector-referencing, cob-safety-controller, cob-scan-unifier, cob-script-server, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-supported-robots, cob-teleop, cob-twist-controller, cob-voltage-control, compressed-depth-image-transport, compressed-image-transport, controller-manager, costmap-2d, diagnostic-aggregator, generic-throttle, image-proc, joint-state-controller, joint-state-publisher, joint-trajectory-controller, joy, laser-filters, nodelet, openni2-launch, position-controllers, realsense2-camera, rgbd-launch, robot-state-publisher, roslaunch, rosserial-python, rosserial-server, rostopic, rviz, spacenav-node, tf2-ros, theora-image-transport, topic-tools, twist-mux, usb-cam, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-cob-bringup";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_bringup/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "55673fc9ae985a04d2aeb117ead7b53f45f69363d72ec52dcf2349fa2db11c96";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_bringup/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "8a3267846b26998d59824974aeb95792d3c3a6da3ce8c44f1d41f4b386683f01";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-calibration-data/default.nix
+++ b/distros/noetic/cob-calibration-data/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-calibration-data";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/noetic/cob_calibration_data/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "c0a110318bf61e339d863b480e66599205a518185054e0796dfc90bf7f3d61cc";
+    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/noetic/cob_calibration_data/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "295b37871f0e2f47e91f7c0975766fa529af22651db1441f88633cebd7ae6b0e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cam3d-throttle/default.nix
+++ b/distros/noetic/cob-cam3d-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, nodelet, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-cam3d-throttle";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_cam3d_throttle/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "3401f950f372a490fe11b3128a01e9b531d1f6a5c6c1ed27d0ddefdbd76acac0";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_cam3d_throttle/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "a5da7ca9b1e883d314d39a47a695296224cd8fcc7af5ee902a6d654414bc5e43";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-canopen-motor/default.nix
+++ b/distros/noetic/cob-canopen-motor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-generic-can, cob-utilities, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-canopen-motor";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "d9dbb960f22d3c6145c87b641c9cd3dfb881a4c127c1c817187a0f8bdfacee55";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_canopen_motor/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "d5384404aab1df6469880701e01e99665ff273da52048fb93241eccad00f40c0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-cartesian-controller/default.nix
+++ b/distros/noetic/cob-cartesian-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-script-server, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-cartesian-controller";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "68a8f80f05a8d5c0d03b7eef9013e9b22e55638a86048fc4d331d644d58b1658";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_cartesian_controller/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "10d82cd1fc2d943ea6465a7415e17e6b03c90352af32445064fe018ba0a411b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-monitor/default.nix
+++ b/distros/noetic/cob-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-moveit-config, moveit-ros-move-group, moveit-ros-planning, pluginlib, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-monitor";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "48e150ed386f0e2257436a253cef0d68a0fba5b27af97fc97156e15621f17054";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_collision_monitor/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "07f518d6a61c83e9e24376471a6f26c9d076719c1d2ef72007d1cde3dcebe4d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-collision-velocity-filter/default.nix
+++ b/distros/noetic/cob-collision-velocity-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-footprint-observer, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-collision-velocity-filter";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "cb8c6d86948b95b5ebd37309aae3297b710b4ff5a84fa7a91a6b550196fbf232";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_collision_velocity_filter/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "fa8f2fdd9e008b125fff2047c9c855a5be2d9ac3834eaac8940a23b4eb515b2c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "1a484c8da8270240c261e8280a70c5ee6fd82564c2aba07a2e68a9ae839ed584";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "86fa80ab0ff6cc1378313d7167c253a26ab7d4017ce6949489903d39a53d1431";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "207771e39629bb4c6ef616efbc4da8d7ff9915e734b3582f68dfab357b723807";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "975db7a7e291f00f79d5f4b83a5ddba16f3a2d4c7947532b16038b0e743fbcb8";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cob-command-gui cob-dashboard cob-helper-tools cob-interactive-teleop cob-monitoring cob-script-server cob-teleop ];
+  propagatedBuildInputs = [ cob-command-gui cob-dashboard cob-helper-tools cob-monitoring cob-script-server cob-teleop ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cob-common/default.nix
+++ b/distros/noetic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-noetic-cob-common";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "e1fe87bb41db9dd0095825e90dcfb2d7dd1d484c6fde3088c5c9d47d688035e4";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/noetic/cob_common/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "08b9e5f6b47a91c3670f463ae940e00a7f3661b352d96a3e83747631a6603702";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-mode-adapter/default.nix
+++ b/distros/noetic/cob-control-mode-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-manager-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-mode-adapter";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "68b0020768e8c74cd85b200e624cf1bc458ecf764fbdd69a30de56daf8e67860";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_control_mode_adapter/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "33e5f2cb81018aaeee0f371914041c51a548796a9fcc596440808814b7aae8a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control-msgs/default.nix
+++ b/distros/noetic/cob-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-control-msgs";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "14aabdec8884a875a648081d10e44b139c208bac724978e529776084de6f582d";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_control_msgs/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "ce396900fc7e79397a8c75e0829f8c1650ce444116831d5e480620607e90f731";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-control/default.nix
+++ b/distros/noetic/cob-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-mecanum-controller, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-control";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_control/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "bcfe8f90340456605bc1b71aea88a26faf0f677bef8624de3074cb566f8be946";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_control/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "39caca89548a797a43f3b03ba96f5cce420b4621ca855cb2adadfdbfe0a9280a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "d214c88a73fc1154a13d60d13e9bfd1ff6eeb10e6b2de0704a76e10635c69f0e";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "ef34366a86bd59099c327cf04a5457f2434e9d872a86235598702f0fdee24e9b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-env-config/default.nix
+++ b/distros/noetic/cob-default-env-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-env-config";
-  version = "0.6.13-r1";
+  version = "0.6.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_default_env_config/0.6.13-1.tar.gz";
-    name = "0.6.13-1.tar.gz";
-    sha256 = "6cde5633df93fa2800618827ee773455398dc8cd7da437f0ae49b363a12d9a7b";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_default_env_config/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "caa6bbd3cd304577b85dd7fdf249b2465c2a490bd925692c6ea73fb6840a26f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-behavior/default.nix
+++ b/distros/noetic/cob-default-robot-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-light, cob-script-server, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-behavior";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "879a26c1f54c4777ae57ce4ce505d150d80482b37342b34de93fd32bf5fb997f";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_behavior/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "6b6dbe96750e89f81ebf55b583b14053c061d01a3670d100810e5cae9a63c124";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-default-robot-config/default.nix
+++ b/distros/noetic/cob-default-robot-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-default-robot-config";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "e06de95ade103c661afe2eafd292ec0c0e7f25233ec3e186d0e78b8d27466edb";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_default_robot_config/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "cd2348f05f7f491e10534d50c5a8eda97d3328ee70058ee6778f1cb4b7411909";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-description/default.nix
+++ b/distros/noetic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-description";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "ee8f63df303ca0b7949e9d3bd36ae142ed118421c1a862f8d8f247ebbbb334e2";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/noetic/cob_description/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "f9bed417cc45fe025ea7e80fb5cc8bd8cd4369fb22dbe2778c6165c8d7395851";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-docker-control/default.nix
+++ b/distros/noetic/cob-docker-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-docker-control";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_docker_control/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "184596b166694089649886c56c4209805fcab2af3be203793b4a38f200736061";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_docker_control/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "ae9dfaca0a9448dfff633b408a0d0efc723f69f17714fd7a752b9852363969c8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-driver/default.nix
+++ b/distros/noetic/cob-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-base-drive-chain, cob-bms-driver, cob-canopen-motor, cob-elmo-homing, cob-generic-can, cob-light, cob-mimic, cob-phidgets, cob-relayboard, cob-scan-unifier, cob-sick-lms1xx, cob-sick-s300, cob-sound, cob-undercarriage-ctrl, cob-utilities, cob-voltage-control }:
 buildRosPackage {
   pname = "ros-noetic-cob-driver";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_driver/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "644a8c05ba870da0fcdc36f29e1ba7f4abe83deec5133731173defa5483d7779";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_driver/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "323172f826aa9a5b2348d1d050840011c90694ebf81340c1ef2c66e0031a643b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-elmo-homing/default.nix
+++ b/distros/noetic/cob-elmo-homing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-402, catkin, pluginlib, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-elmo-homing";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "36d8c76a9e67b7ef718ea1dc7de40e716202a087a6ae13735bc1d2a497135a4a";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_elmo_homing/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "7e7d86ecf196b1a24deb2a8ba45a242041fa1722ece1f868deba1ae6ba434dee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-environments/default.nix
+++ b/distros/noetic/cob-environments/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config }:
 buildRosPackage {
   pname = "ros-noetic-cob-environments";
-  version = "0.6.13-r1";
+  version = "0.6.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_environments/0.6.13-1.tar.gz";
-    name = "0.6.13-1.tar.gz";
-    sha256 = "f6056d5196ddb7a95f096a3fa54a62bf18614e51b30a3e185df9bfb60fa36498";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_environments/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "0dbff2a9633387f45baf480921c0a91b04991d0dc8ba03d31da69938b1686fd8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-extern/default.nix
+++ b/distros/noetic/cob-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libdlib, libntcan, libpcan, libphidgets, opengm }:
 buildRosPackage {
   pname = "ros-noetic-cob-extern";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/cob_extern/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "97e887c73b8759c68eea45d53b7ff0473908de639d557b8c88ea428aa88df5d0";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/cob_extern/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "6fe75f00669f2dad0c35dc724bf98855b9b8dc7b46a11f12ef65367f5d1c5638";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-footprint-observer/default.nix
+++ b/distros/noetic/cob-footprint-observer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-footprint-observer";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "26813497638483560342a79f6699af52b745ceeddf8b21166d10a14e94bed48d";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_footprint_observer/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "e811f191f1a2414b53f1b4f39d48097d5b407d2050feab67d32ef5472e3cd2ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-frame-tracker/default.nix
+++ b/distros/noetic/cob-frame-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-srvs, control-toolbox, dynamic-reconfigure, geometry-msgs, interactive-markers, kdl-conversions, kdl-parser, message-generation, message-runtime, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-frame-tracker";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "2f2862b075805fd5a7bdc588b29ef111297697d65fbc7cdb81d8ce15841412ec";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_frame_tracker/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "9b6fac5b5e2c5bcbd6e79eeb1666ac69d092d00c8b53a4de10c259e555ab0b8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-objects/default.nix
+++ b/distros/noetic/cob-gazebo-objects/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-objects";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_objects/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "cc14a28cbd5d56aa628ae28ca01828721c627cbe8bcb6a6e9918fdd0fef3b840";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_objects/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "5a2acad540840aebe83215f23d009432816771d072f79560a07ca1fba2832b16";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-plugins/default.nix
+++ b/distros/noetic/cob-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-plugins";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "41e7a4febc5a00ef86017729f5bf1b89896fa406578b7903cc388dc715606e15";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "d813d5c889a0fbeb4bbc95ae75de255e74ad93dbd1a3de227279c2e4f0d3e8aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-ros-control/default.nix
+++ b/distros/noetic/cob-gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-ros-control";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "fd49e81694642749589b62ad73957b9e4504ca1f3beb0b7350fb77e1440863db";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "6c371e511098efea6a90e2edda78d1c1dbc663a73f541f3e9490131ddd57a1c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-tools/default.nix
+++ b/distros/noetic/cob-gazebo-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, geometry-msgs, python3Packages, roslib, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-tools";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_tools/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "2a56de346759adc40c7d1ad137b828e03fbc25ca877e7b6599bd6c2a21bd7e5d";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_tools/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "aa501cdeceab9188318532e4c90176934ecc5b1de078628e22da510b7c5c333a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo-worlds/default.nix
+++ b/distros/noetic/cob-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config, controller-manager, gazebo-msgs, gazebo-ros, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rospy, rostest, std-msgs, tf, tf2-ros, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo-worlds";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_worlds/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "0082dd584598a557c7d4c2de67e3c6597dc664cf80fd4963c1b1774797c99093";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo_worlds/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "1113c4aee72d1bb186e50c553c093fcef35ee5021cdedbfb28341d561a1c0bf5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-gazebo/default.nix
+++ b/distros/noetic/cob-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-default-robot-config, cob-gazebo-ros-control, cob-hardware-config, cob-script-server, cob-supported-robots, control-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, roslaunch, rospy, rostest, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-gazebo";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "20050bc078f280f0753f07a114ed2d9daa9a91d05df781a4f729799432e96f56";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_gazebo/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "3092095193a7feda0720ff8b5d459a02b23e5f0caf135c985574992c78de7e3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-generic-can/default.nix
+++ b/distros/noetic/cob-generic-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-utilities, libntcan, libpcan, socketcan-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-generic-can";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "af7d077b04938312aeb4e93615c0bb2c83e8bba1a4bb3d9e9d77f0050c214a8b";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_generic_can/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "ffd34b5084101146e7915eccc559cdf0d66268d9e6946d4e37bd3cd357a732ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-grasp-generation/default.nix
+++ b/distros/noetic/cob-grasp-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-description, cob-manipulation-msgs, geometry-msgs, moveit-msgs, python3Packages, robot-state-publisher, roslib, rospy, rviz, schunk-description, sensor-msgs, std-msgs, tf, tf2-ros, trajectory-msgs, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-grasp-generation";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "840c65e0b48f6b9cf3afb720ebb7053169fc661c06e2c98b39f3d9614a1249aa";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_grasp_generation/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "14a911ecf39f14856ac409a1e95933619929b7446e4f85233c8cec70b8e647d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hand-bridge/default.nix
+++ b/distros/noetic/cob-hand-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, control-msgs, diagnostic-updater, message-generation, message-runtime, rosserial-python, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-hand-bridge";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand_bridge/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "1f91d2568bc33a99e5fe3548714a1f6525890811228c74477a5418651ed8c528";
+    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand_bridge/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "3cd664a82a0ac49c073c770222ac267335cfd3d019d335861781f659d0191eda";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hand/default.nix
+++ b/distros/noetic/cob-hand/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-hand-bridge }:
 buildRosPackage {
   pname = "ros-noetic-cob-hand";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "def20ffe69e0af6e5d173018e5d5e7fdb287a80eecb71217dc8fb7ceaf721899";
+    url = "https://github.com/ipa320/cob_hand-release/archive/release/noetic/cob_hand/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "ecd3856dc3250597f46606cb6f7f845d4c69c880dd59edafa0e07ff42862930c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-config/default.nix
+++ b/distros/noetic/cob-hardware-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-calibration-data, cob-description, cob-omni-drive-controller, cob-supported-robots, costmap-2d, diagnostic-aggregator, joint-state-controller, joint-state-publisher, joint-state-publisher-gui, joint-trajectory-controller, laser-filters, position-controllers, raw-description, robot-state-publisher, roslaunch, rostest, rviz, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-config";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "3936aaa82aed21a861206f4604bf42a1400356935fbe51e5d48bad5b98b55499";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_hardware_config/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "2fbb9ff8462c2987243fa8fb3232e8453d7ade51b28917938b133d0a82e51856";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-hardware-emulation/default.nix
+++ b/distros/noetic/cob-hardware-emulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, move-base-msgs, nav-msgs, roscpp, rosgraph-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-hardware-emulation";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "987c21214aeee2f723c5296fc6d96b7f3a4aa3c8a76f9f6291b5f742f7714922";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_hardware_emulation/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "b92a71b8c640effbdf6aa6ad994bbc0d378f988c0495d34364c6336288c1c02f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, python3Packages, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "8216c2a2bab05f3a7df282656be44290b14e443c52ccbc2feed6efb5eafcb53b";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "e7a1798c1c3a099faed2681812e2259961b593f1befba82b925797fdf8da6c97";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-image-flip/default.nix
+++ b/distros/noetic/cob-image-flip/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-perception-msgs, cv-bridge, geometry-msgs, image-transport, nodelet, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-image-flip";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_image_flip/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "c99621835873ca678c8ae4e5311c5667f66c9f142a97f310d058604319a09ac8";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_image_flip/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "c99f87ee9d87adfee1567f54c9d6330772cfcb3f7474b4b1b2972f16e36c8fe3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-light/default.nix
+++ b/distros/noetic/cob-light/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-light";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_light/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "c014084a6122454fb9ae684fd062a7d3fd348eb192332d312574dba3dd916b23";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_light/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "fdd17b8194f1510ee67d2a724e6803c0c40210d8c0a601bada0c492327e9d2db";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-linear-nav/default.nix
+++ b/distros/noetic/cob-linear-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cob-srvs, geometry-msgs, move-base-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-linear-nav";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_linear_nav/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "6c63a845097a5671841a8004a0e954560a7554cd0190cf894e96ba9bfbf8703f";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_linear_nav/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "f6aae4b360f63f541d35a6c6bdba68c84a02e2a1d0db08df367dfc4884d57885";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-lookat-action/default.nix
+++ b/distros/noetic/cob-lookat-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, angles, catkin, control-msgs, geometry-msgs, kdl-conversions, kdl-parser, message-generation, message-runtime, move-base-msgs, orocos-kdl, roscpp, rospy, sensor-msgs, tf, tf-conversions, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-lookat-action";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "2c21b9e0b75009a1868001a9d34bf3189c38d95e6c937d8badf816c146e62750";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_lookat_action/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "dda1ab08bd19d031d23e6d033cee6d4d404e11c2d482a5e9a77b97fd69dcac02";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation-msgs/default.nix
+++ b/distros/noetic/cob-manipulation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, moveit-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-manipulation-msgs";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "5dbba6a710696cc601c7a1e10cfcaaad7e1d1dc2f47a52222206d1198c7b2e47";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation_msgs/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "3dd9af950c774c0ec9536ebcb8ed85400d456ee4c74fdea51d09839b7be0913e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-manipulation/default.nix
+++ b/distros/noetic/cob-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-collision-monitor, cob-grasp-generation, cob-lookat-action, cob-manipulation-msgs, cob-moveit-bringup, cob-moveit-interface }:
 buildRosPackage {
   pname = "ros-noetic-cob-manipulation";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "60d6b2d0cb1ef39ddd7a5c90a36d460ea2958ebae1a8f2df6ef206772f22dd63";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_manipulation/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "4e7f054c01f433636e7cbce7ae7fe60714f7539d0b4b4776fa543e70fdc4db9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-map-accessibility-analysis/default.nix
+++ b/distros/noetic/cob-map-accessibility-analysis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-3d-mapping-msgs, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, nav-msgs, opencv, pcl, pcl-ros, python3Packages, roscpp, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-map-accessibility-analysis";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_map_accessibility_analysis/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "8ff4e42e7b21d130cf09ccab4f127b4ad75d3bdcd406015bf6f1c5aa040fba8f";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_map_accessibility_analysis/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "d62289db9a793638c1bf1ed9ab2956ac5cb1cf9896b68e33264778f43945316e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mapping-slam/default.nix
+++ b/distros/noetic/cob-mapping-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-navigation-global, cob-supported-robots, gmapping, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-cob-mapping-slam";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_mapping_slam/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "2bf9efc4a947f80d77509c372108f60508bf9a4175c8b1493f112151313d08fa";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_mapping_slam/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "cb09dbf1141e3c8d33f2254853d3aad801c28670594736c387c7864d75224e75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mecanum-controller/default.nix
+++ b/distros/noetic/cob-mecanum-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-mecanum-controller";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "908a8a8dc1fcca65388188b7d62a3e036773650a45c7430c522ac1935086f687";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_mecanum_controller/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "33be91852ff7d325dfb439cb14b58ca90d2ee99282035647f110248e61983236";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-mimic/default.nix
+++ b/distros/noetic/cob-mimic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, diagnostic-msgs, diagnostic-updater, message-generation, message-runtime, roscpp, roslib, rospy, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-mimic";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_mimic/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "29b30dd3d0b6c2b3c5682d0f980841624c01f8c629f00a18908ef606bf59b6a7";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_mimic/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "1e961042c29a570de85b6160bb8b99e89f2b359d6fd2e9b84eee7b10f67dd20c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-model-identifier/default.nix
+++ b/distros/noetic/cob-model-identifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, geometry-msgs, kdl-parser, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-model-identifier";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "6f53964ae943432f0bf14635386301610dbccede1fd3cdb6831db1c88973a16e";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_model_identifier/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "ce3a1b81040b71edae65a7e863ad2c2b3c42dea785bcb5654ce7a1fbf2048e90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "30846d6225eacee8c9e2303bd9615891fabc5e1e76a516a685171f04730b3f3f";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "d0b70f4552d47bd32ab8c25bc85fa4801b4887a3ba745e25120ecafbc39c9841";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin python3Packages.setuptools ];
-  propagatedBuildInputs = [ actionlib cob-light cob-msgs cob-script-server diagnostic-msgs diagnostic-updater ifstat-legacy ipmitool ntp python3Packages.packaging python3Packages.paramiko python3Packages.psutil python3Packages.requests roscpp rospy rostopic sensor-msgs std-msgs sysstat topic-tools ];
+  propagatedBuildInputs = [ actionlib cob-light cob-msgs cob-script-server diagnostic-msgs diagnostic-updater ifstat-legacy ipmitool ntp python3Packages.mechanize python3Packages.packaging python3Packages.paramiko python3Packages.psutil python3Packages.requests roscpp rospy rostopic sensor-msgs std-msgs sysstat topic-tools ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/cob-moveit-bringup/default.nix
+++ b/distros/noetic/cob-moveit-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-hardware-config, cob-moveit-config, joint-state-publisher, moveit-planners-ompl, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, moveit-setup-assistant, robot-state-publisher, rviz, tf, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-bringup";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "7242595db605bba18845104a6b4fdeb7f8105707d228e208bb7039e7c3fc1bec";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_bringup/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "5fc259bd58750c56513829162456fc82d69f969a7f0ceb5c052a45fda8e2e87a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-config/default.nix
+++ b/distros/noetic/cob-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-config";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "72b6535296a5054340be0e4c97c52786e65bd47ed3c90ad8470e84d626683842";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_moveit_config/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "0cfa92bda73eb82d4377d35c857cabe123b3a07a748f936d02868117eaca49aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-moveit-interface/default.nix
+++ b/distros/noetic/cob-moveit-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-script-server, geometry-msgs, moveit-commander, python3Packages, rospy, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-moveit-interface";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "2b2acc0fbe4aa218488a29abc454312d7ba67ce76f339c8a78dafc50c479d1b1";
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/noetic/cob_moveit_interface/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "3ca17fb4383209fb72a72e56add94f096da1cba80be8936147eb4b82b3201d0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-msgs/default.nix
+++ b/distros/noetic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-msgs";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "f08b10f41163babd8fbc526e96591a38185d6cfd650a45f3c4035e495490deec";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/noetic/cob_msgs/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "d02bb299d1c31c31246dfa5aba4110026a1764c4f7c1642d844f1114e2ca117b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-config/default.nix
+++ b/distros/noetic/cob-navigation-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-config";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_config/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "945670c47b4f6c729265fb0890e080a485f2d719cc28674524753d39df227a76";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_config/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "1236b962834786fe57526ddc48a34c2515cd15adec6bf481b52cbd4a6781d79e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-global/default.nix
+++ b/distros/noetic/cob-navigation-global/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, cob-default-env-config, cob-linear-nav, cob-navigation-config, cob-scan-unifier, cob-supported-robots, dwa-local-planner, map-server, move-base, roslaunch, rviz, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-global";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_global/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "2b86771749e01e07c4b31ce956146d42850b11a465f9a45b7e8a3bd0fb34da16";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_global/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "6f5726b0eb6a102cf6254300da16fbd2e3e954d74048b1d286756b1e5b7eb058";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-local/default.nix
+++ b/distros/noetic/cob-navigation-local/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-navigation-config, cob-supported-robots, dwa-local-planner, move-base, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-local";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_local/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "1998136fc253fcdbcd4465efd2aa21dab3a1f21c515a53b3805a6d42d7031244";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_local/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "b0f695bcb4346dad3bfdd3c6ed54f5409b7b5ceb1e74ba6f965eac0113adda94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation-slam/default.nix
+++ b/distros/noetic/cob-navigation-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-mapping-slam, cob-navigation-config, cob-navigation-global, cob-supported-robots, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation-slam";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_slam/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "7da4511a44b23d95e8f8acf33388e421876a8161354bcfbd9e1c0ea31df16a4a";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation_slam/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "51f2f23624808dddc06a3a2c0dc83da68e847037c98579a2f25e3d848bbaf3b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-navigation/default.nix
+++ b/distros/noetic/cob-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-linear-nav, cob-map-accessibility-analysis, cob-mapping-slam, cob-navigation-config, cob-navigation-global, cob-navigation-local, cob-navigation-slam }:
 buildRosPackage {
   pname = "ros-noetic-cob-navigation";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "8443149ed293e66113ae237350968b1bc5ef5b2a04a56f231914eae5a58919b7";
+    url = "https://github.com/ipa320/cob_navigation-release/archive/release/noetic/cob_navigation/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "eff60d6779a3a127737846a5ca8c0b042889c04037d081db0ee4c767e1730933";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-object-detection-msgs/default.nix
+++ b/distros/noetic/cob-object-detection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-object-detection-msgs";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_msgs/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "3545063cd63a307c29456b39f68ab1fcd842b90423e61da31d08942c5d093888";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_msgs/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "a1fe3f5a6217f42c99af3ce5bcdb93f5b6fd19823cf2454c5b54fef7b9a682f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-object-detection-visualizer/default.nix
+++ b/distros/noetic/cob-object-detection-visualizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-object-detection-msgs, cv-bridge, eigen-conversions, image-transport, message-filters, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-object-detection-visualizer";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_visualizer/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "70c64219bb8f8f7bd3316550733227c9defcdbace1172268308370caf34bc925";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_object_detection_visualizer/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "f6400ac18ce13cb54d8508143b4449160740b1f1c717dd3c23c5be46689f8e59";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-obstacle-distance/default.nix
+++ b/distros/noetic/cob-obstacle-distance/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-obstacle-distance";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "3240882f7a65241ef6a98ec1e1ead01dbdc863762be8c668c2606c8425464153";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "8585894ef8b6d1903100ebb37d278efd5764bd7b3fefb422551f453a4a52fe0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-omni-drive-controller/default.nix
+++ b/distros/noetic/cob-omni-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-noetic-cob-omni-drive-controller";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "5dbe37e53b8d0bd8a73d01fd0e4cb0bbe7cc469178e76cdb9ee80bab3b996094";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_omni_drive_controller/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "5d39c42851ca4f7f1e81eace32db3e3f9d22d8a29bc3e0b506e90acc0509954f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-perception-common/default.nix
+++ b/distros/noetic/cob-perception-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-3d-mapping-msgs, cob-cam3d-throttle, cob-image-flip, cob-object-detection-msgs, cob-object-detection-visualizer, cob-perception-msgs, cob-vision-utils }:
 buildRosPackage {
   pname = "ros-noetic-cob-perception-common";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_common/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "f5cd06f99e618d50e13e1a5c79858d58d464414ebcf3db9c90feb4082ef8bcaa";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_common/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "b5bee071918694d4e16ef09dc827756fdcd6c686861155aedae73c23b9ebf9be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-perception-msgs/default.nix
+++ b/distros/noetic/cob-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-perception-msgs";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_msgs/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "c46c5760c1ea6f9494679c6673872abac8b25e4ea6b4f698263eacf2106cabaa";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_perception_msgs/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "66aaf0f34199852386017120c3d71d09c0e6159ba84e0dcb08a74077b7195c5f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-em-state/default.nix
+++ b/distros/noetic/cob-phidget-em-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-em-state";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "6926b7d3d19a711990720e5d3a9f2cba233c40c9e4a6f875321eba1aa085b27a";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_phidget_em_state/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "a4c512ac4be0743b3a95944b9ea19dbef2c251e412356ffa4f59dade33a1ef53";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidget-power-state/default.nix
+++ b/distros/noetic/cob-phidget-power-state/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidget-power-state";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "a529e459525285cbb4580757dd8061775db19e64e4eedf4ba130b923f4a8c2a7";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_phidget_power_state/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "2a7796b920f5a74d71b5572a0cd817e1a665628f28149888420cb1ce4362430b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-phidgets/default.nix
+++ b/distros/noetic/cob-phidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidgets, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-phidgets";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "7c279d4265bb798f8d7355249b7b27eaf2fd08057394df29370e5bc6bbab90eb";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_phidgets/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "40dcf03ffd04df01d92f2982001633075dba76dea389df58138f551a876044b1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-reflector-referencing/default.nix
+++ b/distros/noetic/cob-reflector-referencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-reflector-referencing";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_reflector_referencing/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "6631e274bff81a1e2b68c33d055157ed3dfd0c80c7af0feb9fd9eebaeb6454b2";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_reflector_referencing/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "3a57e47cfe8e4e05617f26256313b384bf3eedf35ceec37477f2184cf42a55eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-relayboard/default.nix
+++ b/distros/noetic/cob-relayboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-relayboard";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "cfb49eb4df06ec1f297fcc7632c7a25f26b3472ad3a7c4f52793d213f2158d5e";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_relayboard/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "d2d792a2448e8e6101163e42e6dfe8e3f09de1c5ca6d27650360513f144e504c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-robots/default.nix
+++ b/distros/noetic/cob-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup, cob-default-robot-behavior, cob-default-robot-config, cob-hardware-config, cob-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-cob-robots";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_robots/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "324b2a78e80b86337ddf497988c69ddc9e7d43df7525be1b1dee1b2d64688c1f";
+    url = "https://github.com/ipa320/cob_robots-release/archive/release/noetic/cob_robots/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "63cebce51a80f8ea1ced166ae630811e58a2bee0937f52a6c57dc3f8ae1844f7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-safety-controller/default.nix
+++ b/distros/noetic/cob-safety-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-safety-controller";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_safety_controller/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "747c9afba9892dabb5d2be7cf75d8c48294badb4125098fd6304a6dae434838a";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_safety_controller/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "8819d9fba129594bf4dd2cfb538218ce2453e859406bd5ad0c29ffb96654154a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-scan-unifier/default.nix
+++ b/distros/noetic/cob-scan-unifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-scan-unifier";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "942307cca2c410eb4f6a536586062cb8b093f0e09f4b7158705080439ca6701a";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_scan_unifier/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "52fd30b027fc2c3a26328fcf1a078940b1e4bf11e4218b3553d33a4ac850af71";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-noetic-cob-script-server";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "b6c71cc57acd88113277e2b4c4ee28d4d39f21e489913c8cd21be2d29263185a";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "08e8ec97a135cdccfa054a55a5b9807144d55bbadb96e8774d12bf867691cae9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-lms1xx/default.nix
+++ b/distros/noetic/cob-sick-lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-lms1xx";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "91ab0b40879ea5df8273b1ccb460032c46685d98a4c36c4412bda3ea05af837f";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_sick_lms1xx/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "30cb9af324fa7e9e515bf9faf50c2565f6cf081df959cf4ea0dd54974204b4bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sick-s300/default.nix
+++ b/distros/noetic/cob-sick-s300/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-sick-s300";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "825fe6cbd5edf33d8bdf966bc6459989fbe69c305c5e8b6f62d1e234e03484ba";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_sick_s300/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "6f5a822a01dd4a7537eba1db435228dad0fc62f9cab829147bf25e97b25a8089";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-simulation/default.nix
+++ b/distros/noetic/cob-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-bringup-sim, cob-gazebo, cob-gazebo-objects, cob-gazebo-tools, cob-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-noetic-cob-simulation";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_simulation/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "2cc5b71c15e6e317a3eb8539a00771616b1b7d1a7757eed693e1f7a22ec71040";
+    url = "https://github.com/ipa320/cob_simulation-release/archive/release/noetic/cob_simulation/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "c0f2dfca431f33c4848bab06cc5ccb705983580b6d2626c97899e0e7bdeea431";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_sound/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "ca3b0da4c45a6a8111a2ab8f2b6ddc4d6bd519534629ee2bf8bcbda844b5dcfc";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_sound/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "8e9abb260e299da6bb5bc9feb4eb21f59483c3913d7d9ea49bde8c7b2c691287";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-srvs/default.nix
+++ b/distros/noetic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-cob-srvs";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "0f0d9aee5c2612bbe687f3bb7ed571940c83a62001900510d2e14ea46b63fd8f";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/noetic/cob_srvs/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "e2f647572f2ef18bd42c8d2bfd86296355be963387b962360ac32f2e1a831360";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-substitute/default.nix
+++ b/distros/noetic/cob-substitute/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-docker-control, cob-reflector-referencing, cob-safety-controller }:
 buildRosPackage {
   pname = "ros-noetic-cob-substitute";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_substitute/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "a14002b4ff9ddf10ae68616f6c2b9bc23d5c390f987e902332cb9d5d7bc68fde";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/cob_substitute/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "1d645b331e16db66ce80eb2e57024373b525ab8bc306342bae70d9f162778279";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-supported-robots/default.nix
+++ b/distros/noetic/cob-supported-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-supported-robots";
-  version = "0.6.17-r1";
+  version = "0.6.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/noetic/cob_supported_robots/0.6.17-1.tar.gz";
-    name = "0.6.17-1.tar.gz";
-    sha256 = "759491f7332143a68c6f8b74311f2f62fb06ebed5f091f3fd29625517328f217";
+    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/noetic/cob_supported_robots/0.6.18-1.tar.gz";
+    name = "0.6.18-1.tar.gz";
+    sha256 = "1c761318b2f1c00a526a2907c1a6ee7739c4afd819f426b54cd109857c280615";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "4a614a4c2329a1e2357f7539b5c1c90b343430729b7743328355a7a2d56379e2";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "85535102327b683deda4921d91e44579c8ab8eda0483e9a1e005dfed7ac7834a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-trajectory-controller/default.nix
+++ b/distros/noetic/cob-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-srvs, control-msgs, dynamic-reconfigure, roscpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-trajectory-controller";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "21923577e7d6959ab3ee8ad023b21c823dbf5e1f4de00470cc899b85f370e36c";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_trajectory_controller/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "41afcacca9de757b87628bca30c8b807e38b15a4d0352c31ad03cf23d9a10d39";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-tricycle-controller/default.nix
+++ b/distros/noetic/cob-tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-tricycle-controller";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "febdd16fbff150f997888234d7c59dc065d6c05b47bb14a48d91bc9f54cd380b";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_tricycle_controller/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "d085fb079b01b4c2905e0a8062e9c61ce04385b828eeac8e7effd1a4df8be8e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-twist-controller/default.nix
+++ b/distros/noetic/cob-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, control-msgs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, python3Packages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cob-twist-controller";
-  version = "0.8.22-r1";
+  version = "0.8.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.22-1.tar.gz";
-    name = "0.8.22-1.tar.gz";
-    sha256 = "5e7415424bf2004b636d0795cb14678cb7928da90f1878c79256c95170162e68";
+    url = "https://github.com/4am-robotics/cob_control-release/archive/release/noetic/cob_twist_controller/0.8.23-1.tar.gz";
+    name = "0.8.23-1.tar.gz";
+    sha256 = "5153128066da7b0abcd5bdba2f30d1f993035a2202b9de12561700023a3e09d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-undercarriage-ctrl/default.nix
+++ b/distros/noetic/cob-undercarriage-ctrl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-utilities, control-msgs, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-cob-undercarriage-ctrl";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "0acd34f9e470b0da42ee34d3b008339e09b53ca8a93ed6a94ba63b6219b1094a";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_undercarriage_ctrl/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "b6825a83f0d25e57f77bcc94eabe89338677511b68388dbfd1f63464f64c04d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-utilities/default.nix
+++ b/distros/noetic/cob-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cob-utilities";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_utilities/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "5f24c761bc9867f51771008d1d3cce67410168293d2e46322ce68dfdd5a97028";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_utilities/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "0319d8a97a3d1ed52fa1c232b50bee817758674fb3c75e6ec731311ea8f12970";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-vision-utils/default.nix
+++ b/distros/noetic/cob-vision-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-vision-utils";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_vision_utils/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "48ed5233202433f45c6c541e46a0cad2f5ae1c352498fcd9584300050d8897bf";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/cob_vision_utils/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "00700adc81c2996385632373984c3abd3225571000b5d25cc91a16f5ab153dd0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-voltage-control/default.nix
+++ b/distros/noetic/cob-voltage-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-phidgets, dynamic-reconfigure, python3Packages, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-voltage-control";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "9276a0be4b9b945d18ea655ce95d542775f4f1d4721f0dda7cb6acac8d70a033";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/cob_voltage_control/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "c671635b93a11179610fece34dcad9d62bff75427a670ff17eaa35302fe004a0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "79d53e101596b4f5781692f83f8b23ffabdfc723a7996a52f83fcaf6d2187420";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e2c903493ee8e8e3a167924d84e1aa439ed5575bfa78746448a9b47db15f707f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "29bc5e60bc9365ac88f570f3896070246b1d1fe11d7e222a5e0c98848f5dbcd1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f2c9b9fcaaa95fada9bd797204bd2e7d81b4370124bbbe3821338faaeb86232c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "ddf81c6308810813687e00f8811bef8fcab5aed2d887e7bfadfeb8b89ed68ac5";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "7ca17e928b89f6596da18921d9671d7a1da1ef25c6d6085de3739ab1c0683bd6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-coding/default.nix
+++ b/distros/noetic/etsi-its-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "926d4150f1e63c6f7cd241d3385f158729bdd3c211a6199006159e5a88045676";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "85054b8bdad4a21b10dc22cda181fdbd183a790c0ddcd1fc96f350af970329a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-conversion/default.nix
+++ b/distros/noetic/etsi-its-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-conversion, etsi-its-denm-conversion, message-runtime, nodelet, ros-environment, roscpp, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "a182e39549f305ac300bf52d84c97ca9b71987d6d1092c1b158adca007f353ca";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b0d132fc1d36d9cd77437c0a358c6dcb0b4b60e08270b2fb47302ffefc1dcec0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-coding/default.nix
+++ b/distros/noetic/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-coding";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "ebe3c0be63682f6728276dcc593d3e26d8c32d72a8cadcf6c25a8ed49fa306d9";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b7671a8f316ee68665dd16fb83ec7140147ae8a4493cb767cef8c83ff06106a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-conversion/default.nix
+++ b/distros/noetic/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "6e92a7cf59ad3dbeb0e5e0ae4db5e380ecf9820a37044107d1909c8226ac2dc0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "d929306e90f7171fc7e440cd51cb929970dd41f6f0fabd564e432aa4682183d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-msgs/default.nix
+++ b/distros/noetic/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "53dcf82e80f4cf5e784dc5f4bfb23c25d10452498c2ac0fd0c3e6f09118f2c0d";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a175eb31500c95c353c22f88dbc1995d558115d5dd011e58acfe16a46aeffd47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-messages/default.nix
+++ b/distros/noetic/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-messages";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "2197d7509b084f0debbff3c1c91d3c5da3d83170129c873057a1ddbd36f9a576";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "354748c4587a42729e4ae5a73216b5454eec8d3b63f9721bac5b6d9ec120cbd8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs-utils/default.nix
+++ b/distros/noetic/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs-utils";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "466ddf22cbb2c08df916e629af63d9cae0004fc723d2b4ee4cbb5eab68ecc447";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "795af3d89f5494d6e5edfc4d5a82e612cc525595b33cd093e5dad15fe1a4d424";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs/default.nix
+++ b/distros/noetic/etsi-its-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "68c1a3cf11322b33e08cca7e7258d2e804f2841dc13a7b4ef6d084976114acc5";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c19e4d2cf3b19f24bf89c4c06e5a5c7589e4a498927877231e689db59963cba4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-primitives-conversion/default.nix
+++ b/distros/noetic/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-primitives-conversion";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b7578ec196b56ecab10ca87156a98e573dd0c561a6bfd49d75c916d12f98712f";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "0eef1a5a72ff5122ff4aeca8ed830004fd052e730918745bf91dca71d1fb54cc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-rviz-plugins/default.nix
+++ b/distros/noetic/etsi-its-rviz-plugins/default.nix
@@ -2,19 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ros-environment }:
+{ lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-rviz-plugins";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9b2d1ba6f73b63276b92e3cce1119d0c05d01126d6fa57c67a6aa276969f3563";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "1a4e99d8f80fe4c2b4f228cd1157799e1fa65ef2bc9712d2e3c6d5dcac922e45";
   };
 
   buildType = "catkin";
+  buildInputs = [ catkin ];
   propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''RViz plugin for ROS 2 messages based on ETSI ITS messages'';

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -380,8 +380,6 @@ self: super: {
 
  cob-image-flip = self.callPackage ./cob-image-flip {};
 
- cob-interactive-teleop = self.callPackage ./cob-interactive-teleop {};
-
  cob-light = self.callPackage ./cob-light {};
 
  cob-linear-nav = self.callPackage ./cob-linear-nav {};
@@ -1825,6 +1823,10 @@ self: super: {
  mapviz = self.callPackage ./mapviz {};
 
  mapviz-plugins = self.callPackage ./mapviz-plugins {};
+
+ marine-acoustic-msgs = self.callPackage ./marine-acoustic-msgs {};
+
+ marine-sensor-msgs = self.callPackage ./marine-sensor-msgs {};
 
  marker-msgs = self.callPackage ./marker-msgs {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "bab46157741cdb6b1a083c1e5e47a10532ee32e23868643a8bf8db7a11c97ac7";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "bed8095818cd955e0afad4a0f3c9db2872c51b1ff44c2c5f4b0e08a534f722c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.3.8-r1";
+  version = "2.3.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.8-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.9-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "b540d39dcc8be8dfe8322769a03874afdd6dd79e8a63768c25011367c39feaa8";
+    sha256 = "7e7420f68f7d728ea801fcd393b015ad5a32fed3a9f3c2e998fb2b0c193d5b0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ipa-3d-fov-visualization/default.nix
+++ b/distros/noetic/ipa-3d-fov-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ipa-3d-fov-visualization";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/ipa_3d_fov_visualization/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "e4baf608248141a7a93ec5f72b1316a6e2a37ab884126be6754b1c425c060136";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/noetic/ipa_3d_fov_visualization/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "eadbbaf42127dd4f5ce9bdf0bf99a1f61ecaa1b6ae4fa7bf67767a25e7eb97b9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ipa-differential-docking/default.nix
+++ b/distros/noetic/ipa-differential-docking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-ipa-differential-docking";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/ipa_differential_docking/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "1702147d1a9b120c18f7c2ee3a821566be140039abbe5013ed217d8383e8e0b7";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/noetic/ipa_differential_docking/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "23f65a937b6c5852bdf71e348caff16f71ca287a82523e0366da9809bb63c4a0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-scan-densifier/default.nix
+++ b/distros/noetic/laser-scan-densifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-scan-densifier";
-  version = "0.7.15-r1";
+  version = "0.7.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.15-1.tar.gz";
-    name = "0.7.15-1.tar.gz";
-    sha256 = "c8de2625fc0cd1bfb821db4c1b6f7100b1fe8c650cd82b64f58f701864e53b30";
+    url = "https://github.com/4am-robotics/cob_driver-release/archive/release/noetic/laser_scan_densifier/0.7.16-2.tar.gz";
+    name = "0.7.16-2.tar.gz";
+    sha256 = "a6403334011fd045d38ef3ca14da51b3ba76bc64d623ee096cb7fbffc159d6f5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libdlib/default.nix
+++ b/distros/noetic/libdlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-libdlib";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libdlib/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "217bb8d8c749b3c2d3235183c0ee685a1bb0310ab92391a8b2a4b1e37a748f7c";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libdlib/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "9202574f85115607c0b0225cd598eaa692cd929c93a809f4a9f080f93d699e6b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libntcan/default.nix
+++ b/distros/noetic/libntcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dpkg }:
 buildRosPackage {
   pname = "ros-noetic-libntcan";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libntcan/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "d7723026b5cf16ace323ad374e6d327cdbd887cf2735d4aa691322458da20659";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libntcan/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "f14b42ba1acb8ba75e2a478a0d7acd5c5c97f7aafc0c36fd032517c6fd6c65fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libpcan/default.nix
+++ b/distros/noetic/libpcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-libpcan";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libpcan/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "634d7fe32f5cdda1a70fd01d76ec7538948cf891bf037594f8358eafbf9ea091";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libpcan/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "078b90c53555b4e0f768a848d7c5b433041d0f0cd88825e35f277c95fda24cd4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libphidgets/default.nix
+++ b/distros/noetic/libphidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidgets";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libphidgets/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "8819ed4fdd6d7f69744ef34c7d5573aee979beb11e64714897e5d9a3cc55e910";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libphidgets/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "8219c6374819b7f9d667689213ce376f72c107e6ecf948fd039c593c99e8f86e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marine-acoustic-msgs/default.nix
+++ b/distros/noetic/marine-acoustic-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marine-acoustic-msgs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CCOMJHC/marine_msgs-release/archive/release/noetic/marine_acoustic_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "823c239989b8368de999b831f3519ccb933a6b97cda42b68c075b0eb402db23f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rosbag-migration-rule std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The marine_acoustic_msgs package, including messages for common
+  underwater sensors (DVL, multibeam sonar, imaging sonar)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/marine-sensor-msgs/default.nix
+++ b/distros/noetic/marine-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marine-sensor-msgs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CCOMJHC/marine_msgs-release/archive/release/noetic/marine_sensor_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2c391fb403d10aa7e749e6ee3a050e378248bf4b96a4302913a8154327a9a415";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The marine_sensor_msgs package, meant to contain messages for common
+  underwater sensors (e.g., conductivity, turbidity, dissolved oxygen)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/ntrip-client/default.nix
+++ b/distros/noetic/ntrip-client/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nmea-msgs, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, nmea-msgs, rospy, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ntrip-client";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "0066bb6efb9cfa6af71bb37d32f95c2daef51fd4f16aab44ba186bf29b9d3e77";
+    url = "https://github.com/LORD-MicroStrain/ntrip_client-release/archive/release/noetic/ntrip_client/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "71f1a3e8b903a369fa3259407a5096f173edf0058e2b6ce3c452188a540b7031";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ mavros-msgs nmea-msgs rospy std-msgs ];
+  propagatedBuildInputs = [ nmea-msgs rospy rtcm-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/opengm/default.nix
+++ b/distros/noetic/opengm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-opengm";
-  version = "0.6.18-r1";
+  version = "0.6.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/opengm/0.6.18-1.tar.gz";
-    name = "0.6.18-1.tar.gz";
-    sha256 = "5c29a653bbc69cc079bdf853a7298bb82844abc10dd215b66374c60b697eb128";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/opengm/0.6.19-1.tar.gz";
+    name = "0.6.19-1.tar.gz";
+    sha256 = "9b00f306a7dd60054b32b0b9e24d6eed80eafed6c2910d6075e4c757bccc6656";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, plotjuggler, qt5, ros-type-introspection, rosbag-storage, roscpp, roscpp-serialization, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0dbcb7e1d14592a367ae3884ef828db6d3bb794850d5280136b0e25662de8575";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "c43b46a095b88bb110de93e23d5a71cf6a34592ac92c0f0f14b20d4f49379d16";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, lz4, protobuf, qt5, roscpp, roslib, zstd }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.9.0-r1";
+  version = "3.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "8c29aadbde72634b1d5341b84f3fc6e5bea630439f21572b1b590568f9d8b8c3";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "ef91aac791288d5aee91a7bfbc6aaa6c3eeca26a09be802e63d63bf0cc1817c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/raw-description/default.nix
+++ b/distros/noetic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-raw-description";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "52001cbe8cd8fe39cd73ec11716e9b7af2cdc91152fdf14bc3a420d9fba4d7d0";
+    url = "https://github.com/4am-robotics/cob_common-release/archive/release/noetic/raw_description/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "a8a56c3cdb9eda1c3fc4eb88f79a29ee7c84876b23c5c9251bb50fa8f576d657";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-conversions/default.nix
+++ b/distros/noetic/rtabmap-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen-conversions, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, roscpp, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-conversions";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_conversions/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "ff8dc32f4f85aad823a6bc1bb13a0f43182c6ccba92adaaade64b851590b5589";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_conversions/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "df39b19b2a8251656d3ac29ef2e0adaa4790f38372606c8bda8b378bf2fff6b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-costmap-plugins/default.nix
+++ b/distros/noetic/rtabmap-costmap-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, dynamic-reconfigure, genmsg, message-generation, pcl, pcl-conversions, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-costmap-plugins";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_costmap_plugins/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "ad0f7169c173a4850b6abe62148113bd712d0d9b8b12e8ace06205f535a0565e";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_costmap_plugins/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "f6016ba2e469dec716707837db37ed03c819fb42f650687ac266f4db9c8357d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-demos/default.nix
+++ b/distros/noetic/rtabmap-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, find-object-2d, hector-mapping, husky-navigation, rtabmap-conversions, rtabmap-costmap-plugins, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz, turtlebot3-bringup, turtlebot3-gazebo, turtlebot3-navigation, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-demos";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_demos/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "c776c670f44854cc3ef005978f0a73ca6f53ee553635dc78997d999cda7d40fb";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_demos/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "04276ca0fc1e6490bcdd1298bc8e360e189e7d51b289df5a1e5314f7ac64d41d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-examples/default.nix
+++ b/distros/noetic/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, message-filters, realsense2-camera, robot-localization, roscpp, rtabmap-conversions, rtabmap-costmap-plugins, rtabmap-demos, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-examples";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_examples/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "d6b9ed8312cb0a080b59ec754c5e7949223a616700b5cbb117ff91637831ba75";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_examples/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "8b065e615e641c4f19f308eb397f1baf9831f5956da7098c34e6f68503f66d25";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-launch/default.nix
+++ b/distros/noetic/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rtabmap-costmap-plugins, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-launch";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_launch/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "c1a42a316c1b18dd4909f9a2a1c4953bc4678ae337967399890021053de36ed1";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_launch/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "bdf6e6841ed47244ef2a9bf9c195cd6fcc6b8c1f180a0046a6e98cd214834f1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-legacy/default.nix
+++ b/distros/noetic/rtabmap-legacy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, image-transport, nodelet, rtabmap-conversions, rtabmap-demos, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-legacy";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_legacy/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "b5c7fa86fed4d1a2322e5cba34c6ece2950b621d2840cdab4d6aa67931cac33d";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_legacy/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "7f45a321515218662bd46239948ae2dc13c802ae3e9276feb085b550672fab45";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-msgs/default.nix
+++ b/distros/noetic/rtabmap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-msgs";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_msgs/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "52c8a6ab184fbccfb0929fbdad4c1e24ac88fbc00f0894961274c9ec77caf256";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_msgs/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "e7dafb926d6ed8626f8ab23f74388e081d12f8c06636d27f3026e8390ffde7eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-odom/default.nix
+++ b/distros/noetic/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, nodelet, pcl-conversions, pcl-ros, pluginlib, roscpp, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-odom";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_odom/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "828bbf46577438b56ffcd01589e8b00a6ed5f3e88d42c9d4e2e454a3f91b1c5e";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_odom/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "3c8b542eef6b97a8de73240d70e10062ea8df28e70e1c71345aee1ac3d183c50";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-python/default.nix
+++ b/distros/noetic/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-python";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_python/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "119a4439fe07536c87115bd9b99f8cce95e34353589c1e9eb404c29b84e321f9";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_python/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "d72002531472bc2fdb37902da988e66d60f2332a30ad166c66de450a446eb596";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rtabmap-conversions, rtabmap-costmap-plugins, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-legacy, rtabmap-msgs, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-ros";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "59f153a7354b6078414c67bde66746b71fb950c433e336e516be82a3efb8d6e5";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "172f2be7d7ddb3cdf06db5a83a894d5552ebb5dbea478b5b284c0f5c6d699a60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-rviz-plugins/default.nix
+++ b/distros/noetic/rtabmap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-conversions, pluginlib, roscpp, rtabmap-conversions, rtabmap-msgs, rviz, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-rviz-plugins";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_rviz_plugins/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "0421389934360b110f1427e75101aba16f9ee8faa45e9fe15006e6a65e646cc4";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_rviz_plugins/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "6ca14347561e6c1e06ade8d41d0eb14797332567f12fb49e14528e889c4130dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-slam/default.nix
+++ b/distros/noetic/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, apriltag-ros, catkin, cv-bridge, geometry-msgs, move-base-msgs, nav-msgs, nodelet, pluginlib, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-slam";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_slam/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "4550ccc2982af2d9785573b3e31583345cc2cafa0d3d8686805b75d61c077cef";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_slam/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "621db97d5080b4b0cd7da4649bad221d74a3351afa6c2ce71dda81a5108feba7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-sync/default.nix
+++ b/distros/noetic/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, nodelet, roscpp, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-sync";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_sync/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "0a45b41ac8e87382426f72c57ef60559a1a447f38442ed54899fcdec796ff6a2";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_sync/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "357f175df2fd3a1ffd10e4a996df33b4f1b3d08248e27d527e6143094de78d4d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-util/default.nix
+++ b/distros/noetic/rtabmap-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, grid-map-ros, image-transport, laser-geometry, message-filters, nav-msgs, nodelet, octomap-msgs, pcl-conversions, pcl-ros, pluginlib, roscpp, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-util";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_util/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "fdb4361908a93871c6160d6d38f3250d925917c1a02dae7d775822b1dff0da33";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_util/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "db902b76a62667f47dfce67c7b16c48cabf09d6168f2cc4ac6ae8a0b3cca01d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-viz/default.nix
+++ b/distros/noetic/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, nav-msgs, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-viz";
-  version = "0.21.3-r4";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_viz/0.21.3-4.tar.gz";
-    name = "0.21.3-4.tar.gz";
-    sha256 = "439f95a8031f2a92c5e55a62052ccf8c3c34caa274a3484851b827b9a884777c";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_viz/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "04725621be9bd8eeca03690420c059e76b405bef68755bcb55fdffe0b449df12";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap/default.nix
+++ b/distros/noetic/rtabmap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, grid-map-core, gtsam, libg2o, libpointmatcher, octomap, pcl, proj, qt-gui-cpp, sqlite, zlib }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap";
-  version = "0.21.3-r1";
+  version = "0.21.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap-release/archive/release/noetic/rtabmap/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "9a63308f4cc9d95c1cdd88954e4fcca6dc5ccb5e9dd8ba2c72a595bb00f58977";
+    url = "https://github.com/introlab/rtabmap-release/archive/release/noetic/rtabmap/0.21.4-1.tar.gz";
+    name = "0.21.4-1.tar.gz";
+    sha256 = "7e01d73a35af9bbcd403143d29671479169708cd0eab0c94a33ef998da2d69e1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "a6024500d38b01fee71c48f2a2a840a3229149fd896b43a82bfe2d3f985c7af6";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "42d0cccfedc0c4a64126497038031a0e562d07fcb3d2113711129cfb834174c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.33-r1";
+  version = "0.6.34-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.33-1.tar.gz";
-    name = "0.6.33-1.tar.gz";
-    sha256 = "ba18250924d0144042b0dccaa4b9e4e92f3147b23fad54453bb5eea275798e59";
+    url = "https://github.com/4am-robotics/cob_command_tools-release/archive/release/noetic/service_tools/0.6.34-1.tar.gz";
+    name = "0.6.34-1.tar.gz";
+    sha256 = "e727a4af7067d9cec72fa8b9317d3f0bc2a91cff0a040a92d876483f28a64616";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.3.4-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.4-1.tar.gz";
-    name = "1.3.4-1.tar.gz";
-    sha256 = "d2152d337556de06073c71742806c6d1d5acabfe432339ca27874923f42e429e";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "4ae5278bf8c1731ba04066a9947220b5f78c2d1f55eb4a35b557f93eed8b2b45";
   };
 
   buildType = "cmake";

--- a/distros/rolling/color-util/default.nix
+++ b/distros/rolling/color-util/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/color_util-release/archive/release/rolling/color_util/1.0.0-2.tar.gz";
+    url = "https://github.com/ros2-gbp/color_util-release/archive/release/rolling/color_util/1.0.0-2.tar.gz";
     name = "1.0.0-2.tar.gz";
     sha256 = "b198e816837b6e32fed161596f19e48b069d321fc038f747b41febeeebd97a02";
   };

--- a/distros/rolling/data-tamer-cpp/default.nix
+++ b/distros/rolling/data-tamer-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, data-tamer-msgs, mcap-vendor, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-data-tamer-cpp";
-  version = "0.9.1-r1";
+  version = "0.9.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/data_tamer-release/archive/release/rolling/data_tamer_cpp/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "f6c074692736cb504954f5bbdba57b889e483513acf3ec853f355d44f9b66cc5";
+    url = "https://github.com/ros2-gbp/data_tamer-release/archive/release/rolling/data_tamer_cpp/0.9.4-2.tar.gz";
+    name = "0.9.4-2.tar.gz";
+    sha256 = "feec315d40e083f93e6c62a34389a3dbfda0a811e9caecb0679596ed8341d15b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/data-tamer-msgs/default.nix
+++ b/distros/rolling/data-tamer-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-data-tamer-msgs";
-  version = "0.9.1-r1";
+  version = "0.9.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/data_tamer-release/archive/release/rolling/data_tamer_msgs/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "da2d94041438abf9602d14850fe82c6c75100603bc480d4c39522abb958bde44";
+    url = "https://github.com/ros2-gbp/data_tamer-release/archive/release/rolling/data_tamer_msgs/0.9.4-2.tar.gz";
+    name = "0.9.4-2.tar.gz";
+    sha256 = "8540f5400ebf34df678bdf67b10651123ee2790dcc56e204eceba0dc48c767dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dual-arm-panda-moveit-config/default.nix
+++ b/distros/rolling/dual-arm-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-rolling-dual-arm-panda-moveit-config";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/dual_arm_panda_moveit_config/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "9dc26abb540ea8917aa46bc51d75da010dcfa84b6ae2538403402ff4e881a1f3";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/dual_arm_panda_moveit_config/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "ebaf1624aa2f4d79c1dd65c109862d9b1a096db2dd763997cc2455086b02c017";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps";
-  version = "2.11.2-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.11.2-1.tar.gz";
-    name = "2.11.2-1.tar.gz";
-    sha256 = "1096d672a0afe6c3f8991dd6c8028ca43384229d20b74fe7cf7cdaa7885b1967";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "ca81486df8fd062242cbc3556f49b8e877a17e4fa5ae7e57526d734b49b5213e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/fields2cover/default.nix
+++ b/distros/rolling/fields2cover/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/Fields2Cover/Fields2Cover-release/archive/release/rolling/fields2cover/1.2.1-2.tar.gz";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/1.2.1-2.tar.gz";
     name = "1.2.1-2.tar.gz";
     sha256 = "5ccd34682b857c296ddd5adb9d9f26d34a1c03191c09dcd2a9ae9503fb1725a8";
   };

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "9bcdd4c023552042de2763cd2107727e3b28d52f39b42f5b82fb11d0abe0fcd7";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "9a1522619318983c1f32c6455da5ba5434398e169b17b4c4e5f0753ad53c035b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -196,8 +196,6 @@ self: super: {
 
  bicycle-steering-controller = self.callPackage ./bicycle-steering-controller {};
 
- bno055 = self.callPackage ./bno055 {};
-
  bond = self.callPackage ./bond {};
 
  bond-core = self.callPackage ./bond-core {};

--- a/distros/rolling/magic-enum/default.nix
+++ b/distros/rolling/magic-enum/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/magic_enum-release/archive/release/rolling/magic_enum/0.9.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/magic_enum-release/archive/release/rolling/magic_enum/0.9.5-1.tar.gz";
     name = "0.9.5-1.tar.gz";
     sha256 = "a08b37a102ff65dde6815ae8309cbb95edc6b8b796fe3257f63beae65706dc8c";
   };

--- a/distros/rolling/message-tf-frame-transformer/default.nix
+++ b/distros/rolling/message-tf-frame-transformer/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release/archive/release/rolling/message_tf_frame_transformer/1.1.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/rolling/message_tf_frame_transformer/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
     sha256 = "180d78942a48f69128e992ec93c95aed62691b32bf4c52c4ef1507ddd15e9515";
   };

--- a/distros/rolling/moveit-resources-fanuc-description/default.nix
+++ b/distros/rolling/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-fanuc-description";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_fanuc_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "8f7db07c55e5970d9f3925f8f8562c38564f354ab5ff5ff40d0197a00a052456";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_fanuc_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "5806bd5329c0006e5dc3adf69c1c98c88c256d6d295c55db0471c0e9a506d110";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/rolling/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-fanuc-moveit-config";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_fanuc_moveit_config/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "6abbe489b433087b304c9c84d7f34fc77711a28ec56e8e0b8e30d1ffaa240563";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_fanuc_moveit_config/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "8e845ea3d3bae19450ef557dabba27cbda0cdf191c5fe2475251784ccac75b79";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-panda-description/default.nix
+++ b/distros/rolling/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-panda-description";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_panda_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "631f835d612fa2e49ee3d266ab05d2e161d726344ea8491d482f6443175da393";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_panda_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "890f6bfeefe3e903cf6e5cb1a49267d4be59f5920365791500cb6fee34e46b5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/rolling/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-panda-moveit-config";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_panda_moveit_config/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "10929316a7b6b38cd80a60b25c243dee1667640809dcb41136c8dfb910a80bba";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_panda_moveit_config/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "3b009f8dc0044cfdb8cab9f112928cd5f2d07e924bbdb6ce4c0138b063b6e609";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-pr2-description/default.nix
+++ b/distros/rolling/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-pr2-description";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_pr2_description/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "c834f97bc1d5acf0f44e939135b594925cd69269bda02d4ba3f84cb3b721e95f";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources_pr2_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "20d0e04324cd86991a2f2a93cd83f7e7529481601bafea3aeba8657d054a21dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources/default.nix
+++ b/distros/rolling/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources";
-  version = "2.1.1-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "48de7ae003afcb683845106159912b12611b85a0cb15a769c78f5fef03e5e73f";
+    url = "https://github.com/ros2-gbp/moveit_resources-release/archive/release/rolling/moveit_resources/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "077781899f0f93b0105454d14f8410b4760f4df2f3c8955e83c632f79f82ba6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "97c31b759e071cf6765982e953b6c9c02ac17cf8ecd9f320c4a6353fe8ab4445";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "86c6e808a836b8f557ed16691aff2e9263d5606067a5ed9be7f9fd8a4b40a44e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mqtt-client-interfaces/default.nix
+++ b/distros/rolling/mqtt-client-interfaces/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "4a700b096cfca0f84891ec9cfa92dba7fec15a4896750aeaf046bda668b71204";
   };

--- a/distros/rolling/mqtt-client/default.nix
+++ b/distros/rolling/mqtt-client/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/rolling/mqtt_client/2.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client/2.2.0-1.tar.gz";
     name = "2.2.0-1.tar.gz";
     sha256 = "2a0092ff5b01d6ebcfa279b34d593753c1e114fe15afd385a0c5965869d96ba0";
   };

--- a/distros/rolling/ntrip-client/default.nix
+++ b/distros/rolling/ntrip-client/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, mavros-msgs, nmea-msgs, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, nmea-msgs, rclpy, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntrip-client";
-  version = "1.2.0-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/rolling/ntrip_client/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "b4ddccb05024a16581082eb67d7ac63e943d8acd256277e647151774e0aa12e3";
+    url = "https://github.com/ros2-gbp/ntrip_client-release/archive/release/rolling/ntrip_client/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "62f4da07cb2c0205e28df54753626368755df54ee68968ce5401b9d3977e7ed3";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ mavros-msgs nmea-msgs rclpy std-msgs ];
+  propagatedBuildInputs = [ nmea-msgs rclpy rtcm-msgs std-msgs ];
 
   meta = {
     description = ''NTRIP client that will publish RTCM corrections to a ROS topic, and optionally subscribe to NMEA messages to send to an NTRIP server'';

--- a/distros/rolling/octomap-mapping/default.nix
+++ b/distros/rolling/octomap-mapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, octomap-server }:
 buildRosPackage {
   pname = "ros-rolling-octomap-mapping";
-  version = "2.0.0-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_mapping-release/archive/release/rolling/octomap_mapping/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "eb217be01c5be5418fe158e8d84d673cb5d8785ba67e6254471d881d78278649";
+    url = "https://github.com/ros2-gbp/octomap_mapping-release/archive/release/rolling/octomap_mapping/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8ae047ac8b11fc7700be2216a7a821b3f02b4f33705a4b9a57c3e7f256598da0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/octomap-server/default.nix
+++ b/distros/rolling/octomap-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, nav-msgs, octomap, octomap-msgs, octomap-ros, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-octomap-server";
-  version = "2.0.0-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_mapping-release/archive/release/rolling/octomap_server/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "f2b78852f1c62652a2160cfb0993577fac2f6cecfdc300e966452c9af06d1558";
+    url = "https://github.com/ros2-gbp/octomap_mapping-release/archive/release/rolling/octomap_server/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "7c98caf885aa2e047e96390cb01900703b918b11ea6b5bea56b0636234c07e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ouster-msgs/default.nix
+++ b/distros/rolling/ouster-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ouster-msgs";
-  version = "0.5.0-r2";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_ouster_drivers-release/archive/release/rolling/ouster_msgs/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "615a89174217aec9923f5bd20c809d79b13f694533843f2d9bc14692640c711d";
+    url = "https://github.com/ros2-gbp/ros2_ouster_drivers-release/archive/release/rolling/ouster_msgs/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "8da3cf0cbb1fe23e91bf7ce74218fb7a0a6bef9908a226d8de9481e83f6b4041";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-statistics-msgs/default.nix
+++ b/distros/rolling/pal-statistics-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.1.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.1.5-1.tar.gz";
     name = "2.1.5-1.tar.gz";
     sha256 = "9b26e68f60417627e378cca066922338008557d03d0ae2cf25db780d60bee958";
   };

--- a/distros/rolling/pal-statistics/default.nix
+++ b/distros/rolling/pal-statistics/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.1.5-1.tar.gz";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.1.5-1.tar.gz";
     name = "2.1.5-1.tar.gz";
     sha256 = "4b414f7def93f04b7c38d0d1baba7073e2c3b0033de228f7e2c902ab85296239";
   };

--- a/distros/rolling/point-cloud-interfaces/default.nix
+++ b/distros/rolling/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-interfaces";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "e2d8b54ae4b00561fba791f1fd3e17eeedab9a772547eb765b9dcafc0ffd5740";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "fa989611d55651f8524dfd7da0e4d9728d420c8d9f14b60e5cd9c6ddfb585b75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-plugins/default.nix
+++ b/distros/rolling/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-plugins";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "42a900962872e4d393ccb23356e0a60bbce4252274c5580ec18350ee9c4e48c4";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "c1c7c33ce7015472b9826b1fa0f4860478f42eb97726554771fa1c56b726ff9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "4c979915bfa8843b5b2ceb01435acc16d77bc3e7c24d87563bc063b74fc8a778";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "1c6ea41a9d2b28ef680d1e5c4c7d19354e4a0347e1e16e8dc00609ac4f4eb1c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "488e7807cdbfcfbe025b0d60b904c948da38139ccaff5846a721c034bb8d69e0";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "8a9c1e801f9e7b65da06c8fdbc3af9f694167f9138802463bdba1cc3fb413126";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pointcloud-to-laserscan/default.nix
+++ b/distros/rolling/pointcloud-to-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, laser-geometry, launch, launch-ros, message-filters, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pointcloud-to-laserscan";
-  version = "2.0.1-r3";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/rolling/pointcloud_to_laserscan/2.0.1-3.tar.gz";
-    name = "2.0.1-3.tar.gz";
-    sha256 = "c71c6c25c68229a86991af070334e4ecd14bdf0f9b3d0648247421ebd1d6d3ee";
+    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/rolling/pointcloud_to_laserscan/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "34619deeecb68d8ad7c6c5770f6eb555692803dce9fd66697e6f052b420b9925";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-demos/default.nix
+++ b/distros/rolling/polygon-demos/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/rolling/polygon_demos/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_demos/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "4037c69e158eb3470777dc1db81ca468cdc2f3819cf6f010cc21e100d109db5a";
   };

--- a/distros/rolling/polygon-msgs/default.nix
+++ b/distros/rolling/polygon-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/rolling/polygon_msgs/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_msgs/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "f9ee21cbf6498ce08661e9ecb7386c449db11ef62a7410e2734709441fdf6ec4";
   };

--- a/distros/rolling/polygon-rviz-plugins/default.nix
+++ b/distros/rolling/polygon-rviz-plugins/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/rolling/polygon_rviz_plugins/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_rviz_plugins/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "0d6496261933d48d56586ba0311450b8038ec16453c55f2ed0f92a95dcb8e3e6";
   };

--- a/distros/rolling/polygon-utils/default.nix
+++ b/distros/rolling/polygon-utils/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/MetroRobots-release/polygon_ros-release/archive/release/rolling/polygon_utils/1.0.2-1.tar.gz";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_utils/1.0.2-1.tar.gz";
     name = "1.0.2-1.tar.gz";
     sha256 = "4f1a64249d943c18684fb0c7e5c605537ee16d347165083a9a5bc9258402cdfa";
   };

--- a/distros/rolling/ros2-ouster/default.nix
+++ b/distros/rolling/ros2-ouster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, launch, launch-ros, libtins, ouster-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-ouster";
-  version = "0.5.0-r2";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_ouster_drivers-release/archive/release/rolling/ros2_ouster/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "03e12ac079d5e5b6aa7fd10a14e2617f350b19fabcc33e4033260a15a59c31e1";
+    url = "https://github.com/ros2-gbp/ros2_ouster_drivers-release/archive/release/rolling/ros2_ouster/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "495e9e3a47abfde2bdbc28d30e0dd4eef631f6828ba319cc80b9a8a0bebed7a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gauges/default.nix
+++ b/distros/rolling/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gauges";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/rolling/rqt_gauges/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "8b354f265053931a57cada694752a5e61daff862b4a3e849345548026845271d";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/rolling/rqt_gauges/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "c381ce40e23a570a6486903d2c27a70f63280ebdf2789d32ba96c3e26387925d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/simple-launch/default.nix
+++ b/distros/rolling/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-simple-launch";
-  version = "1.8.0-r1";
+  version = "1.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/rolling/simple_launch/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "6dea100847eb4bce6b97e2713c4ecc2c8e586a54293bcb5b43b50c06ecab3223";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/rolling/simple_launch/1.9.1-1.tar.gz";
+    name = "1.9.1-1.tar.gz";
+    sha256 = "161a25381579937adbe4cc67b71583cd873dbee07e0900a5d218872406e97e10";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/slider-publisher/default.nix
+++ b/distros/rolling/slider-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-slider-publisher";
-  version = "2.2.1-r2";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/slider_publisher-release/archive/release/rolling/slider_publisher/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "590f2607c4ea1f44136d357c4b4696dfdf1480836f83808378fed4a3132201f8";
+    url = "https://github.com/ros2-gbp/slider_publisher-release/archive/release/rolling/slider_publisher/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "7d8e5a8a161ea5fd6311b72afd8c1c169b353625ad8346ccf7c1b8c59f3bd33d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-based-ros2-control/default.nix
+++ b/distros/rolling/topic-based-ros2-control/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/topic_based_ros2_control-release/archive/release/rolling/topic_based_ros2_control/0.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/topic_based_ros2_control-release/archive/release/rolling/topic_based_ros2_control/0.2.0-1.tar.gz";
     name = "0.2.0-1.tar.gz";
     sha256 = "226ec871a9053c7925d032d435e61aebd1128503d3f654dfa87812715e955b38";
   };

--- a/distros/rolling/tuw-geometry/default.nix
+++ b/distros/rolling/tuw-geometry/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "0.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tuw-robotics/tuw_geometry-release/archive/release/rolling/tuw_geometry/0.0.7-2.tar.gz";
+    url = "https://github.com/ros2-gbp/tuw_geometry-release/archive/release/rolling/tuw_geometry/0.0.7-2.tar.gz";
     name = "0.0.7-2.tar.gz";
     sha256 = "de41212d3c5d7b39a51e69098aaff89793edf155ba35d104f5fa23dc5031ad16";
   };

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.3.4-r1";
+  version = "1.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.4-1.tar.gz";
-    name = "1.3.4-1.tar.gz";
-    sha256 = "057e0e6d2e362caf25eb57fbaf43fc12df06aadc2ad18254a6a7df7e33cdb037";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.5-1.tar.gz";
+    name = "1.3.5-1.tar.gz";
+    sha256 = "de1df581012f6ed8b0848fb8889ba2b5fee88fb445a90ac749d63f6117cd4add";
   };
 
   buildType = "cmake";

--- a/distros/rolling/zlib-point-cloud-transport/default.nix
+++ b/distros/rolling/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zlib-point-cloud-transport";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "666444d708b9b634abecbfa18d1308283eb6b0ff76cdf7a4ae2cc16de55f7bdf";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "ab8052134cde0c30b8cf4ba22bab51f8dfeb570b28ed27ee9f6dd39adce9717a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-point-cloud-transport/default.nix
+++ b/distros/rolling/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-point-cloud-transport";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "876616645f7f89efda15d264b48c32722b96c4689e40c794ab0f9b15e2659185";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "a7e214a4ef407249ea3deb782288e160da38bd1e4ae3713b4a83a2ce37d3d0d0";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 5f5fc569845b81487033d553c748e140e2ef4ca2.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ament-cmake 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-auto 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-core 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-definitions 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-dependencies 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-include-directories 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-interfaces 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-libraries 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-link-flags 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-export-targets 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-gen-version-h 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-gmock 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-google-benchmark 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-gtest 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-include-directories 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-libraries 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-nose 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-pytest 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-python 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-target-dependencies 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-test 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-vendor-package 1.3.7-r1 --> 1.3.8-r1*
* *ament-cmake-version 1.3.7-r1 --> 1.3.8-r1*
* *caret-analyze-cpp-impl 0.5.0-r1 --> 0.5.0-r5*
* *caret-msgs 0.5.0-r4 --> 0.5.0-r6*
* *cob-actions 2.7.9-r1 --> 2.7.10-r1*
* *cob-msgs 2.7.9-r1 --> 2.7.10-r1*
* *cob-srvs 2.7.9-r1 --> 2.7.10-r1*
* *controller-interface 2.37.0-r1 --> 2.39.1-r1*
* *controller-manager 2.37.0-r1 --> 2.39.1-r1*
* *controller-manager-msgs 2.37.0-r1 --> 2.39.1-r1*
* *dataspeed-dbw-common 2.1.3-r1 --> 2.1.10-r1*
* *dataspeed-ulc 2.1.3-r1 --> 2.1.10-r1*
* *dataspeed-ulc-can 2.1.3-r1 --> 2.1.10-r1*
* *dataspeed-ulc-msgs 2.1.3-r1 --> 2.1.10-r1*
* *dbw-fca 2.1.3-r1 --> 2.1.10-r1*
* *dbw-fca-can 2.1.3-r1 --> 2.1.10-r1*
* *dbw-fca-description 2.1.3-r1 --> 2.1.10-r1*
* *dbw-fca-joystick-demo 2.1.3-r1 --> 2.1.10-r1*
* *dbw-fca-msgs 2.1.3-r1 --> 2.1.10-r1*
* *dbw-ford 2.1.3-r1 --> 2.1.10-r1*
* *dbw-ford-can 2.1.3-r1 --> 2.1.10-r1*
* *dbw-ford-description 2.1.3-r1 --> 2.1.10-r1*
* *dbw-ford-joystick-demo 2.1.3-r1 --> 2.1.10-r1*
* *dbw-ford-msgs 2.1.3-r1 --> 2.1.10-r1*
* *dbw-polaris 2.1.3-r1 --> 2.1.10-r1*
* *dbw-polaris-can 2.1.3-r1 --> 2.1.10-r1*
* *dbw-polaris-description 2.1.3-r1 --> 2.1.10-r1*
* *dbw-polaris-joystick-demo 2.1.3-r1 --> 2.1.10-r1*
* *dbw-polaris-msgs 2.1.3-r1 --> 2.1.10-r1*
* *ds-dbw 2.1.10-r1*
* *ds-dbw-can 2.1.10-r1*
* *ds-dbw-joystick-demo 2.1.10-r1*
* *ds-dbw-msgs 2.1.10-r1*
* *etsi-its-cam-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-cam-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-cam-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-messages 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-msgs-utils 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-primitives-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-rviz-plugins 2.0.0-r1 --> 2.0.1-r1*
* *examples-tf2-py 0.25.5-r1 --> 0.25.6-r1*
* *flir-camera-description 2.0.8-r2 --> 2.0.8-r3*
* *flir-camera-msgs 2.0.8-r2 --> 2.0.8-r3*
* *gazebo-no-physics-plugin 0.1.1-r1*
* *geometry2 0.25.5-r1 --> 0.25.6-r1*
* *hardware-interface 2.37.0-r1 --> 2.39.1-r1*
* *hardware-interface-testing 2.39.1-r1*
* *joint-limits 2.37.0-r1 --> 2.39.1-r1*
* *kinematics-interface 0.2.0-r1 --> 0.3.0-r1*
* *kinematics-interface-kdl 0.2.0-r1 --> 0.3.0-r1*
* *launch 1.0.4-r1 --> 1.0.5-r1*
* *launch-pytest 1.0.4-r1 --> 1.0.5-r1*
* *launch-testing 1.0.4-r1 --> 1.0.5-r1*
* *launch-testing-ament-cmake 1.0.4-r1 --> 1.0.5-r1*
* *launch-xml 1.0.4-r1 --> 1.0.5-r1*
* *launch-yaml 1.0.4-r1 --> 1.0.5-r1*
* *leo 1.2.0-r1 --> 1.2.1-r1*
* *leo-description 1.2.0-r1 --> 1.2.1-r1*
* *leo-msgs 1.2.0-r1 --> 1.2.1-r1*
* *leo-teleop 1.2.0-r1 --> 1.2.1-r1*
* *mp2p-icp 1.1.1-r1 --> 1.2.0-r1*
* *ntrip-client 1.2.0-r1 --> 1.3.0-r1*
* *pcl-conversions 2.4.0-r5 --> 2.4.0-r6*
* *pcl-ros 2.4.0-r5 --> 2.4.0-r6*
* *perception-pcl 2.4.0-r5 --> 2.4.0-r6*
* *plotjuggler 3.9.0-r1 --> 3.9.1-r1*
* *point-cloud-interfaces 1.0.9-r1 --> 1.0.10-r1*
* *point-cloud-transport 1.0.15-r1 --> 1.0.16-r1*
* *point-cloud-transport-plugins 1.0.9-r1 --> 1.0.10-r1*
* *point-cloud-transport-py 1.0.15-r1 --> 1.0.16-r1*
* *psdk-interfaces 0.0.5-r1 --> 1.1.0-r1*
* *psdk-wrapper 0.0.5-r1 --> 1.1.0-r1*
* *rclpy 3.3.11-r1 --> 3.3.12-r1*
* *rcpputils 2.4.1-r1 --> 2.4.2-r1*
* *rcutils 5.1.4-r1 --> 5.1.5-r1*
* *robotraconteur 1.0.0-r1 --> 1.0.0-r2*
* *ros2-control 2.37.0-r1 --> 2.39.1-r1*
* *ros2-control-test-assets 2.37.0-r1 --> 2.39.1-r1*
* *ros2action 0.18.8-r1 --> 0.18.9-r1*
* *ros2caret 0.5.0-r2 --> 0.5.0-r6*
* *ros2cli 0.18.8-r1 --> 0.18.9-r1*
* *ros2cli-test-interfaces 0.18.8-r1 --> 0.18.9-r1*
* *ros2component 0.18.8-r1 --> 0.18.9-r1*
* *ros2controlcli 2.37.0-r1 --> 2.39.1-r1*
* *ros2doctor 0.18.8-r1 --> 0.18.9-r1*
* *ros2interface 0.18.8-r1 --> 0.18.9-r1*
* *ros2lifecycle 0.18.8-r1 --> 0.18.9-r1*
* *ros2lifecycle-test-fixtures 0.18.8-r1 --> 0.18.9-r1*
* *ros2multicast 0.18.8-r1 --> 0.18.9-r1*
* *ros2node 0.18.8-r1 --> 0.18.9-r1*
* *ros2param 0.18.8-r1 --> 0.18.9-r1*
* *ros2pkg 0.18.8-r1 --> 0.18.9-r1*
* *ros2run 0.18.8-r1 --> 0.18.9-r1*
* *ros2service 0.18.8-r1 --> 0.18.9-r1*
* *ros2topic 0.18.8-r1 --> 0.18.9-r1*
* *rqt 1.1.6-r2 --> 1.1.7-r1*
* *rqt-console 2.0.2-r3 --> 2.0.3-r1*
* *rqt-controller-manager 2.37.0-r1 --> 2.39.1-r1*
* *rqt-gauges 0.0.1-r1 --> 0.0.2-r1*
* *rqt-gui 1.1.6-r2 --> 1.1.7-r1*
* *rqt-gui-cpp 1.1.6-r2 --> 1.1.7-r1*
* *rqt-gui-py 1.1.6-r2 --> 1.1.7-r1*
* *rqt-py-common 1.1.6-r2 --> 1.1.7-r1*
* *rtabmap 0.21.3-r1 --> 0.21.4-r1*
* *rtabmap-conversions 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-demos 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-examples 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-launch 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-msgs 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-odom 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-python 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-ros 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-rviz-plugins 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-slam 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-sync 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-util 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-viz 0.21.3-r1 --> 0.21.4-r2*
* *rviz-assimp-vendor 11.2.10-r1 --> 11.2.11-r1*
* *rviz-common 11.2.10-r1 --> 11.2.11-r1*
* *rviz-default-plugins 11.2.10-r1 --> 11.2.11-r1*
* *rviz-ogre-vendor 11.2.10-r1 --> 11.2.11-r1*
* *rviz-rendering 11.2.10-r1 --> 11.2.11-r1*
* *rviz-rendering-tests 11.2.10-r1 --> 11.2.11-r1*
* *rviz-visual-testing-framework 11.2.10-r1 --> 11.2.11-r1*
* *rviz2 11.2.10-r1 --> 11.2.11-r1*
* *sick-scan-xd 3.1.11-r1 --> 3.1.11-r3*
* *simple-launch 1.9.0-r1 --> 1.9.1-r1*
* *spinnaker-camera-driver 2.0.8-r2 --> 2.0.8-r3*
* *tf2 0.25.5-r1 --> 0.25.6-r1*
* *tf2-bullet 0.25.5-r1 --> 0.25.6-r1*
* *tf2-eigen 0.25.5-r1 --> 0.25.6-r1*
* *tf2-eigen-kdl 0.25.5-r1 --> 0.25.6-r1*
* *tf2-geometry-msgs 0.25.5-r1 --> 0.25.6-r1*
* *tf2-kdl 0.25.5-r1 --> 0.25.6-r1*
* *tf2-msgs 0.25.5-r1 --> 0.25.6-r1*
* *tf2-py 0.25.5-r1 --> 0.25.6-r1*
* *tf2-ros 0.25.5-r1 --> 0.25.6-r1*
* *tf2-ros-py 0.25.5-r1 --> 0.25.6-r1*
* *tf2-sensor-msgs 0.25.5-r1 --> 0.25.6-r1*
* *tf2-tools 0.25.5-r1 --> 0.25.6-r1*
* *tracetools-trace 4.1.1-r1*
* *transmission-interface 2.37.0-r1 --> 2.39.1-r1*
* *ur-client-library 1.3.4-r1 --> 1.3.5-r1*
* *zlib-point-cloud-transport 1.0.9-r1 --> 1.0.10-r1*
* *zstd-point-cloud-transport 1.0.9-r1 --> 1.0.10-r1*

Iron Changes:
-------------
* *etsi-its-cam-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-cam-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-cam-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-messages 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-msgs-utils 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-primitives-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-rviz-plugins 2.0.0-r1 --> 2.0.1-r1*
* *flir-camera-description 2.0.8-r1 --> 2.0.8-r2*
* *flir-camera-msgs 2.0.8-r1 --> 2.0.8-r2*
* *mp2p-icp 1.1.1-r1 --> 1.2.0-r1*
* *ntrip-client 1.2.0-r3 --> 1.3.0-r1*
* *plotjuggler-ros 2.1.0-r1 --> 2.1.1-r1*
* *point-cloud-interfaces 2.0.3-r1 --> 2.0.4-r1*
* *point-cloud-transport-plugins 2.0.3-r1 --> 2.0.4-r1*
* *rqt-gauges 0.0.1-r1 --> 0.0.2-r1*
* *rtabmap 0.21.3-r1 --> 0.21.4-r1*
* *rtabmap-conversions 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-demos 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-examples 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-launch 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-msgs 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-odom 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-python 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-ros 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-rviz-plugins 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-slam 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-sync 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-util 0.21.3-r1 --> 0.21.4-r2*
* *rtabmap-viz 0.21.3-r1 --> 0.21.4-r2*
* *simple-launch 1.9.0-r1 --> 1.9.1-r1*
* *spinnaker-camera-driver 2.0.8-r1 --> 2.0.8-r2*
* *tracetools-trace 6.3.1-r1*
* *ur-client-library 1.3.4-r1 --> 1.3.5-r1*
* *zlib-point-cloud-transport 2.0.3-r1 --> 2.0.4-r1*
* *zstd-point-cloud-transport 2.0.3-r1 --> 2.0.4-r1*

Noetic Changes:
---------------
* *care-o-bot 0.7.10-r1 --> 0.7.11-r1*
* *care-o-bot-robot 0.7.10-r1 --> 0.7.11-r1*
* *care-o-bot-simulation 0.7.10-r1 --> 0.7.11-r1*
* *cob-3d-mapping-msgs 0.6.19-r1 --> 0.6.20-r1*
* *cob-actions 0.7.9-r1 --> 0.7.10-r1*
* *cob-android 0.1.10-r1 --> 0.1.11-r1*
* *cob-android-msgs 0.1.10-r1 --> 0.1.11-r1*
* *cob-android-resource-server 0.1.10-r1 --> 0.1.11-r1*
* *cob-android-script-server 0.1.10-r1 --> 0.1.11-r1*
* *cob-android-settings 0.1.10-r1 --> 0.1.11-r1*
* *cob-base-controller-utils 0.8.22-r1 --> 0.8.23-r1*
* *cob-base-drive-chain 0.7.15-r1 --> 0.7.16-r2*
* *cob-base-velocity-smoother 0.8.22-r1 --> 0.8.23-r1*
* *cob-bms-driver 0.7.15-r1 --> 0.7.16-r2*
* *cob-bringup 0.7.9-r1 --> 0.7.10-r1*
* *cob-bringup-sim 0.7.7-r1 --> 0.7.8-r1*
* *cob-calibration-data 0.6.18-r1 --> 0.6.19-r1*
* *cob-cam3d-throttle 0.6.19-r1 --> 0.6.20-r1*
* *cob-canopen-motor 0.7.15-r1 --> 0.7.16-r2*
* *cob-cartesian-controller 0.8.22-r1 --> 0.8.23-r1*
* *cob-collision-monitor 0.7.8-r1 --> 0.7.9-r1*
* *cob-collision-velocity-filter 0.8.22-r1 --> 0.8.23-r1*
* *cob-command-gui 0.6.33-r1 --> 0.6.34-r1*
* *cob-command-tools 0.6.33-r1 --> 0.6.34-r1*
* *cob-common 0.7.9-r1 --> 0.7.10-r1*
* *cob-control 0.8.22-r1 --> 0.8.23-r1*
* *cob-control-mode-adapter 0.8.22-r1 --> 0.8.23-r1*
* *cob-control-msgs 0.8.22-r1 --> 0.8.23-r1*
* *cob-dashboard 0.6.33-r1 --> 0.6.34-r1*
* *cob-default-env-config 0.6.13-r1 --> 0.6.14-r1*
* *cob-default-robot-behavior 0.7.9-r1 --> 0.7.10-r1*
* *cob-default-robot-config 0.7.9-r1 --> 0.7.10-r1*
* *cob-description 0.7.9-r1 --> 0.7.10-r1*
* *cob-docker-control 0.6.12-r1 --> 0.6.13-r1*
* *cob-driver 0.7.15-r1 --> 0.7.16-r2*
* *cob-elmo-homing 0.7.15-r1 --> 0.7.16-r2*
* *cob-environments 0.6.13-r1 --> 0.6.14-r1*
* *cob-extern 0.6.18-r1 --> 0.6.19-r1*
* *cob-footprint-observer 0.8.22-r1 --> 0.8.23-r1*
* *cob-frame-tracker 0.8.22-r1 --> 0.8.23-r1*
* *cob-gazebo 0.7.7-r1 --> 0.7.8-r1*
* *cob-gazebo-objects 0.7.7-r1 --> 0.7.8-r1*
* *cob-gazebo-plugins 0.7.7-r1 --> 0.7.8-r1*
* *cob-gazebo-ros-control 0.7.7-r1 --> 0.7.8-r1*
* *cob-gazebo-tools 0.7.7-r1 --> 0.7.8-r1*
* *cob-gazebo-worlds 0.7.7-r1 --> 0.7.8-r1*
* *cob-generic-can 0.7.15-r1 --> 0.7.16-r2*
* *cob-grasp-generation 0.7.8-r1 --> 0.7.9-r1*
* *cob-hand 0.6.10-r1 --> 0.6.11-r1*
* *cob-hand-bridge 0.6.10-r1 --> 0.6.11-r1*
* *cob-hardware-config 0.7.9-r1 --> 0.7.10-r1*
* *cob-hardware-emulation 0.8.22-r1 --> 0.8.23-r1*
* *cob-helper-tools 0.6.33-r1 --> 0.6.34-r1*
* *cob-image-flip 0.6.19-r1 --> 0.6.20-r1*
* *cob-light 0.7.15-r1 --> 0.7.16-r2*
* *cob-linear-nav 0.6.14-r1 --> 0.6.15-r1*
* *cob-lookat-action 0.7.8-r1 --> 0.7.9-r1*
* *cob-manipulation 0.7.8-r1 --> 0.7.9-r1*
* *cob-manipulation-msgs 0.7.8-r1 --> 0.7.9-r1*
* *cob-map-accessibility-analysis 0.6.14-r1 --> 0.6.15-r1*
* *cob-mapping-slam 0.6.14-r1 --> 0.6.15-r1*
* *cob-mecanum-controller 0.8.22-r1 --> 0.8.23-r1*
* *cob-mimic 0.7.15-r1 --> 0.7.16-r2*
* *cob-model-identifier 0.8.22-r1 --> 0.8.23-r1*
* *cob-monitoring 0.6.33-r1 --> 0.6.34-r1*
* *cob-moveit-bringup 0.7.8-r1 --> 0.7.9-r1*
* *cob-moveit-config 0.7.9-r1 --> 0.7.10-r1*
* *cob-moveit-interface 0.7.8-r1 --> 0.7.9-r1*
* *cob-msgs 0.7.9-r1 --> 0.7.10-r1*
* *cob-navigation 0.6.14-r1 --> 0.6.15-r1*
* *cob-navigation-config 0.6.14-r1 --> 0.6.15-r1*
* *cob-navigation-global 0.6.14-r1 --> 0.6.15-r1*
* *cob-navigation-local 0.6.14-r1 --> 0.6.15-r1*
* *cob-navigation-slam 0.6.14-r1 --> 0.6.15-r1*
* *cob-object-detection-msgs 0.6.19-r1 --> 0.6.20-r1*
* *cob-object-detection-visualizer 0.6.19-r1 --> 0.6.20-r1*
* *cob-obstacle-distance 0.8.22-r1 --> 0.8.23-r1*
* *cob-omni-drive-controller 0.8.22-r1 --> 0.8.23-r1*
* *cob-perception-common 0.6.19-r1 --> 0.6.20-r1*
* *cob-perception-msgs 0.6.19-r1 --> 0.6.20-r1*
* *cob-phidget-em-state 0.7.15-r1 --> 0.7.16-r2*
* *cob-phidget-power-state 0.7.15-r1 --> 0.7.16-r2*
* *cob-phidgets 0.7.15-r1 --> 0.7.16-r2*
* *cob-reflector-referencing 0.6.12-r1 --> 0.6.13-r1*
* *cob-relayboard 0.7.15-r1 --> 0.7.16-r2*
* *cob-robots 0.7.9-r1 --> 0.7.10-r1*
* *cob-safety-controller 0.6.12-r1 --> 0.6.13-r1*
* *cob-scan-unifier 0.7.15-r1 --> 0.7.16-r2*
* *cob-script-server 0.6.33-r1 --> 0.6.34-r1*
* *cob-sick-lms1xx 0.7.15-r1 --> 0.7.16-r2*
* *cob-sick-s300 0.7.15-r1 --> 0.7.16-r2*
* *cob-simulation 0.7.7-r1 --> 0.7.8-r1*
* *cob-sound 0.7.15-r1 --> 0.7.16-r2*
* *cob-srvs 0.7.9-r1 --> 0.7.10-r1*
* *cob-substitute 0.6.12-r1 --> 0.6.13-r1*
* *cob-supported-robots 0.6.17-r1 --> 0.6.18-r1*
* *cob-teleop 0.6.33-r1 --> 0.6.34-r1*
* *cob-trajectory-controller 0.8.22-r1 --> 0.8.23-r1*
* *cob-tricycle-controller 0.8.22-r1 --> 0.8.23-r1*
* *cob-twist-controller 0.8.22-r1 --> 0.8.23-r1*
* *cob-undercarriage-ctrl 0.7.15-r1 --> 0.7.16-r2*
* *cob-utilities 0.7.15-r1 --> 0.7.16-r2*
* *cob-vision-utils 0.6.19-r1 --> 0.6.20-r1*
* *cob-voltage-control 0.7.15-r1 --> 0.7.16-r2*
* *etsi-its-cam-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-cam-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-cam-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-coding 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-denm-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-messages 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-msgs 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-msgs-utils 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-primitives-conversion 2.0.0-r1 --> 2.0.1-r1*
* *etsi-its-rviz-plugins 2.0.0-r1 --> 2.0.1-r1*
* *generic-throttle 0.6.33-r1 --> 0.6.34-r1*
* *image-transport-codecs 2.3.8-r1 --> 2.3.9-r1*
* *ipa-3d-fov-visualization 0.6.19-r1 --> 0.6.20-r1*
* *ipa-differential-docking 0.6.12-r1 --> 0.6.13-r1*
* *laser-scan-densifier 0.7.15-r1 --> 0.7.16-r2*
* *libdlib 0.6.18-r1 --> 0.6.19-r1*
* *libntcan 0.6.18-r1 --> 0.6.19-r1*
* *libpcan 0.6.18-r1 --> 0.6.19-r1*
* *libphidgets 0.6.18-r1 --> 0.6.19-r1*
* *marine-acoustic-msgs 2.0.1-r1*
* *marine-sensor-msgs 2.0.1-r1*
* *ntrip-client 1.2.0-r1 --> 1.3.0-r1*
* *opengm 0.6.18-r1 --> 0.6.19-r1*
* *plotjuggler 3.9.0-r1 --> 3.9.1-r1*
* *plotjuggler-ros 2.1.0-r1 --> 2.1.1-r2*
* *raw-description 0.7.9-r1 --> 0.7.10-r1*
* *rtabmap 0.21.3-r1 --> 0.21.4-r1*
* *rtabmap-conversions 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-costmap-plugins 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-demos 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-examples 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-launch 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-legacy 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-msgs 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-odom 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-python 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-ros 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-rviz-plugins 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-slam 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-sync 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-util 0.21.3-r4 --> 0.21.4-r1*
* *rtabmap-viz 0.21.3-r4 --> 0.21.4-r1*
* *scenario-test-tools 0.6.33-r1 --> 0.6.34-r1*
* *service-tools 0.6.33-r1 --> 0.6.34-r1*
* *ur-client-library 1.3.4-r1 --> 1.3.5-r1*

Rolling Changes:
----------------
* *data-tamer-cpp 0.9.1-r1 --> 0.9.4-r2*
* *data-tamer-msgs 0.9.1-r1 --> 0.9.4-r2*
* *dual-arm-panda-moveit-config 2.1.1-r1 --> 3.0.0-r1*
* *fastrtps 2.11.2-r1 --> 2.13.2-r1*
* *foxglove-bridge 0.7.5-r1 --> 0.7.6-r1*
* *moveit-resources 2.1.1-r1 --> 3.0.0-r1*
* *moveit-resources-fanuc-description 2.1.1-r1 --> 3.0.0-r1*
* *moveit-resources-fanuc-moveit-config 2.1.1-r1 --> 3.0.0-r1*
* *moveit-resources-panda-description 2.1.1-r1 --> 3.0.0-r1*
* *moveit-resources-panda-moveit-config 2.1.1-r1 --> 3.0.0-r1*
* *moveit-resources-pr2-description 2.1.1-r1 --> 3.0.0-r1*
* *mp2p-icp 1.1.1-r1 --> 1.2.0-r1*
* *ntrip-client 1.2.0-r2 --> 1.3.0-r1*
* *octomap-mapping 2.0.0-r3 --> 2.1.0-r1*
* *octomap-server 2.0.0-r3 --> 2.1.0-r1*
* *ouster-msgs 0.5.0-r2 --> 0.5.1-r1*
* *point-cloud-interfaces 3.0.2-r1 --> 3.0.3-r1*
* *point-cloud-transport 3.0.3-r1 --> 3.0.4-r1*
* *point-cloud-transport-plugins 3.0.2-r1 --> 3.0.3-r1*
* *point-cloud-transport-py 3.0.3-r1 --> 3.0.4-r1*
* *pointcloud-to-laserscan 2.0.1-r3 --> 2.0.2-r1*
* *ros2-ouster 0.5.0-r2 --> 0.5.1-r1*
* *rqt-gauges 0.0.1-r1 --> 0.0.2-r1*
* *simple-launch 1.8.0-r1 --> 1.9.1-r1*
* *slider-publisher 2.2.1-r2 --> 2.3.1-r1*
* *ur-client-library 1.3.4-r1 --> 1.3.5-r1*
* *zlib-point-cloud-transport 3.0.2-r1 --> 3.0.3-r1*
* *zstd-point-cloud-transport 3.0.2-r1 --> 3.0.3-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libxkbcommon-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-smbus
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

