### PR TITLE
Adding easy_handeye2 packages

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -239,6 +239,16 @@ let
       '';
     });
 
+    easy-handeye2 = rosSuper.easy-handeye2.overrideAttrs ({
+      nativeBuildInputs ? [], postFixup ? "", ...
+    }: {
+      dontWrapQtApps = false;
+      nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
+      postFixup = postFixup + ''
+        wrapQtApp "$out/lib/easy_handeye2/rqt_calibrator.py"
+      '';
+    });
+
     rqt-msg = rosSuper.rqt-msg.overrideAttrs ({
       nativeBuildInputs ? [], postFixup ? "", ...
     }: {

--- a/distros/humble/easy-handeye2-msgs/default.nix
+++ b/distros/humble/easy-handeye2-msgs/default.nix
@@ -1,0 +1,25 @@
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchFromGitHub, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs, geometry-msgs }:
+buildRosPackage {
+  pname = "ros-humble-easy-handeye2-msgs";
+  version = "1.1.7-r1";
+
+  src = fetchFromGitHub {
+    owner = "Thieso";
+    repo = "easy_handeye2_msgs";
+    rev = "480de5a";
+    hash = "sha256-zHsVO/97NCXnzjVwy4xq9D2r2aPGQLH3OErc4RwXvNo=";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs geometry-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "Easy handeye2 messages";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/easy-handeye2/default.nix
+++ b/distros/humble/easy-handeye2/default.nix
@@ -1,15 +1,16 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
+{ lib, buildRosPackage, fetchFromGitHub, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-humble-easy-handeye2";
   version = "1.1.7-r1";
 
-  src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui/1.1.7-1.tar.gz";
-    name = "1.1.7-1.tar.gz";
-    sha256 = "aa99f15e7b90e0a7b271b3be81c014a1f1ea01e7e03c655e835b58bca17c5ca6";
+  src = fetchFromGitHub {
+    owner = "Thieso";
+    repo = "easy_handeye2";
+    rev = "f8ce95b";
+    hash = "sha256-Y43jFDMOf+zyxWhkglMbCNygBvauRZ40Brm2MLNrT4I=";
   };
 
   buildType = "ament_python";

--- a/distros/humble/easy-handeye2/default.nix
+++ b/distros/humble/easy-handeye2/default.nix
@@ -1,0 +1,23 @@
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
+buildRosPackage {
+  pname = "ros-humble-easy-handeye2";
+  version = "1.1.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/humble/rqt_gui/1.1.7-1.tar.gz";
+    name = "1.1.7-1.tar.gz";
+    sha256 = "aa99f15e7b90e0a7b271b3be81c014a1f1ea01e7e03c655e835b58bca17c5ca6";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.catkin-pkg qt-gui rclpy ];
+
+  meta = {
+    description = "rqt_gui provides the main to start an instance of the ROS integrated graphical user interface provided by qt_gui.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -576,6 +576,10 @@ self: super: {
 
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
+ easy-handeye2 = self.callPackage ./easy-handeye2 {};
+
+ easy-handeye2-msgs = self.callPackage ./easy-handeye2-msgs {};
+
  ecal = self.callPackage ./ecal {};
 
  ecl-build = self.callPackage ./ecl-build {};


### PR DESCRIPTION
Hello, 

I wanted to use the easy_handeye2 package https://github.com/marcoesposito1988/easy_handeye2 and it uses a rqt plugin for its GUI. This makes it impossible to just put it in the workspace and build it in the `nix develop` shell because then it cannot find the QT plugins. Thats why I added them to the distro here. 

However, the original repo https://github.com/marcoesposito1988/easy_handeye2 builds 2 packages, one for the rqt plugin and the other for the messages. Is it possible to change the build folder accordingly? Because otherwise the `setup.py` is not found because it is not in the parent directory. Right now I just split it up into two directories. 

Furthermore, for the rqt plugins one has to copy the xml files `plugin_calibrator.xml` and `plugin_evaluator.xml` into the local ROS install folder but I have no idea how to do this in nix. Do you have experience with this? For now I copied it by hand. 

So when I can improve these two things everything works great. 