### PR TITLE
rosdistro sync, Fri Mar 15 13:07:36 2024

### DIFF
--- a/distros/humble/apriltag/default.nix
+++ b/distros/humble/apriltag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, opencv, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-apriltag";
-  version = "3.2.0-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/humble/apriltag/3.2.0-2.tar.gz";
-    name = "3.2.0-2.tar.gz";
-    sha256 = "fc489bc60d251437c4e25fb49c00dae9883dfbcce466b13ba179a7ba29c09e95";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/humble/apriltag/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "fe3806ce91f6ad0007f50473631d0ef1dd3136474f2f4f3ec5e726ad9b7b5fd4";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake python3Packages.numpy ];
+  buildInputs = [ cmake python3 python3Packages.numpy ];
   checkInputs = [ opencv opencv.cxxdev ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "6f78411f04c8aca816662bad2bd9cc4e2863d9e69ff135f52838c6788b478e86";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "7b80d458f997b338545edc3fa04857f348d4b084095391ca35c28de36c8e8c3e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/cmake-generate-parameter-module-example/default.nix
+++ b/distros/humble/cmake-generate-parameter-module-example/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-cmake-generate-parameter-module-example";
+  version = "0.3.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/cmake_generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "4297eeabee5a00e4e13362018b0c66a1ec50230bd0e0b111569cc3a7c27c3333";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module with cmake.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "60fb5461e793042d5c674d01faaa49b38aeb1ef9dbbbdbeb9c7deec7b4ec2a6d";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "5353138a85680f1f05493875db8927adf35065d2088cb52be281092ac9611fb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.8-r3";
+  version = "2.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.8-3.tar.gz";
-    name = "2.0.8-3.tar.gz";
-    sha256 = "36db1c9a8e803c8dabf3fd221a1477dad144e81b7d1acde0c956b9f0737b3d7b";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.1.13-1.tar.gz";
+    name = "2.1.13-1.tar.gz";
+    sha256 = "d460f83d18379c3c7df34bd969a6525df92cf87d5a752f298acf44dd56fd282b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.8-r3";
+  version = "2.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.8-3.tar.gz";
-    name = "2.0.8-3.tar.gz";
-    sha256 = "bbd0f118cc69b2f3dd87ddcb0354dbbec4210780ef00146e4a9c7f8518e4234b";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.1.13-1.tar.gz";
+    name = "2.1.13-1.tar.gz";
+    sha256 = "5c66c4b64b7bd1cbce83bb8f9561ed64c69e0a21336007c6c461165156a881c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "9b723972cc752894f1999f6389b1a5b5de5907315dacd02ee81cf1e44390640c";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "6247e486cc8f1801866ed49fe27205d798fd640bda7fdc70839face2fce07d0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-py/default.nix
+++ b/distros/humble/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-py";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "0c1dbaad18fc2abc2e498e96442c9749419b8e6c71579daaadfa1d1fbc021246";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "8c7fc9d771455c021ab6e23034055c13c3f43a2511f2c94d3d8d55869a630ff7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "dd613acf03ee7c06c93b3f71cfb8a21ff5a6207fa2bcb501af6184a3e922b838";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "949d568868cfb9de77cd18b8ead166b54d2eec57325256fbceceeb1d701fefc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-module-example/default.nix
+++ b/distros/humble/generate-parameter-module-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-module-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "541046c0c70cf5df383818d08a08bcc5e3f220d6058e9e71c7c2a47d0bb159c5";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "fff2b7def1c2da4146aba1ec93cb4295f15dcc0bec71f1b8a5da7c1b927f6f89";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -362,6 +362,8 @@ self: super: {
 
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
+ cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
+
  cob-actions = self.callPackage ./cob-actions {};
 
  cob-msgs = self.callPackage ./cob-msgs {};
@@ -786,7 +788,11 @@ self: super: {
 
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
 
+ generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
+
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -2387,6 +2393,8 @@ self: super: {
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
+
+ spinnaker-synchronized-camera-driver = self.callPackage ./spinnaker-synchronized-camera-driver {};
 
  splsm-7 = self.callPackage ./splsm-7 {};
 

--- a/distros/humble/libphidget22/default.nix
+++ b/distros/humble/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-humble-libphidget22";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/libphidget22/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "ba9b0efce856d2c750015b277ce27595fdb93e9a9b4a385ee7de77905afcd7b0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/libphidget22/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c7a2796129e60c2a37d01b261162851a25141416f984cf14196fca619075e08b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/motion-capture-tracking-interfaces/default.nix
+++ b/distros/humble/motion-capture-tracking-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-motion-capture-tracking-interfaces";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking_interfaces/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "318bf3b94084d418aa57a077c0c936166c10d641d9914d3eb5c93db74cfbd492";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking_interfaces/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f175cf9133f7a9c71192d1f21ace127b4ce5e37aa0baa6b45cd5f743db1f93a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/motion-capture-tracking/default.nix
+++ b/distros/humble/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-motion-capture-tracking";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "a1b2115dfa4fa78e45bc193bdfd04f815e5e7592727d60330c338271cd3dafed";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e453b522cc0d7cc301f50034f793420ad73dd562f308e9251045953ce97af666";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "89ed6b444a9c2aadc0f5b0db472d7cd67a0d30b9a8c8df40d8dac393c80a53fb";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0592aefd609388d5065e8f17fe3762133328f67f939c9d4797b58cc40401211d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.11.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "d85a18e539ea4cf2419ff4067245dc3fc19d512971723c22d50829e3ab45bc54";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.12-1.tar.gz";
+    name = "2.11.12-1.tar.gz";
+    sha256 = "15431817414bb0f74a0f2ffdad8023ac06c761c66c06c67837b00e84b1dc0917";
   };
 
   buildType = "cmake";

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "44cd95440c4a5cec51563a1243eea8acc8ee155212dabdf44db1df2a4b297501";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "c8ea4fdd18bbeb455c54c7cab30502e47bf4f91dac12fb96d05e929fa1be5fe6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-accelerometer/default.nix
+++ b/distros/humble/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-accelerometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_accelerometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f1f7d2924805fb147683a6e7e9b7e0e7867740d767f85211db13a7691f0ae9cd";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_accelerometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "e77adf22ca94e2b9934bd6ac3f2e3af0352187548833c738564dbb413c1f526a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-analog-inputs/default.nix
+++ b/distros/humble/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-analog-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "8f507032c9a18b36742667776af76ef9df3a575c73c3d5ca870fba228f81b4d5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "9837c9be3ee053a2669c51314dc6a28712283bd1d021c4f76f33367daadb3de5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-analog-outputs/default.nix
+++ b/distros/humble/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-analog-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "c2137a2fe32a6f2e1cdf61b3720e82b7b9348bc44ae941fccfec609e41548b0e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "1495dacf4f5724b229fed0f8dc07e7d0affdff401bd5379f8095de63dad1906f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-api/default.nix
+++ b/distros/humble/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-humble-phidgets-api";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_api/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "0ed49709613bf3a37b87211b15f148ceb4fc7534222c3a4ba72a94b53f7053cc";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "0656b2b9b283f008a0ed03c64795d4615d24cdf31387b1bee19988fee18703b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-digital-inputs/default.nix
+++ b/distros/humble/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-digital-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "afed4616956fb988b4eba1173d0c6f6a72aaa2ccbb3a9cb14577bd95c36fd419";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "d3bba232005e07a87fa1070eb21e9a1f57487563413e98f57d3468a47f35c4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-digital-outputs/default.nix
+++ b/distros/humble/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-digital-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "bcd4824c27bac1d475502097082e4057f7c14fcb214838e3effd5548dc64bd53";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5cec62f533d31df66723c9e0c1053d14eddc9e2329b79dc305dde0805a7619b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-drivers/default.nix
+++ b/distros/humble/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-humble-phidgets-drivers";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_drivers/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "3bd5cf062b90b2c86e5e410b49663ca5af99e9b97149702cb52bdeed6d928752";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_drivers/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5a7829da71127539210aa45d5348083bead0c5e783cac1aa5a08456899fd151f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-gyroscope/default.nix
+++ b/distros/humble/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-gyroscope";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_gyroscope/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "e8356d1d23311552eb98aa6bb328794ec6262a1989654ab9d6b1741e0aed2010";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_gyroscope/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "976ade6f40422e2c7f863a378900d2cd7734b09d9fe1137fc97e0d7773d3ff0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-high-speed-encoder/default.nix
+++ b/distros/humble/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-high-speed-encoder";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "cfdcd43c4ced7fad39c3747196f44357fb690af9746d6ae770b3a6669d8b14d3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_high_speed_encoder/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "7dd7f1b8cc775d8bd4c401de87140e9a5619985d041fc3d7a1f8682175517ed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-ik/default.nix
+++ b/distros/humble/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-ik";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_ik/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "1dd3bb0f53f336108eabc19eba4d837e61e827406d6aaa3dbd22c4f845ad0a06";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_ik/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c2d6b6550ecfd6de0f6f437bfbdf3cd97a4a88c081f6626825d409885aca9d37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-magnetometer/default.nix
+++ b/distros/humble/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-magnetometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_magnetometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "9474645c0d322d980735a496cc94be2e5bf240b89ea5e1129daba24719568651";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_magnetometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "8105ce10f732b36ae4c45391123afba1f15db3c8363959542c72f0f194d1bd66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-motors/default.nix
+++ b/distros/humble/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-motors";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_motors/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "2dd8754269be49079f22c907ce288a0592d82104ce0a9f122f6de1baa7316346";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_motors/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c1fa00e10bc4d05cb92f5a8f95bfb0dc11cd74c075e56ce570692be02ccdfa50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-msgs/default.nix
+++ b/distros/humble/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-msgs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "15994d6f8f68ce830618ecd5da87102d67877f4fa603478ee14a8b3c9b1ea271";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "41b056a981a273ead1fd2324cd4aaa2e21e2d8952ede3da291e87edebe735b3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-spatial/default.nix
+++ b/distros/humble/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-spatial";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_spatial/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "6b406afeb980aaa4e5e64cfaa2bc21ea2a4390df07002b37ecd8b0a247495c36";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_spatial/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "45fe328cfc5f70822e2b5523ebda7c2a666264bd4b7e160942e13a4d4afcb679";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-temperature/default.nix
+++ b/distros/humble/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-temperature";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_temperature/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "8301cdc3165351f9221a6a9205d849406c9fd683228ab3a9a9d03ee3744a41ed";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_temperature/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a062ce75d929c565c30aee3b3db783bcb81b1f73583daad24e2f2acf194698e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-description/default.nix
+++ b/distros/humble/raspimouse-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ign-ros2-control, joint-state-publisher, joint-state-publisher-gui, launch, realsense2-description, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-description";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1efeb025cfb4d1d272507302a820654ad5f10c7cd199f42a6806678a4f6be0f2";
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ffae980fa75d09ea29705a78cb0818b68595a6055377624b92e79f1932c6914b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-fake/default.nix
+++ b/distros/humble/raspimouse-fake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-fake";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_fake/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4adecba84f76d80c1463225bc67e18b40950cda89b6a652451e83f841defd2e9";
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_fake/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d1408df1c47df7c882c5f485ffb524b3a2295a2ee8c952810b742c7e52cdd7c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-gazebo/default.nix
+++ b/distros/humble/raspimouse-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, raspimouse-description, raspimouse-fake, robot-state-publisher, ros-gz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster, raspimouse-description, raspimouse-fake, robot-state-publisher, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-gazebo";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_gazebo/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "7adc317ef48ae001338b8d53c2d4cb12ac3928d1b7abf11bdc3071cd49cd8a44";
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_gazebo/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "32135b9eb45ff4d333362ced8439b0eaddb45f66c0e157920a377c69ee60a57f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ controller-manager raspimouse-description raspimouse-fake robot-state-publisher ros-gz ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster raspimouse-description raspimouse-fake robot-state-publisher ros-gz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/raspimouse-navigation/default.nix
+++ b/distros/humble/raspimouse-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, nav2-bringup, raspimouse, raspimouse-slam, rplidar-ros, rviz2, urg-node }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-navigation";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_navigation/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "346741fbad99e1bb73faaa57836685d9b075bc2d3498dd51e2d627d6d9507246";
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_navigation/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "075eb97a30504017edb643f751ae63d458668c8548159d4c097b5f45e074d189";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-ros2-examples/default.nix
+++ b/distros/humble/raspimouse-ros2-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, usb-cam, v4l-utils }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-ros2-examples";
-  version = "2.1.0-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4567bff84be33ef7d59c41fb4945ba38adb19accd63aa094748f07cf385e20ba";
+    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "0554257dd89a8ab704a2ee597cd9ee16a38d404e3735085eb7c5fb15fae0ff30";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv opencv.cxxdev raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs v4l-utils ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv opencv.cxxdev raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs usb-cam v4l-utils ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/raspimouse-sim/default.nix
+++ b/distros/humble/raspimouse-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-fake, raspimouse-gazebo }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-sim";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_sim/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d6ac04a616abb7bd5a303faebdc4f6f5012fbe02db42ac18199a53d1639c9f00";
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_sim/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3f27d185166372abae4c7ae1bf490c4ec31e6197773cfd1d82e2bbfe9b703f85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-slam-navigation/default.nix
+++ b/distros/humble/raspimouse-slam-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-navigation, raspimouse-slam }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-slam-navigation";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam_navigation/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "5a9489190a4b66b2ae957c592212ef587707e2cb170b0653f9214ff69ec5bd36";
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam_navigation/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "32722e53ba88069bdcfb9ac83203c56daaddc07e2113f52c4ba63d542475e541";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-slam/default.nix
+++ b/distros/humble/raspimouse-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, joint-state-publisher, joy-linux, nav2-map-server, raspimouse, raspimouse-description, raspimouse-ros2-examples, robot-state-publisher, rplidar-ros, rviz2, slam-toolbox, urg-node, xacro }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-slam";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8bffec08cfe0808dbb3eea36d7393381628e1c0be7a4d32a23fbb5592c240d3d";
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "783dfc6c4ac4cf0c97a22bcb9960f20a9603a9f4c76fe23a658e93d222a16ab1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rc-genicam-api/default.nix
+++ b/distros/humble/rc-genicam-api/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-humble-rc-genicam-api";
-  version = "2.6.1-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/humble/rc_genicam_api/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "4cdc2098ffb586101b7c130bda8073b5ffb7f71687ae4c7c4f7e09413458c609";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/humble/rc_genicam_api/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "3c36c72e5d2f853918def54567cbd33fc2e806feb4d9c575029ee5cc1fa693e0";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libpng libusb1 ];
+  propagatedBuildInputs = [ libpng libusb1 ncurses ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/rqt-gauges/default.nix
+++ b/distros/humble/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-gauges";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/humble/rqt_gauges/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "43b9cb3e99359ead65731c49f5d2402afa06a8ecffe7d2839e68e0f677fd7b58";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/humble/rqt_gauges/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "d2598a85f94ad6a5f6833aeac3af8de694036eadfb036b9cda82e45d4ca4e43e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/sick-scan-xd/default.nix
+++ b/distros/humble/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-sick-scan-xd";
-  version = "3.1.11-r3";
+  version = "3.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_scan_xd-release/archive/release/humble/sick_scan_xd/3.1.11-3.tar.gz";
-    name = "3.1.11-3.tar.gz";
-    sha256 = "6fa1966620d69c090a7e28defea775aaa6724dcbb2f881d36138d08de51aa92a";
+    url = "https://github.com/ros2-gbp/sick_scan_xd-release/archive/release/humble/sick_scan_xd/3.2.5-1.tar.gz";
+    name = "3.2.5-1.tar.gz";
+    sha256 = "40b3d8502f6a7b2c6f11d8ea9d55f5d5f749fbdce66749c835bffcae96e40ac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.8-r3";
+  version = "2.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.8-3.tar.gz";
-    name = "2.0.8-3.tar.gz";
-    sha256 = "db632c142b60bc0df147152dee60ed79c5a394f0851fa7ed6546d5739df5f541";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.1.13-1.tar.gz";
+    name = "2.1.13-1.tar.gz";
+    sha256 = "1105918bcb128a071271f3ff18b10caa242bf1e2b3e2f4797a256d607a3a241e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/humble/spinnaker-synchronized-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
+buildRosPackage {
+  pname = "ros-humble-spinnaker-synchronized-camera-driver";
+  version = "2.1.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_synchronized_camera_driver/2.1.13-1.tar.gz";
+    name = "2.1.13-1.tar.gz";
+    sha256 = "9c36a13cf66d497d8e1958119dbb2a60e284b143c33c0e082e5070172411bcba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components spinnaker-camera-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver for synchronized flir cameras using the Spinnaker SDK'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/teleop-twist-keyboard/default.nix
+++ b/distros/humble/teleop-twist-keyboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
 buildRosPackage {
   pname = "ros-humble-teleop-twist-keyboard";
-  version = "2.3.2-r4";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/humble/teleop_twist_keyboard/2.3.2-4.tar.gz";
-    name = "2.3.2-4.tar.gz";
-    sha256 = "74c1b9d9105826029bf614c66abd1414ec1f7b87697c5d97e286e0740123718a";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/humble/teleop_twist_keyboard/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "32c54e0b5e1c03d6ef24be8ed5f14e47fa17dbbdcc53ef80157734df61d11572";
   };
 
   buildType = "ament_python";

--- a/distros/humble/wireless-msgs/default.nix
+++ b/distros/humble/wireless-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-wireless-msgs";
-  version = "1.0.1-r2";
+  version = "1.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_msgs/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "b98ca63ded730e8c29e17e6a181c6f02757d29d88d83906575298df1be5c30d6";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_msgs/1.0.1-3.tar.gz";
+    name = "1.0.1-3.tar.gz";
+    sha256 = "99a4eb2721187e34aac47fecf05ac57e6c370d4d2b33bc3f15dcdc3fe275a709";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/wireless-watcher/default.nix
+++ b/distros/humble/wireless-watcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, wireless-msgs, wirelesstools }:
 buildRosPackage {
   pname = "ros-humble-wireless-watcher";
-  version = "1.0.1-r2";
+  version = "1.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_watcher/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "b6a676b9466668ae678049eb476411ca1bac2a7d3b888e9541c7eb319d5b1d4e";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_watcher/1.0.1-3.tar.gz";
+    name = "1.0.1-3.tar.gz";
+    sha256 = "010038d379705a30cd71aa488ff8da5464112d778b8e3bbf2287114495c1578d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/azure-iot-sdk-c/default.nix
+++ b/distros/iron/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-iron-azure-iot-sdk-c";
-  version = "1.12.0-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "b35017fcc97c8020d789900557eef5137903e94ced3c3b6c037750b9242cf736";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "02a7e86d2efe916395fbcf0d914a64f663e138ad30b3998e2280b6af9f7ebb6a";
   };
 
   buildType = "cmake";

--- a/distros/iron/cmake-generate-parameter-module-example/default.nix
+++ b/distros/iron/cmake-generate-parameter-module-example/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-cmake-generate-parameter-module-example";
+  version = "0.3.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/cmake_generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "217073e4cfc34e41ffcb4064e70e89035b659ac943e6fe39b550fc9cc308f4a7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module with cmake.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/depthai/default.nix
+++ b/distros/iron/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-depthai";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "95a262e1c68e3150da9768270101963f3756cd52486667a1defde2652d1a9f52";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "94a63a1adf147445d985933d2c0f9d12b69d42af3a3f6fe8a72f658e2f8bc1f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/event-camera-py/default.nix
+++ b/distros/iron/event-camera-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py, rpyutils }:
 buildRosPackage {
   pname = "ros-iron-event-camera-py";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/iron/event_camera_py/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "26e1438be4284ff454f6a6f5d3cf46de08ac090c398a1b44aeca1083ad6a3150";
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/iron/event_camera_py/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "f84d183d6a9d8769d73e476d1ac761e33e32f804efcb5a1d997b1741f7052835";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy rclpy rosbag2-py rosbag2-storage-default-plugins rosidl-runtime-py ];
-  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment rpyutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/iron/flir-camera-description/default.nix
+++ b/distros/iron/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-description";
-  version = "2.0.8-r2";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "c28fdb71a7c4a82b6befe799881c635a7e9e360a7629da25a7c7909b54de09cf";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "058d62cb78ee0830bbb63a36627fdd51a7e905fff3895ea92784c0af13af3778";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/flir-camera-msgs/default.nix
+++ b/distros/iron/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-msgs";
-  version = "2.0.8-r2";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "40a71402d01d7dd098c211fa413c2a732ce05632e53deda81769ec6403ea3cd4";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "01023f30418137021d3d4c02cd0eb7f719fbf85cbba56d1d2f7dfbd876d13cce";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-library-example/default.nix
+++ b/distros/iron/generate-parameter-library-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "3170753249cde8bcbe014651292b45965f71a2eadd1637aac24e5fd50accc940";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "a76ab9a544c27b3123e7ab5993faea42fd7ca0959d065aafd3bc9310ed09c777";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-library-py/default.nix
+++ b/distros/iron/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-py";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "34d0686416877e62693352cd77d7490ccec6ac2fc2ac56d15ce9bc846dbfac62";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "8fe90f5cf8d4499320ed6a992977db6bf8111254b5d6b76254dc66d320068649";
   };
 
   buildType = "ament_python";

