### PR TITLE
- moveit-kinematics: add moveit-ros-planning to build inputs

### DIFF
--- a/distros/humble/moveit-kinematics/default.nix
+++ b/distros/humble/moveit-kinematics/default.nix
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-param-builder moveit-configs-utils moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
-  propagatedBuildInputs = [ class-loader eigen moveit-common moveit-core moveit-msgs orocos-kdl-vendor pluginlib python3Packages.lxml tf2 tf2-kdl urdfdom ];
+  propagatedBuildInputs = [ class-loader eigen moveit-common moveit-core moveit-msgs moveit-ros-planning orocos-kdl-vendor pluginlib python3Packages.lxml tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {


### PR DESCRIPTION
Build errors out otherwise.