### PR TITLE
gazebo: add wrapGAppsHook

### DIFF
--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -5,6 +5,7 @@
 , ignition-common ? ignition.common, ignition-math ? ignition.math4
 , ignition-transport ? ignition.transport8, ignition-msgs ? ignition.msgs5
 , ignition-fuel-tools ? ignition.fuel-tools4
+, wrapGAppsHook
 
 , bullet, withBulletEngineSupport ? false }:
 
@@ -21,7 +22,7 @@ mkDerivation rec {
 
   cmakeFlags = [ "-DUSE_HOST_CFLAGS=False" ];
 
-  nativeBuildInputs = [ cmake pkg-config ronn ];
+  nativeBuildInputs = [ cmake pkg-config ronn wrapGAppsHook ];
 
   buildInputs = [
     libGL


### PR DESCRIPTION
makes the derivation more pure, without this it leads to (gzclient:1568911): GLib-GIO-ERROR **: 15:37:29.803: No GSettings schemas are installed on the system, unless you happen to be lucky enough to have the right files in your environment