--- a/distros/iron/generate-parameter-library/default.nix
+++ b/distros/iron/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "7bad8adac3783a4181d99dcf688b89c6f1ab8ef6176d20cacaac22034e181d68";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "1c7ed4296ae545db1cdc82b4a11c527c93dfe433596a235ae298a96f48772215";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-module-example/default.nix
+++ b/distros/iron/generate-parameter-module-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-module-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "72475cf5472ce06e4f391a2a601e8bfe55adafa28bb1b5aec03e08770a2e72c8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "8e68e10b9dc8959ab2405c2826d553eea809139d3b3216683f7c7953bc6bae58";
   };
 
   buildType = "ament_python";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -238,6 +238,8 @@ self: super: {
 
  classic-bags = self.callPackage ./classic-bags {};
 
+ cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
+
  color-names = self.callPackage ./color-names {};
 
  color-util = self.callPackage ./color-util {};
@@ -640,7 +642,11 @@ self: super: {
 
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
 
+ generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
+
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -2085,6 +2091,8 @@ self: super: {
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
+
+ spinnaker-synchronized-camera-driver = self.callPackage ./spinnaker-synchronized-camera-driver {};
 
  splsm-7 = self.callPackage ./splsm-7 {};
 

--- a/distros/iron/libphidget22/default.nix
+++ b/distros/iron/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-iron-libphidget22";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/libphidget22/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "d4a3e3f94b0e88d08871bd04a71fb1b8e4fd069109733c50414b113ca9aaa2b5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/libphidget22/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "fcbcb17ea740415cd2577b11fa135ab839fc38ef5a5bdd57bc201340ff192502";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/motion-capture-tracking-interfaces/default.nix
+++ b/distros/iron/motion-capture-tracking-interfaces/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-motion-capture-tracking-interfaces";
-  version = "1.0.2-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking_interfaces/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1c304aafc5822a50b52a65b3204a368a2d3ed7c1b9596c0dd7ac62fa48c342ad";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking_interfaces/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "4095ae5847b4ed44fda0f442a96c9f1a69958c9e9914ea657d4625e5ce732220";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/iron/motion-capture-tracking/default.nix
+++ b/distros/iron/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-motion-capture-tracking";
-  version = "1.0.2-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3662a1815abca644937fcab4208e9eb6e78ea4ba04341c9a7e5f0691304d17fa";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "8ed84ec19b7cec06b814c86f8bd34e9c0baf67451a9567ea5170b248cf8e836f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "013a16649971f3e386f3a795b26882591c79aeec25608542c5620769ff73c657";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "189f69380753229bed87ed215b21187e0fa1e42837c5e943f3203ad1816133ee";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.11.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "5e9b3c4ff4b1463483bc7d7be67f786511273725cb5494fea4aae31341877756";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.12-1.tar.gz";
+    name = "2.11.12-1.tar.gz";
+    sha256 = "be9f923337d211730945875e7f9671497c5c5de705ce70d73f2ac146e8723f1a";
   };
 
   buildType = "cmake";

--- a/distros/iron/parameter-traits/default.nix
+++ b/distros/iron/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-parameter-traits";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "cdc317d58b65c57998ea590802e13fbd36dcec5309f6d698afbfe7063ac18e55";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "0b7fa00152ddfd2eb8bace89cdbe138f81bc21322c91200f02a90b3cd2e65419";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-accelerometer/default.nix
+++ b/distros/iron/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-accelerometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_accelerometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "aa6c80a40a8ce930c0896a5cfd83a6ee33f5665c108673d6af0c9f9394bc3334";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_accelerometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "69bf22b77fbce1213f73b291eb339c8bc1ecfd11fb74ee0710efcb657f416910";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-analog-inputs/default.nix
+++ b/distros/iron/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-analog-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "2a5915ec426069e12d28fde80845fe18d8ab761c292998887abc968f92927600";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "7b72140338778c42f184dafcc4984665c79c1207015456a44b0277f52fd84761";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-analog-outputs/default.nix
+++ b/distros/iron/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-analog-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "e45b3d5c258578b0f38c770d32fc5798f86a161d637775761503a9cfce07782a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c9b102283db5363557ed29e87d8e5ec42855abdb10250236d0d294f6d8173567";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-api/default.nix
+++ b/distros/iron/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-iron-phidgets-api";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_api/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "136f1c3fa6a5c5f6aeedea8b0215cf76481f2c900558159c45ee69f52b4366b6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "51dd2225e704bf0870cb46c1c0379ecae191a8dac3e5fe44c2de8602cac1f99b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-digital-inputs/default.nix
+++ b/distros/iron/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-digital-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "6d3587788deb7f9a5427dbce84ecf256207ff0ab18af4eef28b36727c9f0c443";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "9dec5eb36beaa7b9f38ad0c3bf046ec47ff8df8f8d7f9e7789fbaf6619258df8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-digital-outputs/default.nix
+++ b/distros/iron/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-digital-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "57e1f4216480af21aaf9d5a442fcff6359703aa426e82e3f68a1ec1086f16508";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "f4f2f9d282c5f7b74eae617e94870bf7d963651f3735917e6a8ee07f6c4c03c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-drivers/default.nix
+++ b/distros/iron/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-iron-phidgets-drivers";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_drivers/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "d3bc49b5c6a1101ccac4954da7a4f1dc4c2d44bafaddc2f08398d9dae674bee8";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_drivers/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a0bf453122627560758096c47eb86d264c55f5701b95be35c8d863a2ca8001bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-gyroscope/default.nix
+++ b/distros/iron/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-gyroscope";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_gyroscope/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f75efc7558ba579a552fb1b4a3914faf4dd84d8903f48b100eac9ac1f40fbed2";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_gyroscope/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5240674614d8e4f0fa0e71c49aea9f868b25d31084f8db2b7618c8013833627d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-high-speed-encoder/default.nix
+++ b/distros/iron/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-high-speed-encoder";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "02d9e3c5c32d2f763ae47e24b975c740cd742ab8b645d649a342fa4a215e136d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_high_speed_encoder/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "49db649c12afe9e11eb5c3ca656ab1f017c14edc5f907d1079c305f0270bd607";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-ik/default.nix
+++ b/distros/iron/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-ik";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_ik/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "78e073adfe1adf1d0b90a163c6e05277da9a3889907efb51adc09b18a3988440";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_ik/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "370da1d6bfe2f2097481981c4a7bdf852eb2d3934548efa62c46bca3e4717e2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-magnetometer/default.nix
+++ b/distros/iron/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-magnetometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_magnetometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "62acf1e3cf99cc27b2a0ba3472ed3eec26912f9f520e1f433f490dd159af85cc";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_magnetometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a208a8261ca3fd2ab6fa2c14ea38dfe23c446c849075d3527cb5cf6032bd1000";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-motors/default.nix
+++ b/distros/iron/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-motors";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_motors/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "28b56a9db4b195732f6b151084a371be5e961e9e5e5c4b858f939f00757c5fe7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_motors/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a023cb1e158b2a544dd4615401be92048489808641ec9db2c58879147b138fc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-msgs/default.nix
+++ b/distros/iron/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-msgs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "a838f173127f2f123067ca280cb8a68b17d60888f390dc2061014ee477d3fbc0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "d92761c8e0bcd91fd8b6809f2d4d04035b94e67e69e87eb3f10f16bb67bee489";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-spatial/default.nix
+++ b/distros/iron/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-spatial";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_spatial/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "12e7cc27ac1e373401a186653f31fea536596a3a5583b6a0ed7c68c5a825b430";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_spatial/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "296213799ed4f3060f44566fed36cdf5623d62a1cd647a6fb096c4005959fec6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-temperature/default.nix
+++ b/distros/iron/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-temperature";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_temperature/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f468564c332b2c0183dd49e393822f059ae711f8b3edd8eef7632dbfd746e9d2";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_temperature/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a1368091b0be628bd05a77df4ef407bc6efa5e131f103eb27a787c699f39abd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-gauges/default.nix
+++ b/distros/iron/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-gauges";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/iron/rqt_gauges/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "b2104eac32117f2da319023316c8f0b73af6637f503017530d6d51641d6801e3";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/iron/rqt_gauges/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "ccc81b060fea71fda4d5d988d45652b88e089cef0aaa286fd4eada384927da08";
   };
 
   buildType = "ament_python";

--- a/distros/iron/spinnaker-camera-driver/default.nix
+++ b/distros/iron/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-spinnaker-camera-driver";
-  version = "2.0.8-r2";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "313d78fb103ef26ff3b85905902386d71393097d464e2e9e48cd0b4d1f947118";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "2bba7d141187049768f3b7bfcd6e1c3ca15feee2fa94f5bcb4a0ef153ff207ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/iron/spinnaker-synchronized-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
+buildRosPackage {
+  pname = "ros-iron-spinnaker-synchronized-camera-driver";
+  version = "2.2.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_synchronized_camera_driver/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "953579f0479e5d5f5245eba3d17ae1346a5aefed44af8f6914784328e964750c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components spinnaker-camera-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver for synchronized flir cameras using the Spinnaker SDK'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/iron/teleop-twist-keyboard/default.nix
+++ b/distros/iron/teleop-twist-keyboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
 buildRosPackage {
   pname = "ros-iron-teleop-twist-keyboard";
-  version = "2.3.2-r5";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/iron/teleop_twist_keyboard/2.3.2-5.tar.gz";
-    name = "2.3.2-5.tar.gz";
-    sha256 = "e58f953801d5dfbe6f31d687ceb1f3a1f5ba3889bc26f14c070aa7a98ba7de49";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/iron/teleop_twist_keyboard/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a7f6f21fdc75e28c13bf34aa7c635fbbf78a11277175cb98aeea4e9195c7507c";
   };
 
   buildType = "ament_python";

--- a/distros/noetic/camera-aravis/default.nix
+++ b/distros/noetic/camera-aravis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aravis, camera-info-manager, catkin, diagnostic-msgs, dynamic-reconfigure, glib, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-camera-aravis";
-  version = "4.0.5-r3";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.5-3.tar.gz";
-    name = "4.0.5-3.tar.gz";
-    sha256 = "6e0f6a3e6647eec18d87d77c6f2c687454698961b22ad32332d00fb8ab824bf9";
+    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "f3f5e83315b871e70a00a229ecb6a0fea941d2ca335f2f01d2aeeb53ccf79b2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.23.0-r1";
+  version = "2.24.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "8c1f937648cc3f174604169dc79f0851fda2942653065798f5ab75bb5d1a23dc";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.24.0-2.tar.gz";
+    name = "2.24.0-2.tar.gz";
+    sha256 = "1808d74c39484d688f54846357bb4105fe5487922468f9f10bc2483bbaa18d45";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -2432,6 +2432,8 @@ self: super: {
 
  phidgets-high-speed-encoder = self.callPackage ./phidgets-high-speed-encoder {};
 
+ phidgets-humidity = self.callPackage ./phidgets-humidity {};
+
  phidgets-ik = self.callPackage ./phidgets-ik {};
 
  phidgets-magnetometer = self.callPackage ./phidgets-magnetometer {};

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "6f7f6dfe7c964dcc87434885850967cf04e0f73efbb9dd1aed98b3f7cf1c353a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "83c34e6d6b0962497abd568181fc9265f5a56484903e9a01c44c1120469de878";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-geometry-msgs, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.11.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "090cf1e90b7ad7d3bef6bf29fc266ecc124a49f1eb1529f308e0da423170d8cf";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.12-1.tar.gz";
+    name = "2.11.12-1.tar.gz";
+    sha256 = "33bd217c508f094dc38ffd839f212d3aa3ecc1a801d19163567f8811f0b15675";
   };
 
   buildType = "cmake";

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "8085344f3a271328e2ab17eee91c26d5d30271b0025b79b2508ba7b27cdcb160";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "39e3d2e0954bee0dacef1be215916a523ac38ede2f9766ad8e337b06f7aee0a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "47309ebea0e71e9cfe5268a64e1c060ad653d612e7c75ced9f994718e34f0893";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "021b92331c7649a02e99497381e2e007c560fcd922db519c7600385530e7a9ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-outputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "9e37ee97d06875556179553175f1c809acfdba9892a24b2efd6c2f5dca00b6aa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "923551bfd397aaba04ef8acb8e57411223998edde6edc58df55ce379c0245ce5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "c9253eb517be349ae393958d4713bdf698e8e0cde10de78099c5db5fde34441b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3358a03bd9a2648fbc7a8857e89fbe960ab405e6de675083a0eabed03057fb19";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "fa69386af49d7847e4e7b4a8620415e00a2f3dff28cb16fd42a43fa5e75d28aa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7c100312e4352c16706541aa2beaa84730f296ebf31ed36f064ca82a0817c709";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "d8d849b2d0ae65eec75080c58e78de5607d1cfbdccc4fbdbeb9a8b2b552ddb9f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "e1af2c20a2a8f06b55c0321d90273e3f067e5c59e7c60cec3233b1bd00cf2754";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "570610ae7e8377d3c613127797533178d8e34637b7fe5f69c53397081dcf1eff";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "bd139897d0e9dc09b0603ec65e2ac7abe01fae8065a518a3b1eaf6cd7f614696";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "0ec6b91f3f777277f94b73087cae6671796c4fb5a08ea19d13c72dba7a293bd6";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "e31a01ab448c3ce3cfef388980b15ebe96d763e365f1add355f257dba036c15a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "4f39aaf04e9638710a8db22ba2e0ac2ae3a892639aff0c83b6bff81b62da5f3d";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "61ef753f9db2a36f29c025840f304f1331c8288bbed7de67612310de01a385bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-humidity/default.nix
+++ b/distros/noetic/phidgets-humidity/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-humidity";
+  version = "1.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_humidity/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "d0b215669cc86aaf0103becc79fb46d018c315a8e81dd7a9a8550dc40ee31517";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Humidity devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "a1d80e0e81dec854f28245cd2b15484c52c9d11b3dc1ae87ec72751cf5659b94";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0e0e85629bb0480fa9ce35a5c1abce706c0347ae1880e6506f5875af427a4361";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "472670f7a6fe7c538173873537227c32573528ba96f4cdb8cfde7c887f53f3e7";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "31ddb7bb888e7a87840bdd3f5f77aae1eb54d275bb5f8d7f9f5b019c6464b102";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "14b6a856bdba644c2f2e475a26c0baf26dd1e3f867e1d074efdd9676fc06342a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "d2430a197a6635a7b0bbcbd3f7f8152787ccbd30bf73f8cdeb3adcf6ba6ae049";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "c145ac3cd922918f02630e908e794ae4f246f979a2afcd9c7d6c47b87fd26aaf";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "4f9306f91909a8b4a893f0323db97c37166a38aefbbb84066dedc58688be88b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "753bde2f729fe8b93dd41c8098cf4aca73185fcda0ab92888fe911c1d62ffd00";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "6daf3629dbd74c94c859a70b455c640ccf56aa30e9bb9428e55c94bdc817583f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "2fcb7ab02afb1c7781448688d996405200e5742aff2e77ae044022117b3917b9";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "edaf8b2a446c14d6c8958bba2d5c3c6e74a299633fd44e99fbd6e379d7522e5a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
-  version = "2.6.1-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "dcfe40169c77cfca98488db442517f001efe243c98b6baf87c1a59a66d07f792";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "16837d9781d1dde8c502d9185d55f243dc95dcf174c2bbc9b523bff93b98aaec";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libpng libusb1 ];
+  propagatedBuildInputs = [ libpng libusb1 ncurses ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/sick-scan-xd/default.nix
+++ b/distros/noetic/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslib, rospy, rviz, sensor-msgs, std-msgs, tf, tf2, tf2-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan-xd";
-  version = "3.1.5-r1";
+  version = "3.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "6eed40eceaa8dc9bda5c547ade68486317d454d51f005a6bacaf379d67023cce";
+    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.2.6-1.tar.gz";
+    name = "3.2.6-1.tar.gz";
+    sha256 = "17f6417d6b4c3c97d162aca5450ab31f31e5cc19117e9cfb6832ae8327debcef";
   };
 
   buildType = "catkin";

--- a/distros/rolling/apriltag/default.nix
+++ b/distros/rolling/apriltag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, opencv, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-apriltag";
-  version = "3.2.0-r6";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.2.0-6.tar.gz";
-    name = "3.2.0-6.tar.gz";
-    sha256 = "062d373bd1bb3ed898f7db6d6a90380dcf6926133a43397833cd1378596ed00c";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "1793c9596426ce997ea2c038485af35530f6e24fcbcd7c48527460d8bcd1eb53";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake python3Packages.numpy ];
+  buildInputs = [ cmake python3 python3Packages.numpy ];
   checkInputs = [ opencv opencv.cxxdev ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/rolling/cmake-generate-parameter-module-example/default.nix
+++ b/distros/rolling/cmake-generate-parameter-module-example/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
+buildRosPackage {
+  pname = "ros-rolling-cmake-generate-parameter-module-example";
+  version = "0.3.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/cmake_generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "b2fe595aebcd1b184fa8a453ab595bf6d4406937b676fc705e9b0c67eea1bd50";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module with cmake.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "cd4920013bf5dfab4330e112f1ffce0b5df02047c4206adec14b450339c37bba";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "83aab42b1757d1a2cb49ddd1fba6d9c3ee46c234e22eb644426c481ca401686b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "22662dd932cece6ad542d1c86465c868a6d6f3ed753e68f1de347a3d082b0260";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "d3c54eb4c154518da500602aa33218e92e61ec96d6d4240215414d1bf3619e07";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "1613400e536c910c79b07854c50139eb60fb181a8d9fa6d56d2b3c2d93d63ece";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "0f501e40021679d39fa89ca917bffb19b444c12f5b40d3d301cbeed2921e0277";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/filters/default.nix
+++ b/distros/rolling/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-uncrustify, ament-cmake-xmllint, boost, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-filters";
-  version = "2.1.0-r5";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/filters-release/archive/release/rolling/filters/2.1.0-5.tar.gz";
-    name = "2.1.0-5.tar.gz";
-    sha256 = "4fbe698a563b73bc4d3505c987e0df1e552815b9b2755a785f4c1669af19797c";
+    url = "https://github.com/ros2-gbp/filters-release/archive/release/rolling/filters/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ca5c6ffe6084ad9468f9e6b7e86b1346a5f4416a52c272dbc20cd3c1565af1df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-library-example/default.nix
+++ b/distros/rolling/generate-parameter-library-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "9ab0b0d9763442d0c6a384c60a2021d0f83f014267c7c5702aa51fc9e6763ce8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "b89d40f5e138db8adc4371f6f6b510e94823d4707236c1fce279347611af8dcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-library-py/default.nix
+++ b/distros/rolling/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-py";
-  version = "0.3.7-r3";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.7-3.tar.gz";
-    name = "0.3.7-3.tar.gz";
-    sha256 = "7d8c67a138db02cf7ea026d32d433d9f408dbb5176cfe9e9cfb4ce540f856832";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "f25631062a3807770fda3d5a534e9671a9726577f0061f01b5e088c4a446bae4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generate-parameter-library/default.nix
+++ b/distros/rolling/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library";
-  version = "0.3.7-r3";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.7-3.tar.gz";
-    name = "0.3.7-3.tar.gz";
-    sha256 = "4954169319a4da6bab4f963e6ee0a33bd3239ad67cfb79909128cfe1355970f6";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "956098991aed17cf6e1e0b721e037d9d707d302dd8565bb822e7035ee8f5a017";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-module-example/default.nix
+++ b/distros/rolling/generate-parameter-module-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-module-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "44e0beed2cd6bcee023dcfd8bbf6c79f19670775d65e08abe42ef04aabdc5d73";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "eabad0107103d2aa56faf728a0a24244ff520b9909c065b413077e14d8c02cbc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -254,6 +254,8 @@ self: super: {
 
  classic-bags = self.callPackage ./classic-bags {};
 
+ cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
+
  color-names = self.callPackage ./color-names {};
 
  color-util = self.callPackage ./color-util {};
@@ -566,7 +568,11 @@ self: super: {
 
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
 
+ generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
+
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -813,6 +819,8 @@ self: super: {
  libnabo = self.callPackage ./libnabo {};
 
  libphidget22 = self.callPackage ./libphidget22 {};
+
+ libpointmatcher = self.callPackage ./libpointmatcher {};
 
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
 
@@ -1240,6 +1248,8 @@ self: super: {
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
+ rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
+
  rc-genicam-api = self.callPackage ./rc-genicam-api {};
 
  rc-genicam-driver = self.callPackage ./rc-genicam-driver {};
@@ -1318,17 +1328,25 @@ self: super: {
 
  rig-reconfigure = self.callPackage ./rig-reconfigure {};
 
+ rmf-api-msgs = self.callPackage ./rmf-api-msgs {};
+
  rmf-battery = self.callPackage ./rmf-battery {};
 
  rmf-building-map-msgs = self.callPackage ./rmf-building-map-msgs {};
 
  rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
 
+ rmf-charging-schedule = self.callPackage ./rmf-charging-schedule {};
+
  rmf-cmake-uncrustify = self.callPackage ./rmf-cmake-uncrustify {};
 
  rmf-dispenser-msgs = self.callPackage ./rmf-dispenser-msgs {};
 
  rmf-door-msgs = self.callPackage ./rmf-door-msgs {};
+
+ rmf-fleet-adapter = self.callPackage ./rmf-fleet-adapter {};
+
+ rmf-fleet-adapter-python = self.callPackage ./rmf-fleet-adapter-python {};
 
  rmf-fleet-msgs = self.callPackage ./rmf-fleet-msgs {};
 
@@ -1342,13 +1360,21 @@ self: super: {
 
  rmf-site-map-msgs = self.callPackage ./rmf-site-map-msgs {};
 
+ rmf-task = self.callPackage ./rmf-task {};
+
  rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-task-ros2 = self.callPackage ./rmf-task-ros2 {};
+
+ rmf-task-sequence = self.callPackage ./rmf-task-sequence {};
 
  rmf-traffic = self.callPackage ./rmf-traffic {};
 
  rmf-traffic-examples = self.callPackage ./rmf-traffic-examples {};
 
  rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
+
+ rmf-traffic-ros2 = self.callPackage ./rmf-traffic-ros2 {};
 
  rmf-utils = self.callPackage ./rmf-utils {};
 
@@ -1362,7 +1388,15 @@ self: super: {
 
  rmf-visualization-msgs = self.callPackage ./rmf-visualization-msgs {};
 
+ rmf-visualization-navgraphs = self.callPackage ./rmf-visualization-navgraphs {};
+
  rmf-visualization-obstacles = self.callPackage ./rmf-visualization-obstacles {};
+
+ rmf-visualization-rviz2-plugins = self.callPackage ./rmf-visualization-rviz2-plugins {};
+
+ rmf-visualization-schedule = self.callPackage ./rmf-visualization-schedule {};
+
+ rmf-websocket = self.callPackage ./rmf-websocket {};
 
  rmf-workcell-msgs = self.callPackage ./rmf-workcell-msgs {};
 

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "36d2784543d2c4cf3336dbe7081288572864371345fe10391566cc7bf1712c6c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "7e5cf2219fe3f62978be1736afee9fda6edce584c97e80f2e2caf43aec2ca437";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "2c5d251a2afe76fca1ed9a71ad7f1dbe6ca598d701c5fd4442731c80b52b5bc2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "ac69becdc159f6a52f68f5f1cbc20427365184fbf36a38a6b465a0d905c2af80";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/iceoryx-binding-c/default.nix
+++ b/distros/rolling/iceoryx-binding-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-binding-c";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_binding_c/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "a2e7ec6691a5ac4aa45c912d475aebd5d94d8d7910837f3ab517b8c5fa27b1d7";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_binding_c/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "fe5e5b0284eec1c021790bdc66eb096d1f30dc631c32a46048392dc228992d8f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-hoofs/default.nix
+++ b/distros/rolling/iceoryx-hoofs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, acl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-hoofs";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_hoofs/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "b0485194d694970b13fe9a0dd6770effed6f27fd88ac5d6ed2c40dafbe8001d9";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_hoofs/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "2b0a29c55e952d8e0e73b5e7a17f4be7ed8996eebdf99a49e1661325fc633081";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-introspection/default.nix
+++ b/distros/rolling/iceoryx-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh, ncurses }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-introspection";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_introspection/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "d74a7a2ec712a576d30aa04fb3f037768b3b4f8f0a485e7c27f96aca2947b1f6";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_introspection/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "c88c228b308e9e4e2b8920a186a4fa6a61956bd8c12b0e380ee24771260c7db2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-posh/default.nix
+++ b/distros/rolling/iceoryx-posh/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, iceoryx-hoofs }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-posh";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_posh/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "f2dbb6892b3e047ebdff3a64fe11fcc9f2476aada6c45162559a897e51388bc4";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_posh/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "835e1bb27160e4bfc51dc6ff84f70b4d6324bc9e828a7a0840c42225a772024e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "dd65625499a2a957764f9b3de062609247f6de4b2b6e07fe9d87063e289b5359";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "7c542fb13da093222aa8e3a2df022dd48bd50863bf47d672f3108515e01adb79";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libphidget22/default.nix
+++ b/distros/rolling/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-rolling-libphidget22";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/libphidget22/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "065f25c7ddae2ad2b35782106f05cec4f691410e1db67abed0d0a49a6fbe1509";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/libphidget22/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "023bf4808aad96c293de58c67b5c449d5ac3374c355207e10cda36ff4ee0a6bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libpointmatcher/default.nix
+++ b/distros/rolling/libpointmatcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, libnabo }:
 buildRosPackage {
   pname = "ros-rolling-libpointmatcher";
-  version = "1.3.1-r4";
+  version = "1.3.1-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libpointmatcher-release/archive/release/rolling/libpointmatcher/1.3.1-4.tar.gz";
-    name = "1.3.1-4.tar.gz";
-    sha256 = "70e3664ade8660c4d26fbdb557a74c9c576836c159ad778a19c36bb0cda82b99";
+    url = "https://github.com/ros2-gbp/libpointmatcher-release/archive/release/rolling/libpointmatcher/1.3.1-5.tar.gz";
+    name = "1.3.1-5.tar.gz";
+    sha256 = "8cf25c35f51df31f0beb3d20971b9226a065665f125ba3480984bfa0cd9429d6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "2e40d4f2deef2a4869b8dd070995141895a5254aa24fb690c12eb834e9a69910";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "52c589c9ff38c7a250ba0c99e6db4edb85d06c8c2262053fc3cc2a982b6a282e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parameter-traits/default.nix
+++ b/distros/rolling/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-parameter-traits";
-  version = "0.3.7-r3";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.7-3.tar.gz";
-    name = "0.3.7-3.tar.gz";
-    sha256 = "41588536f64c7df2adb7d600b3610b085c06cb1ad341e54ba4414e41e08fe699";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "647888440d664a052a1a27ca8c14989711f24be237b14212f7e9c9fc615679e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-accelerometer/default.nix
+++ b/distros/rolling/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-accelerometer";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_accelerometer/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "65d34598c8cda2460a5031552e3f4e71fa4f5fed48068613a7a52f8bca1ee46b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_accelerometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "181494ebe46885f7aa00c3db60432534a6b63a5ac092b637b2b3b2440884f07e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-analog-inputs/default.nix
+++ b/distros/rolling/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-analog-inputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_inputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "c8a723f4ec234a590bf27994f24e3cfc2a5ac27695fe903a06bbf4bec9bdcd93";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "556550953689227e27a4c522b380a531bd6298381f8914c13aec35fb0fe5765d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-analog-outputs/default.nix
+++ b/distros/rolling/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-analog-outputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_outputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "f9d971852df8e34665852be42ca531e053c70cd0de59257e722e69c502cdfec4";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "4e56ae1decbfe3957c03def4e0a400de2846fba170b184644486d29519824015";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-api/default.nix
+++ b/distros/rolling/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-api";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_api/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6f1a6957a7f2d31a6071f8b8fd2550caee2d007bf41b7b8f54c163eda9a12381";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "3a81df0722760113893cffdc7c1d9521f0474f8de2b3f6e85462a606c89cb1a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-digital-inputs/default.nix
+++ b/distros/rolling/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-digital-inputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_inputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "bcee8eddc8458e5a57f57eaa378a3de9f9fa0c69843f1e47ef80f09250f71862";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "59bf4279682a58e3ee98bc9e4fef1fb9c6ddca376f93b17c3d881dba4b5e04e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-digital-outputs/default.nix
+++ b/distros/rolling/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-digital-outputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_outputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6821b199b7cec8839689dac080987b6004d1fccc5648e4d315926d635cbd9bd3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a64b4aff2e181efee0adfa34c090e6e0b64304d908ad98f5ab447e6837822f97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-drivers/default.nix
+++ b/distros/rolling/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-drivers";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_drivers/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "b1cbbf3c3ca3bbf1fb6dcf166bb282e7fd1f1acda33df9eae235c744922d4523";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_drivers/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "8e289943de83f09a49738fe7fce31f40389a75208f702a9b19fce049529b8ec7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-gyroscope/default.nix
+++ b/distros/rolling/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-gyroscope";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_gyroscope/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "255314dca51beddfd79980a6a8d1448374c06a0015dba2dc39d45a89ae2fb87e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_gyroscope/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5c53beb0c310ff57a2fdb386793e721d6d3f968d75ec7ae0ea0f4fc18cdbb6d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-high-speed-encoder/default.nix
+++ b/distros/rolling/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-high-speed-encoder";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_high_speed_encoder/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "2a4fffe846d0a8e18688af2869f6b200c86a295b644eda76e898b126b5a0b34a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_high_speed_encoder/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "f994c45fd436b6ec8706f02b83b21f6509578cf9b4b7926e267588f0ffcb7f16";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-ik/default.nix
+++ b/distros/rolling/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-ik";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_ik/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "61e2d0202d3c13bf11acad6a474d9cd86ff6ad34ec0d976f8789292f9e4f5d86";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_ik/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "24d6f533594806e0dd40594486e780296f245fe30d5f06dfa2853255138d846f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-magnetometer/default.nix
+++ b/distros/rolling/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-magnetometer";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_magnetometer/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6a65430a8047644c4993ade519cb4e115985de7f82e30be080ee2c7537f65755";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_magnetometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "aaeb79cc4fc3aba21f8f80b36d6f93183168591ea25f0f90ec7b7373112b2488";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-motors/default.nix
+++ b/distros/rolling/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-motors";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_motors/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "37f77f68b20343438e7f9525bd71372fcc3913677d571147ed4e3968a103418f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_motors/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "80e54cb68c70bfee130fc87ed97fb2e4e8d8eb201083e7067778a8397286f6c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-msgs/default.nix
+++ b/distros/rolling/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-msgs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_msgs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "e341762b851f9e6d879798d8ab33d80780cd9accd60e3896a9123b61c0c94e10";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "1fa389a996fadfe992fdf2fd24debab2fbd30f1c0117cc8784fe71122dc09737";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-spatial/default.nix
+++ b/distros/rolling/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-spatial";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_spatial/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "3469879da72a26fc037f6090ba601553910024c93fe02171910bc86fb4fc5121";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_spatial/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "212f2def298432274086d9de0a926592d3baad9e309959739d5f26b8676276e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-temperature/default.nix
+++ b/distros/rolling/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-temperature";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_temperature/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6f8d5ecf7784948c5c97c2ab329d7cef4d042df28f422ade9437c3e97245af44";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_temperature/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "2785618af4aa6da265e1625fda585a3171dd07d87825189854e6be95c243b399";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rc-dynamics-api/default.nix
+++ b/distros/rolling/rc-dynamics-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, protobuf }:
 buildRosPackage {
   pname = "ros-rolling-rc-dynamics-api";
-  version = "0.10.3-r3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_dynamics_api-release/archive/release/rolling/rc_dynamics_api/0.10.3-3.tar.gz";
-    name = "0.10.3-3.tar.gz";
-    sha256 = "f9870a4378fafd10fb4edf173aefc4c2c1e9fe53e6dc189ed4cb33978af3c0d1";
+    url = "https://github.com/ros2-gbp/rc_dynamics_api-release/archive/release/rolling/rc_dynamics_api/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "0e77c562601a0a92146f43f5141daf3faf0b9c6236d10a739fea9be3be88035b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rc-genicam-api/default.nix
+++ b/distros/rolling/rc-genicam-api/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-rolling-rc-genicam-api";
-  version = "2.6.1-r3";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/rolling/rc_genicam_api/2.6.1-3.tar.gz";
-    name = "2.6.1-3.tar.gz";
-    sha256 = "044f2119766f5948db0f7a75aeaa4c924106e120dad1fb6ec046fdd8ea3354bc";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/rolling/rc_genicam_api/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "2cd2bb6d745ad7b9d5604527a56bf8bb10c101b64dcadc50c3366dd19c548bf9";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libpng libusb1 ];
+  propagatedBuildInputs = [ libpng libusb1 ncurses ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/rcdiscover/default.nix
+++ b/distros/rolling/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-rcdiscover";
-  version = "1.1.6-r3";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/rolling/rcdiscover/1.1.6-3.tar.gz";
-    name = "1.1.6-3.tar.gz";
-    sha256 = "7c83a4b917ed25a05ad968afc28bdb5fa80c5aa58e73eb59e24c7089d42dd2f0";
+    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/rolling/rcdiscover/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "adb577bf90a75e984895ddaad462744e9ff35b5c92d4209d02aa81b800db6b1f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-api-msgs/default.nix
+++ b/distros/rolling/rmf-api-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nlohmann_json, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rmf-api-msgs";
-  version = "0.2.1-r1";
+  version = "0.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/rolling/rmf_api_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "d98ffe2714cb55bc42eb3c4ee2a99456feecf6e5d0062491bf9b90879fc58890";
+    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/rolling/rmf_api_msgs/0.2.1-2.tar.gz";
+    name = "0.2.1-2.tar.gz";
+    sha256 = "bcb443abf05d810746ef17f7643570205574934cbebb24aef848e6f77cedd66d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-charging-schedule/default.nix
+++ b/distros/rolling/rmf-charging-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-charging-schedule";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_charging_schedule/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "0d648f5f8fcb13a3aef6157df87aa86b15f3db3a1d314ed01808f211489a716c";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_charging_schedule/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "225c6844e9b29759a05179c30c6d291b020ce4b3bc32aa8c4d2974d1473f1d5e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-fleet-adapter-python/default.nix
+++ b/distros/rolling/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter-python";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "ec630315c25dfcc6a7be663593d13098d4abd45e3353746a35065ffdf7efaeb7";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "3cb6552aa6bb993b7f9b03f62e06aac3fb7f035ae0e06cc905c1f502673f8d89";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-fleet-adapter/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "95e73ed2af8cde391d1307fe64eadd12f2b3a03e2529c936bd075e17773a269d";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "35795ec7d0aa318c39aacb2ed914f60226bc155502dc684e01542ff2fb7f6cc5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen yaml-cpp ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
+  propagatedBuildInputs = [ backward-ros nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-task-ros2/default.nix
+++ b/distros/rolling/rmf-task-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-ros2";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "733f24fd92f68883c726af8705cbaa97f0dc29a554a083ee95d82d393cd5e417";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "75563017b2263d68072eaf34991e3616e9cb7a989a3a596d8e9789fa9d85715e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rmf-api-msgs rmf-task-msgs rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket ];
+  propagatedBuildInputs = [ backward-ros nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rmf-api-msgs rmf-task-msgs rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-task-sequence/default.nix
+++ b/distros/rolling/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-sequence";
-  version = "2.4.0-r1";
+  version = "2.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "25183800004c54654c73339b1c0998ffdf9836a784e16d4ce97301a243d63561";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.4.0-2.tar.gz";
+    name = "2.4.0-2.tar.gz";
+    sha256 = "5d0bf089ee24083408afe8f61daaee918e270cbc143b0336baae3e0d61e26f4e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-task/default.nix
+++ b/distros/rolling/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task";
-  version = "2.4.0-r1";
+  version = "2.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "f18ec24e476b56a5f522daa8f3b6b37a9dd0daee6bd957beb9a5c801a0dd3790";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.4.0-2.tar.gz";
+    name = "2.4.0-2.tar.gz";
+    sha256 = "b53282c5b96061112fa52b2d973efcc43c743296be71c39301af04d893fdca46";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-traffic-ros2/default.nix
+++ b/distros/rolling/rmf-traffic-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-ros2";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "0577be3e33e68766f35694092da3f9e01ef57abacf38e309f4bacdeeed52d7da";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "f4e6da14c87ec79a9b0b602a8eacca7a1c67854ba1390ed0e12637ed28dc16dc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
+  propagatedBuildInputs = [ backward-ros nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-visualization-navgraphs/default.nix
+++ b/distros/rolling/rmf-visualization-navgraphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, rclcpp-components, rmf-building-map-msgs, rmf-fleet-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-navgraphs";
-  version = "2.2.1-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "56da9f79f4c6d30c0900052477d4ade1f7744922a75fb02c1987a896e8c47ed4";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "33e2d61f0eafaf0539a27a66f8528359a9f016f12990b6284405bbe1a5197837";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
+++ b/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, eigen, pluginlib, qt5, rclcpp, resource-retriever, rmf-door-msgs, rmf-lift-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rviz-common, rviz-default-plugins, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-rviz2-plugins";
-  version = "2.2.1-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "d94bb9cda183897c6cc1a038bbf32d48594b647b2a4392bbd9bf036b5e6fe835";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "0e3460aee667d8fcfc90996118a739d297a2cf149b3e9f1b46d7aa9110ea5cb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-schedule/default.nix
+++ b/distros/rolling/rmf-visualization-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, eigen, geometry-msgs, openssl, rclcpp, rclcpp-components, rmf-traffic, rmf-traffic-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rosidl-default-generators, visualization-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-schedule";
-  version = "2.2.1-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "ba06e9f52e7c6adfc8502c1e8498f7dab7dbe00e2307335b1f66b75a850c8472";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "9044afa4e9f883d2b9682da256ebef42253c2d23b04f917b1d4f36330ca40750";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-websocket/default.nix
+++ b/distros/rolling/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-websocket";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "d1985f8ff895a8d8fa56888794a6a30a561cc85900373a2c7df785a21680c65f";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "538af0475f8eb72f8e0f50311c6a551c0b4e2a92e0485ec903d654434fdef22c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.20.0-r2";
+  version = "0.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.20.0-2.tar.gz";
-    name = "0.20.0-2.tar.gz";
-    sha256 = "e816a343d5556277d77224663ba95f97bdf83986cce4425561eac90505b058d9";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.20.1-1.tar.gz";
+    name = "0.20.1-1.tar.gz";
+    sha256 = "dc61a234fbae21fc6814e5d80b90e7b50a5f9af1758df1748b3e6f58225e43dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.20.0-r2";
+  version = "0.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.20.0-2.tar.gz";
-    name = "0.20.0-2.tar.gz";
-    sha256 = "9067d7d7358ec696d7fc17cca2c2c7df80b7cd2a424c4e384fdd8efa96b584f5";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.20.1-1.tar.gz";
+    name = "0.20.1-1.tar.gz";
+    sha256 = "2e259b78b3260deb8279c4870790d4cfddeabb9d2d03a31402d901c982935420";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "8d701f44c8ebb92099f7f48a012347f92e9fa5ada72d46386bd7e0382312c9c2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "cb9d08aabb24529fafa1a7fe96ce619c65404956469bc69a340a11df63504c7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "7851546f98b5dd43882f6de6f1ec1ec53e81dfd9afb1b59bb5623bf510736c25";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "40cd9acb576b97f648a8075a7fc8830607fc0e46385eb781cb249d07bc20db69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "5e5cfc8a2ba213846c5b77e28507ee04943f92f0d7a79baa6d12173ad6cae1a9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "488cd2eb4c106503d2fbe6c8385b4f959f2513f9365bc04488133777a5147f14";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "4a80c154b359c288570b4a69f0dee262aaea4685bddd73e4e569bc8128b06814";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "f62be2cd8b9f2e295c2e1a3960b28a4cda7e86292bbc2728059db808cd03138d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "b5e66605c52c4cc4799baa0a63af137398199c27860f9b56f1a246d9a6d1ab1c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "7219700f24b3120eb721d96f093339e635d56424c2ecd4aa0de06d624beae0f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "d9008001bf5fa27a7c9c7c4f9c6adb6c8ea1222b59795af0e904028e2199f910";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "c162b8251b80a4ea63ac84af6c09e0f000dfbe8e137fa9cd6850c849b2973507";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "1d341ee24482e15cf9505d00f8581b5efa21b7cf419e46440883d025fdb47827";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "3ad81229fbd930e16226c3d1ee497e02c888c51b848146a00d4c2fbe882646ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "9aadcb52cbb6b4133555ec3399005ab86865e92adbf41e27753d367d04203fe9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "ceb9462ffccfd0ebe7839496c6ff765d869511c6715fdf27f9da9da71e848a1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "cbf809a4113b9b9b2e32e7e5d113b03c96fafd08b66e3f4a17b83bba18f7c5b6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "485ff76dfd4b2696eb62c1cb89191e980c981002d69ee8d12c1c9de482cf12e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "9d5b1792e7bb7b543de5f12674f8610c01bc988d1111f056b9d32e46e48894a2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "b3fc5564853f3798965361d7a7c22557e87d04faa05de78138ab7150b3656340";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "b211c37e2884e9c0c020d62d671215aa5d80685d73ad083e160ec48ebe6638c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "682aa6fc9b5e709d19b45e7a5943c4573851fd9050db612fbc22d9137aab94d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "16a537d338f88e9f51a8500a662d1a2342cd3043da0a875cb153524f6d7e3036";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "120fcd88d4e8d80b5ca1703ad6de64c39ac4c7e7e17621c5b928ff03ae120941";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "6bae557d11345206ca931aba4577de0bb27007ed4d69e10b0a94c6d40fa12697";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0f73c29758843795d0fe97defed33c8781091e833e4d004544714f7a812006ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "352a705d5c6484593b220b460ca55cb3e1f9f79260f812f61dac00843468f3c4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "1b9af46452155e33b111fbec745401c81e4ee7dbc35c995f6293e1a59f85d87e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "162fff69e6c8b0992b656e7dd7f00ff7a0475599fe7594fd855c32a776d10867";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "193ae009ac8fb23120d34b11624da7cd05241f2bc27664022af8093e6b040fc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "89b1842b337e1ee1018623d01c865c056b304627530f91edaac9bbb90ea7eb38";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "3cbff9b3eaeee4840d48bc59fc04196d142a866614551cc7da28877660379ad9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "8687f460a3da765c4952daf55056ec85735b44b00bee3f149857f9f4f90a8d2d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0b49339957e1526755106bb79a2a74616c52d5cceb80f237e6546c3f7b1d56b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "d730c440ee7ba698e08f3cbcf098071db114136c12812946781f1d8ccbfeea0d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "381c2345d5d95b8c17c568805dce363998682c9c950ead9b5f2c2dff853d7285";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "56a47102a919db62ad57463cfc8ef2a61458df7a9b56756c91cfae4840f3047a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "6fdb6c74f3f87c1176c3529028de1117a6de8fff9d89e492f6a57248f413e4e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "8059d7a7dcf2891600b7eac3282462f5274e5c6bcaaecf24cc5078d8d6ed17ce";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0eaabcd341f10c86c3aa213faa02f4507f5a4cc93e971c4468aa8644817a8781";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "8bc52dd4709b1ba6be60fbcab5cdd9574bad4caea2c8c39acff999020dd38e19";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "1532bcbefa8a5f3c6bbb69291442938ce31e39e0a80b95477211b8d6b74f6fa1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "79b44058b8bd13e0de749d8ae7a6698e084b7cf9e0401cbc49a9f04c281faf29";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "66e5636eb14e89a6617609f228fc98616256eca38eb52e01b9b749ae51071987";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rot-conv/default.nix
+++ b/distros/rolling/rot-conv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-rot-conv";
-  version = "1.1.0-r2";
+  version = "1.1.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rot_conv_lib-release/archive/release/rolling/rot_conv/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "af9b11611dd34e2aa930dbc2956457feee916b69f61d431e017496528182daa3";
+    url = "https://github.com/ros2-gbp/rot_conv_lib-release/archive/release/rolling/rot_conv/1.1.0-3.tar.gz";
+    name = "1.1.0-3.tar.gz";
+    sha256 = "fc8fc8d953695d041ad3b6e7cbbec2d43e9b5923b978878a2f34ad1b7f913e5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "f2f2b8e091e5a0c537b85382cefb69e459e25ee46bfde14f99c55b7136cfecf2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "976b0009aaa8d78cd0ba6ccff4053d7f643ecc344e21b92f39733f0d643ce0d9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gauges/default.nix
+++ b/distros/rolling/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gauges";
-  version = "0.0.2-r2";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/rolling/rqt_gauges/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "ddb38f8f1133823bdee1a27bb252d5a6ee4ace3af3c3f558ed76a5427906460e";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/rolling/rqt_gauges/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "46ecd6bbfba2041ab327e216fa3b16bf85797e0d0e8ea85083b81c8836a6f5e0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.20.0-r2";
+  version = "0.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.20.0-2.tar.gz";
-    name = "0.20.0-2.tar.gz";
-    sha256 = "f27a90c33621f0562db8e5dac26bbb8e7537bb17c263ab96e6beb273c7e7441f";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.20.1-1.tar.gz";
+    name = "0.20.1-1.tar.gz";
+    sha256 = "5b3b9a88e1a1ea439e88e4feeb161a18a838f84a8beb00d5dbe09ef16951f0f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "e6a149af1cf7d21ae471344ddce26bb96d953007d9adbdfaedb5b6dd953d6567";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "1e0b81888cd9dd591bc651963d84315f275b7ef7eeb74df5c287ae7e5091680c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "7c741422e73b0cabfc67336ac70aab66618d24a6d6dd28ed239efa2ee35a69b5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "5ff7a521bbaf2a3a7551cd36accb589dbdd851b46ba19269085d42804f9f8d71";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "6637af1aba668f8f842884dbd76203a9699b232800fe1b9f05705c15748ac176";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "46a4d39dff9f04b026599007c2ef75d33521673a8da81ef280df909ba066d044";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "64011f9c8d5c972f0e2bd9131c4ff5af844da05374c383e57ed799af8b1b1e8e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "ce583f5c2deac7af762f46c57a199fe9f901c68a22223f7b49ac500ad3dce762";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "6516d93ebf0387e93b9e5213e17b73e88a7bc81fb06175614fb370ebf3eedb93";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "d71dd1de63b136767fa800a59c6ea268fc3e3e81ee161b2ac19e616602df9a31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "696c7b63f59c6c8656095fa320cad940122273d5bb6143691cdf68b0d6e4a081";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "0e45b3355b4319cf3e7199d2a7e42668609bbe75e0f02735a71567c37d6346e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "7219e397a3e831b58319116884ac4544bb5993bee3360c6be9932ae16c8af681";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "d0f312f6ef6b97ef0a45dccaf55af12e7fa688849f7be22aee3232bf8754b873";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "01b5aeb4da070f12ec5316df2541ec1d31434f079e6b66ed49623b2b38b3f5d2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "afcef75ede14ae865cb818f33fd8d7023d21ba49302293d4353cc24c1f43da14";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shared-queues-vendor/default.nix
+++ b/distros/rolling/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-shared-queues-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "cd4e1aa7d59c88418ef50cba467e4a8d3c2b5d5f173134040c79cbded3e0ba93";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "1b4c422f4f70af93cb56355cc9bdead94ae61abccf08b4c6d2ba5054871772c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sqlite3-vendor/default.nix
+++ b/distros/rolling/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-sqlite3-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "dd29dae2b05c908df3bb979979e077102f60b466d848b969479adaa32c099e22";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0adef19b281d113f7f61c00d1d2d3bbbee1f7c317cb4747bd72ea86eb8a2d99f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "2a3c6a9bffc1791e16c731b639c50a42a0fd98d7c576c0133c75b12d80a92b8c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "d0c80bc3cb727a1d987342b7a20d79d0775bb2dcf015b1ec547bdfe6f778f988";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-vendor/default.nix
+++ b/distros/rolling/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "bad8a96cd038f2ca35ae506c2cc8573a4fa406102e38f5a6e47354b82cb2226f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "e2a9b32171b7d0d3ae316b426e3810f8dcb7d7055534b245b4b59e9ade3d163a";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit de1ea0a747635d6c0b33b7cfd99b75db6031d05d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *apriltag 3.2.0-r2 --> 3.4.0-r1*
* *clearpath-config 0.2.4-r1 --> 0.2.5-r1*
* *cmake-generate-parameter-module-example 0.3.8-r1*
* *depthai 2.23.0-r1 --> 2.24.0-r1*
* *flir-camera-description 2.0.8-r3 --> 2.1.13-r1*
* *flir-camera-msgs 2.0.8-r3 --> 2.1.13-r1*
* *generate-parameter-library 0.3.7-r1 --> 0.3.8-r1*
* *generate-parameter-library-example 0.3.6-r1 --> 0.3.8-r1*
* *generate-parameter-library-py 0.3.7-r1 --> 0.3.8-r1*
* *generate-parameter-module-example 0.3.6-r1 --> 0.3.8-r1*
* *libphidget22 2.3.2-r1 --> 2.3.3-r1*
* *motion-capture-tracking 1.0.3-r1 --> 1.0.5-r1*
* *motion-capture-tracking-interfaces 1.0.3-r1 --> 1.0.5-r1*
* *mp2p-icp 1.2.0-r1 --> 1.3.0-r1*
* *mrpt2 2.11.11-r1 --> 2.11.12-r1*
* *parameter-traits 0.3.7-r1 --> 0.3.8-r1*
* *phidgets-accelerometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-api 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-drivers 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-gyroscope 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-high-speed-encoder 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-ik 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-magnetometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-motors 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-msgs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-spatial 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-temperature 2.3.2-r1 --> 2.3.3-r1*
* *raspimouse-description 1.1.0-r1 --> 1.2.0-r1*
* *raspimouse-fake 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-gazebo 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-navigation 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-ros2-examples 2.1.0-r1 --> 2.2.0-r2*
* *raspimouse-sim 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-slam 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-slam-navigation 2.0.0-r1 --> 2.1.0-r1*
* *rc-genicam-api 2.6.1-r1 --> 2.6.5-r1*
* *rqt-gauges 0.0.2-r1 --> 0.0.3-r1*
* *sick-scan-xd 3.1.11-r3 --> 3.2.5-r1*
* *spinnaker-camera-driver 2.0.8-r3 --> 2.1.13-r1*
* *spinnaker-synchronized-camera-driver 2.1.13-r1*
* *teleop-twist-keyboard 2.3.2-r4 --> 2.4.0-r1*
* *wireless-msgs 1.0.1-r2 --> 1.0.1-r3*
* *wireless-watcher 1.0.1-r2 --> 1.0.1-r3*

Iron Changes:
-------------
* *azure-iot-sdk-c 1.12.0-r1 --> 1.13.0-r1*
* *cmake-generate-parameter-module-example 0.3.8-r1*
* *depthai 2.23.0-r1 --> 2.24.0-r1*
* *event-camera-py 1.2.4-r1 --> 1.2.5-r1*
* *flir-camera-description 2.0.8-r2 --> 2.2.13-r1*
* *flir-camera-msgs 2.0.8-r2 --> 2.2.13-r1*
* *generate-parameter-library 0.3.7-r1 --> 0.3.8-r1*
* *generate-parameter-library-example 0.3.6-r1 --> 0.3.8-r1*
* *generate-parameter-library-py 0.3.7-r1 --> 0.3.8-r1*
* *generate-parameter-module-example 0.3.6-r1 --> 0.3.8-r1*
* *libphidget22 2.3.2-r1 --> 2.3.3-r1*
* *motion-capture-tracking 1.0.2-r1 --> 1.0.4-r1*
* *motion-capture-tracking-interfaces 1.0.2-r1 --> 1.0.4-r1*
* *mp2p-icp 1.2.0-r1 --> 1.3.0-r1*
* *mrpt2 2.11.11-r1 --> 2.11.12-r1*
* *parameter-traits 0.3.7-r1 --> 0.3.8-r1*
* *phidgets-accelerometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-api 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-drivers 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-gyroscope 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-high-speed-encoder 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-ik 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-magnetometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-motors 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-msgs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-spatial 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-temperature 2.3.2-r1 --> 2.3.3-r1*
* *rqt-gauges 0.0.2-r1 --> 0.0.3-r1*
* *spinnaker-camera-driver 2.0.8-r2 --> 2.2.13-r1*
* *spinnaker-synchronized-camera-driver 2.2.13-r1*
* *teleop-twist-keyboard 2.3.2-r5 --> 2.4.0-r1*

Noetic Changes:
---------------
* *camera-aravis 4.0.5-r3 --> 4.1.0-r1*
* *depthai 2.23.0-r1 --> 2.24.0-r2*
* *libphidget22 1.0.8-r2 --> 1.0.9-r1*
* *mrpt2 2.11.11-r1 --> 2.11.12-r1*
* *phidgets-accelerometer 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-analog-inputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-analog-outputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-api 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-digital-inputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-digital-outputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-drivers 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-gyroscope 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-high-speed-encoder 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-humidity 1.0.9-r1*
* *phidgets-ik 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-magnetometer 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-motors 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-msgs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-spatial 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-temperature 1.0.8-r2 --> 1.0.9-r1*
* *rc-genicam-api 2.6.1-r1 --> 2.6.5-r1*
* *sick-scan-xd 3.1.5-r1 --> 3.2.6-r1*

Rolling Changes:
----------------
* *apriltag 3.2.0-r6 --> 3.4.0-r1*
* *cmake-generate-parameter-module-example 0.3.8-r1*
* *controller-interface 4.5.0-r2 --> 4.6.0-r1*
* *controller-manager 4.5.0-r2 --> 4.6.0-r1*
* *controller-manager-msgs 4.5.0-r2 --> 4.6.0-r1*
* *filters 2.1.0-r5 --> 2.1.1-r1*
* *generate-parameter-library 0.3.7-r3 --> 0.3.8-r1*
* *generate-parameter-library-example 0.3.6-r1 --> 0.3.8-r1*
* *generate-parameter-library-py 0.3.7-r3 --> 0.3.8-r1*
* *generate-parameter-module-example 0.3.6-r1 --> 0.3.8-r1*
* *hardware-interface 4.5.0-r2 --> 4.6.0-r1*
* *hardware-interface-testing 4.5.0-r2 --> 4.6.0-r1*
* *iceoryx-binding-c 2.0.5-r4 --> 2.0.5-r5*
* *iceoryx-hoofs 2.0.5-r4 --> 2.0.5-r5*
* *iceoryx-introspection 2.0.5-r4 --> 2.0.5-r5*
* *iceoryx-posh 2.0.5-r4 --> 2.0.5-r5*
* *joint-limits 4.5.0-r2 --> 4.6.0-r1*
* *libphidget22 2.3.2-r2 --> 2.3.3-r1*
* *libpointmatcher 1.3.1-r4 --> 1.3.1-r5*
* *mcap-vendor 0.24.0-r2 --> 0.24.0-r3*
* *parameter-traits 0.3.7-r3 --> 0.3.8-r1*
* *phidgets-accelerometer 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-analog-inputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-analog-outputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-api 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-digital-inputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-digital-outputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-drivers 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-gyroscope 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-high-speed-encoder 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-ik 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-magnetometer 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-motors 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-msgs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-spatial 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-temperature 2.3.2-r2 --> 2.3.3-r1*
* *rc-dynamics-api 0.10.3-r3 --> 0.10.5-r1*
* *rc-genicam-api 2.6.1-r3 --> 2.6.5-r1*
* *rcdiscover 1.1.6-r3 --> 1.1.7-r1*
* *rmf-api-msgs 0.2.1-r1 --> 0.2.1-r2*
* *rmf-charging-schedule 2.5.0-r1 --> 2.6.0-r1*
* *rmf-fleet-adapter 2.5.0-r1 --> 2.6.0-r1*
* *rmf-fleet-adapter-python 2.5.0-r1 --> 2.6.0-r1*
* *rmf-task 2.4.0-r1 --> 2.4.0-r2*
* *rmf-task-ros2 2.5.0-r1 --> 2.6.0-r1*
* *rmf-task-sequence 2.4.0-r1 --> 2.4.0-r2*
* *rmf-traffic-ros2 2.5.0-r1 --> 2.6.0-r1*
* *rmf-visualization-navgraphs 2.2.1-r1 --> 2.2.1-r2*
* *rmf-visualization-rviz2-plugins 2.2.1-r1 --> 2.2.1-r2*
* *rmf-visualization-schedule 2.2.1-r1 --> 2.2.1-r2*
* *rmf-websocket 2.5.0-r1 --> 2.6.0-r1*
* *rmw-connextdds 0.20.0-r2 --> 0.20.1-r1*
* *rmw-connextdds-common 0.20.0-r2 --> 0.20.1-r1*
* *ros2-control 4.5.0-r2 --> 4.6.0-r1*
* *ros2-control-test-assets 4.5.0-r2 --> 4.6.0-r1*
* *ros2bag 0.24.0-r2 --> 0.24.0-r3*
* *ros2controlcli 4.5.0-r2 --> 4.6.0-r1*
* *rosbag2 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-compression 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-compression-zstd 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-cpp 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-examples-cpp 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-examples-py 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-interfaces 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-performance-benchmarking 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-performance-benchmarking-msgs 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-py 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage-default-plugins 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage-mcap 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage-sqlite3 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-test-common 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-test-msgdefs 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-tests 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-transport 0.24.0-r2 --> 0.24.0-r3*
* *rot-conv 1.1.0-r2 --> 1.1.0-r3*
* *rqt-controller-manager 4.5.0-r2 --> 4.6.0-r1*
* *rqt-gauges 0.0.2-r2 --> 0.0.3-r1*
* *rti-connext-dds-cmake-module 0.20.0-r2 --> 0.20.1-r1*
* *rviz-assimp-vendor 13.3.1-r2 --> 13.4.0-r2*
* *rviz-common 13.3.1-r2 --> 13.4.0-r2*
* *rviz-default-plugins 13.3.1-r2 --> 13.4.0-r2*
* *rviz-ogre-vendor 13.3.1-r2 --> 13.4.0-r2*
* *rviz-rendering 13.3.1-r2 --> 13.4.0-r2*
* *rviz-rendering-tests 13.3.1-r2 --> 13.4.0-r2*
* *rviz-visual-testing-framework 13.3.1-r2 --> 13.4.0-r2*
* *rviz2 13.3.1-r2 --> 13.4.0-r2*
* *shared-queues-vendor 0.24.0-r2 --> 0.24.0-r3*
* *sqlite3-vendor 0.24.0-r2 --> 0.24.0-r3*
* *transmission-interface 4.5.0-r2 --> 4.6.0-r1*
* *zstd-vendor 0.24.0-r2 --> 0.24.0-r3*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libxkbcommon-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-smbus
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rmf_building_map_tools
 * [ ] rmf_building_sim_common
 * [ ] rmf_building_sim_gz_classic_plugins
 * [ ] rmf_building_sim_gz_plugins
 * [ ] rmf_robot_sim_common
 * [ ] rmf_robot_sim_gz_classic_plugins
 * [ ] rmf_robot_sim_gz_plugins
 * [ ] rmf_traffic_editor
 * [ ] rmf_traffic_editor_assets
 * [ ] rmf_traffic_editor_test_maps
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] ros_ign_gazebo_demos
 * [ ] ros_ign_image
 * [ ] ros_ign_interfaces
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

