### PR TITLE
rosdistro sync, Fri Mar 22 13:05:17 2024

### DIFF
--- a/distros/humble/apriltag/default.nix
+++ b/distros/humble/apriltag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, opencv, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-apriltag";
-  version = "3.2.0-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/humble/apriltag/3.2.0-2.tar.gz";
-    name = "3.2.0-2.tar.gz";
-    sha256 = "fc489bc60d251437c4e25fb49c00dae9883dfbcce466b13ba179a7ba29c09e95";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/humble/apriltag/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "fe3806ce91f6ad0007f50473631d0ef1dd3136474f2f4f3ec5e726ad9b7b5fd4";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake python3Packages.numpy ];
+  buildInputs = [ cmake python3 python3Packages.numpy ];
   checkInputs = [ opencv opencv.cxxdev ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/humble/cartographer-ros-msgs/default.nix
+++ b/distros/humble/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-cartographer-ros-msgs";
-  version = "2.0.9000-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_ros_msgs/2.0.9000-2.tar.gz";
-    name = "2.0.9000-2.tar.gz";
-    sha256 = "3e4e58bdad366d3d87a89964e361f1e9615665f5586110ac325d04d964dbd9e2";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_ros_msgs/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "1a86383b76c72cff09585fdc2a203315a0d96853d20cf81f2a61686c15bf126e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cartographer-ros/default.nix
+++ b/distros/humble/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, builtin-interfaces, cartographer, cartographer-ros-msgs, eigen, geometry-msgs, gflags, glog, gtest, launch, nav-msgs, pcl, pcl-conversions, python3Packages, rclcpp, robot-state-publisher, rosbag2-cpp, rosbag2-storage, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-cartographer-ros";
-  version = "2.0.9000-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_ros/2.0.9000-2.tar.gz";
-    name = "2.0.9000-2.tar.gz";
-    sha256 = "b6e2e164edc8518b4e0b5d0085004537e44c7ebcd1c5c13065b057431c3797ba";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_ros/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "8db0a0ab4543aa1c6c21bc3e8ca9036481eb4303b25153bfe4e06006916e10f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cartographer-rviz/default.nix
+++ b/distros/humble/cartographer-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, boost, cartographer, cartographer-ros, cartographer-ros-msgs, eigen, pluginlib, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-cartographer-rviz";
-  version = "2.0.9000-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_rviz/2.0.9000-2.tar.gz";
-    name = "2.0.9000-2.tar.gz";
-    sha256 = "44cdae3209cad289d23c68c52065cfc6f3ac6a4b3642025f50a1e68a0b7cbae1";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/humble/cartographer_rviz/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "685e1436bb64cc5322644bd0c27e5aaf8d782edbe8064f0bc846f9f687bee6aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cartographer/default.nix
+++ b/distros/humble/cartographer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, boost, cairo, ceres-solver, cmake, eigen, gflags, git, glog, gtest, lua5, protobuf, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-cartographer";
-  version = "2.0.9002-r2";
+  version = "2.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/humble/cartographer/2.0.9002-2.tar.gz";
-    name = "2.0.9002-2.tar.gz";
-    sha256 = "ee74f0e0d86be3b0c946edf63212372e6420861713cce3b79955c2d1eb9c0cca";
+    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/humble/cartographer/2.0.9003-1.tar.gz";
+    name = "2.0.9003-1.tar.gz";
+    sha256 = "eabfde564729afc123db44693aec27d5034a8cb7209ab53c0b21dd40657c0178";
   };
 
   buildType = "cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "6f78411f04c8aca816662bad2bd9cc4e2863d9e69ff135f52838c6788b478e86";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "7b80d458f997b338545edc3fa04857f348d4b084095391ca35c28de36c8e8c3e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/cmake-generate-parameter-module-example/default.nix
+++ b/distros/humble/cmake-generate-parameter-module-example/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-cmake-generate-parameter-module-example";
+  version = "0.3.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/cmake_generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "4297eeabee5a00e4e13362018b0c66a1ec50230bd0e0b111569cc3a7c27c3333";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = ''Example usage of generate_parameter_library for a python module with cmake.'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "60fb5461e793042d5c674d01faaa49b38aeb1ef9dbbbdbeb9c7deec7b4ec2a6d";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "5353138a85680f1f05493875db8927adf35065d2088cb52be281092ac9611fb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.0.8-r3";
+  version = "2.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.0.8-3.tar.gz";
-    name = "2.0.8-3.tar.gz";
-    sha256 = "36db1c9a8e803c8dabf3fd221a1477dad144e81b7d1acde0c956b9f0737b3d7b";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.1.14-1.tar.gz";
+    name = "2.1.14-1.tar.gz";
+    sha256 = "8ebc96c41da6e0491e644796bf19ef3f39c51a3765807698d4a56934a269d4db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.0.8-r3";
+  version = "2.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.0.8-3.tar.gz";
-    name = "2.0.8-3.tar.gz";
-    sha256 = "bbd0f118cc69b2f3dd87ddcb0354dbbec4210780ef00146e4a9c7f8518e4234b";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.1.14-1.tar.gz";
+    name = "2.1.14-1.tar.gz";
+    sha256 = "63754286d912717293f6d96333aa8218ac411b86e9b18701012e2123184391bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gazebo-ros2-control-demos/default.nix
+++ b/distros/humble/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control-demos";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "7ad81155ac1ffed75c78b7e71b673a707f6696486509f0d10010da94afc1588b";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "91ce0ff033acaeab7fdb947f67d50bc2ed1d13d660d7c97a4d0780f4fd21d1ea";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gazebo-ros2-control/default.nix
+++ b/distros/humble/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "52dc2021c2fa873b05da64934c22e268451e8e8bbbed19ef5ee0319dbdfc9984";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "2a840a003c503b712151d682422a297e41d9cd87a12ed8488fcc58856acca5ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "9b723972cc752894f1999f6389b1a5b5de5907315dacd02ee81cf1e44390640c";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "6247e486cc8f1801866ed49fe27205d798fd640bda7fdc70839face2fce07d0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-py/default.nix
+++ b/distros/humble/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-py";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "0c1dbaad18fc2abc2e498e96442c9749419b8e6c71579daaadfa1d1fbc021246";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "8c7fc9d771455c021ab6e23034055c13c3f43a2511f2c94d3d8d55869a630ff7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "dd613acf03ee7c06c93b3f71cfb8a21ff5a6207fa2bcb501af6184a3e922b838";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "949d568868cfb9de77cd18b8ead166b54d2eec57325256fbceceeb1d701fefc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-module-example/default.nix
+++ b/distros/humble/generate-parameter-module-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-module-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "541046c0c70cf5df383818d08a08bcc5e3f220d6058e9e71c7c2a47d0bb159c5";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "fff2b7def1c2da4146aba1ec93cb4295f15dcc0bec71f1b8a5da7c1b927f6f89";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -362,6 +362,8 @@ self: super: {
 
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
+ cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
+
  cob-actions = self.callPackage ./cob-actions {};
 
  cob-msgs = self.callPackage ./cob-msgs {};
@@ -786,7 +788,11 @@ self: super: {
 
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
 
+ generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
+
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -875,6 +881,8 @@ self: super: {
  hpp-fcl = self.callPackage ./hpp-fcl {};
 
  hri-msgs = self.callPackage ./hri-msgs {};
+
+ human-description = self.callPackage ./human-description {};
 
  ibeo-msgs = self.callPackage ./ibeo-msgs {};
 
@@ -993,6 +1001,8 @@ self: super: {
  kinova-gen3-6dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-6dof-robotiq-2f-85-moveit-config {};
 
  kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
+
+ kitti-metrics-eval = self.callPackage ./kitti-metrics-eval {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 
@@ -1134,6 +1144,10 @@ self: super: {
 
  mapviz-plugins = self.callPackage ./mapviz-plugins {};
 
+ marine-acoustic-msgs = self.callPackage ./marine-acoustic-msgs {};
+
+ marine-sensor-msgs = self.callPackage ./marine-sensor-msgs {};
+
  marker-msgs = self.callPackage ./marker-msgs {};
 
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
@@ -1220,9 +1234,47 @@ self: super: {
 
  mod = self.callPackage ./mod {};
 
+ mola = self.callPackage ./mola {};
+
+ mola-bridge-ros2 = self.callPackage ./mola-bridge-ros2 {};
+
  mola-common = self.callPackage ./mola-common {};
 
+ mola-demos = self.callPackage ./mola-demos {};
+
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
+ mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
+
+ mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
+
+ mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
+
+ mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
+
+ mola-kernel = self.callPackage ./mola-kernel {};
+
+ mola-launcher = self.callPackage ./mola-launcher {};
+
+ mola-metric-maps = self.callPackage ./mola-metric-maps {};
+
+ mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};
+
+ mola-pose-list = self.callPackage ./mola-pose-list {};
+
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
+
+ mola-traj-tools = self.callPackage ./mola-traj-tools {};
+
+ mola-viz = self.callPackage ./mola-viz {};
+
+ mola-yaml = self.callPackage ./mola-yaml {};
 
  motion-capture-tracking = self.callPackage ./motion-capture-tracking {};
 
@@ -1970,6 +2022,8 @@ self: super: {
 
  robotiq-description = self.callPackage ./robotiq-description {};
 
+ robotont-driver = self.callPackage ./robotont-driver {};
+
  robotraconteur = self.callPackage ./robotraconteur {};
 
  ros2-control = self.callPackage ./ros2-control {};
@@ -2387,6 +2441,8 @@ self: super: {
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
+
+ spinnaker-synchronized-camera-driver = self.callPackage ./spinnaker-synchronized-camera-driver {};
 
  splsm-7 = self.callPackage ./splsm-7 {};
 

--- a/distros/humble/human-description/default.nix
+++ b/distros/humble/human-description/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, robot-state-publisher, urdf-test, xacro }:
+buildRosPackage {
+  pname = "ros-humble-human-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/human_description-release/archive/release/humble/human_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "537aabd95297bcbe4079dc98e1ce18bf728ee2b7467398298ee4ea2559f19ac6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake robot-state-publisher urdf-test ];
+  propagatedBuildInputs = [ launch launch-pal launch-param-builder launch-ros xacro ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''This package contains a parametric kinematic description of humans. 
+        The files in this package are parsed and used by a variety of other 
+        components, notably in the context of human-robot interaction.
+        Most users will not interact directly with this package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ign-ros2-control-demos/default.nix
+++ b/distros/humble/ign-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-ign-gazebo, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-ign-gazebo, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control-demos";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "475b4f802295b91923c1656de6ec8dd0cd6d987874045dd8cd9b68ca96fe7f31";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "bac8b751eafe2f8eb06584f51230d58c3c64fa72be326a4c90085b099feb54d1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs hardware-interface ign-ros2-control imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-ign-gazebo ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs hardware-interface ign-ros2-control imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-gz-bridge ros-ign-gazebo ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-kitti-metrics-eval";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a39e8f26939190a8bddd07db011ecf5c8b6edfbadf35028e0469c388835c3a92";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''CLI tool to evaluate the KITTI odometry bechmark metrics to trajectory files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/libphidget22/default.nix
+++ b/distros/humble/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-humble-libphidget22";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/libphidget22/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "ba9b0efce856d2c750015b277ce27595fdb93e9a9b4a385ee7de77905afcd7b0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/libphidget22/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c7a2796129e60c2a37d01b261162851a25141416f984cf14196fca619075e08b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marine-acoustic-msgs/default.nix
+++ b/distros/humble/marine-acoustic-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-marine-acoustic-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marine_msgs-release/archive/release/humble/marine_acoustic_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "eefc3142e1c2fc35655ec99c5be92ad72706af7e61cc21635ce30655f4e2849e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The marine_acoustic_msgs package, including messages for common
+  underwater sensors (DVL, multibeam sonar, imaging sonar)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/marine-sensor-msgs/default.nix
+++ b/distros/humble/marine-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-marine-sensor-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marine_msgs-release/archive/release/humble/marine_sensor_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3a65bf08586a94555ab2f917f0760b6d95371530f98fffadea5a9cc416d4a442";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The marine_sensor_msgs package, meant to contain messages for common
+  underwater sensors (e.g., conductivity, turbidity, dissolved oxygen)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/message-tf-frame-transformer/default.nix
+++ b/distros/humble/message-tf-frame-transformer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-tf-frame-transformer";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/humble/message_tf_frame_transformer/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "51bf95fac905e0ea0f9119ee44795a449662b0ddf7693dfd211421e34ed18f34";
+    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/humble/message_tf_frame_transformer/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "65e15a5d214f1386c5b87013748c987d518fc22f9a93f09d9d925784730bb335";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-humble-mola-bridge-ros2";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "39fe4a216483e142df966eae63112bbc2f7f62aa62cef0f3cdbe23f6a59fc6bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
+
+  meta = {
+    description = ''Bidirectional bridge ROS2-MOLA'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "b5bb43267c8d1200e2fc524a489f985a1247fe2e6efbb5ab6e9e87799fe4f6b5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "cbd6b32e8a8fbe817cb1d06446be0bec5d5d2b1af130af3474b34e1acdccfad0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "72b280f8b8e93ff916abccc9075ff92d9e36e5899cafa6f77a6468df0816b5e4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "926ce9e9d7b39578b24d9fd6b2a8f2c53cb7bbff368427405c3bddd3cac7623e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "83ccb89ef6628f753f67be6e3b12496378ceccb09768662d8383d3a3060e9a66";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d306f1d7df8bcb5831165764b84b6195c0880e4b37945b1926c3c895fdf0b464";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "1bca27c957b2fd8e911bec4c2d52005f179e635dc867e0e886491ae800f22781";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "312cbe0d95877583e8ab55c58bc3b3c4187b23914b482aae71c3e70f59dd738f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-kitti360-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "43816c3d6b449f9838e0ed65c94e4ef2f9f3c4d37d732cb41c79a7dc86815c7f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Kitti-360 datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-mulran-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "efe71b17c91d568eb2907d6848b55c6d1f1d4fdfc0977033401fc4cc2fa7b59f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from MulRan datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-paris-luco-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a29be46eb85d06e1fee07bf7a0675fca14c42373ded626a57d663da07630c185";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Paris LUCO (CT-ICP) odometry/SLAM datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "c299d9501ba0ac2c16c88b2be07b9e79b6b5fbe51a4092d10b8ac1fda2e72783";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ef800f9d1ae626bc385d3847fb12c00f8ac4f8dbdfc6e482e1d796006177274a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-mola-input-rosbag2";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "212253a36740d8b5bceccadbb712326e2f8ecf5fbc3ad1b9b02eee0d552f3979";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ cv-bridge mola-kernel mrpt2 rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from rosbag2 datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "57108ad222bde0ca8e46bd734761892a08383bbd956d9862990fbf23c721b6b0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e1c1f401a36933d1f3b6094b3e5f582a9fd907645f7f20b8a43f5dba9dbf842b";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -1,22 +1,23 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "e9f2e57dfe118476d15a517a892ce2fb59b08c3a8785a98077f20b7ad92bd070";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ad469125cee9151493592028d49415f0dcc6c33e06707042f41c7d2add9b63bc";
   };
 
-  buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ mola-kernel mrpt2 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {
     description = ''Launcher app for MOLA systems'';

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-mola-metric-maps";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9a3647e6aac38b58b70e70c51f26f23c2ecd393988452a6abba0bdecf691e03c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = ''Advanced metric map classes, using the generic `mrpt::maps::CMetricMap` interface, for use in other MOLA odometry and SLAM modules.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-navstate-fuse/default.nix
+++ b/distros/humble/mola-navstate-fuse/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-navstate-fuse";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fb537c2d504f9c31e97bf27916202393121144ba54283f6c6f6b9f162a365a29";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''SE(3) pose and twist path data fusion estimator'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-pose-list";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3ed881afaff174f103e8935c5b704b7211afd30aab74fed66e68f8b27cce3135";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ library for searchable pose lists'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-humble-mola-traj-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4c8fded9eb1178068881a3770719c30f38eb7147e73808a5b4572ca20f1cd741";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''CLI tools to manipulate trajectory files as a complement to the evo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "6f2c71dc9d0d96b6eb186191015f2c9cc7014b3b6478e5afc56a0e8ae1828a69";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3c4cd895b1d35cc9074813a7ec96d9f09a07a6433015c5b3eb7ebfca0c539c94";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d88bb0fa62c746b2c9d88b71577a2aaf09d09822c2aa282ff69023ad8d946052";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9adb6501a38adbe2f134c4237a5f93404746f99782a8d9e415efdc1e9731516c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
+buildRosPackage {
+  pname = "ros-humble-mola";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "46df8506c5f91928b142add9bd7f12c1813cc8e768c2c94e6e7e7ad07e6f40be";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fuse mola-pose-list mola-traj-tools mola-viz mola-yaml ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage with all core open-sourced MOLA packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/motion-capture-tracking-interfaces/default.nix
+++ b/distros/humble/motion-capture-tracking-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-motion-capture-tracking-interfaces";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking_interfaces/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "318bf3b94084d418aa57a077c0c936166c10d641d9914d3eb5c93db74cfbd492";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking_interfaces/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f175cf9133f7a9c71192d1f21ace127b4ce5e37aa0baa6b45cd5f743db1f93a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/motion-capture-tracking/default.nix
+++ b/distros/humble/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-motion-capture-tracking";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "a1b2115dfa4fa78e45bc193bdfd04f815e5e7592727d60330c338271cd3dafed";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/humble/motion_capture_tracking/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e453b522cc0d7cc301f50034f793420ad73dd562f308e9251045953ce97af666";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "89ed6b444a9c2aadc0f5b0db472d7cd67a0d30b9a8c8df40d8dac393c80a53fb";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0592aefd609388d5065e8f17fe3762133328f67f939c9d4797b58cc40401211d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mqtt-client-interfaces/default.nix
+++ b/distros/humble/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client-interfaces";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0c250c21ab149d4801d3ea6c5b43f062a532c70ce793df25d10425d85f44f0e9";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client_interfaces/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "b9f58ed48def6d0ca73facf5bced2f74727b01584da9c6cdf099f6a389d58667";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mqtt-client/default.nix
+++ b/distros/humble/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mqtt-client";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e737e5a922bf8797cf326b80d00fb39298ed1ec19c6d435320c8e12b5792c794";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/humble/mqtt_client/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "280b4ea55755597deaf1d115e68a9c6b2223765b6758fe90f5662f6ca910200d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-path-planning/default.nix
+++ b/distros/humble/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
 buildRosPackage {
   pname = "ros-humble-mrpt-path-planning";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "494cf2bcd1c04772531d516e656a1b5a37eb460f0e69e3c5e8d0cbb6d1a572db";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "6f13bd958235728001015feb70db05e60dbad2cf8f370a5cdd3ec6609119d618";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "d85a18e539ea4cf2419ff4067245dc3fc19d512971723c22d50829e3ab45bc54";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "11edfed1f060d405fd097646d2ebec36453793859dd58a16cabbd6d57ccfa06e";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv opencv.cxxdev rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs opencv opencv.cxxdev rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "0742f543114b6850f6e2d110c2d259a0d0a0f32d0535dec7c6ea2b4ab0bec241";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "10779c23498f9ec2f109ac9266308692aecf3d2dc3065553882834958c716c13";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-driver/default.nix
+++ b/distros/humble/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-driver";
-  version = "4.1.1-r2";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_driver/4.1.1-2.tar.gz";
-    name = "4.1.1-2.tar.gz";
-    sha256 = "78d486865936a2f02e99fa9fea1bb0c39243ee9677bfd6021907f7cee4e21bbb";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_driver/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "d573621a4a4d1d93dd0eefd0ea01e5a3722f8b0c43937c4a3e97c8e9859ccea6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-msgs/default.nix
+++ b/distros/humble/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-msgs";
-  version = "4.1.1-r2";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_msgs/4.1.1-2.tar.gz";
-    name = "4.1.1-2.tar.gz";
-    sha256 = "a114c62a2cf518dba63512014612730d8ac13d936f6e43ab243d6f442b9f8fe6";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_msgs/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "5dec6da4ed98461f572730d17ed29759e5bdd7cbb2d466949e7864dcab8b244f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "44cd95440c4a5cec51563a1243eea8acc8ee155212dabdf44db1df2a4b297501";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "c8ea4fdd18bbeb455c54c7cab30502e47bf4f91dac12fb96d05e929fa1be5fe6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-accelerometer/default.nix
+++ b/distros/humble/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-accelerometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_accelerometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f1f7d2924805fb147683a6e7e9b7e0e7867740d767f85211db13a7691f0ae9cd";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_accelerometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "e77adf22ca94e2b9934bd6ac3f2e3af0352187548833c738564dbb413c1f526a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-analog-inputs/default.nix
+++ b/distros/humble/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-analog-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "8f507032c9a18b36742667776af76ef9df3a575c73c3d5ca870fba228f81b4d5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "9837c9be3ee053a2669c51314dc6a28712283bd1d021c4f76f33367daadb3de5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-analog-outputs/default.nix
+++ b/distros/humble/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-analog-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "c2137a2fe32a6f2e1cdf61b3720e82b7b9348bc44ae941fccfec609e41548b0e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_analog_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "1495dacf4f5724b229fed0f8dc07e7d0affdff401bd5379f8095de63dad1906f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-api/default.nix
+++ b/distros/humble/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-humble-phidgets-api";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_api/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "0ed49709613bf3a37b87211b15f148ceb4fc7534222c3a4ba72a94b53f7053cc";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "0656b2b9b283f008a0ed03c64795d4615d24cdf31387b1bee19988fee18703b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-digital-inputs/default.nix
+++ b/distros/humble/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-digital-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "afed4616956fb988b4eba1173d0c6f6a72aaa2ccbb3a9cb14577bd95c36fd419";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "d3bba232005e07a87fa1070eb21e9a1f57487563413e98f57d3468a47f35c4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-digital-outputs/default.nix
+++ b/distros/humble/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-digital-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "bcd4824c27bac1d475502097082e4057f7c14fcb214838e3effd5548dc64bd53";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_digital_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5cec62f533d31df66723c9e0c1053d14eddc9e2329b79dc305dde0805a7619b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-drivers/default.nix
+++ b/distros/humble/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-humble-phidgets-drivers";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_drivers/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "3bd5cf062b90b2c86e5e410b49663ca5af99e9b97149702cb52bdeed6d928752";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_drivers/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5a7829da71127539210aa45d5348083bead0c5e783cac1aa5a08456899fd151f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-gyroscope/default.nix
+++ b/distros/humble/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-gyroscope";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_gyroscope/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "e8356d1d23311552eb98aa6bb328794ec6262a1989654ab9d6b1741e0aed2010";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_gyroscope/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "976ade6f40422e2c7f863a378900d2cd7734b09d9fe1137fc97e0d7773d3ff0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-high-speed-encoder/default.nix
+++ b/distros/humble/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-high-speed-encoder";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "cfdcd43c4ced7fad39c3747196f44357fb690af9746d6ae770b3a6669d8b14d3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_high_speed_encoder/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "7dd7f1b8cc775d8bd4c401de87140e9a5619985d041fc3d7a1f8682175517ed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-ik/default.nix
+++ b/distros/humble/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-ik";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_ik/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "1dd3bb0f53f336108eabc19eba4d837e61e827406d6aaa3dbd22c4f845ad0a06";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_ik/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c2d6b6550ecfd6de0f6f437bfbdf3cd97a4a88c081f6626825d409885aca9d37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-magnetometer/default.nix
+++ b/distros/humble/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-magnetometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_magnetometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "9474645c0d322d980735a496cc94be2e5bf240b89ea5e1129daba24719568651";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_magnetometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "8105ce10f732b36ae4c45391123afba1f15db3c8363959542c72f0f194d1bd66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-motors/default.nix
+++ b/distros/humble/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-motors";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_motors/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "2dd8754269be49079f22c907ce288a0592d82104ce0a9f122f6de1baa7316346";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_motors/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c1fa00e10bc4d05cb92f5a8f95bfb0dc11cd74c075e56ce570692be02ccdfa50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-msgs/default.nix
+++ b/distros/humble/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-msgs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "15994d6f8f68ce830618ecd5da87102d67877f4fa603478ee14a8b3c9b1ea271";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "41b056a981a273ead1fd2324cd4aaa2e21e2d8952ede3da291e87edebe735b3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-spatial/default.nix
+++ b/distros/humble/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-spatial";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_spatial/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "6b406afeb980aaa4e5e64cfaa2bc21ea2a4390df07002b37ecd8b0a247495c36";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_spatial/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "45fe328cfc5f70822e2b5523ebda7c2a666264bd4b7e160942e13a4d4afcb679";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/phidgets-temperature/default.nix
+++ b/distros/humble/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-phidgets-temperature";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_temperature/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "8301cdc3165351f9221a6a9205d849406c9fd683228ab3a9a9d03ee3744a41ed";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/humble/phidgets_temperature/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a062ce75d929c565c30aee3b3db783bcb81b1f73583daad24e2f2acf194698e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-description/default.nix
+++ b/distros/humble/raspimouse-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ign-ros2-control, joint-state-publisher, joint-state-publisher-gui, launch, realsense2-description, robot-state-publisher, rviz2, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-description";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1efeb025cfb4d1d272507302a820654ad5f10c7cd199f42a6806678a4f6be0f2";
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/humble/raspimouse_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ffae980fa75d09ea29705a78cb0818b68595a6055377624b92e79f1932c6914b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-fake/default.nix
+++ b/distros/humble/raspimouse-fake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-fake";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_fake/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4adecba84f76d80c1463225bc67e18b40950cda89b6a652451e83f841defd2e9";
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_fake/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d1408df1c47df7c882c5f485ffb524b3a2295a2ee8c952810b742c7e52cdd7c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-gazebo/default.nix
+++ b/distros/humble/raspimouse-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, raspimouse-description, raspimouse-fake, robot-state-publisher, ros-gz }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster, raspimouse-description, raspimouse-fake, robot-state-publisher, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-gazebo";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_gazebo/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "7adc317ef48ae001338b8d53c2d4cb12ac3928d1b7abf11bdc3071cd49cd8a44";
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_gazebo/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "32135b9eb45ff4d333362ced8439b0eaddb45f66c0e157920a377c69ee60a57f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ controller-manager raspimouse-description raspimouse-fake robot-state-publisher ros-gz ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster raspimouse-description raspimouse-fake robot-state-publisher ros-gz ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/raspimouse-navigation/default.nix
+++ b/distros/humble/raspimouse-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, nav2-bringup, raspimouse, raspimouse-slam, rplidar-ros, rviz2, urg-node }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-navigation";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_navigation/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "346741fbad99e1bb73faaa57836685d9b075bc2d3498dd51e2d627d6d9507246";
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_navigation/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "075eb97a30504017edb643f751ae63d458668c8548159d4c097b5f45e074d189";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-ros2-examples/default.nix
+++ b/distros/humble/raspimouse-ros2-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, usb-cam, v4l-utils }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-ros2-examples";
-  version = "2.1.0-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4567bff84be33ef7d59c41fb4945ba38adb19accd63aa094748f07cf385e20ba";
+    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/humble/raspimouse_ros2_examples/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "0554257dd89a8ab704a2ee597cd9ee16a38d404e3735085eb7c5fb15fae0ff30";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv opencv.cxxdev raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs v4l-utils ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv opencv.cxxdev raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs usb-cam v4l-utils ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/raspimouse-sim/default.nix
+++ b/distros/humble/raspimouse-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-fake, raspimouse-gazebo }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-sim";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_sim/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d6ac04a616abb7bd5a303faebdc4f6f5012fbe02db42ac18199a53d1639c9f00";
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/humble/raspimouse_sim/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3f27d185166372abae4c7ae1bf490c4ec31e6197773cfd1d82e2bbfe9b703f85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-slam-navigation/default.nix
+++ b/distros/humble/raspimouse-slam-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-navigation, raspimouse-slam }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-slam-navigation";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam_navigation/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "5a9489190a4b66b2ae957c592212ef587707e2cb170b0653f9214ff69ec5bd36";
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam_navigation/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "32722e53ba88069bdcfb9ac83203c56daaddc07e2113f52c4ba63d542475e541";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/raspimouse-slam/default.nix
+++ b/distros/humble/raspimouse-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, hls-lfcd-lds-driver, joint-state-publisher, joy-linux, nav2-map-server, raspimouse, raspimouse-description, raspimouse-ros2-examples, robot-state-publisher, rplidar-ros, rviz2, slam-toolbox, urg-node, xacro }:
 buildRosPackage {
   pname = "ros-humble-raspimouse-slam";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8bffec08cfe0808dbb3eea36d7393381628e1c0be7a4d32a23fbb5592c240d3d";
+    url = "https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release/archive/release/humble/raspimouse_slam/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "783dfc6c4ac4cf0c97a22bcb9960f20a9603a9f4c76fe23a658e93d222a16ab1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rc-genicam-api/default.nix
+++ b/distros/humble/rc-genicam-api/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-humble-rc-genicam-api";
-  version = "2.6.1-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/humble/rc_genicam_api/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "4cdc2098ffb586101b7c130bda8073b5ffb7f71687ae4c7c4f7e09413458c609";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/humble/rc_genicam_api/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "3c36c72e5d2f853918def54567cbd33fc2e806feb4d9c575029ee5cc1fa693e0";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libpng libusb1 ];
+  propagatedBuildInputs = [ libpng libusb1 ncurses ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/robotont-driver/default.nix
+++ b/distros/humble/robotont-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, asio, asio-cmake-module, geometry-msgs, io-context, nav-msgs, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, serial-driver, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-robotont-driver";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/robotont_driver-release/archive/release/humble/robotont_driver/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "29765d70dcc2ae33eabae5ecfd4b12e56db84d8609fb5ea0804030e146796e4f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto asio-cmake-module ];
+  propagatedBuildInputs = [ asio geometry-msgs io-context nav-msgs pluginlib rclcpp rclcpp-components rclcpp-lifecycle serial-driver std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto asio-cmake-module ];
+
+  meta = {
+    description = ''Hardware driver for the Robotont robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/robotraconteur/default.nix
+++ b/distros/humble/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-humble-robotraconteur";
-  version = "1.0.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "289563494bbd6d49daca9a7b348732c440a3dd103a02b7a388c8a9327f53d961";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "93add797df392d650edff054674f3f2f02a2a539c6c90da18c3b19f8d2ec0990";
   };
 
   buildType = "cmake";

--- a/distros/humble/rqt-gauges/default.nix
+++ b/distros/humble/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-gauges";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/humble/rqt_gauges/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "43b9cb3e99359ead65731c49f5d2402afa06a8ecffe7d2839e68e0f677fd7b58";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/humble/rqt_gauges/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "d2598a85f94ad6a5f6833aeac3af8de694036eadfb036b9cda82e45d4ca4e43e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/sick-scan-xd/default.nix
+++ b/distros/humble/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, geometry-msgs, nav-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-sick-scan-xd";
-  version = "3.1.11-r3";
+  version = "3.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sick_scan_xd-release/archive/release/humble/sick_scan_xd/3.1.11-3.tar.gz";
-    name = "3.1.11-3.tar.gz";
-    sha256 = "6fa1966620d69c090a7e28defea775aaa6724dcbb2f881d36138d08de51aa92a";
+    url = "https://github.com/ros2-gbp/sick_scan_xd-release/archive/release/humble/sick_scan_xd/3.2.5-1.tar.gz";
+    name = "3.2.5-1.tar.gz";
+    sha256 = "40b3d8502f6a7b2c6f11d8ea9d55f5d5f749fbdce66749c835bffcae96e40ac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sophus/default.nix
+++ b/distros/humble/sophus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-humble-sophus";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sophus-release/archive/release/humble/sophus/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "be643cba4f75f64999979f3af952e7187925b671a46aeabeafabdeb3478ea17c";
+    url = "https://github.com/ros2-gbp/sophus-release/archive/release/humble/sophus/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "19f18c6a0dad27ebd33c4e872c7c7346bff95ad8e81f15bbc60a711d46da44a4";
   };
 
   buildType = "cmake";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.0.8-r3";
+  version = "2.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.0.8-3.tar.gz";
-    name = "2.0.8-3.tar.gz";
-    sha256 = "db632c142b60bc0df147152dee60ed79c5a394f0851fa7ed6546d5739df5f541";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.1.14-1.tar.gz";
+    name = "2.1.14-1.tar.gz";
+    sha256 = "b9bf154de3f4addc2d95db68a4359cc2fc1056aed27689f4b6f719a99624c8fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/humble/spinnaker-synchronized-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
+buildRosPackage {
+  pname = "ros-humble-spinnaker-synchronized-camera-driver";
+  version = "2.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_synchronized_camera_driver/2.1.14-1.tar.gz";
+    name = "2.1.14-1.tar.gz";
+    sha256 = "3d5351b470dcdda66c859c177d47f71a472aabc26fa58e95d08bab2e3c39af53";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components spinnaker-camera-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver for synchronized flir cameras using the Spinnaker SDK'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/teleop-twist-keyboard/default.nix
+++ b/distros/humble/teleop-twist-keyboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
 buildRosPackage {
   pname = "ros-humble-teleop-twist-keyboard";
-  version = "2.3.2-r4";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/humble/teleop_twist_keyboard/2.3.2-4.tar.gz";
-    name = "2.3.2-4.tar.gz";
-    sha256 = "74c1b9d9105826029bf614c66abd1414ec1f7b87697c5d97e286e0740123718a";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/humble/teleop_twist_keyboard/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "32c54e0b5e1c03d6ef24be8ed5f14e47fa17dbbdcc53ef80157734df61d11572";
   };
 
   buildType = "ament_python";

--- a/distros/humble/wireless-msgs/default.nix
+++ b/distros/humble/wireless-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-wireless-msgs";
-  version = "1.0.1-r2";
+  version = "1.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_msgs/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "b98ca63ded730e8c29e17e6a181c6f02757d29d88d83906575298df1be5c30d6";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_msgs/1.0.1-3.tar.gz";
+    name = "1.0.1-3.tar.gz";
+    sha256 = "99a4eb2721187e34aac47fecf05ac57e6c370d4d2b33bc3f15dcdc3fe275a709";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/wireless-watcher/default.nix
+++ b/distros/humble/wireless-watcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, wireless-msgs, wirelesstools }:
 buildRosPackage {
   pname = "ros-humble-wireless-watcher";
-  version = "1.0.1-r2";
+  version = "1.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_watcher/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "b6a676b9466668ae678049eb476411ca1bac2a7d3b888e9541c7eb319d5b1d4e";
+    url = "https://github.com/clearpath-gbp/wireless-release/archive/release/humble/wireless_watcher/1.0.1-3.tar.gz";
+    name = "1.0.1-3.tar.gz";
+    sha256 = "010038d379705a30cd71aa488ff8da5464112d778b8e3bbf2287114495c1578d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/azure-iot-sdk-c/default.nix
+++ b/distros/iron/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-iron-azure-iot-sdk-c";
-  version = "1.12.0-r1";
+  version = "1.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "b35017fcc97c8020d789900557eef5137903e94ced3c3b6c037750b9242cf736";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.13.0-1.tar.gz";
+    name = "1.13.0-1.tar.gz";
+    sha256 = "02a7e86d2efe916395fbcf0d914a64f663e138ad30b3998e2280b6af9f7ebb6a";
   };
 
   buildType = "cmake";

--- a/distros/iron/cartographer-ros-msgs/default.nix
+++ b/distros/iron/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-cartographer-ros-msgs";
-  version = "2.0.9001-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/iron/cartographer_ros_msgs/2.0.9001-2.tar.gz";
-    name = "2.0.9001-2.tar.gz";
-    sha256 = "6cf821f3b65838ade056f34399b1b65ea0e63929fe09344aef83356c336244aa";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/iron/cartographer_ros_msgs/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "5c8038ac52a7cd8997dbf3e8cf52646d312556269ab63dcdc150281e5f92a36e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cartographer-ros/default.nix
+++ b/distros/iron/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, builtin-interfaces, cartographer, cartographer-ros-msgs, eigen, geometry-msgs, gflags, glog, gtest, launch, nav-msgs, pcl, pcl-conversions, python3Packages, rclcpp, robot-state-publisher, rosbag2-cpp, rosbag2-storage, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-cartographer-ros";
-  version = "2.0.9001-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/iron/cartographer_ros/2.0.9001-2.tar.gz";
-    name = "2.0.9001-2.tar.gz";
-    sha256 = "7007ca33e361d7523603e82146c3d8f3f91ee739368ff2f8d650e1cfbc587ddf";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/iron/cartographer_ros/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "b58b36dfd13866aa3b801f89c46e426c81f48e5e11a7602a09aa1c420a9ba8ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cartographer-rviz/default.nix
+++ b/distros/iron/cartographer-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, boost, cartographer, cartographer-ros, cartographer-ros-msgs, eigen, pluginlib, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-cartographer-rviz";
-  version = "2.0.9001-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/iron/cartographer_rviz/2.0.9001-2.tar.gz";
-    name = "2.0.9001-2.tar.gz";
-    sha256 = "1ffb14b0ee241aaa4f7c98a2f579ada851c0db4576a9d8d507a08e3b4b24b618";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/iron/cartographer_rviz/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "788152cfaf166c110205ebeed12dfed2683ac6db6d17577a4baca1030dd316de";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cartographer/default.nix
+++ b/distros/iron/cartographer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, boost, cairo, ceres-solver, cmake, eigen, gflags, git, glog, gtest, lua5, protobuf, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-cartographer";
-  version = "2.0.9002-r5";
+  version = "2.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/iron/cartographer/2.0.9002-5.tar.gz";
-    name = "2.0.9002-5.tar.gz";
-    sha256 = "3213541ddbb4d4b7bf3856afa5c5c07c16d551149848e6ca47256dfe77c4784d";
+    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/iron/cartographer/2.0.9003-1.tar.gz";
+    name = "2.0.9003-1.tar.gz";
+    sha256 = "9a7a64bb7042ae113863898517b755df218a3793b2d788f3a089c2a052ea7e81";
   };
 
   buildType = "cmake";

--- a/distros/iron/depthai/default.nix
+++ b/distros/iron/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-depthai";
-  version = "2.23.0-r1";
+  version = "2.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "95a262e1c68e3150da9768270101963f3756cd52486667a1defde2652d1a9f52";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/iron/depthai/2.24.0-1.tar.gz";
+    name = "2.24.0-1.tar.gz";
+    sha256 = "94a63a1adf147445d985933d2c0f9d12b69d42af3a3f6fe8a72f658e2f8bc1f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/event-camera-py/default.nix
+++ b/distros/iron/event-camera-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, event-camera-codecs, event-camera-msgs, pybind11-vendor, python-cmake-module, python3Packages, rclpy, ros-environment, rosbag2-py, rosbag2-storage-default-plugins, rosidl-runtime-py, rpyutils }:
 buildRosPackage {
   pname = "ros-iron-event-camera-py";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/iron/event_camera_py/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "26e1438be4284ff454f6a6f5d3cf46de08ac090c398a1b44aeca1083ad6a3150";
+    url = "https://github.com/ros2-gbp/event_camera_py-release/archive/release/iron/event_camera_py/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "f84d183d6a9d8769d73e476d1ac761e33e32f804efcb5a1d997b1741f7052835";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
   checkInputs = [ ament-cmake-clang-format ament-cmake-pytest ament-lint-auto ament-lint-common python3Packages.numpy rclpy rosbag2-py rosbag2-storage-default-plugins rosidl-runtime-py ];
-  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment ];
+  propagatedBuildInputs = [ event-camera-codecs event-camera-msgs pybind11-vendor ros-environment rpyutils ];
   nativeBuildInputs = [ ament-cmake ament-cmake-auto ament-cmake-python ament-cmake-ros python-cmake-module ];
 
   meta = {

--- a/distros/iron/flir-camera-description/default.nix
+++ b/distros/iron/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-description";
-  version = "2.0.8-r2";
+  version = "2.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "c28fdb71a7c4a82b6befe799881c635a7e9e360a7629da25a7c7909b54de09cf";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.2.14-1.tar.gz";
+    name = "2.2.14-1.tar.gz";
+    sha256 = "7cfea352fcca13681f399fe46ab0ab17598252ed7141b599201f494d4eb7abf9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/flir-camera-msgs/default.nix
+++ b/distros/iron/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-msgs";
-  version = "2.0.8-r2";
+  version = "2.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "40a71402d01d7dd098c211fa413c2a732ce05632e53deda81769ec6403ea3cd4";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.2.14-1.tar.gz";
+    name = "2.2.14-1.tar.gz";
+    sha256 = "aaa91f16feb1929f885a825acf02780828c492385a7ad6110af3b28c105e94d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gazebo-ros2-control-demos/default.nix
+++ b/distros/iron/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-gazebo-ros2-control-demos";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control_demos/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "d84d9e7f61bd15a9511c04ff38a231cb9c23879ba4f3d0fff11d2958f3d689d3";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control_demos/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "1a755c112a3f8770719bcf3101821a9d4e6423d1fc9c767dde2e529a6880c17f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/gazebo-ros2-control/default.nix
+++ b/distros/iron/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-gazebo-ros2-control";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "1a1b83f1967581678d0c0be0509b654d31bda11ffe15e3f4c3b16e48741f7c2c";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "4ea6e089296a2b671192975672186a29212a0eed48a089aa0395e9591056e3c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -818,6 +818,8 @@ self: super: {
 
  kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
 
+ kitti-metrics-eval = self.callPackage ./kitti-metrics-eval {};
+
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
@@ -942,6 +944,10 @@ self: super: {
 
  mapviz-plugins = self.callPackage ./mapviz-plugins {};
 
+ marine-acoustic-msgs = self.callPackage ./marine-acoustic-msgs {};
+
+ marine-sensor-msgs = self.callPackage ./marine-sensor-msgs {};
+
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
@@ -994,9 +1000,47 @@ self: super: {
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
+ mola = self.callPackage ./mola {};
+
+ mola-bridge-ros2 = self.callPackage ./mola-bridge-ros2 {};
+
  mola-common = self.callPackage ./mola-common {};
 
+ mola-demos = self.callPackage ./mola-demos {};
+
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
+ mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
+
+ mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
+
+ mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
+
+ mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
+
+ mola-kernel = self.callPackage ./mola-kernel {};
+
+ mola-launcher = self.callPackage ./mola-launcher {};
+
+ mola-metric-maps = self.callPackage ./mola-metric-maps {};
+
+ mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};
+
+ mola-pose-list = self.callPackage ./mola-pose-list {};
+
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
+
+ mola-traj-tools = self.callPackage ./mola-traj-tools {};
+
+ mola-viz = self.callPackage ./mola-viz {};
+
+ mola-yaml = self.callPackage ./mola-yaml {};
 
  motion-capture-tracking = self.callPackage ./motion-capture-tracking {};
 
@@ -2086,6 +2130,8 @@ self: super: {
 
  spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
 
+ spinnaker-synchronized-camera-driver = self.callPackage ./spinnaker-synchronized-camera-driver {};
+
  splsm-7 = self.callPackage ./splsm-7 {};
 
  splsm-7-conversion = self.callPackage ./splsm-7-conversion {};
@@ -2111,10 +2157,6 @@ self: super: {
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
  stomp = self.callPackage ./stomp {};
-
- stubborn-buddies = self.callPackage ./stubborn-buddies {};
-
- stubborn-buddies-msgs = self.callPackage ./stubborn-buddies-msgs {};
 
  swri-cli-tools = self.callPackage ./swri-cli-tools {};
 

--- a/distros/iron/gz-ros2-control-demos/default.nix
+++ b/distros/iron/gz-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-gz-ros2-control-demos";
-  version = "1.1.4-r2";
+  version = "1.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/iron/gz_ros2_control_demos/1.1.4-2.tar.gz";
-    name = "1.1.4-2.tar.gz";
-    sha256 = "44b0cb0cfdfe7ea1aac70c410594e68d85d376d831204cbefc96f7aa1a4de202";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/iron/gz_ros2_control_demos/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "1ec0622439436ad15ae0eea23368b15acb56e4e102e979d0180cbdfef55b1340";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/kitti-metrics-eval/default.nix
+++ b/distros/iron/kitti-metrics-eval/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-kitti-metrics-eval";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e636539836ef1d0be216efa9b46e2faf6d1dc3b5629efea9f41fc3e804701c39";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''CLI tool to evaluate the KITTI odometry bechmark metrics to trajectory files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/libphidget22/default.nix
+++ b/distros/iron/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-iron-libphidget22";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/libphidget22/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "d4a3e3f94b0e88d08871bd04a71fb1b8e4fd069109733c50414b113ca9aaa2b5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/libphidget22/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "fcbcb17ea740415cd2577b11fa135ab839fc38ef5a5bdd57bc201340ff192502";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/marine-acoustic-msgs/default.nix
+++ b/distros/iron/marine-acoustic-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-marine-acoustic-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marine_msgs-release/archive/release/iron/marine_acoustic_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3d7c0768adbfa8d8af31965d40e7dd60882bd244d467300698e4107e882235f4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The marine_acoustic_msgs package, including messages for common
+  underwater sensors (DVL, multibeam sonar, imaging sonar)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/marine-sensor-msgs/default.nix
+++ b/distros/iron/marine-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-marine-sensor-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marine_msgs-release/archive/release/iron/marine_sensor_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b31e44f46a6b9613ec39bedd1bf0a5869474818e82640d03b01c3f4ebff9e61f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The marine_sensor_msgs package, meant to contain messages for common
+  underwater sensors (e.g., conductivity, turbidity, dissolved oxygen)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/message-tf-frame-transformer/default.nix
+++ b/distros/iron/message-tf-frame-transformer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-message-tf-frame-transformer";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/iron/message_tf_frame_transformer/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "deee91f888bc5747e4176a3092e1c20a5c04ef6c641958e57a34b41d234b948f";
+    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/iron/message_tf_frame_transformer/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "60482d0e319e832aefd7445222d8ec5ab5b030ae11e4b33b52681f8ea6f8ded4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-bridge-ros2/default.nix
+++ b/distros/iron/mola-bridge-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-iron-mola-bridge-ros2";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "79d0c578be046d862007fcc7c8df7d43e55c0b82d3ce308c9bd674b3198006bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
+
+  meta = {
+    description = ''Bidirectional bridge ROS2-MOLA'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mola-demos/default.nix
+++ b/distros/iron/mola-demos/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-demos";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "f59e2d3947e15c2e06ed1405f7598be5f8c649863fc7abd1b3ad51b264274eb4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "774a12c3d79a1281ee69b35be253f2d0c346323d934d10af009b8730729d1274";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-imu-preintegration/default.nix
+++ b/distros/iron/mola-imu-preintegration/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-imu-preintegration";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "cff59fbcf73ee6fabd8ec431abc2cd197f0a3765a4767d07c4b0eb1709438cd5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "24658102da265b527910c2f425a19b41daf0e3153ba72acf560020b025fcd418";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-euroc-dataset";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "4b53745bf09c561d8428fc8ce2fc12226599943beb7bf92a9972963020286288";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6911ffdf8a806a4a8d2d50e7f5de32037c745906130a45a950ddd56cd2a5166b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti-dataset";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "a21bceb6d11b63787b47bb0d2907db2ae9c3210d6079d5a7008a90a5c416dd80";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f8e21c9ff6382c2100b2d0edcf089f44765c74deb8f7a8e866e634c20d2f2b7e";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti360-dataset/default.nix
+++ b/distros/iron/mola-input-kitti360-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-input-kitti360-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3bb2a33f6f5174caa5d63822adbf055485ef97146f475c8dc35a230de4e893ed";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Kitti-360 datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-input-mulran-dataset/default.nix
+++ b/distros/iron/mola-input-mulran-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-input-mulran-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "39baf969f24ff1dbb3787bf5eadc702ee598bab788968bb523c861fe04decf57";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from MulRan datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-input-paris-luco-dataset/default.nix
+++ b/distros/iron/mola-input-paris-luco-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-input-paris-luco-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "44c4f11901a17cfa84d9c817475dddb1de24f1f2220b5d2b48e12bba59946a4e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Paris LUCO (CT-ICP) odometry/SLAM datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-input-rawlog/default.nix
+++ b/distros/iron/mola-input-rawlog/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rawlog";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "19c897172e2206e88ec11def0ff343c702748bbde9ed57e5f1223df6f6493908";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e8eb1a5993542a77850d61136793e6967d7f179da6fbea977a5aa4f782fd8350";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rosbag2/default.nix
+++ b/distros/iron/mola-input-rosbag2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-mola-input-rosbag2";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c111f74ab79bbba9cb72ae1a9d16499362bb2bb3686b41785f21fb08a9e3fe81";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ cv-bridge mola-kernel mrpt2 rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from rosbag2 datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-kernel";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "8d61d802133d9ba8d3b5a33751e5a8e0877e19eabffa5ad66b253594af8b0216";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "edd0275ad083804c4f0f7d0a2f07ff73226e35fa6258c1bbd5a321e2e7e2116f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-launcher/default.nix
+++ b/distros/iron/mola-launcher/default.nix
@@ -1,22 +1,23 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-launcher";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "5efdf5664504d96b92b4aaa96ccb801cf5387ce9f92742094da0a63fee49cfd5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5fd141c2404a7bbb8ebe5af5365eb26501801229b21f7895ae53c4e647cbbc6b";
   };
 
-  buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ mola-kernel mrpt2 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {
     description = ''Launcher app for MOLA systems'';

--- a/distros/iron/mola-metric-maps/default.nix
+++ b/distros/iron/mola-metric-maps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-mola-metric-maps";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "23661a311409be6b2d18c5bcae7e0b3122022d7f76c2129409fceee10a702a91";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = ''Advanced metric map classes, using the generic `mrpt::maps::CMetricMap` interface, for use in other MOLA odometry and SLAM modules.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-navstate-fuse/default.nix
+++ b/distros/iron/mola-navstate-fuse/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-navstate-fuse";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "15f7f83ae875be8b7f33f51919a1dc3373df543a6b5582284e2c98112617685f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''SE(3) pose and twist path data fusion estimator'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-pose-list/default.nix
+++ b/distros/iron/mola-pose-list/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-pose-list";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a3410d15d95a3c7e7e7843007130d9c35c2b8e75f156836122d933ed9b271372";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ library for searchable pose lists'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-traj-tools/default.nix
+++ b/distros/iron/mola-traj-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-traj-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "42dabcd65105f3488f475296212007d719eaefe085fd23835403f174974a8681";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''CLI tools to manipulate trajectory files as a complement to the evo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/mola-viz/default.nix
+++ b/distros/iron/mola-viz/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-viz";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "3a461b3dee7c4340745d7baea9f85b065e565d6469bb9632e008d5c94c97cf8b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "762b85aa0fcec3f1398ba342009dba39b1df4d1e9c9d639633ff8a598c0fee74";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "6f443d3e8b602002ca7cbdc70c609787442f835f2dd32b57a2285389c359ce09";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8611646d5b5c103308347139d690a464e4fe8417062d497ae88d6190ee11b943";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola/default.nix
+++ b/distros/iron/mola/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
+buildRosPackage {
+  pname = "ros-iron-mola";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7c9b6c37c721be11c64ca1f0a538d4274954dc628e1ae3bc0261609e96dbd70b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fuse mola-pose-list mola-traj-tools mola-viz mola-yaml ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage with all core open-sourced MOLA packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/motion-capture-tracking-interfaces/default.nix
+++ b/distros/iron/motion-capture-tracking-interfaces/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-motion-capture-tracking-interfaces";
-  version = "1.0.2-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking_interfaces/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1c304aafc5822a50b52a65b3204a368a2d3ed7c1b9596c0dd7ac62fa48c342ad";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking_interfaces/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "4095ae5847b4ed44fda0f442a96c9f1a69958c9e9914ea657d4625e5ce732220";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/iron/motion-capture-tracking/default.nix
+++ b/distros/iron/motion-capture-tracking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, motion-capture-tracking-interfaces, pcl, rclcpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-motion-capture-tracking";
-  version = "1.0.2-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3662a1815abca644937fcab4208e9eb6e78ea4ba04341c9a7e5f0691304d17fa";
+    url = "https://github.com/ros2-gbp/motion_capture_tracking-release/archive/release/iron/motion_capture_tracking/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "8ed84ec19b7cec06b814c86f8bd34e9c0baf67451a9567ea5170b248cf8e836f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "013a16649971f3e386f3a795b26882591c79aeec25608542c5620769ff73c657";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "189f69380753229bed87ed215b21187e0fa1e42837c5e943f3203ad1816133ee";
   };
 
   buildType = "cmake";

--- a/distros/iron/mqtt-client-interfaces/default.nix
+++ b/distros/iron/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mqtt-client-interfaces";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f2e5e9f011bc2b4219e618818da701c9854effcc9bc7592d7825e0de330b434b";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/iron/mqtt_client_interfaces/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "562d59c4e98bb3576d56947103ef99a175da60ec7cfbbfa18e6f82d7cc76da7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mqtt-client/default.nix
+++ b/distros/iron/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mqtt-client";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/iron/mqtt_client/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "55d5a46ba0595cdf74cd67a4f73ee84f8b8251dcfe36dc5f5941c11df5936b74";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/iron/mqtt_client/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "db3d01ead931e49c2ee2eb89340c50bb8defcf55062eb4287e2dcb3da70627e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt-path-planning/default.nix
+++ b/distros/iron/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
 buildRosPackage {
   pname = "ros-iron-mrpt-path-planning";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "894431be27b5c6f0b240413eef280e0312bf560abc545e2b28789d51b7b16c37";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "39edb10457f01fcb1d31812cbf4defbc508477895e0f5fd096384f6dd1a35336";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "5e9b3c4ff4b1463483bc7d7be67f786511273725cb5494fea4aae31341877756";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "ecc0a9a724da3ca500affd9e089d4124c953144a8fe5781754f9529dca25eab9";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv opencv.cxxdev rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs opencv opencv.cxxdev rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/mvsim/default.nix
+++ b/distros/iron/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-iron-mvsim";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "4dd7d3c6f6de7c955df7294f8533fe89ecf6fcd10020e018637cb0e8c016e3f0";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/iron/mvsim/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "1c1f1650c414c738417f3a4a3a256fbe3989cbf09afc7a09f9f05d4c8e0c33a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/novatel-gps-driver/default.nix
+++ b/distros/iron/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-novatel-gps-driver";
-  version = "4.1.1-r1";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_driver/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "05551522d5c27b368e5579b701e2b5a324dd88f0a378295421d315b02444b2ee";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_driver/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "51de13bce19a68c15de71b67e31fc9b89182269453f5cdfb182f5ec11804ad38";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/novatel-gps-msgs/default.nix
+++ b/distros/iron/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-novatel-gps-msgs";
-  version = "4.1.1-r1";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_msgs/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "97e34d9fb5f02ca73c874b27ed9baec583a69835067bac1447feabe3d2f21b4e";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_msgs/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "7c08bf81d3e12334aeeadc73e04b03656eeeffeb14ecfd77766af4af023692ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ntrip-client-node/default.nix
+++ b/distros/iron/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ntrip-client-node";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "9f32ec85eff3e1578a8547ce2ee758528cc34ed1a1312265d3bfb98f153dfaa6";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ntrip_client_node/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "546d8b15522bb8ddac6e77cb230ddf4adae698de754ba45cb6d141e3d8f24375";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-accelerometer/default.nix
+++ b/distros/iron/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-accelerometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_accelerometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "aa6c80a40a8ce930c0896a5cfd83a6ee33f5665c108673d6af0c9f9394bc3334";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_accelerometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "69bf22b77fbce1213f73b291eb339c8bc1ecfd11fb74ee0710efcb657f416910";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-analog-inputs/default.nix
+++ b/distros/iron/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-analog-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "2a5915ec426069e12d28fde80845fe18d8ab761c292998887abc968f92927600";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "7b72140338778c42f184dafcc4984665c79c1207015456a44b0277f52fd84761";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-analog-outputs/default.nix
+++ b/distros/iron/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-analog-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "e45b3d5c258578b0f38c770d32fc5798f86a161d637775761503a9cfce07782a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_analog_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "c9b102283db5363557ed29e87d8e5ec42855abdb10250236d0d294f6d8173567";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-api/default.nix
+++ b/distros/iron/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-iron-phidgets-api";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_api/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "136f1c3fa6a5c5f6aeedea8b0215cf76481f2c900558159c45ee69f52b4366b6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "51dd2225e704bf0870cb46c1c0379ecae191a8dac3e5fe44c2de8602cac1f99b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-digital-inputs/default.nix
+++ b/distros/iron/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-digital-inputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_inputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "6d3587788deb7f9a5427dbce84ecf256207ff0ab18af4eef28b36727c9f0c443";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "9dec5eb36beaa7b9f38ad0c3bf046ec47ff8df8f8d7f9e7789fbaf6619258df8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-digital-outputs/default.nix
+++ b/distros/iron/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-digital-outputs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_outputs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "57e1f4216480af21aaf9d5a442fcff6359703aa426e82e3f68a1ec1086f16508";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_digital_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "f4f2f9d282c5f7b74eae617e94870bf7d963651f3735917e6a8ee07f6c4c03c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-drivers/default.nix
+++ b/distros/iron/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-iron-phidgets-drivers";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_drivers/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "d3bc49b5c6a1101ccac4954da7a4f1dc4c2d44bafaddc2f08398d9dae674bee8";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_drivers/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a0bf453122627560758096c47eb86d264c55f5701b95be35c8d863a2ca8001bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-gyroscope/default.nix
+++ b/distros/iron/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-gyroscope";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_gyroscope/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f75efc7558ba579a552fb1b4a3914faf4dd84d8903f48b100eac9ac1f40fbed2";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_gyroscope/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5240674614d8e4f0fa0e71c49aea9f868b25d31084f8db2b7618c8013833627d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-high-speed-encoder/default.nix
+++ b/distros/iron/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-high-speed-encoder";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_high_speed_encoder/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "02d9e3c5c32d2f763ae47e24b975c740cd742ab8b645d649a342fa4a215e136d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_high_speed_encoder/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "49db649c12afe9e11eb5c3ca656ab1f017c14edc5f907d1079c305f0270bd607";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-ik/default.nix
+++ b/distros/iron/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-ik";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_ik/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "78e073adfe1adf1d0b90a163c6e05277da9a3889907efb51adc09b18a3988440";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_ik/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "370da1d6bfe2f2097481981c4a7bdf852eb2d3934548efa62c46bca3e4717e2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-magnetometer/default.nix
+++ b/distros/iron/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-magnetometer";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_magnetometer/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "62acf1e3cf99cc27b2a0ba3472ed3eec26912f9f520e1f433f490dd159af85cc";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_magnetometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a208a8261ca3fd2ab6fa2c14ea38dfe23c446c849075d3527cb5cf6032bd1000";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-motors/default.nix
+++ b/distros/iron/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-motors";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_motors/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "28b56a9db4b195732f6b151084a371be5e961e9e5e5c4b858f939f00757c5fe7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_motors/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a023cb1e158b2a544dd4615401be92048489808641ec9db2c58879147b138fc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-msgs/default.nix
+++ b/distros/iron/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-msgs";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "a838f173127f2f123067ca280cb8a68b17d60888f390dc2061014ee477d3fbc0";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "d92761c8e0bcd91fd8b6809f2d4d04035b94e67e69e87eb3f10f16bb67bee489";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-spatial/default.nix
+++ b/distros/iron/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-spatial";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_spatial/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "12e7cc27ac1e373401a186653f31fea536596a3a5583b6a0ed7c68c5a825b430";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_spatial/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "296213799ed4f3060f44566fed36cdf5623d62a1cd647a6fb096c4005959fec6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/phidgets-temperature/default.nix
+++ b/distros/iron/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-phidgets-temperature";
-  version = "2.3.2-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_temperature/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f468564c332b2c0183dd49e393822f059ae711f8b3edd8eef7632dbfd746e9d2";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/iron/phidgets_temperature/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a1368091b0be628bd05a77df4ef407bc6efa5e131f103eb27a787c699f39abd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robotraconteur/default.nix
+++ b/distros/iron/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-iron-robotraconteur";
-  version = "1.0.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/iron/robotraconteur/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "b6be3ff8330ae553dce1beeccc482c40ab659587e1e61913d8a4ac1948dabe2d";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/iron/robotraconteur/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d8c4b6665e9826694246c9e6c4106b835658ef20d2b90b49985ee0a95e2895bd";
   };
 
   buildType = "cmake";

--- a/distros/iron/rqt-gauges/default.nix
+++ b/distros/iron/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-gauges";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/iron/rqt_gauges/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "b2104eac32117f2da319023316c8f0b73af6637f503017530d6d51641d6801e3";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/iron/rqt_gauges/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "ccc81b060fea71fda4d5d988d45652b88e089cef0aaa286fd4eada384927da08";
   };
 
   buildType = "ament_python";

--- a/distros/iron/sophus/default.nix
+++ b/distros/iron/sophus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-iron-sophus";
-  version = "1.3.1-r3";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sophus-release/archive/release/iron/sophus/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "8d33ae85782f2f8868ad6515b74177bdb1b6231390562cc85bffeffb0d1d0827";
+    url = "https://github.com/ros2-gbp/sophus-release/archive/release/iron/sophus/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "d1e8183120617de2f79ea109679f1ac23eabeef14c68991e11a6ea3099cff1ce";
   };
 
   buildType = "cmake";

--- a/distros/iron/spinnaker-camera-driver/default.nix
+++ b/distros/iron/spinnaker-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-spinnaker-camera-driver";
-  version = "2.0.8-r2";
+  version = "2.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.0.8-2.tar.gz";
-    name = "2.0.8-2.tar.gz";
-    sha256 = "313d78fb103ef26ff3b85905902386d71393097d464e2e9e48cd0b4d1f947118";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.2.14-1.tar.gz";
+    name = "2.2.14-1.tar.gz";
+    sha256 = "4b693a2e29a369951194ddecefa9a7ee6d96b6e1f630b86208cab0f168de9f23";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/iron/spinnaker-synchronized-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
+buildRosPackage {
+  pname = "ros-iron-spinnaker-synchronized-camera-driver";
+  version = "2.2.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_synchronized_camera_driver/2.2.14-1.tar.gz";
+    name = "2.2.14-1.tar.gz";
+    sha256 = "8d2c865a17fe4a7cddbd71da0b0a07c6b97380a03b3b308ce339d1629ae133b9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components spinnaker-camera-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 driver for synchronized flir cameras using the Spinnaker SDK'';
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/iron/teleop-twist-keyboard/default.nix
+++ b/distros/iron/teleop-twist-keyboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, rclpy }:
 buildRosPackage {
   pname = "ros-iron-teleop-twist-keyboard";
-  version = "2.3.2-r5";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/iron/teleop_twist_keyboard/2.3.2-5.tar.gz";
-    name = "2.3.2-5.tar.gz";
-    sha256 = "e58f953801d5dfbe6f31d687ceb1f3a1f5ba3889bc26f14c070aa7a98ba7de49";
+    url = "https://github.com/ros2-gbp/teleop_twist_keyboard-release/archive/release/iron/teleop_twist_keyboard/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a7f6f21fdc75e28c13bf34aa7c635fbbf78a11277175cb98aeea4e9195c7507c";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ublox-dgnss-node/default.nix
+++ b/distros/iron/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss-node";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "104add79ef0961048558dfe70e263530f26e93c4cf007b529fbf0594ca984f82";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss_node/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "0466efa587aec18eea4cae3d6d7c571edebf30d9c0a6e3ec5340e49a12aca705";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-dgnss/default.nix
+++ b/distros/iron/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-dgnss";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "21813d7ec62da342fcb8ea421e3c30827fd6145de945be6736c159c1a0cfc675";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_dgnss/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "0ccf9eb008f64dba3b2315e6898c5ce9147ea312d180b180e3d54e0fab3671c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/iron/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-nav-sat-fix-hp-node";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "b2c5e8aa62fdc5bcd01799c3dc12f337c016788329fc462fe8cf254e926f6a55";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_nav_sat_fix_hp_node/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "d21b004c0199cbb0b1d431ed1e1ec0a64240663bcb1d67043a930ad09d79c9ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-interfaces/default.nix
+++ b/distros/iron/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-interfaces";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "529111489aaed27cf7f83db4feeee67f92849665290adc3f0dbeee7032065644";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_interfaces/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "6448d5f2d0993c55f196acf2f86e7fa94c1416a99b440b1acbf1ad41767d09e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ublox-ubx-msgs/default.nix
+++ b/distros/iron/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ublox-ubx-msgs";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "51b78d567117874f23f9f4e5cefe9ed0b56b4e4f9d2296cd08e6fd09659e9961";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/iron/ublox_ubx_msgs/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "9451015cd79b71651154016d84480c300cdbd29f478f31acfdf9d388bee84e74";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/camera-aravis/default.nix
+++ b/distros/noetic/camera-aravis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aravis, camera-info-manager, catkin, diagnostic-msgs, dynamic-reconfigure, glib, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-camera-aravis";
-  version = "4.0.5-r3";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.0.5-3.tar.gz";
-    name = "4.0.5-3.tar.gz";
-    sha256 = "6e0f6a3e6647eec18d87d77c6f2c687454698961b22ad32332d00fb8ab824bf9";
+    url = "https://github.com/FraunhoferIOSB/camera_aravis-release/archive/release/noetic/camera_aravis/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "f3f5e83315b871e70a00a229ecb6a0fea941d2ca335f2f01d2aeeb53ccf79b2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-fiducials/default.nix
+++ b/distros/noetic/cob-fiducials/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-object-detection-msgs, cob-vision-utils, cv-bridge, diagnostic-msgs, diagnostic-updater, image-transport, opencv, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf, tinyxml, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-cob-fiducials";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/4am-robotics/cob_fiducials-release/archive/release/noetic/cob_fiducials/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "ae99f6e6e6e3e1e0667b872a509134e5f9b053ae73620458f260a98890359741";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ boost cmake-modules cob-object-detection-msgs cob-vision-utils cv-bridge diagnostic-msgs diagnostic-updater image-transport opencv opencv.cxxdev roscpp rospy sensor-msgs std-msgs std-srvs tf tinyxml visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Fiducial recognition. Implementation of different 2D tags like PI-tag from Bergamasco et al. for recognition with a single 2D camera.'';
+    license = with lib.licenses; [ "LGPL" ];
+  };
+}

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.23.0-r1";
+  version = "2.24.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.23.0-1.tar.gz";
-    name = "2.23.0-1.tar.gz";
-    sha256 = "8c1f937648cc3f174604169dc79f0851fda2942653065798f5ab75bb5d1a23dc";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.24.0-2.tar.gz";
+    name = "2.24.0-2.tar.gz";
+    sha256 = "1808d74c39484d688f54846357bb4105fe5487922468f9f10bc2483bbaa18d45";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -362,6 +362,8 @@ self: super: {
 
  cob-extern = self.callPackage ./cob-extern {};
 
+ cob-fiducials = self.callPackage ./cob-fiducials {};
+
  cob-footprint-observer = self.callPackage ./cob-footprint-observer {};
 
  cob-frame-tracker = self.callPackage ./cob-frame-tracker {};
@@ -2431,6 +2433,8 @@ self: super: {
  phidgets-gyroscope = self.callPackage ./phidgets-gyroscope {};
 
  phidgets-high-speed-encoder = self.callPackage ./phidgets-high-speed-encoder {};
+
+ phidgets-humidity = self.callPackage ./phidgets-humidity {};
 
  phidgets-ik = self.callPackage ./phidgets-ik {};
 

--- a/distros/noetic/husky-control/default.nix
+++ b/distros/noetic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, teleop-twist-keyboard, twist-mux }:
 buildRosPackage {
   pname = "ros-noetic-husky-control";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "97c15ce309d32e60754a8b70d0169d59580233121a366021633aab588e916ec3";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "445c1dfb9e874677d394a3aba29c5121f5dfb94e90c914800a68c6ca6ce1478e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-description/default.nix
+++ b/distros/noetic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpr-onav-description, fath-pivot-mount-description, flir-camera-description, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-noetic-husky-description";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "a11156cd54fd44a5b2e74b20a0ac5f4dcd0db19b5dd1d57230a9a3684e2a66b1";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "000859677ab9bde8fa5574408acc5114fde3dbc21060bc2b342505182217d865";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-desktop/default.nix
+++ b/distros/noetic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-noetic-husky-desktop";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "e2be7312321051ae82a338b9e7bb6be8a7b463f91b745aa64ccd67bf800a4b04";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "342d89266261cbaa66735bccd2700e3d50601d0b2df7731d5fbd6325a41e8b89";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-gazebo/default.nix
+++ b/distros/noetic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-husky-gazebo";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "02bf1fbc4d39e010a8ae1131f8ae3684203ee236fa58c48003471ef5fa47acf2";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "0167781c07ce44b8628f523df499f2c02ab17838008ba4bf0cfd8179c2def0f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-msgs/default.nix
+++ b/distros/noetic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-husky-msgs";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "c39040eadb65b499b9bc4e3a9121eed8f5be64ffbe448f6038e2ade625def81f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "85be2472ee76a31ff6b845ad8fc663d159f3db48c0179da4df12160361de5a3d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-navigation/default.nix
+++ b/distros/noetic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-husky-navigation";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "0dd6d17b0cce10de97c7fb14c66fef972f992e7d2f934450c080cf525b7b671a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "60718d47589ac780a0d2bee85ca57c0f7ddf5599b828a6d1eb3ffd827a57ffe7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-simulator/default.nix
+++ b/distros/noetic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-noetic-husky-simulator";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "636c3d4c41be397c6722ba49054dd5ef2734aca91288372864022b9cd20f59ab";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "ea6d308ad7e4b0b5939f498ccd359935a86f2903c72002450068d3868304ccca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/husky-viz/default.nix
+++ b/distros/noetic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rqt-console, rqt-gui, rqt-robot-monitor, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-husky-viz";
-  version = "0.6.9-r1";
+  version = "0.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "0bf9ef8d543e56e590b1e4b7e268cac9167b1678192fc636f32a4e8dc0db8a9a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.10-1.tar.gz";
+    name = "0.6.10-1.tar.gz";
+    sha256 = "1b1c6091fba69b953f406820a607ff76078d0d0c2376b6596b49f1c35309a7eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "6f7f6dfe7c964dcc87434885850967cf04e0f73efbb9dd1aed98b3f7cf1c353a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "83c34e6d6b0962497abd568181fc9265f5a56484903e9a01c44c1120469de878";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marine-acoustic-msgs/default.nix
+++ b/distros/noetic/marine-acoustic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marine-acoustic-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CCOMJHC/marine_msgs-release/archive/release/noetic/marine_acoustic_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "823c239989b8368de999b831f3519ccb933a6b97cda42b68c075b0eb402db23f";
+    url = "https://github.com/CCOMJHC/marine_msgs-release/archive/release/noetic/marine_acoustic_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "dd092f33c87942745815f92900168156e0bf96be8ebb9d400d6d7c242f5b61ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marine-sensor-msgs/default.nix
+++ b/distros/noetic/marine-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marine-sensor-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CCOMJHC/marine_msgs-release/archive/release/noetic/marine_sensor_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "2c391fb403d10aa7e749e6ee3a050e378248bf4b96a4302913a8154327a9a415";
+    url = "https://github.com/CCOMJHC/marine_msgs-release/archive/release/noetic/marine_sensor_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "d4c984439b7520c0203dca46e4d4695771bf57f0bcfa8bac2db919740bb658c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/message-tf-frame-transformer/default.nix
+++ b/distros/noetic/message-tf-frame-transformer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nodelet, ros-environment, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-message-tf-frame-transformer";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release/archive/release/noetic/message_tf_frame_transformer/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "40e3c44b79357536c8f8a6da4fcbf6315774663382acc19068e89a4172f07624";
+    url = "https://github.com/ika-rwth-aachen/message_tf_frame_transformer-release/archive/release/noetic/message_tf_frame_transformer/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1c47e7e6679f5d47bba3d792783484492fcfd39186074b6e5f72ec387161dae1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mqtt-client-interfaces/default.nix
+++ b/distros/noetic/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client-interfaces";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client_interfaces/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "6675f85695f6ea7aaaa39113e986e088bf53b0c9d03379034268bfc7c1c470a3";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client_interfaces/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1c727f6cd1d05dc3c9a8c0abcbf1dc5499cda920be619b05f62aee27e75ed92d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mqtt-client/default.nix
+++ b/distros/noetic/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mqtt-client-interfaces, nodelet, paho-mqtt-cpp, ros-environment, roscpp, rosfmt, std-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mqtt-client";
-  version = "2.2.0-r2";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/2.2.0-2.tar.gz";
-    name = "2.2.0-2.tar.gz";
-    sha256 = "5434f3f30f25a1434dc28db0efad124fef097437d69331866bc64b7a6684c9c5";
+    url = "https://github.com/ika-rwth-aachen/mqtt_client-release/archive/release/noetic/mqtt_client/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "cd99b24d1ed0f4fa3e839c503be9d86adaf8fb99dee2cb0ac07e99ae4280f2f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-generic-sensor/default.nix
+++ b/distros/noetic/mrpt-generic-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, mrpt-sensorlib, mrpt2, ros-environment, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-generic-sensor";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_generic_sensor/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "af22fedd26147af93bb3194a75c4dc6fc87b834498cea553bb7493773265b619";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_generic_sensor/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "147a9d09f9351cd8e64c80c6e3270cb38b1cb6f8fcb3a378a765e2aed597b2f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-local-obstacles/default.nix
+++ b/distros/noetic/mrpt-local-obstacles/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt2, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-local-obstacles";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7fc52ddb77541926e5d7a3672ad0798e0b92c813e3ccd67715fcb5b96e5eeb32";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9a8495aa6fc40a95e1ae4930e7a7e6568dd336f68db7f80403a2ea698ab22d67";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-localization/default.nix
+++ b/distros/noetic/mrpt-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-localization";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "89970b5eb3a02f2d35c1644c12ab59e22d55aa94ece9989e3df3e5197d041bc7";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "487dcc6e8c2058f47663c3d142e02fd19f32444478ffa061658f996de03d1a88";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-map/default.nix
+++ b/distros/noetic/mrpt-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt2, nav-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-map";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "eba76b2b463bcd9892c395964b239d54a8ec98d959efddbda69c8a31cb1b65e5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "288b74bf615f58f3d4120de178bbdab0430ab6a0a46ecea02f2552311194d820";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-msgs-bridge/default.nix
+++ b/distros/noetic/mrpt-msgs-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, marker-msgs, mrpt-msgs, mrpt2, ros-environment, roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs-bridge";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "42e7b404e3f26ee6978452fdccaea8d45355b53f4b7b60933d6482b6fbf6f56a";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "728cdfad5b650ef8cd263cb55ff0e93f354f0e30f7a9d1483de58d570ac8d297";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-navigation/default.nix
+++ b/distros/noetic/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-navigation";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7f613b9cd26f1817c0dc436f5964ce6ae79821e9ef84e04ae320bbb746f16715";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "61b33bce5ebbac1f0a14f39902a9187294724a38fcc7e81eb6958695bf865cc1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-path-planning/default.nix
+++ b/distros/noetic/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-path-planning";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f343bf5f422b53ac663f7a6c52251b529a71f97af65cffd8f07975151ba333e5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "e17d1a3de76dcf13df544d750aa8bad89c1bd1d4e8012a03c3d57f3c9bd923b6";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-rawlog/default.nix
+++ b/distros/noetic/mrpt-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rawlog";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "c4be56e30652a73d7cf284541860d0bcd255a093ce2a37525680f8ade556b2d8";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7cc37cd2aa8528fa61b75460299e2c5a1829b51e0082926dde1ba482c04b936b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-reactivenav2d/default.nix
+++ b/distros/noetic/mrpt-reactivenav2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt2, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-msgs, mrpt2, nav-msgs, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-reactivenav2d";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "a5d2455fe3ede367f2041cd1126900c6ff73a258bea4da8b95898e4005ca3a7f";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "4b7943fdea1de6606573158dce800d622b91905973573250d462223071878729";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt2 roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-msgs mrpt2 nav-msgs roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-sensorlib/default.nix
+++ b/distros/noetic/mrpt-sensorlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, geometry-msgs, message-generation, message-runtime, mrpt-msgs, mrpt2, ros-environment, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-sensorlib";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensorlib/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "fcbf23e17fc5d597149a648ffa04b5825ba6a8c9e75ddbc114cce420ca2fecb0";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensorlib/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "edc15bebbb79ff5afb2796909b5586c6702c235b03c8373cc8bd40ec8cf3176e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-sensors-examples/default.nix
+++ b/distros/noetic/mrpt-sensors-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-generic-sensor }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-sensors-examples";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensors_examples/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "04d111842bf17e49a60f89a550ff021b595989ef81dd6ab14c7dae17c81919b6";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensors_examples/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "3288cce064049a7d2b4d41edf8d26a5ee9da3c58d5fc83614128b5a48c0abc01";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-sensors/default.nix
+++ b/distros/noetic/mrpt-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-generic-sensor, mrpt-sensorlib, mrpt-sensors-examples }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-sensors";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensors/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "037baa2964f8248a214a3115d39a7bd3678329441b333d43dffbbd2869b838df";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_sensors-release/archive/release/noetic/mrpt_sensors/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "00186fb0ac9842cc130596c19381586fc3aada1d162b44c0222ba25a4103d4d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-tutorials/default.nix
+++ b/distros/noetic/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-tutorials";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "2938032d293e2594c0cafffd28e2c92c0f1ca32d487ef892dbb1f61f8377eed0";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "b3e3dcd831acd3dcacc7c36d53afb0bfd0479bdfec3bef517234839602edabfd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-geometry-msgs, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-geometry-msgs, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "090cf1e90b7ad7d3bef6bf29fc266ecc124a49f1eb1529f308e0da423170d8cf";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "dc7eba761f89db0e68290a5041b6f3622549fbebf05864dd4711c965beeb96af";
   };
 
   buildType = "cmake";
   buildInputs = [ assimp cmake ffmpeg freenect jsoncpp libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv opencv.cxxdev rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-geometry-msgs tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs opencv opencv.cxxdev rosbag-storage roscpp sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-geometry-msgs tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "8085344f3a271328e2ab17eee91c26d5d30271b0025b79b2508ba7b27cdcb160";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "39e3d2e0954bee0dacef1be215916a523ac38ede2f9766ad8e337b06f7aee0a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "47309ebea0e71e9cfe5268a64e1c060ad653d612e7c75ced9f994718e34f0893";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "021b92331c7649a02e99497381e2e007c560fcd922db519c7600385530e7a9ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-outputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "9e37ee97d06875556179553175f1c809acfdba9892a24b2efd6c2f5dca00b6aa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "923551bfd397aaba04ef8acb8e57411223998edde6edc58df55ce379c0245ce5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "c9253eb517be349ae393958d4713bdf698e8e0cde10de78099c5db5fde34441b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3358a03bd9a2648fbc7a8857e89fbe960ab405e6de675083a0eabed03057fb19";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "fa69386af49d7847e4e7b4a8620415e00a2f3dff28cb16fd42a43fa5e75d28aa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7c100312e4352c16706541aa2beaa84730f296ebf31ed36f064ca82a0817c709";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "d8d849b2d0ae65eec75080c58e78de5607d1cfbdccc4fbdbeb9a8b2b552ddb9f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "e1af2c20a2a8f06b55c0321d90273e3f067e5c59e7c60cec3233b1bd00cf2754";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "570610ae7e8377d3c613127797533178d8e34637b7fe5f69c53397081dcf1eff";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "bd139897d0e9dc09b0603ec65e2ac7abe01fae8065a518a3b1eaf6cd7f614696";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "0ec6b91f3f777277f94b73087cae6671796c4fb5a08ea19d13c72dba7a293bd6";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "e31a01ab448c3ce3cfef388980b15ebe96d763e365f1add355f257dba036c15a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "4f39aaf04e9638710a8db22ba2e0ac2ae3a892639aff0c83b6bff81b62da5f3d";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "61ef753f9db2a36f29c025840f304f1331c8288bbed7de67612310de01a385bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-humidity/default.nix
+++ b/distros/noetic/phidgets-humidity/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-humidity";
+  version = "1.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_humidity/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "d0b215669cc86aaf0103becc79fb46d018c315a8e81dd7a9a8550dc40ee31517";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Humidity devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "a1d80e0e81dec854f28245cd2b15484c52c9d11b3dc1ae87ec72751cf5659b94";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0e0e85629bb0480fa9ce35a5c1abce706c0347ae1880e6506f5875af427a4361";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "472670f7a6fe7c538173873537227c32573528ba96f4cdb8cfde7c887f53f3e7";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "31ddb7bb888e7a87840bdd3f5f77aae1eb54d275bb5f8d7f9f5b019c6464b102";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "14b6a856bdba644c2f2e475a26c0baf26dd1e3f867e1d074efdd9676fc06342a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "d2430a197a6635a7b0bbcbd3f7f8152787ccbd30bf73f8cdeb3adcf6ba6ae049";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "c145ac3cd922918f02630e908e794ae4f246f979a2afcd9c7d6c47b87fd26aaf";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "4f9306f91909a8b4a893f0323db97c37166a38aefbbb84066dedc58688be88b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "753bde2f729fe8b93dd41c8098cf4aca73185fcda0ab92888fe911c1d62ffd00";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "6daf3629dbd74c94c859a70b455c640ccf56aa30e9bb9428e55c94bdc817583f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.8-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.8-2.tar.gz";
-    name = "1.0.8-2.tar.gz";
-    sha256 = "2fcb7ab02afb1c7781448688d996405200e5742aff2e77ae044022117b3917b9";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "edaf8b2a446c14d6c8958bba2d5c3c6e74a299633fd44e99fbd6e379d7522e5a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
-  version = "2.6.1-r1";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "dcfe40169c77cfca98488db442517f001efe243c98b6baf87c1a59a66d07f792";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "16837d9781d1dde8c502d9185d55f243dc95dcf174c2bbc9b523bff93b98aaec";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libpng libusb1 ];
+  propagatedBuildInputs = [ libpng libusb1 ncurses ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/robotraconteur/default.nix
+++ b/distros/noetic/robotraconteur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bluez, boost, catkin, cmake, dbus, gtest, libusb1, openssl, python3, python3Packages, zlib }:
 buildRosPackage {
   pname = "ros-noetic-robotraconteur";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros-release/archive/release/noetic/robotraconteur/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b13a141955c7375111c1b297f9af90d8ac3f50fd977ba3ef6851e6f7475a8370";
+    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros-release/archive/release/noetic/robotraconteur/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "45540814eed0ed5ff78624a0e8adfb5a85a304a4967802b667565c111d8b2fcf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rosbag-fancy-msgs/default.nix
+++ b/distros/noetic/rosbag-fancy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-fancy-msgs";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/noetic/rosbag_fancy_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "279efdf8d7369d1e98ecc2bdac8ecb25302b7b3de0cb86a039ca9adbe70e3586";
+    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/noetic/rosbag_fancy_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "df1b48f77ed32bf587535472c8b78f21bdd44e4d2bf172bb08e38974bde48505";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-fancy/default.nix
+++ b/distros/noetic/rosbag-fancy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, ncurses, rosbag-fancy-msgs, rosbag-storage, roscpp, rosfmt, roslz4, std-srvs, tf2-ros, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-fancy";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/noetic/rosbag_fancy/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b4ca4599a76b1f6b7e010e8b86250c82810294019c47e2135a968854d1a96ccf";
+    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/noetic/rosbag_fancy/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c7f7a8026c1a12bec25d47069d1d43291077cb3448218534d134f3ecdef29a22";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-rosbag-fancy/default.nix
+++ b/distros/noetic/rqt-rosbag-fancy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, rosbag-fancy-msgs, rosfmt, rqt-gui, rqt-gui-cpp, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-rosbag-fancy";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/noetic/rqt_rosbag_fancy/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "4ac455e9bdccfca046e48afc148f6d390dfc7023fdd438a38021953ec2699549";
+    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/noetic/rqt_rosbag_fancy/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d2de3ef53df647a60ed01833cd880e83892b96a9a6b115329237d849792e3c75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-scan-xd/default.nix
+++ b/distros/noetic/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslib, rospy, rviz, sensor-msgs, std-msgs, tf, tf2, tf2-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan-xd";
-  version = "3.1.5-r1";
+  version = "3.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "6eed40eceaa8dc9bda5c547ade68486317d454d51f005a6bacaf379d67023cce";
+    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.2.6-1.tar.gz";
+    name = "3.2.6-1.tar.gz";
+    sha256 = "17f6417d6b4c3c97d162aca5450ab31f31e5cc19117e9cfb6832ae8327debcef";
   };
 
   buildType = "catkin";

--- a/distros/rolling/apriltag/default.nix
+++ b/distros/rolling/apriltag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, opencv, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-apriltag";
-  version = "3.2.0-r6";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.2.0-6.tar.gz";
-    name = "3.2.0-6.tar.gz";
-    sha256 = "062d373bd1bb3ed898f7db6d6a90380dcf6926133a43397833cd1378596ed00c";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "1793c9596426ce997ea2c038485af35530f6e24fcbcd7c48527460d8bcd1eb53";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake python3Packages.numpy ];
+  buildInputs = [ cmake python3 python3Packages.numpy ];
   checkInputs = [ opencv opencv.cxxdev ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/rolling/cartographer-ros-msgs/default.nix
+++ b/distros/rolling/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-cartographer-ros-msgs";
-  version = "2.0.9001-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/rolling/cartographer_ros_msgs/2.0.9001-2.tar.gz";
-    name = "2.0.9001-2.tar.gz";
-    sha256 = "6df78f5bf9eb02fbce6553767f27ea8b1763b5794b32217d0f19de756b067b65";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/rolling/cartographer_ros_msgs/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "e31e392742ca96855ae41925bf2ff2f96e74b42cbace2b03692adfe106c46119";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cartographer-ros/default.nix
+++ b/distros/rolling/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, builtin-interfaces, cartographer, cartographer-ros-msgs, eigen, geometry-msgs, gflags, glog, gtest, launch, nav-msgs, pcl, pcl-conversions, python3Packages, rclcpp, robot-state-publisher, rosbag2-cpp, rosbag2-storage, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-cartographer-ros";
-  version = "2.0.9001-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/rolling/cartographer_ros/2.0.9001-2.tar.gz";
-    name = "2.0.9001-2.tar.gz";
-    sha256 = "add489f6d227877ee0d37ba4a6977c5d507a20ce1da097154ae61a5d8845e8e0";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/rolling/cartographer_ros/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "db5c1fc1226a853563f8fc96dc6d4dabea826a11332347f6379ca4294cc7f48a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cartographer-rviz/default.nix
+++ b/distros/rolling/cartographer-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, ament-cmake, boost, cartographer, cartographer-ros, cartographer-ros-msgs, eigen, pluginlib, rclcpp, rviz-common, rviz-ogre-vendor, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-cartographer-rviz";
-  version = "2.0.9001-r2";
+  version = "2.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/rolling/cartographer_rviz/2.0.9001-2.tar.gz";
-    name = "2.0.9001-2.tar.gz";
-    sha256 = "66c6f73715ddb2a04ff9d80a3965e1f1b6d3978c167a73ff283da8b5542d3378";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/rolling/cartographer_rviz/2.0.9002-1.tar.gz";
+    name = "2.0.9002-1.tar.gz";
+    sha256 = "6df60f58915417b6e45010466ff90433a6182046525cba2f10f749ab139ba144";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cartographer/default.nix
+++ b/distros/rolling/cartographer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, abseil-cpp, boost, cairo, ceres-solver, cmake, eigen, gflags, git, glog, gtest, lua5, protobuf, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-cartographer";
-  version = "2.0.9002-r5";
+  version = "2.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/rolling/cartographer/2.0.9002-5.tar.gz";
-    name = "2.0.9002-5.tar.gz";
-    sha256 = "c200f47cd01605084cbd7b308f56cf434ed3158e260586c5909c3dd7a2a7ea38";
+    url = "https://github.com/ros2-gbp/cartographer-release/archive/release/rolling/cartographer/2.0.9003-1.tar.gz";
+    name = "2.0.9003-1.tar.gz";
+    sha256 = "1dd29f1b47f4ed0f42eb9c40730c620c08c0e9925f4e27006b1cf73f3596c338";
   };
 
   buildType = "cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "cd4920013bf5dfab4330e112f1ffce0b5df02047c4206adec14b450339c37bba";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "83aab42b1757d1a2cb49ddd1fba6d9c3ee46c234e22eb644426c481ca401686b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "22662dd932cece6ad542d1c86465c868a6d6f3ed753e68f1de347a3d082b0260";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "d3c54eb4c154518da500602aa33218e92e61ec96d6d4240215414d1bf3619e07";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "1613400e536c910c79b07854c50139eb60fb181a8d9fa6d56d2b3c2d93d63ece";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "0f501e40021679d39fa89ca917bffb19b444c12f5b40d3d301cbeed2921e0277";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dynamic-edt-3d/default.nix
+++ b/distros/rolling/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, octomap }:
 buildRosPackage {
   pname = "ros-rolling-dynamic-edt-3d";
-  version = "1.9.8-r3";
+  version = "1.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap-release/archive/release/rolling/dynamic_edt_3d/1.9.8-3.tar.gz";
-    name = "1.9.8-3.tar.gz";
-    sha256 = "7ba15666ae76950262e3a34a32d8cad2796db9fe6712d3b3bd0ead39ef835d94";
+    url = "https://github.com/ros2-gbp/octomap-release/archive/release/rolling/dynamic_edt_3d/1.10.0-3.tar.gz";
+    name = "1.10.0-3.tar.gz";
+    sha256 = "63927575903cd0143fc7e88dcdea013e15a58780bdd0382bdfa011e8116e97c6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/filters/default.nix
+++ b/distros/rolling/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-uncrustify, ament-cmake-xmllint, boost, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-filters";
-  version = "2.1.0-r5";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/filters-release/archive/release/rolling/filters/2.1.0-5.tar.gz";
-    name = "2.1.0-5.tar.gz";
-    sha256 = "4fbe698a563b73bc4d3505c987e0df1e552815b9b2755a785f4c1669af19797c";
+    url = "https://github.com/ros2-gbp/filters-release/archive/release/rolling/filters/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ca5c6ffe6084ad9468f9e6b7e86b1346a5f4416a52c272dbc20cd3c1565af1df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -714,6 +714,8 @@ self: super: {
 
  kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
 
+ kitti-metrics-eval = self.callPackage ./kitti-metrics-eval {};
+
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
@@ -814,6 +816,8 @@ self: super: {
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
+ libpointmatcher = self.callPackage ./libpointmatcher {};
+
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
@@ -837,6 +841,10 @@ self: super: {
  mapviz-interfaces = self.callPackage ./mapviz-interfaces {};
 
  mapviz-plugins = self.callPackage ./mapviz-plugins {};
+
+ marine-acoustic-msgs = self.callPackage ./marine-acoustic-msgs {};
+
+ marine-sensor-msgs = self.callPackage ./marine-sensor-msgs {};
 
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
@@ -892,9 +900,47 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mola = self.callPackage ./mola {};
+
+ mola-bridge-ros2 = self.callPackage ./mola-bridge-ros2 {};
+
  mola-common = self.callPackage ./mola-common {};
 
+ mola-demos = self.callPackage ./mola-demos {};
+
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
+ mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
+
+ mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
+
+ mola-input-kitti-dataset = self.callPackage ./mola-input-kitti-dataset {};
+
+ mola-input-mulran-dataset = self.callPackage ./mola-input-mulran-dataset {};
+
+ mola-input-paris-luco-dataset = self.callPackage ./mola-input-paris-luco-dataset {};
+
+ mola-input-rawlog = self.callPackage ./mola-input-rawlog {};
+
+ mola-input-rosbag2 = self.callPackage ./mola-input-rosbag2 {};
+
+ mola-kernel = self.callPackage ./mola-kernel {};
+
+ mola-launcher = self.callPackage ./mola-launcher {};
+
+ mola-metric-maps = self.callPackage ./mola-metric-maps {};
+
+ mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};
+
+ mola-pose-list = self.callPackage ./mola-pose-list {};
+
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
+
+ mola-traj-tools = self.callPackage ./mola-traj-tools {};
+
+ mola-viz = self.callPackage ./mola-viz {};
+
+ mola-yaml = self.callPackage ./mola-yaml {};
 
  motion-capture-tracking = self.callPackage ./motion-capture-tracking {};
 
@@ -991,6 +1037,10 @@ self: super: {
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
  mp2p-icp = self.callPackage ./mp2p-icp {};
+
+ mqtt-client = self.callPackage ./mqtt-client {};
+
+ mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
@@ -1240,6 +1290,8 @@ self: super: {
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
+ rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
+
  rc-genicam-api = self.callPackage ./rc-genicam-api {};
 
  rc-genicam-driver = self.callPackage ./rc-genicam-driver {};
@@ -1318,17 +1370,25 @@ self: super: {
 
  rig-reconfigure = self.callPackage ./rig-reconfigure {};
 
+ rmf-api-msgs = self.callPackage ./rmf-api-msgs {};
+
  rmf-battery = self.callPackage ./rmf-battery {};
 
  rmf-building-map-msgs = self.callPackage ./rmf-building-map-msgs {};
 
  rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
 
+ rmf-charging-schedule = self.callPackage ./rmf-charging-schedule {};
+
  rmf-cmake-uncrustify = self.callPackage ./rmf-cmake-uncrustify {};
 
  rmf-dispenser-msgs = self.callPackage ./rmf-dispenser-msgs {};
 
  rmf-door-msgs = self.callPackage ./rmf-door-msgs {};
+
+ rmf-fleet-adapter = self.callPackage ./rmf-fleet-adapter {};
+
+ rmf-fleet-adapter-python = self.callPackage ./rmf-fleet-adapter-python {};
 
  rmf-fleet-msgs = self.callPackage ./rmf-fleet-msgs {};
 
@@ -1342,13 +1402,21 @@ self: super: {
 
  rmf-site-map-msgs = self.callPackage ./rmf-site-map-msgs {};
 
+ rmf-task = self.callPackage ./rmf-task {};
+
  rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-task-ros2 = self.callPackage ./rmf-task-ros2 {};
+
+ rmf-task-sequence = self.callPackage ./rmf-task-sequence {};
 
  rmf-traffic = self.callPackage ./rmf-traffic {};
 
  rmf-traffic-examples = self.callPackage ./rmf-traffic-examples {};
 
  rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
+
+ rmf-traffic-ros2 = self.callPackage ./rmf-traffic-ros2 {};
 
  rmf-utils = self.callPackage ./rmf-utils {};
 
@@ -1362,7 +1430,15 @@ self: super: {
 
  rmf-visualization-msgs = self.callPackage ./rmf-visualization-msgs {};
 
+ rmf-visualization-navgraphs = self.callPackage ./rmf-visualization-navgraphs {};
+
  rmf-visualization-obstacles = self.callPackage ./rmf-visualization-obstacles {};
+
+ rmf-visualization-rviz2-plugins = self.callPackage ./rmf-visualization-rviz2-plugins {};
+
+ rmf-visualization-schedule = self.callPackage ./rmf-visualization-schedule {};
+
+ rmf-websocket = self.callPackage ./rmf-websocket {};
 
  rmf-workcell-msgs = self.callPackage ./rmf-workcell-msgs {};
 
@@ -1777,10 +1853,6 @@ self: super: {
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
  stomp = self.callPackage ./stomp {};
-
- stubborn-buddies = self.callPackage ./stubborn-buddies {};
-
- stubborn-buddies-msgs = self.callPackage ./stubborn-buddies-msgs {};
 
  swri-cli-tools = self.callPackage ./swri-cli-tools {};
 

--- a/distros/rolling/gps-msgs/default.nix
+++ b/distros/rolling/gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-msgs";
-  version = "1.0.4-r5";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_msgs/1.0.4-5.tar.gz";
-    name = "1.0.4-5.tar.gz";
-    sha256 = "12aa51b9acbf874518f931ee95763e2baba6bfeb96090d4c60434e0610b08d0d";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "35420bdb1447812d1a7f7000b956525c1c7c0d55cfc444382571edb096f3c736";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-tools/default.nix
+++ b/distros/rolling/gps-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, gps-msgs, nav-msgs, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gps-tools";
-  version = "1.0.4-r5";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_tools/1.0.4-5.tar.gz";
-    name = "1.0.4-5.tar.gz";
-    sha256 = "3dd9a570e1ebc010501661e58ddf909c381e90dfc96d3357d23c39b787bc9d76";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_tools/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "8aa0f72d17f2f6bfaeb1be6a17dc3dfe74685d8fc4992233a6a5a6c14149c3cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gps-umd/default.nix
+++ b/distros/rolling/gps-umd/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gps-tools, gpsd-client }:
 buildRosPackage {
   pname = "ros-rolling-gps-umd";
-  version = "1.0.4-r5";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_umd/1.0.4-5.tar.gz";
-    name = "1.0.4-5.tar.gz";
-    sha256 = "69df50c82aeccd1e574af1d18fe477a4189f9fc0752eda95a9dca17797782157";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gps_umd/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5793a7930c5a997965725b307300b59f65e4b6f6c3f0093c0355f1d76e097c60";
   };
 
-  buildType = "catkin";
+  buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   propagatedBuildInputs = [ gps-msgs gps-tools gpsd-client ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/rolling/gpsd-client/default.nix
+++ b/distros/rolling/gpsd-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gps-msgs, gpsd, pkg-config, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-gpsd-client";
-  version = "1.0.4-r5";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gpsd_client/1.0.4-5.tar.gz";
-    name = "1.0.4-5.tar.gz";
-    sha256 = "8684025cafef4f916b3d9867c3dbc0305aa40206aacd766cc932b5e203a77e58";
+    url = "https://github.com/ros2-gbp/gps_umd-release/archive/release/rolling/gpsd_client/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "1e30dc0586e76721f412bc21756c79306b12f1995c147bc609f49cc7bd6c7f54";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "36d2784543d2c4cf3336dbe7081288572864371345fe10391566cc7bf1712c6c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "7e5cf2219fe3f62978be1736afee9fda6edce584c97e80f2e2caf43aec2ca437";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "2c5d251a2afe76fca1ed9a71ad7f1dbe6ca598d701c5fd4442731c80b52b5bc2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "ac69becdc159f6a52f68f5f1cbc20427365184fbf36a38a6b465a0d905c2af80";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hash-library-vendor/default.nix
+++ b/distros/rolling/hash-library-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-rolling-hash-library-vendor";
-  version = "0.1.1-r5";
+  version = "0.1.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hash_library_vendor-release/archive/release/rolling/hash_library_vendor/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "a29ee3b049894dc3d3ded35e66f972b9d963ebd0e28d007d6f40282a3cef43a4";
+    url = "https://github.com/ros2-gbp/hash_library_vendor-release/archive/release/rolling/hash_library_vendor/0.1.1-6.tar.gz";
+    name = "0.1.1-6.tar.gz";
+    sha256 = "542b80b6cac36ab95d018c73a7a6514de517b3d06187ce7e6f0b7cf8c52236e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/iceoryx-binding-c/default.nix
+++ b/distros/rolling/iceoryx-binding-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-binding-c";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_binding_c/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "a2e7ec6691a5ac4aa45c912d475aebd5d94d8d7910837f3ab517b8c5fa27b1d7";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_binding_c/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "fe5e5b0284eec1c021790bdc66eb096d1f30dc631c32a46048392dc228992d8f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-hoofs/default.nix
+++ b/distros/rolling/iceoryx-hoofs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, acl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-hoofs";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_hoofs/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "b0485194d694970b13fe9a0dd6770effed6f27fd88ac5d6ed2c40dafbe8001d9";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_hoofs/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "2b0a29c55e952d8e0e73b5e7a17f4be7ed8996eebdf99a49e1661325fc633081";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-introspection/default.nix
+++ b/distros/rolling/iceoryx-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-hoofs, iceoryx-posh, ncurses }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-introspection";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_introspection/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "d74a7a2ec712a576d30aa04fb3f037768b3b4f8f0a485e7c27f96aca2947b1f6";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_introspection/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "c88c228b308e9e4e2b8920a186a4fa6a61956bd8c12b0e380ee24771260c7db2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/iceoryx-posh/default.nix
+++ b/distros/rolling/iceoryx-posh/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, git, iceoryx-hoofs }:
 buildRosPackage {
   pname = "ros-rolling-iceoryx-posh";
-  version = "2.0.5-r4";
+  version = "2.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_posh/2.0.5-4.tar.gz";
-    name = "2.0.5-4.tar.gz";
-    sha256 = "f2dbb6892b3e047ebdff3a64fe11fcc9f2476aada6c45162559a897e51388bc4";
+    url = "https://github.com/ros2-gbp/iceoryx-release/archive/release/rolling/iceoryx_posh/2.0.5-5.tar.gz";
+    name = "2.0.5-5.tar.gz";
+    sha256 = "835e1bb27160e4bfc51dc6ff84f70b4d6324bc9e828a7a0840c42225a772024e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "dd65625499a2a957764f9b3de062609247f6de4b2b6e07fe9d87063e289b5359";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "7c542fb13da093222aa8e3a2df022dd48bd50863bf47d672f3108515e01adb79";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-kitti-metrics-eval";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6447c380cab184c236abc20b12966460a4c2286f617b44844f140876b280101e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''CLI tool to evaluate the KITTI odometry bechmark metrics to trajectory files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/lanelet2-core/default.nix
+++ b/distros/rolling/lanelet2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, eigen, gtest, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-core";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_core/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "5fec6bb514920159485e747964651fde04252c2a0383e33f75d6898450d6ec84";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_core/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "073568f570ddd870f00a7aee803bf44a32d207aa3b7336886c47ffd31a86cb0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-examples/default.nix
+++ b/distros/rolling/lanelet2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-matching, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-examples";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_examples/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "471dd38643b9a484060fe5b077615c8865727b3c33fe592ef4f603ca8b9c80d4";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_examples/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "bd2070005620a2b0208441b9760bc437c6d28194a7a2d7f4e4284105a6585787";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-io/default.nix
+++ b/distros/rolling/lanelet2-io/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, mrt-cmake-modules, pugixml }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-io";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_io/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "755c003d1c5e515ba533d21f40e018370c47751656adaadadca0d5b33f98916c";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_io/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "5a18c9a793957874dda93d2389025ba9c21a967e310ea33472711888684f6dc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-maps/default.nix
+++ b/distros/rolling/lanelet2-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-maps";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_maps/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "300bf4526628d67e9682082a9125b9aa1e20d731c03e629210cb037c9e0bbe92";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_maps/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "ea0fbbe75752c1ab60ae59ea4d91fe3d7771dbdb4b1e647bbac0662ab7581030";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-matching/default.nix
+++ b/distros/rolling/lanelet2-matching/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-matching";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_matching/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "96dfed708bf94dc41a050c59af51b4128d9548f215bda2b960fcce571aef23fe";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_matching/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "e24ee229d96dce1777076a1b5ecee8c6d17d4b6563d56db3bdcb7fe1df3f6f52";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-projection/default.nix
+++ b/distros/rolling/lanelet2-projection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, geographiclib, gtest, lanelet2-io, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-projection";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_projection/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "df75dd3691b54271f09e4c9d6825e9c36f2c04f55702f798c69dbd425db1aeb5";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_projection/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "103ba9fe38442c50bb0466e01910cee7556a5d4764de2add9e5f10a6e66ab2ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-python/default.nix
+++ b/distros/rolling/lanelet2-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-io, lanelet2-matching, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-python";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_python/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "e2f1f213c67c3f89e21e4b2c08dbfbbd0fd16f55fd92d10fd708168cd9d50589";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_python/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "baa7832f83df13cffc95b0d521609faa1020b3bc48072c0add12ccb0629c856d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-routing/default.nix
+++ b/distros/rolling/lanelet2-routing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-routing";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_routing/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "5252151cacf404664dd25f00d7991051cb2d6e3571f394b655423b274164b6af";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_routing/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "bf9dcb260c136a1763a308dad1d2c2ddd396629c9020ac4deae8752cebec89d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-traffic-rules/default.nix
+++ b/distros/rolling/lanelet2-traffic-rules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-traffic-rules";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_traffic_rules/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "a8130161bb06a38778ea1eaa60369eba6ae7f0ea76954dfe88111bc2d87ccf88";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_traffic_rules/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "80bb835dc042d7f6f0b72ee31cb9e0e158b0265bcd6f9a1266b5ffee93b62bd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2-validation/default.nix
+++ b/distros/rolling/lanelet2-validation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2-validation";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_validation/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "abb1b0529bbbdca184043b0d1726334310ac5e59dbc80a7c21d40f1d8ccc08ae";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2_validation/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "7e01c5c940b44d7bb890d3a04ad6d6da3e389cdf67c3a0d7c93cfa59c3adba66";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lanelet2/default.nix
+++ b/distros/rolling/lanelet2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, lanelet2-examples, lanelet2-io, lanelet2-maps, lanelet2-matching, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-lanelet2";
-  version = "1.2.1-r5";
+  version = "1.2.1-r6";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "8decd3304eb08ef582001a33c26a1ee12d5064b9c4753713e2288e8dadbf23b4";
+    url = "https://github.com/ros2-gbp/lanelet2-release/archive/release/rolling/lanelet2/1.2.1-6.tar.gz";
+    name = "1.2.1-6.tar.gz";
+    sha256 = "7d097fca7bbd0058f73e95cbb99decba7300785eb3d6d3f89a94c23f67538120";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libnabo/default.nix
+++ b/distros/rolling/libnabo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen }:
 buildRosPackage {
   pname = "ros-rolling-libnabo";
-  version = "1.0.7-r4";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libnabo-release/archive/release/rolling/libnabo/1.0.7-4.tar.gz";
-    name = "1.0.7-4.tar.gz";
-    sha256 = "99993b352d68db7945342c578b7cd8ec54727b1fa041cb9ac88ef16ead2d7c7a";
+    url = "https://github.com/ros2-gbp/libnabo-release/archive/release/rolling/libnabo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "3cfcdfa3eba6cfd5e2cc817813619e77e7d0663ee464bee07ab8b4820b17e65d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/libphidget22/default.nix
+++ b/distros/rolling/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-rolling-libphidget22";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/libphidget22/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "065f25c7ddae2ad2b35782106f05cec4f691410e1db67abed0d0a49a6fbe1509";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/libphidget22/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "023bf4808aad96c293de58c67b5c449d5ac3374c355207e10cda36ff4ee0a6bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libpointmatcher/default.nix
+++ b/distros/rolling/libpointmatcher/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, libnabo }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, libnabo, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-libpointmatcher";
-  version = "1.3.1-r4";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libpointmatcher-release/archive/release/rolling/libpointmatcher/1.3.1-4.tar.gz";
-    name = "1.3.1-4.tar.gz";
-    sha256 = "70e3664ade8660c4d26fbdb557a74c9c576836c159ad778a19c36bb0cda82b99";
+    url = "https://github.com/ros2-gbp/libpointmatcher-release/archive/release/rolling/libpointmatcher/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "c9e9635505876483aa54fc78a6557a2e08b69a991dc5e6e1f9783da9fd104e78";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ boost eigen libnabo ];
+  propagatedBuildInputs = [ boost eigen libnabo yaml-cpp ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/marine-acoustic-msgs/default.nix
+++ b/distros/rolling/marine-acoustic-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-marine-acoustic-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marine_msgs-release/archive/release/rolling/marine_acoustic_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "edcfabbdbd4bd408578957abeb001471a86748ad6d1623fd8c2bfa4f95a12714";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The marine_acoustic_msgs package, including messages for common
+  underwater sensors (DVL, multibeam sonar, imaging sonar)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/marine-sensor-msgs/default.nix
+++ b/distros/rolling/marine-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-marine-sensor-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/marine_msgs-release/archive/release/rolling/marine_sensor_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "050f2ca069345dfa04685a7e2bae7eff22a6624c230992777bbb9b90bf26708e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The marine_sensor_msgs package, meant to contain messages for common
+  underwater sensors (e.g., conductivity, turbidity, dissolved oxygen)'';
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "2e40d4f2deef2a4869b8dd070995141895a5254aa24fb690c12eb834e9a69910";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "52c589c9ff38c7a250ba0c99e6db4edb85d06c8c2262053fc3cc2a982b6a282e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-tf-frame-transformer/default.nix
+++ b/distros/rolling/message-tf-frame-transformer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-tf-frame-transformer";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/rolling/message_tf_frame_transformer/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "a9e3b768263f91fad1355fd9c8e4e8ae48f2c27fee8cdea1ece3966328698f38";
+    url = "https://github.com/ros2-gbp/message_tf_frame_transformer-release/archive/release/rolling/message_tf_frame_transformer/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1a8f4b6613a1e52267ef5277de2c90a2f88cdbaf034b9312a6b10492e7656065";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-mola-bridge-ros2";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b6ed47d2708fe389384e854e49d592a51711d912f241fbd7b02c49f90bc4fc3d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
+
+  meta = {
+    description = ''Bidirectional bridge ROS2-MOLA'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "179f833b1939a6eb833463c050573df2b74855e3aaf09d8a3372fba3ed45817d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1ba38dd3868779259057e4c8862b373eeed3d2150148c22a769efa80688615c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "b4c53d06ccf60198a654dee68210187caa6343c9ed566b6a970d081aab7d288d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f95b63dfe01096e3db2860c500900f111aa900176220943a0ef0ab2f769e96c4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "cbbb5edf9d0cf173f402aa2672c0438c1109300118d020c98e21e272041be937";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a24b602e925d76963a1492ef5cb5f8b27f9877e6c45c2c6e8b2cbfe575902d41";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "28096ed6ee91ec49b8ced0d152d778c5e14635d83d47054b83f2518230486e37";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6d845442c9993a92a169b56041cf4501e154431403f344faf2271b2f98145f0c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-kitti360-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "34a21868f0761284c465e5894bb34e00793a0b49a5391ab5d46ebb5b29b1e298";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Kitti-360 datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-mulran-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9e65879e37c7507a616deb61071c2f051e23d356f429a23ffc26348ba9d901a0";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from MulRan datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-paris-luco-dataset";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8bbee6da37597810fd0e720a37dfd605735de6a58b4a6ebad857ea677adc7f3e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-kernel mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from Paris LUCO (CT-ICP) odometry/SLAM datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "38e26bc2191fe0bb68df7e55724726bb13f619eaf7ee7d292ccbe6998102be6e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ef733a69a853d6d36cf7a0a7ee84dd2bd78e5e6c87ba766f14c19c83982aded3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-mola-input-rosbag2";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9382ad00b0d2bed9d2211de3ccb333c9fc9b1a7f21b537a5d5ec3023b3ecc978";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ cv-bridge mola-kernel mrpt2 rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Offline RawDataSource from rosbag2 datasets'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "be95ce763e51fa21071f826823bb5af2d191580a9e15ace393c1e0aa8795899c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a83c59c7109bb65ad47938c215cff229d7803f301bf994623a09f477e9353260";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -1,22 +1,23 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "798a15acab250fd5bb4ec53d3eb703eb9254f3d03e8171d5a201fdf8c973c7a9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c713786a0de2bf9382c594b7ccdfbc3eea397162d129859c742eb582f9ce196f";
   };
 
-  buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ mola-kernel mrpt2 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {
     description = ''Launcher app for MOLA systems'';

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
+buildRosPackage {
+  pname = "ros-rolling-mola-metric-maps";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c059c09c4d3f7b14db7d8de940a41fb86f1320e9fc8ceddf4db060c936ae0eca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
+
+  meta = {
+    description = ''Advanced metric map classes, using the generic `mrpt::maps::CMetricMap` interface, for use in other MOLA odometry and SLAM modules.'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-navstate-fuse/default.nix
+++ b/distros/rolling/mola-navstate-fuse/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-navstate-fuse";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2483fde2c9f4f21265623fb57d70951e4eca5660c677f9b69d9f4a935064df6d";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''SE(3) pose and twist path data fusion estimator'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-pose-list";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f34a35994e823a1d4838e5c0cb6e1ca8ac4d2d4bb72dca35841a08ea88139644";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ library for searchable pose lists'';
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
+buildRosPackage {
+  pname = "ros-rolling-mola-traj-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c30613162f912b1fdf6f10119d806c24c4dbe5ef360e934edbe5c054624abaab";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''CLI tools to manipulate trajectory files as a complement to the evo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "948f802286f774e70b460c7d26fd3f0b0a285705daa089c8a78c3f09d1f6534a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e4800bac705d57f43512a679a6142a37daf816c6f4e0037a07c320ff15efee0d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "0787c7420ac1a0245e5fd6bbc4b5576be528165d40813a7b008762b784f5dcd6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8401a2a69f8943f6d04e49dd50243c133d94169772f4f69da9d0f7df1aaf4594";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
+buildRosPackage {
+  pname = "ros-rolling-mola";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2c2701500ac809f52a07dc40d1a3a8bde9292b22c63210376bb6d85bef1998f4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fuse mola-pose-list mola-traj-tools mola-viz mola-yaml ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage with all core open-sourced MOLA packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.2.0-r2";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "78a746c9caef5b2a5b6f355c9852930321fa12a375aaf0f9e2a2a743d8dad097";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "c7c00182bb893ce9d8b72b70b5b7be3150c1d9d462fd2a78cbd448401164f150";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mqtt-client-interfaces/default.nix
+++ b/distros/rolling/mqtt-client-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client-interfaces";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4a700b096cfca0f84891ec9cfa92dba7fec15a4896750aeaf046bda668b71204";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client_interfaces/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "98d1aa64778f6316131af36eedc939feebce386679f08bc0235414b4d38352f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mqtt-client/default.nix
+++ b/distros/rolling/mqtt-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, mqtt-client-interfaces, paho-mqtt-c, paho-mqtt-cpp, rclcpp, rclcpp-components, rcpputils, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mqtt-client";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2a0092ff5b01d6ebcfa279b34d593753c1e114fe15afd385a0c5965869d96ba0";
+    url = "https://github.com/ros2-gbp/mqtt_client-release/archive/release/rolling/mqtt_client/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "49b71f139fb0e4a52f13dc60bf465aaba9ada0986e06977f8696d02fe1bdbbe0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-path-planning/default.nix
+++ b/distros/rolling/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt2, mvsim }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-path-planning";
-  version = "0.1.0-r2";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "2ff0915bc79287cef68e4772187891560515cf5dff3a79a98fd11be20fe1229b";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "752f3d06447c32374d827e6a91146aeccc05fec069d671f0fbdbdfc9b9d6f52f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.11.11-r1";
+  version = "2.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.11.11-1.tar.gz";
-    name = "2.11.11-1.tar.gz";
-    sha256 = "29f2d39376f2584e4a17618a341e15f260c5f13c288e13ce25ec915fb0a54afc";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.12.0-1.tar.gz";
+    name = "2.12.0-1.tar.gz";
+    sha256 = "c4d50c688c4591880b1efaff8f0b7fd1443da778349601eb9ff6758363427903";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake ffmpeg freenect jsoncpp libfyaml libjpeg libpcap libusb1 openni2 pkg-config python3Packages.pip pythonPackages.pybind11 qt5.qtbase ros-environment tinyxml-2 udev wxGTK32 zlib ];
-  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs octomap opencv opencv.cxxdev rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
+  propagatedBuildInputs = [ cv-bridge eigen freeglut geometry-msgs glfw3 libGL libGLU nav-msgs opencv opencv.cxxdev rclcpp rosbag2-storage sensor-msgs std-msgs stereo-msgs suitesparse tf2 tf2-msgs xorg.libXrandr xorg.libXxf86vm ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, ros2launch, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.8.3-r2";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.8.3-2.tar.gz";
-    name = "0.8.3-2.tar.gz";
-    sha256 = "ab515da0d8e47ca7559a6ecd6e9b91710d1e68ad3e30152379baea58e37d9718";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "07b63ccf9c7654b7e7c6b331714b87e2e9912439a5b8eddc707e995a40e6633b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/novatel-gps-driver/default.nix
+++ b/distros/rolling/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-driver";
-  version = "4.1.0-r4";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_driver/4.1.0-4.tar.gz";
-    name = "4.1.0-4.tar.gz";
-    sha256 = "c1b74c158024d57117da987c98cc71bc316eec926bf510400fa6489057cbee6d";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_driver/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "0bdda7f61d50a80cccdd373334737112f990dc0404720e4c4d95e84cfc9393e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/novatel-gps-msgs/default.nix
+++ b/distros/rolling/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-msgs";
-  version = "4.1.0-r4";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_msgs/4.1.0-4.tar.gz";
-    name = "4.1.0-4.tar.gz";
-    sha256 = "a8a45e1daa0465fc8239070ef9f96469511ffea3c2cb2a01dae2c0f93f7066f1";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_msgs/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "c3d1c631ec60c90303ab52aa4d2d8d9199529aaae2d831208a68ea291f83ac7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ntrip-client-node/default.nix
+++ b/distros/rolling/ntrip-client-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libcurl-vendor, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ntrip-client-node";
-  version = "0.5.2-r2";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.5.2-2.tar.gz";
-    name = "0.5.2-2.tar.gz";
-    sha256 = "5799f524c49ea8bf44f9bddb4f45d311aae767ed599b9bc851893073ca89bd7b";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ntrip_client_node/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "5cf470ad82e456780343be727034e495532f0377891a233468cda5479bea695f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/octomap/default.nix
+++ b/distros/rolling/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-octomap";
-  version = "1.9.8-r3";
+  version = "1.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap-release/archive/release/rolling/octomap/1.9.8-3.tar.gz";
-    name = "1.9.8-3.tar.gz";
-    sha256 = "845e231dd981854939951c3a71fc3a0baade9290b305ee97dccf2b4b82dd1a2d";
+    url = "https://github.com/ros2-gbp/octomap-release/archive/release/rolling/octomap/1.10.0-3.tar.gz";
+    name = "1.10.0-3.tar.gz";
+    sha256 = "c17096b3826d369339197e8ba77f9be64aeb94b58c369cd1f9271f3882ef30b9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/octovis/default.nix
+++ b/distros/rolling/octovis/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
+{ lib, buildRosPackage, fetchurl, cmake, libGL, libGLU, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-rolling-octovis";
-  version = "1.9.8-r3";
+  version = "1.10.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap-release/archive/release/rolling/octovis/1.9.8-3.tar.gz";
-    name = "1.9.8-3.tar.gz";
-    sha256 = "72c9f47bc3ce2a6995579248b640de36b40175142a37f5fe37eed73818b1e6e2";
+    url = "https://github.com/ros2-gbp/octomap-release/archive/release/rolling/octovis/1.10.0-3.tar.gz";
+    name = "1.10.0-3.tar.gz";
+    sha256 = "bb5d68a66a4ad60ebc7cfbc4deffa5f6a70ebe648d17d199e6932438e6a35a09";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libsForQt5.libqglviewer octomap qt5.qtbase ];
+  propagatedBuildInputs = [ libGL libGLU libsForQt5.libqglviewer octomap qt5.qtbase ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/openni2-camera/default.nix
+++ b/distros/rolling/openni2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, camera-info-manager, depth-image-proc, image-transport, openni2, pkg-config, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-openni2-camera";
-  version = "2.1.0-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openni2_camera-release/archive/release/rolling/openni2_camera/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "10d8f1b9e7c637162fb65beb0047c5405fa0514d0c1eb54f5cd68b3a83b8f976";
+    url = "https://github.com/ros2-gbp/openni2_camera-release/archive/release/rolling/openni2_camera/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "9ceed83f0e54270ffadb95a3b0c3f7b32b704790c5220c94a77cb45ca0cde435";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/performance-test/default.nix
+++ b/distros/rolling/performance-test/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch, launch-testing, osrf-testing-tools-cpp, rclcpp, rmw-implementation, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, git, rclcpp, rmw-implementation, ros-environment, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-performance-test";
-  version = "1.2.1-r4";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/rolling/performance_test/1.2.1-4.tar.gz";
-    name = "1.2.1-4.tar.gz";
-    sha256 = "afb4acd3dac551a919eeaa23818916ae5ef2a3102bd5e2e06fc56b9b7dbdb9a9";
+    url = "https://github.com/ros2-gbp/performance_test-release/archive/release/rolling/performance_test/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "15256519e27f2bdafce987fb91565223ce6af718d39793d592e2643b09e751c6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake osrf-testing-tools-cpp rosidl-default-generators ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing rmw-implementation-cmake ];
+  buildInputs = [ ament-cmake git ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rclcpp rmw-implementation rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake git rosidl-default-generators ];
 
   meta = {
     description = ''Tool to test performance of ROS2 and DDS data layers and communication.'';

--- a/distros/rolling/phidgets-accelerometer/default.nix
+++ b/distros/rolling/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-accelerometer";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_accelerometer/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "65d34598c8cda2460a5031552e3f4e71fa4f5fed48068613a7a52f8bca1ee46b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_accelerometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "181494ebe46885f7aa00c3db60432534a6b63a5ac092b637b2b3b2440884f07e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-analog-inputs/default.nix
+++ b/distros/rolling/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-analog-inputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_inputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "c8a723f4ec234a590bf27994f24e3cfc2a5ac27695fe903a06bbf4bec9bdcd93";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "556550953689227e27a4c522b380a531bd6298381f8914c13aec35fb0fe5765d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-analog-outputs/default.nix
+++ b/distros/rolling/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-analog-outputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_outputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "f9d971852df8e34665852be42ca531e053c70cd0de59257e722e69c502cdfec4";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_analog_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "4e56ae1decbfe3957c03def4e0a400de2846fba170b184644486d29519824015";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-api/default.nix
+++ b/distros/rolling/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-api";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_api/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6f1a6957a7f2d31a6071f8b8fd2550caee2d007bf41b7b8f54c163eda9a12381";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "3a81df0722760113893cffdc7c1d9521f0474f8de2b3f6e85462a606c89cb1a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-digital-inputs/default.nix
+++ b/distros/rolling/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-digital-inputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_inputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "bcee8eddc8458e5a57f57eaa378a3de9f9fa0c69843f1e47ef80f09250f71862";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_inputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "59bf4279682a58e3ee98bc9e4fef1fb9c6ddca376f93b17c3d881dba4b5e04e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-digital-outputs/default.nix
+++ b/distros/rolling/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-digital-outputs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_outputs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6821b199b7cec8839689dac080987b6004d1fccc5648e4d315926d635cbd9bd3";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_digital_outputs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "a64b4aff2e181efee0adfa34c090e6e0b64304d908ad98f5ab447e6837822f97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-drivers/default.nix
+++ b/distros/rolling/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-drivers";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_drivers/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "b1cbbf3c3ca3bbf1fb6dcf166bb282e7fd1f1acda33df9eae235c744922d4523";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_drivers/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "8e289943de83f09a49738fe7fce31f40389a75208f702a9b19fce049529b8ec7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-gyroscope/default.nix
+++ b/distros/rolling/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-gyroscope";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_gyroscope/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "255314dca51beddfd79980a6a8d1448374c06a0015dba2dc39d45a89ae2fb87e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_gyroscope/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5c53beb0c310ff57a2fdb386793e721d6d3f968d75ec7ae0ea0f4fc18cdbb6d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-high-speed-encoder/default.nix
+++ b/distros/rolling/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-high-speed-encoder";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_high_speed_encoder/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "2a4fffe846d0a8e18688af2869f6b200c86a295b644eda76e898b126b5a0b34a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_high_speed_encoder/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "f994c45fd436b6ec8706f02b83b21f6509578cf9b4b7926e267588f0ffcb7f16";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-ik/default.nix
+++ b/distros/rolling/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-ik";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_ik/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "61e2d0202d3c13bf11acad6a474d9cd86ff6ad34ec0d976f8789292f9e4f5d86";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_ik/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "24d6f533594806e0dd40594486e780296f245fe30d5f06dfa2853255138d846f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-magnetometer/default.nix
+++ b/distros/rolling/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-magnetometer";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_magnetometer/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6a65430a8047644c4993ade519cb4e115985de7f82e30be080ee2c7537f65755";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_magnetometer/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "aaeb79cc4fc3aba21f8f80b36d6f93183168591ea25f0f90ec7b7373112b2488";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-motors/default.nix
+++ b/distros/rolling/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-motors";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_motors/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "37f77f68b20343438e7f9525bd71372fcc3913677d571147ed4e3968a103418f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_motors/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "80e54cb68c70bfee130fc87ed97fb2e4e8d8eb201083e7067778a8397286f6c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-msgs/default.nix
+++ b/distros/rolling/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-msgs";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_msgs/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "e341762b851f9e6d879798d8ab33d80780cd9accd60e3896a9123b61c0c94e10";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_msgs/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "1fa389a996fadfe992fdf2fd24debab2fbd30f1c0117cc8784fe71122dc09737";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-spatial/default.nix
+++ b/distros/rolling/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-spatial";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_spatial/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "3469879da72a26fc037f6090ba601553910024c93fe02171910bc86fb4fc5121";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_spatial/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "212f2def298432274086d9de0a926592d3baad9e309959739d5f26b8676276e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/phidgets-temperature/default.nix
+++ b/distros/rolling/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-phidgets-temperature";
-  version = "2.3.2-r2";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_temperature/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "6f8d5ecf7784948c5c97c2ab329d7cef4d042df28f422ade9437c3e97245af44";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/rolling/phidgets_temperature/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "2785618af4aa6da265e1625fda585a3171dd07d87825189854e6be95c243b399";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "3.0.4-r2";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.4-2.tar.gz";
-    name = "3.0.4-2.tar.gz";
-    sha256 = "55dc464325e7e1bb0faebdde6373979572404e5e6b1a92a7e1164085a4b3dfd2";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "206267355654492cf4c53d7e2c6cd896611256265f69752e3809c16bc4f3bf67";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-tutorial/default.nix
+++ b/distros/rolling/point-cloud-transport-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, point-cloud-transport, point-cloud-transport-plugins, rclcpp, rcpputils, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-tutorial";
-  version = "0.0.1-r2";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_tutorial-release/archive/release/rolling/point_cloud_transport_tutorial/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "504ae06e52d656c57ed25d40ebf463005395d6c5c22d3eb69722c39e258218f1";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_tutorial-release/archive/release/rolling/point_cloud_transport_tutorial/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "6b1275f5154a2e5243b6219907fe29f7e320ce26520a5ddc5ef7d80f49fbfbb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "3.0.4-r2";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.4-2.tar.gz";
-    name = "3.0.4-2.tar.gz";
-    sha256 = "510b3ba529719d8a65b93e36a9d77c3a3fcccc2d3ab8b04fb018f800333c74c7";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "82ad470cb08550d6a35d54cd29ed777e3c4a11513af0da9d1b35fb554a27ec9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rc-dynamics-api/default.nix
+++ b/distros/rolling/rc-dynamics-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, protobuf }:
 buildRosPackage {
   pname = "ros-rolling-rc-dynamics-api";
-  version = "0.10.3-r3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_dynamics_api-release/archive/release/rolling/rc_dynamics_api/0.10.3-3.tar.gz";
-    name = "0.10.3-3.tar.gz";
-    sha256 = "f9870a4378fafd10fb4edf173aefc4c2c1e9fe53e6dc189ed4cb33978af3c0d1";
+    url = "https://github.com/ros2-gbp/rc_dynamics_api-release/archive/release/rolling/rc_dynamics_api/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "0e77c562601a0a92146f43f5141daf3faf0b9c6236d10a739fea9be3be88035b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rc-genicam-api/default.nix
+++ b/distros/rolling/rc-genicam-api/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1, ncurses }:
 buildRosPackage {
   pname = "ros-rolling-rc-genicam-api";
-  version = "2.6.1-r3";
+  version = "2.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/rolling/rc_genicam_api/2.6.1-3.tar.gz";
-    name = "2.6.1-3.tar.gz";
-    sha256 = "044f2119766f5948db0f7a75aeaa4c924106e120dad1fb6ec046fdd8ea3354bc";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/rolling/rc_genicam_api/2.6.5-1.tar.gz";
+    name = "2.6.5-1.tar.gz";
+    sha256 = "2cd2bb6d745ad7b9d5604527a56bf8bb10c101b64dcadc50c3366dd19c548bf9";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ libpng libusb1 ];
+  propagatedBuildInputs = [ libpng libusb1 ncurses ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/rcdiscover/default.nix
+++ b/distros/rolling/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-rcdiscover";
-  version = "1.1.6-r3";
+  version = "1.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/rolling/rcdiscover/1.1.6-3.tar.gz";
-    name = "1.1.6-3.tar.gz";
-    sha256 = "7c83a4b917ed25a05ad968afc28bdb5fa80c5aa58e73eb59e24c7089d42dd2f0";
+    url = "https://github.com/ros2-gbp/rcdiscover-release/archive/release/rolling/rcdiscover/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "adb577bf90a75e984895ddaad462744e9ff35b5c92d4209d02aa81b800db6b1f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rig-reconfigure/default.nix
+++ b/distros/rolling/rig-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, git, glfw3, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rig-reconfigure";
-  version = "1.4.0-r2";
+  version = "1.4.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/rolling/rig_reconfigure/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "ce4a7b59f312d5b654463f1c56f0da50372c83db2e93349a597aeb2b92e52598";
+    url = "https://github.com/ros2-gbp/rig_reconfigure-release/archive/release/rolling/rig_reconfigure/1.4.0-3.tar.gz";
+    name = "1.4.0-3.tar.gz";
+    sha256 = "9b3147d3f57fa9d13cfb1d28be2b566fad9fddc4d14395a3bdda92a1be3bb556";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-api-msgs/default.nix
+++ b/distros/rolling/rmf-api-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nlohmann_json, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rmf-api-msgs";
-  version = "0.2.1-r1";
+  version = "0.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/rolling/rmf_api_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "d98ffe2714cb55bc42eb3c4ee2a99456feecf6e5d0062491bf9b90879fc58890";
+    url = "https://github.com/ros2-gbp/rmf_api_msgs-release/archive/release/rolling/rmf_api_msgs/0.2.1-2.tar.gz";
+    name = "0.2.1-2.tar.gz";
+    sha256 = "bcb443abf05d810746ef17f7643570205574934cbebb24aef848e6f77cedd66d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-charging-schedule/default.nix
+++ b/distros/rolling/rmf-charging-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-charging-schedule";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_charging_schedule/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "0d648f5f8fcb13a3aef6157df87aa86b15f3db3a1d314ed01808f211489a716c";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_charging_schedule/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "225c6844e9b29759a05179c30c6d291b020ce4b3bc32aa8c4d2974d1473f1d5e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-fleet-adapter-python/default.nix
+++ b/distros/rolling/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter-python";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "ec630315c25dfcc6a7be663593d13098d4abd45e3353746a35065ffdf7efaeb7";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "3cb6552aa6bb993b7f9b03f62e06aac3fb7f035ae0e06cc905c1f502673f8d89";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-fleet-adapter/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "95e73ed2af8cde391d1307fe64eadd12f2b3a03e2529c936bd075e17773a269d";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "35795ec7d0aa318c39aacb2ed914f60226bc155502dc684e01542ff2fb7f6cc5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen yaml-cpp ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
+  propagatedBuildInputs = [ backward-ros nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-task-ros2/default.nix
+++ b/distros/rolling/rmf-task-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-ros2";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "733f24fd92f68883c726af8705cbaa97f0dc29a554a083ee95d82d393cd5e417";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "75563017b2263d68072eaf34991e3616e9cb7a989a3a596d8e9789fa9d85715e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rmf-api-msgs rmf-task-msgs rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket ];
+  propagatedBuildInputs = [ backward-ros nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rmf-api-msgs rmf-task-msgs rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-task-sequence/default.nix
+++ b/distros/rolling/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-sequence";
-  version = "2.4.0-r1";
+  version = "2.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "25183800004c54654c73339b1c0998ffdf9836a784e16d4ce97301a243d63561";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.4.0-2.tar.gz";
+    name = "2.4.0-2.tar.gz";
+    sha256 = "5d0bf089ee24083408afe8f61daaee918e270cbc143b0336baae3e0d61e26f4e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-task/default.nix
+++ b/distros/rolling/rmf-task/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task";
-  version = "2.4.0-r1";
+  version = "2.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "f18ec24e476b56a5f522daa8f3b6b37a9dd0daee6bd957beb9a5c801a0dd3790";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.4.0-2.tar.gz";
+    name = "2.4.0-2.tar.gz";
+    sha256 = "b53282c5b96061112fa52b2d973efcc43c743296be71c39301af04d893fdca46";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-traffic-ros2/default.nix
+++ b/distros/rolling/rmf-traffic-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-ros2";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "0577be3e33e68766f35694092da3f9e01ef57abacf38e309f4bacdeeed52d7da";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "f4e6da14c87ec79a9b0b602a8eacca7a1c67854ba1390ed0e12637ed28dc16dc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
+  propagatedBuildInputs = [ backward-ros nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-visualization-navgraphs/default.nix
+++ b/distros/rolling/rmf-visualization-navgraphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, rclcpp-components, rmf-building-map-msgs, rmf-fleet-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-navgraphs";
-  version = "2.2.1-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "56da9f79f4c6d30c0900052477d4ade1f7744922a75fb02c1987a896e8c47ed4";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "33e2d61f0eafaf0539a27a66f8528359a9f016f12990b6284405bbe1a5197837";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
+++ b/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, eigen, pluginlib, qt5, rclcpp, resource-retriever, rmf-door-msgs, rmf-lift-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rviz-common, rviz-default-plugins, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-rviz2-plugins";
-  version = "2.2.1-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "d94bb9cda183897c6cc1a038bbf32d48594b647b2a4392bbd9bf036b5e6fe835";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "0e3460aee667d8fcfc90996118a739d297a2cf149b3e9f1b46d7aa9110ea5cb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-schedule/default.nix
+++ b/distros/rolling/rmf-visualization-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, eigen, geometry-msgs, openssl, rclcpp, rclcpp-components, rmf-traffic, rmf-traffic-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rosidl-default-generators, visualization-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-schedule";
-  version = "2.2.1-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "ba06e9f52e7c6adfc8502c1e8498f7dab7dbe00e2307335b1f66b75a850c8472";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "9044afa4e9f883d2b9682da256ebef42253c2d23b04f917b1d4f36330ca40750";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-websocket/default.nix
+++ b/distros/rolling/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-websocket";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "d1985f8ff895a8d8fa56888794a6a30a561cc85900373a2c7df785a21680c65f";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "538af0475f8eb72f8e0f50311c6a551c0b4e2a92e0485ec903d654434fdef22c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.20.0-r2";
+  version = "0.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.20.0-2.tar.gz";
-    name = "0.20.0-2.tar.gz";
-    sha256 = "e816a343d5556277d77224663ba95f97bdf83986cce4425561eac90505b058d9";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.20.1-1.tar.gz";
+    name = "0.20.1-1.tar.gz";
+    sha256 = "dc61a234fbae21fc6814e5d80b90e7b50a5f9af1758df1748b3e6f58225e43dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.20.0-r2";
+  version = "0.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.20.0-2.tar.gz";
-    name = "0.20.0-2.tar.gz";
-    sha256 = "9067d7d7358ec696d7fc17cca2c2c7df80b7cd2a424c4e384fdd8efa96b584f5";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.20.1-1.tar.gz";
+    name = "0.20.1-1.tar.gz";
+    sha256 = "2e259b78b3260deb8279c4870790d4cfddeabb9d2d03a31402d901c982935420";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-localization/default.nix
+++ b/distros/rolling/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, message-filters, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-robot-localization";
-  version = "3.6.0-r2";
+  version = "3.6.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.6.0-2.tar.gz";
-    name = "3.6.0-2.tar.gz";
-    sha256 = "26e5cd8c08c9a0097de19db62a09b4eb4328d6d0df6c419183026f45e507f88f";
+    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.6.0-3.tar.gz";
+    name = "3.6.0-3.tar.gz";
+    sha256 = "9350bce936ff5aac8cbd12b28ebbaa51078d201293c771e0e0f59784e161e5bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "8d701f44c8ebb92099f7f48a012347f92e9fa5ada72d46386bd7e0382312c9c2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "cb9d08aabb24529fafa1a7fe96ce619c65404956469bc69a340a11df63504c7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "7851546f98b5dd43882f6de6f1ec1ec53e81dfd9afb1b59bb5623bf510736c25";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "40cd9acb576b97f648a8075a7fc8830607fc0e46385eb781cb249d07bc20db69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "5e5cfc8a2ba213846c5b77e28507ee04943f92f0d7a79baa6d12173ad6cae1a9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "488cd2eb4c106503d2fbe6c8385b4f959f2513f9365bc04488133777a5147f14";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "4a80c154b359c288570b4a69f0dee262aaea4685bddd73e4e569bc8128b06814";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "f62be2cd8b9f2e295c2e1a3960b28a4cda7e86292bbc2728059db808cd03138d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "b5e66605c52c4cc4799baa0a63af137398199c27860f9b56f1a246d9a6d1ab1c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "7219700f24b3120eb721d96f093339e635d56424c2ecd4aa0de06d624beae0f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "d9008001bf5fa27a7c9c7c4f9c6adb6c8ea1222b59795af0e904028e2199f910";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "c162b8251b80a4ea63ac84af6c09e0f000dfbe8e137fa9cd6850c849b2973507";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "1d341ee24482e15cf9505d00f8581b5efa21b7cf419e46440883d025fdb47827";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "3ad81229fbd930e16226c3d1ee497e02c888c51b848146a00d4c2fbe882646ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "9aadcb52cbb6b4133555ec3399005ab86865e92adbf41e27753d367d04203fe9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "ceb9462ffccfd0ebe7839496c6ff765d869511c6715fdf27f9da9da71e848a1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "cbf809a4113b9b9b2e32e7e5d113b03c96fafd08b66e3f4a17b83bba18f7c5b6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "485ff76dfd4b2696eb62c1cb89191e980c981002d69ee8d12c1c9de482cf12e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "9d5b1792e7bb7b543de5f12674f8610c01bc988d1111f056b9d32e46e48894a2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "b3fc5564853f3798965361d7a7c22557e87d04faa05de78138ab7150b3656340";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "b211c37e2884e9c0c020d62d671215aa5d80685d73ad083e160ec48ebe6638c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "682aa6fc9b5e709d19b45e7a5943c4573851fd9050db612fbc22d9137aab94d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "16a537d338f88e9f51a8500a662d1a2342cd3043da0a875cb153524f6d7e3036";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "120fcd88d4e8d80b5ca1703ad6de64c39ac4c7e7e17621c5b928ff03ae120941";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "6bae557d11345206ca931aba4577de0bb27007ed4d69e10b0a94c6d40fa12697";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0f73c29758843795d0fe97defed33c8781091e833e4d004544714f7a812006ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "352a705d5c6484593b220b460ca55cb3e1f9f79260f812f61dac00843468f3c4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "1b9af46452155e33b111fbec745401c81e4ee7dbc35c995f6293e1a59f85d87e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "162fff69e6c8b0992b656e7dd7f00ff7a0475599fe7594fd855c32a776d10867";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "193ae009ac8fb23120d34b11624da7cd05241f2bc27664022af8093e6b040fc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "89b1842b337e1ee1018623d01c865c056b304627530f91edaac9bbb90ea7eb38";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "3cbff9b3eaeee4840d48bc59fc04196d142a866614551cc7da28877660379ad9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "8687f460a3da765c4952daf55056ec85735b44b00bee3f149857f9f4f90a8d2d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0b49339957e1526755106bb79a2a74616c52d5cceb80f237e6546c3f7b1d56b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "d730c440ee7ba698e08f3cbcf098071db114136c12812946781f1d8ccbfeea0d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "381c2345d5d95b8c17c568805dce363998682c9c950ead9b5f2c2dff853d7285";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "56a47102a919db62ad57463cfc8ef2a61458df7a9b56756c91cfae4840f3047a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "6fdb6c74f3f87c1176c3529028de1117a6de8fff9d89e492f6a57248f413e4e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "8059d7a7dcf2891600b7eac3282462f5274e5c6bcaaecf24cc5078d8d6ed17ce";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0eaabcd341f10c86c3aa213faa02f4507f5a4cc93e971c4468aa8644817a8781";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "8bc52dd4709b1ba6be60fbcab5cdd9574bad4caea2c8c39acff999020dd38e19";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "1532bcbefa8a5f3c6bbb69291442938ce31e39e0a80b95477211b8d6b74f6fa1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "79b44058b8bd13e0de749d8ae7a6698e084b7cf9e0401cbc49a9f04c281faf29";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "66e5636eb14e89a6617609f228fc98616256eca38eb52e01b9b749ae51071987";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rot-conv/default.nix
+++ b/distros/rolling/rot-conv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-rot-conv";
-  version = "1.1.0-r2";
+  version = "1.1.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rot_conv_lib-release/archive/release/rolling/rot_conv/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "af9b11611dd34e2aa930dbc2956457feee916b69f61d431e017496528182daa3";
+    url = "https://github.com/ros2-gbp/rot_conv_lib-release/archive/release/rolling/rot_conv/1.1.0-3.tar.gz";
+    name = "1.1.0-3.tar.gz";
+    sha256 = "fc8fc8d953695d041ad3b6e7cbbec2d43e9b5923b978878a2f34ad1b7f913e5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "f2f2b8e091e5a0c537b85382cefb69e459e25ee46bfde14f99c55b7136cfecf2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "976b0009aaa8d78cd0ba6ccff4053d7f643ecc344e21b92f39733f0d643ce0d9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gauges/default.nix
+++ b/distros/rolling/rqt-gauges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-index-python, ament-xmllint, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gauges";
-  version = "0.0.2-r2";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/rolling/rqt_gauges/0.0.2-2.tar.gz";
-    name = "0.0.2-2.tar.gz";
-    sha256 = "ddb38f8f1133823bdee1a27bb252d5a6ee4ace3af3c3f558ed76a5427906460e";
+    url = "https://github.com/ros2-gbp/rqt_gauges-release/archive/release/rolling/rqt_gauges/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "46ecd6bbfba2041ab327e216fa3b16bf85797e0d0e8ea85083b81c8836a6f5e0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.20.0-r2";
+  version = "0.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.20.0-2.tar.gz";
-    name = "0.20.0-2.tar.gz";
-    sha256 = "f27a90c33621f0562db8e5dac26bbb8e7537bb17c263ab96e6beb273c7e7441f";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.20.1-1.tar.gz";
+    name = "0.20.1-1.tar.gz";
+    sha256 = "5b3b9a88e1a1ea439e88e4feeb161a18a838f84a8beb00d5dbe09ef16951f0f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "e6a149af1cf7d21ae471344ddce26bb96d953007d9adbdfaedb5b6dd953d6567";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "1e0b81888cd9dd591bc651963d84315f275b7ef7eeb74df5c287ae7e5091680c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "7c741422e73b0cabfc67336ac70aab66618d24a6d6dd28ed239efa2ee35a69b5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "5ff7a521bbaf2a3a7551cd36accb589dbdd851b46ba19269085d42804f9f8d71";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "6637af1aba668f8f842884dbd76203a9699b232800fe1b9f05705c15748ac176";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "46a4d39dff9f04b026599007c2ef75d33521673a8da81ef280df909ba066d044";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "64011f9c8d5c972f0e2bd9131c4ff5af844da05374c383e57ed799af8b1b1e8e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "ce583f5c2deac7af762f46c57a199fe9f901c68a22223f7b49ac500ad3dce762";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "6516d93ebf0387e93b9e5213e17b73e88a7bc81fb06175614fb370ebf3eedb93";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "d71dd1de63b136767fa800a59c6ea268fc3e3e81ee161b2ac19e616602df9a31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "696c7b63f59c6c8656095fa320cad940122273d5bb6143691cdf68b0d6e4a081";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "0e45b3355b4319cf3e7199d2a7e42668609bbe75e0f02735a71567c37d6346e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "7219e397a3e831b58319116884ac4544bb5993bee3360c6be9932ae16c8af681";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "d0f312f6ef6b97ef0a45dccaf55af12e7fa688849f7be22aee3232bf8754b873";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.3.1-r2";
+  version = "13.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.3.1-2.tar.gz";
-    name = "13.3.1-2.tar.gz";
-    sha256 = "01b5aeb4da070f12ec5316df2541ec1d31434f079e6b66ed49623b2b38b3f5d2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.4.0-2.tar.gz";
+    name = "13.4.0-2.tar.gz";
+    sha256 = "afcef75ede14ae865cb818f33fd8d7023d21ba49302293d4353cc24c1f43da14";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shared-queues-vendor/default.nix
+++ b/distros/rolling/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-shared-queues-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "cd4e1aa7d59c88418ef50cba467e4a8d3c2b5d5f173134040c79cbded3e0ba93";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "1b4c422f4f70af93cb56355cc9bdead94ae61abccf08b4c6d2ba5054871772c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sophus/default.nix
+++ b/distros/rolling/sophus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-rolling-sophus";
-  version = "1.3.1-r3";
+  version = "1.22.9100-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sophus-release/archive/release/rolling/sophus/1.3.1-3.tar.gz";
-    name = "1.3.1-3.tar.gz";
-    sha256 = "62bf548430e63dd485903fac8cc98d0535a9c64905e8d1a7a2aeed293de1c8cf";
+    url = "https://github.com/ros2-gbp/sophus-release/archive/release/rolling/sophus/1.22.9100-1.tar.gz";
+    name = "1.22.9100-1.tar.gz";
+    sha256 = "7d2e7c41aad833b0fc1a4c42ba4f95e7586fa37d08aa9f2d1bf0daa52e8eafd0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/sqlite3-vendor/default.nix
+++ b/distros/rolling/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-sqlite3-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "dd29dae2b05c908df3bb979979e077102f60b466d848b969479adaa32c099e22";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "0adef19b281d113f7f61c00d1d2d3bbbee1f7c317cb4747bd72ea86eb8a2d99f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tinyspline-vendor/default.nix
+++ b/distros/rolling/tinyspline-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-rolling-tinyspline-vendor";
-  version = "0.6.0-r4";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tinyspline_vendor-release/archive/release/rolling/tinyspline_vendor/0.6.0-4.tar.gz";
-    name = "0.6.0-4.tar.gz";
-    sha256 = "65c7033e502a2cf51b70154503a71f9e2ffa98dea3a2feeaf28f75a8604ee78a";
+    url = "https://github.com/ros2-gbp/tinyspline_vendor-release/archive/release/rolling/tinyspline_vendor/0.6.0-5.tar.gz";
+    name = "0.6.0-5.tar.gz";
+    sha256 = "897f2167e232401b3450b3a3a9334afe189b559f6ca727af5265ce678aca8f61";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.5.0-r2";
+  version = "4.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.5.0-2.tar.gz";
-    name = "4.5.0-2.tar.gz";
-    sha256 = "2a3c6a9bffc1791e16c731b639c50a42a0fd98d7c576c0133c75b12d80a92b8c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.6.0-1.tar.gz";
+    name = "4.6.0-1.tar.gz";
+    sha256 = "d0c80bc3cb727a1d987342b7a20d79d0775bb2dcf015b1ec547bdfe6f778f988";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss-node/default.nix
+++ b/distros/rolling/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, libusb1, pkg-config, rclcpp, rclcpp-components, rtcm-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss-node";
-  version = "0.5.2-r2";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.5.2-2.tar.gz";
-    name = "0.5.2-2.tar.gz";
-    sha256 = "ebc195ce2171346b717a0d1f7584f3e87b6e1f1594244ab48baa6b0c2fb29407";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss_node/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "5c9ef2050ef71648d1584f57fb895739b4ff7a69b1ab61d8373bbac6c8590011";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-dgnss/default.nix
+++ b/distros/rolling/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ntrip-client-node, ublox-dgnss-node, ublox-nav-sat-fix-hp-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-dgnss";
-  version = "0.5.2-r2";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.5.2-2.tar.gz";
-    name = "0.5.2-2.tar.gz";
-    sha256 = "f8e7f278d0d2100c9908647643c596fe4e34044faf751c54aebe71c621ed0b6e";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_dgnss/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "cdda262ab5ebd2e6a65a00a84faff91afbe323d2d5a679a182327d3dcb0f6014";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
+++ b/distros/rolling/ublox-nav-sat-fix-hp-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-nav-sat-fix-hp-node";
-  version = "0.5.2-r2";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.5.2-2.tar.gz";
-    name = "0.5.2-2.tar.gz";
-    sha256 = "fc7ff3e349c37047899a80caa7a50c910e119d76f6f30f58782f95bb0b18eff3";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_nav_sat_fix_hp_node/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "7fa246ccb6bd2370423fccea3423dc78c70f75c7dc7296d1e096219fdd5e3d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-interfaces/default.nix
+++ b/distros/rolling/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-interfaces";
-  version = "0.5.2-r2";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.5.2-2.tar.gz";
-    name = "0.5.2-2.tar.gz";
-    sha256 = "897623ce42ccdb2a9b7e70713ea5383c478009a9db393bbd7778e8ef366fa72e";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_interfaces/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "28202d33eaf5516434ac98fa9cea35da7689ed1b2e67bc2d2bca7001373bf17a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ublox-ubx-msgs/default.nix
+++ b/distros/rolling/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ublox-ubx-msgs";
-  version = "0.5.2-r2";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.5.2-2.tar.gz";
-    name = "0.5.2-2.tar.gz";
-    sha256 = "a9864c41055f73bcb1b4aa67d7daa5a3d19d287a7ed60da85404aed5b9984e33";
+    url = "https://github.com/ros2-gbp/ublox_dgnss-release/archive/release/rolling/ublox_ubx_msgs/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "f65612404f9194d2db4971d5bc07bea3528337d25042fdcd377853c6fcbc2506";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-vendor/default.nix
+++ b/distros/rolling/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-vendor";
-  version = "0.24.0-r2";
+  version = "0.24.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.24.0-2.tar.gz";
-    name = "0.24.0-2.tar.gz";
-    sha256 = "bad8a96cd038f2ca35ae506c2cc8573a4fa406102e38f5a6e47354b82cb2226f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.24.0-3.tar.gz";
+    name = "0.24.0-3.tar.gz";
+    sha256 = "e2a9b32171b7d0d3ae316b426e3810f8dcb7d7055534b245b4b59e9ade3d163a";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit de1ea0a747635d6c0b33b7cfd99b75db6031d05d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *apriltag 3.2.0-r2 --> 3.4.0-r1*
* *cartographer 2.0.9002-r2 --> 2.0.9003-r1*
* *cartographer-ros 2.0.9000-r2 --> 2.0.9002-r1*
* *cartographer-ros-msgs 2.0.9000-r2 --> 2.0.9002-r1*
* *cartographer-rviz 2.0.9000-r2 --> 2.0.9002-r1*
* *clearpath-config 0.2.4-r1 --> 0.2.5-r1*
* *cmake-generate-parameter-module-example 0.3.8-r1*
* *depthai 2.23.0-r1 --> 2.24.0-r1*
* *flir-camera-description 2.0.8-r3 --> 2.1.14-r1*
* *flir-camera-msgs 2.0.8-r3 --> 2.1.14-r1*
* *gazebo-ros2-control 0.4.6-r1 --> 0.4.7-r1*
* *gazebo-ros2-control-demos 0.4.6-r1 --> 0.4.7-r1*
* *generate-parameter-library 0.3.7-r1 --> 0.3.8-r1*
* *generate-parameter-library-example 0.3.6-r1 --> 0.3.8-r1*
* *generate-parameter-library-py 0.3.7-r1 --> 0.3.8-r1*
* *generate-parameter-module-example 0.3.6-r1 --> 0.3.8-r1*
* *human-description 2.0.2-r1*
* *ign-ros2-control-demos 0.7.5-r1 --> 0.7.6-r1*
* *kitti-metrics-eval 1.0.0-r1*
* *libphidget22 2.3.2-r1 --> 2.3.3-r1*
* *marine-acoustic-msgs 2.1.0-r1*
* *marine-sensor-msgs 2.1.0-r1*
* *message-tf-frame-transformer 1.1.0-r1 --> 1.1.1-r1*
* *mola 1.0.0-r1*
* *mola-bridge-ros2 1.0.0-r1*
* *mola-demos 0.2.2-r1 --> 1.0.0-r1*
* *mola-imu-preintegration 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-euroc-dataset 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-kitti-dataset 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-kitti360-dataset 1.0.0-r1*
* *mola-input-mulran-dataset 1.0.0-r1*
* *mola-input-paris-luco-dataset 1.0.0-r1*
* *mola-input-rawlog 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-rosbag2 1.0.0-r1*
* *mola-kernel 0.2.2-r1 --> 1.0.0-r1*
* *mola-launcher 0.2.2-r1 --> 1.0.0-r1*
* *mola-metric-maps 1.0.0-r1*
* *mola-navstate-fuse 1.0.0-r1*
* *mola-pose-list 1.0.0-r1*
* *mola-traj-tools 1.0.0-r1*
* *mola-viz 0.2.2-r1 --> 1.0.0-r1*
* *mola-yaml 0.2.2-r1 --> 1.0.0-r1*
* *motion-capture-tracking 1.0.3-r1 --> 1.0.5-r1*
* *motion-capture-tracking-interfaces 1.0.3-r1 --> 1.0.5-r1*
* *mp2p-icp 1.2.0-r1 --> 1.3.0-r1*
* *mqtt-client 2.2.0-r1 --> 2.2.1-r1*
* *mqtt-client-interfaces 2.2.0-r1 --> 2.2.1-r1*
* *mrpt-path-planning 0.1.0-r1 --> 0.1.1-r1*
* *mrpt2 2.11.11-r1 --> 2.12.0-r1*
* *mvsim 0.9.1-r1 --> 0.9.2-r1*
* *novatel-gps-driver 4.1.1-r2 --> 4.1.2-r1*
* *novatel-gps-msgs 4.1.1-r2 --> 4.1.2-r1*
* *parameter-traits 0.3.7-r1 --> 0.3.8-r1*
* *phidgets-accelerometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-api 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-drivers 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-gyroscope 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-high-speed-encoder 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-ik 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-magnetometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-motors 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-msgs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-spatial 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-temperature 2.3.2-r1 --> 2.3.3-r1*
* *raspimouse-description 1.1.0-r1 --> 1.2.0-r1*
* *raspimouse-fake 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-gazebo 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-navigation 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-ros2-examples 2.1.0-r1 --> 2.2.0-r2*
* *raspimouse-sim 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-slam 2.0.0-r1 --> 2.1.0-r1*
* *raspimouse-slam-navigation 2.0.0-r1 --> 2.1.0-r1*
* *rc-genicam-api 2.6.1-r1 --> 2.6.5-r1*
* *robotont-driver 0.1.2-r1*
* *robotraconteur 1.0.0-r2 --> 1.1.1-r1*
* *rqt-gauges 0.0.2-r1 --> 0.0.3-r1*
* *sick-scan-xd 3.1.11-r3 --> 3.2.5-r1*
* *sophus 1.3.1-r1 --> 1.3.2-r1*
* *spinnaker-camera-driver 2.0.8-r3 --> 2.1.14-r1*
* *spinnaker-synchronized-camera-driver 2.1.14-r1*
* *teleop-twist-keyboard 2.3.2-r4 --> 2.4.0-r1*
* *wireless-msgs 1.0.1-r2 --> 1.0.1-r3*
* *wireless-watcher 1.0.1-r2 --> 1.0.1-r3*

Iron Changes:
-------------
* *azure-iot-sdk-c 1.12.0-r1 --> 1.13.0-r1*
* *cartographer 2.0.9002-r5 --> 2.0.9003-r1*
* *cartographer-ros 2.0.9001-r2 --> 2.0.9002-r1*
* *cartographer-ros-msgs 2.0.9001-r2 --> 2.0.9002-r1*
* *cartographer-rviz 2.0.9001-r2 --> 2.0.9002-r1*
* *depthai 2.23.0-r1 --> 2.24.0-r1*
* *event-camera-py 1.2.4-r1 --> 1.2.5-r1*
* *flir-camera-description 2.0.8-r2 --> 2.2.14-r1*
* *flir-camera-msgs 2.0.8-r2 --> 2.2.14-r1*
* *gazebo-ros2-control 0.6.4-r1 --> 0.6.5-r1*
* *gazebo-ros2-control-demos 0.6.4-r1 --> 0.6.5-r1*
* *gz-ros2-control-demos 1.1.4-r2 --> 1.1.5-r1*
* *kitti-metrics-eval 1.0.0-r1*
* *libphidget22 2.3.2-r1 --> 2.3.3-r1*
* *marine-acoustic-msgs 2.1.0-r1*
* *marine-sensor-msgs 2.1.0-r1*
* *message-tf-frame-transformer 1.1.0-r1 --> 1.1.1-r1*
* *mola 1.0.0-r1*
* *mola-bridge-ros2 1.0.0-r1*
* *mola-demos 0.2.2-r1 --> 1.0.0-r1*
* *mola-imu-preintegration 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-euroc-dataset 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-kitti-dataset 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-kitti360-dataset 1.0.0-r1*
* *mola-input-mulran-dataset 1.0.0-r1*
* *mola-input-paris-luco-dataset 1.0.0-r1*
* *mola-input-rawlog 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-rosbag2 1.0.0-r1*
* *mola-kernel 0.2.2-r1 --> 1.0.0-r1*
* *mola-launcher 0.2.2-r1 --> 1.0.0-r1*
* *mola-metric-maps 1.0.0-r1*
* *mola-navstate-fuse 1.0.0-r1*
* *mola-pose-list 1.0.0-r1*
* *mola-traj-tools 1.0.0-r1*
* *mola-viz 0.2.2-r1 --> 1.0.0-r1*
* *mola-yaml 0.2.2-r1 --> 1.0.0-r1*
* *motion-capture-tracking 1.0.2-r1 --> 1.0.4-r1*
* *motion-capture-tracking-interfaces 1.0.2-r1 --> 1.0.4-r1*
* *mp2p-icp 1.2.0-r1 --> 1.3.0-r1*
* *mqtt-client 2.2.0-r1 --> 2.2.1-r1*
* *mqtt-client-interfaces 2.2.0-r1 --> 2.2.1-r1*
* *mrpt-path-planning 0.1.0-r1 --> 0.1.1-r1*
* *mrpt2 2.11.11-r1 --> 2.12.0-r1*
* *mvsim 0.9.1-r1 --> 0.9.2-r1*
* *novatel-gps-driver 4.1.1-r1 --> 4.1.2-r1*
* *novatel-gps-msgs 4.1.1-r1 --> 4.1.2-r1*
* *ntrip-client-node 0.5.2-r1 --> 0.5.3-r1*
* *phidgets-accelerometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-analog-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-api 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-inputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-digital-outputs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-drivers 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-gyroscope 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-high-speed-encoder 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-ik 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-magnetometer 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-motors 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-msgs 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-spatial 2.3.2-r1 --> 2.3.3-r1*
* *phidgets-temperature 2.3.2-r1 --> 2.3.3-r1*
* *robotraconteur 1.0.0-r2 --> 1.1.1-r1*
* *rqt-gauges 0.0.2-r1 --> 0.0.3-r1*
* *sophus 1.3.1-r3 --> 1.3.2-r1*
* *spinnaker-camera-driver 2.0.8-r2 --> 2.2.14-r1*
* *spinnaker-synchronized-camera-driver 2.2.14-r1*
* *teleop-twist-keyboard 2.3.2-r5 --> 2.4.0-r1*
* *ublox-dgnss 0.5.2-r1 --> 0.5.3-r1*
* *ublox-dgnss-node 0.5.2-r1 --> 0.5.3-r1*
* *ublox-nav-sat-fix-hp-node 0.5.2-r1 --> 0.5.3-r1*
* *ublox-ubx-interfaces 0.5.2-r1 --> 0.5.3-r1*
* *ublox-ubx-msgs 0.5.2-r1 --> 0.5.3-r1*

Noetic Changes:
---------------
* *camera-aravis 4.0.5-r3 --> 4.1.0-r1*
* *cob-fiducials 0.1.1-r1*
* *depthai 2.23.0-r1 --> 2.24.0-r2*
* *husky-control 0.6.9-r1 --> 0.6.10-r1*
* *husky-description 0.6.9-r1 --> 0.6.10-r1*
* *husky-desktop 0.6.9-r1 --> 0.6.10-r1*
* *husky-gazebo 0.6.9-r1 --> 0.6.10-r1*
* *husky-msgs 0.6.9-r1 --> 0.6.10-r1*
* *husky-navigation 0.6.9-r1 --> 0.6.10-r1*
* *husky-simulator 0.6.9-r1 --> 0.6.10-r1*
* *husky-viz 0.6.9-r1 --> 0.6.10-r1*
* *libphidget22 1.0.8-r2 --> 1.0.9-r1*
* *marine-acoustic-msgs 2.0.1-r1 --> 2.0.2-r1*
* *marine-sensor-msgs 2.0.1-r1 --> 2.0.2-r1*
* *message-tf-frame-transformer 1.1.0-r1 --> 1.1.1-r1*
* *mqtt-client 2.2.0-r2 --> 2.2.1-r1*
* *mqtt-client-interfaces 2.2.0-r2 --> 2.2.1-r1*
* *mrpt-generic-sensor 0.0.3-r1 --> 0.0.4-r1*
* *mrpt-local-obstacles 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-localization 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-map 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-msgs-bridge 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-navigation 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-path-planning 0.1.0-r1 --> 0.1.1-r1*
* *mrpt-rawlog 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-reactivenav2d 1.0.4-r1 --> 1.0.5-r1*
* *mrpt-sensorlib 0.0.3-r1 --> 0.0.4-r1*
* *mrpt-sensors 0.0.3-r1 --> 0.0.4-r1*
* *mrpt-sensors-examples 0.0.3-r1 --> 0.0.4-r1*
* *mrpt-tutorials 1.0.4-r1 --> 1.0.5-r1*
* *mrpt2 2.11.11-r1 --> 2.12.0-r1*
* *phidgets-accelerometer 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-analog-inputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-analog-outputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-api 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-digital-inputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-digital-outputs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-drivers 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-gyroscope 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-high-speed-encoder 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-humidity 1.0.9-r1*
* *phidgets-ik 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-magnetometer 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-motors 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-msgs 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-spatial 1.0.8-r2 --> 1.0.9-r1*
* *phidgets-temperature 1.0.8-r2 --> 1.0.9-r1*
* *rc-genicam-api 2.6.1-r1 --> 2.6.5-r1*
* *robotraconteur 1.0.0-r1 --> 1.1.1-r1*
* *rosbag-fancy 1.0.1-r1 --> 1.1.0-r1*
* *rosbag-fancy-msgs 1.0.1-r1 --> 1.1.0-r1*
* *rqt-rosbag-fancy 1.0.1-r1 --> 1.1.0-r1*
* *sick-scan-xd 3.1.5-r1 --> 3.2.6-r1*

Rolling Changes:
----------------
* *apriltag 3.2.0-r6 --> 3.4.0-r1*
* *cartographer 2.0.9002-r5 --> 2.0.9003-r1*
* *cartographer-ros 2.0.9001-r2 --> 2.0.9002-r1*
* *cartographer-ros-msgs 2.0.9001-r2 --> 2.0.9002-r1*
* *cartographer-rviz 2.0.9001-r2 --> 2.0.9002-r1*
* *controller-interface 4.5.0-r2 --> 4.6.0-r1*
* *controller-manager 4.5.0-r2 --> 4.6.0-r1*
* *controller-manager-msgs 4.5.0-r2 --> 4.6.0-r1*
* *dynamic-edt-3d 1.9.8-r3 --> 1.10.0-r3*
* *filters 2.1.0-r5 --> 2.1.1-r1*
* *gps-msgs 1.0.4-r5 --> 2.0.3-r1*
* *gps-tools 1.0.4-r5 --> 2.0.3-r1*
* *gps-umd 1.0.4-r5 --> 2.0.3-r1*
* *gpsd-client 1.0.4-r5 --> 2.0.3-r1*
* *hardware-interface 4.5.0-r2 --> 4.6.0-r1*
* *hardware-interface-testing 4.5.0-r2 --> 4.6.0-r1*
* *hash-library-vendor 0.1.1-r5 --> 0.1.1-r6*
* *iceoryx-binding-c 2.0.5-r4 --> 2.0.5-r5*
* *iceoryx-hoofs 2.0.5-r4 --> 2.0.5-r5*
* *iceoryx-introspection 2.0.5-r4 --> 2.0.5-r5*
* *iceoryx-posh 2.0.5-r4 --> 2.0.5-r5*
* *joint-limits 4.5.0-r2 --> 4.6.0-r1*
* *kitti-metrics-eval 1.0.0-r1*
* *lanelet2 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-core 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-examples 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-io 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-maps 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-matching 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-projection 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-python 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-routing 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-traffic-rules 1.2.1-r5 --> 1.2.1-r6*
* *lanelet2-validation 1.2.1-r5 --> 1.2.1-r6*
* *libnabo 1.0.7-r4 --> 1.1.1-r1*
* *libphidget22 2.3.2-r2 --> 2.3.3-r1*
* *libpointmatcher 1.3.1-r4 --> 1.4.1-r1*
* *marine-acoustic-msgs 2.1.0-r1*
* *marine-sensor-msgs 2.1.0-r1*
* *mcap-vendor 0.24.0-r2 --> 0.24.0-r3*
* *message-tf-frame-transformer 1.1.0-r2 --> 1.1.1-r1*
* *mola 1.0.0-r1*
* *mola-bridge-ros2 1.0.0-r1*
* *mola-demos 0.2.2-r1 --> 1.0.0-r1*
* *mola-imu-preintegration 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-euroc-dataset 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-kitti-dataset 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-kitti360-dataset 1.0.0-r1*
* *mola-input-mulran-dataset 1.0.0-r1*
* *mola-input-paris-luco-dataset 1.0.0-r1*
* *mola-input-rawlog 0.2.2-r1 --> 1.0.0-r1*
* *mola-input-rosbag2 1.0.0-r1*
* *mola-kernel 0.2.2-r1 --> 1.0.0-r1*
* *mola-launcher 0.2.2-r1 --> 1.0.0-r1*
* *mola-metric-maps 1.0.0-r1*
* *mola-navstate-fuse 1.0.0-r1*
* *mola-pose-list 1.0.0-r1*
* *mola-traj-tools 1.0.0-r1*
* *mola-viz 0.2.2-r1 --> 1.0.0-r1*
* *mola-yaml 0.2.2-r1 --> 1.0.0-r1*
* *mp2p-icp 1.2.0-r2 --> 1.3.0-r1*
* *mqtt-client 2.2.0-r1 --> 2.2.1-r1*
* *mqtt-client-interfaces 2.2.0-r1 --> 2.2.1-r1*
* *mrpt-path-planning 0.1.0-r2 --> 0.1.1-r1*
* *mrpt2 2.11.11-r1 --> 2.12.0-r1*
* *mvsim 0.8.3-r2 --> 0.9.2-r1*
* *novatel-gps-driver 4.1.0-r4 --> 4.1.2-r1*
* *novatel-gps-msgs 4.1.0-r4 --> 4.1.2-r1*
* *ntrip-client-node 0.5.2-r2 --> 0.5.3-r1*
* *octomap 1.9.8-r3 --> 1.10.0-r3*
* *octovis 1.9.8-r3 --> 1.10.0-r3*
* *openni2-camera 2.1.0-r2 --> 2.2.0-r1*
* *performance-test 1.2.1-r4 --> 2.0.0-r1*
* *phidgets-accelerometer 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-analog-inputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-analog-outputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-api 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-digital-inputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-digital-outputs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-drivers 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-gyroscope 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-high-speed-encoder 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-ik 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-magnetometer 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-motors 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-msgs 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-spatial 2.3.2-r2 --> 2.3.3-r1*
* *phidgets-temperature 2.3.2-r2 --> 2.3.3-r1*
* *point-cloud-transport 3.0.4-r2 --> 3.0.5-r1*
* *point-cloud-transport-py 3.0.4-r2 --> 3.0.5-r1*
* *point-cloud-transport-tutorial 0.0.1-r2 --> 0.0.2-r1*
* *rc-dynamics-api 0.10.3-r3 --> 0.10.5-r1*
* *rc-genicam-api 2.6.1-r3 --> 2.6.5-r1*
* *rcdiscover 1.1.6-r3 --> 1.1.7-r1*
* *rig-reconfigure 1.4.0-r2 --> 1.4.0-r3*
* *rmf-api-msgs 0.2.1-r1 --> 0.2.1-r2*
* *rmf-charging-schedule 2.5.0-r1 --> 2.6.0-r1*
* *rmf-fleet-adapter 2.5.0-r1 --> 2.6.0-r1*
* *rmf-fleet-adapter-python 2.5.0-r1 --> 2.6.0-r1*
* *rmf-task 2.4.0-r1 --> 2.4.0-r2*
* *rmf-task-ros2 2.5.0-r1 --> 2.6.0-r1*
* *rmf-task-sequence 2.4.0-r1 --> 2.4.0-r2*
* *rmf-traffic-ros2 2.5.0-r1 --> 2.6.0-r1*
* *rmf-visualization-navgraphs 2.2.1-r1 --> 2.2.1-r2*
* *rmf-visualization-rviz2-plugins 2.2.1-r1 --> 2.2.1-r2*
* *rmf-visualization-schedule 2.2.1-r1 --> 2.2.1-r2*
* *rmf-websocket 2.5.0-r1 --> 2.6.0-r1*
* *rmw-connextdds 0.20.0-r2 --> 0.20.1-r1*
* *rmw-connextdds-common 0.20.0-r2 --> 0.20.1-r1*
* *robot-localization 3.6.0-r2 --> 3.6.0-r3*
* *ros2-control 4.5.0-r2 --> 4.6.0-r1*
* *ros2-control-test-assets 4.5.0-r2 --> 4.6.0-r1*
* *ros2bag 0.24.0-r2 --> 0.24.0-r3*
* *ros2controlcli 4.5.0-r2 --> 4.6.0-r1*
* *rosbag2 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-compression 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-compression-zstd 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-cpp 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-examples-cpp 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-examples-py 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-interfaces 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-performance-benchmarking 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-performance-benchmarking-msgs 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-py 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage-default-plugins 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage-mcap 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-storage-sqlite3 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-test-common 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-test-msgdefs 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-tests 0.24.0-r2 --> 0.24.0-r3*
* *rosbag2-transport 0.24.0-r2 --> 0.24.0-r3*
* *rot-conv 1.1.0-r2 --> 1.1.0-r3*
* *rqt-controller-manager 4.5.0-r2 --> 4.6.0-r1*
* *rqt-gauges 0.0.2-r2 --> 0.0.3-r1*
* *rti-connext-dds-cmake-module 0.20.0-r2 --> 0.20.1-r1*
* *rviz-assimp-vendor 13.3.1-r2 --> 13.4.0-r2*
* *rviz-common 13.3.1-r2 --> 13.4.0-r2*
* *rviz-default-plugins 13.3.1-r2 --> 13.4.0-r2*
* *rviz-ogre-vendor 13.3.1-r2 --> 13.4.0-r2*
* *rviz-rendering 13.3.1-r2 --> 13.4.0-r2*
* *rviz-rendering-tests 13.3.1-r2 --> 13.4.0-r2*
* *rviz-visual-testing-framework 13.3.1-r2 --> 13.4.0-r2*
* *rviz2 13.3.1-r2 --> 13.4.0-r2*
* *shared-queues-vendor 0.24.0-r2 --> 0.24.0-r3*
* *sophus 1.3.1-r3 --> 1.22.9100-r1*
* *sqlite3-vendor 0.24.0-r2 --> 0.24.0-r3*
* *tinyspline-vendor 0.6.0-r4 --> 0.6.0-r5*
* *transmission-interface 4.5.0-r2 --> 4.6.0-r1*
* *ublox-dgnss 0.5.2-r2 --> 0.5.3-r1*
* *ublox-dgnss-node 0.5.2-r2 --> 0.5.3-r1*
* *ublox-nav-sat-fix-hp-node 0.5.2-r2 --> 0.5.3-r1*
* *ublox-ubx-interfaces 0.5.2-r2 --> 0.5.3-r1*
* *ublox-ubx-msgs 0.5.2-r2 --> 0.5.3-r1*
* *zstd-vendor 0.24.0-r2 --> 0.24.0-r3*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libxkbcommon-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-smbus
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rmf_building_map_tools
 * [ ] rmf_building_sim_common
 * [ ] rmf_building_sim_gz_classic_plugins
 * [ ] rmf_building_sim_gz_plugins
 * [ ] rmf_robot_sim_common
 * [ ] rmf_robot_sim_gz_classic_plugins
 * [ ] rmf_robot_sim_gz_plugins
 * [ ] rmf_traffic_editor
 * [ ] rmf_traffic_editor_assets
 * [ ] rmf_traffic_editor_test_maps
 * [ ] ros_gz_bridge
 * [ ] ros_gz_sim
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] ros_ign_gazebo_demos
 * [ ] ros_ign_image
 * [ ] ros_ign_interfaces
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

