### PR TITLE
rosdistro sync, Fri Mar 29 13:17:38 2024

### DIFF
--- a/distros/humble/aerostack2/default.nix
+++ b/distros/humble/aerostack2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-gazebo-assets, as2-gazebo-classic-assets, as2-keyboard-teleoperation, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-crazyflie, as2-platform-gazebo, as2-platform-tello, as2-python-api, as2-realsense-interface, as2-state-estimator, as2-usb-camera-interface }:
 buildRosPackage {
   pname = "ros-humble-aerostack2";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6c9053d00e2a179c7be6ad81f243e52b188d60d69eb8282f08e4694fe41d0f76";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "829c5e8d1169fea0ed0035977778c8c2ba4e6162701e37ca4adeb55dfb0a8d89";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-alphanumeric-viewer/default.nix
+++ b/distros/humble/as2-alphanumeric-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, ncurses, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-alphanumeric-viewer";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "5ea05e948bf00c6e9ac16b41395e2364cafc966b8396c7c4fdb5ef02533f435a";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "441e298083ccd0b1257df827b200a9252f8992f42d7d34d8afa95993d4a0c055";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior-tree/default.nix
+++ b/distros/humble/as2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, behaviortree-cpp-v3, geometry-msgs, nav2-behavior-tree, nav2-msgs, rclcpp, rclcpp-action, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior-tree";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d2d418c90a55bf6819664e874a6375ca20407bd90ff8aedb27e70594ae28a418";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "60a7df49d71dec0a3c869ad532fbd1dfd41fdc0c364b82e2076e2881c1c839d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior/default.nix
+++ b/distros/humble/as2-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "4ee00a267c0003cd428305b794b60c237f4970188535bb75f79fbf5924697c82";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "12133d34dac20ccca0cad3b5552e5495760449785b9186d69bb3013840de5d57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-motion/default.nix
+++ b/distros/humble/as2-behaviors-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-motion";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "8f021b4964be53ba172f8ee8ccaeb1a2ad57b81159f18a2bf064d64f5737e7f4";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "9e6a08e40c19e0758d5b05a9b374235f377d8c09eb70dac2e6b62bd1a7e1446c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-perception/default.nix
+++ b/distros/humble/as2-behaviors-perception/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-perception";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "dcfc2effa8b86b1e63fe618af24be04696313e38f965a0ae3b4ec7f179218dcc";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "48b616f7d76b221e3c41f945071065aa3800a8ab720d2d7b4de1e66c269ed674";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-cmake as2-behavior as2-core as2-msgs cv-bridge rclcpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/as2-behaviors-platform/default.nix
+++ b/distros/humble/as2-behaviors-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-platform";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9cb381b8e065a95fdf7fa813f2f383ef7d59fac00685b683cbe757dd7b093d77";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "e6b4a8668288b89489536a4a044f84cf9bea4a29c9b3ab81cbc80b338f07db8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-trajectory-generation/default.nix
+++ b/distros/humble/as2-behaviors-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-components, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-trajectory-generation";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b0ecb8d25e5ee8edf4c7c522776e738be4108aee6809b84870e0a81b4984feb2";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "f3db255eb7b9c847461b22b9f4861002d7ec863bc1c7883643cb7adef888fb62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-cli/default.nix
+++ b/distros/humble/as2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-as2-cli";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c05a8b768197c2b6becb6665c002aabe37dbe812f96027873565aed8f78fe21a";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7b38088d612d188280ce6a250351888f06a6a2755de2c9be27b173ece7a0be1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, pythonPackages, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c901d184e468281bb8fd4b225ed74f40a47d903832b8db535d51f30b2ca15e6c";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7e655ac39064c0439b85f44fbac3020fc20a9b9fa76fc2371529f04478c421e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-gazebo-classic-assets/default.nix
+++ b/distros/humble/as2-gazebo-classic-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, python3Packages, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-gazebo-classic-assets";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6941d8fcf610cf1a40c3a0653f2ed2574344463230dc0d2601e699d0040c317e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_classic_assets/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "fc75c4f52fec0eece3168a4296d4449da820825d14de5084bd2a31af01f78c03";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-keyboard-teleoperation/default.nix
+++ b/distros/humble/as2-keyboard-teleoperation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-motion-reference-handlers, as2-python-api, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-as2-keyboard-teleoperation";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "4dad4aefdea5724ab2b2c99d4dbfc1c280723a5de40a4abc798b0ebbeed0f29f";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0236ddff52bc2c8956c1e65d4328d91b08114ec307ee2bbe36653aedb687b2f7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-lint-auto, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "2d20b8d998dbfd40c8d2d22dc9bc0a78107dc4603bb5f0d886da20aaed5d8ab4";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "b1c9fbdd931e8aa8dcf0e19039f886abc410d6befdac8074db132f5400104f24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-motion-reference-handlers/default.nix
+++ b/distros/humble/as2-motion-reference-handlers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-action, rclpy, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-reference-handlers";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "1fcba1242b555ea7865635c8d1879ddddaf213e4a2d659ce774dce6785ebe323";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "66c16898e5c24221c2e7558c297599c74f9d42c6acde3a52a81e3aed4e1d29e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-msgs/default.nix
+++ b/distros/humble/as2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-msgs";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d50374751703b58dfb7b72da67f3f24b70398dc78dbabb99ce78c25af904a424";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "c93668a789ef59a82f77d3a7bcb6d98c8695825262f4ba9017840de298611a52";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-crazyflie/default.nix
+++ b/distros/humble/as2-platform-crazyflie/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-crazyflie";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "1aefef5519b863fb6a29b8398ee441bbd06a9806da68a842cbf8712a9e0994fe";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "662b0d104723703a5caa603973155c658403360cb270118aec2e8db7c3754bab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-dji-osdk/default.nix
+++ b/distros/humble/as2-platform-dji-osdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, libusb1, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-dji-osdk";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "502f3817c6f039873b3c83f0ff4df311301d89e6d41736671ef402482a1a9ca1";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "009e4cc80ebfdb10012e8e80a0ead9dd43a9f28182b760e46fc2cac804668494";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-gazebo/default.nix
+++ b/distros/humble/as2-platform-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-gazebo-assets, as2-msgs, geometry-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-gazebo";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d64942c13ac119fe2ee68d17ab0abaff6f2311f7203d0fb9e6fb1dda9131d177";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "6782dbb8f6f89138db710ca527b9493b1fb436291e83b53bdbbee533c4294aea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-tello/default.nix
+++ b/distros/humble/as2-platform-tello/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-tello";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "701b82dfce32d1966944d9b85ce72c14669f1676ff9fda07185562c6a35725a3";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "81b7b95784a068e4828ec86f267cc71d34bd99a621378e46fd5c3348943cd914";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-realsense-interface/default.nix
+++ b/distros/humble/as2-realsense-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, geometry-msgs, librealsense2, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-realsense-interface";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f792cdd87ea2a362c140c62185592b2c33dce1d2cf3f1d70e48963f0ec85b094";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7f4d1dee5fe75fbc8ca42d53534e834441f4467231e69a14ab4fcab4787810d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-state-estimator/default.nix
+++ b/distros/humble/as2-state-estimator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, geometry-msgs, nav-msgs, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-state-estimator";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "cf9ba8347528a1c39b0d39eb989f2fc8660230e1543daf2df1ab6fc059587903";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0d4969f6f9879296bdd3d6e5dfc68040093518f0e543352ce9bbe69f88498dd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-usb-camera-interface/default.nix
+++ b/distros/humble/as2-usb-camera-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-usb-camera-interface";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "eb0d62b863ca4f7abd504ecc6829a5611ccaca704f58eb73f0a27151351165ba";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "ca61c8bde58ff2e38b036889a9c1b200902500f1d818e58a7a2e707fed1ed705";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-calibration-parsers/default.nix
+++ b/distros/humble/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration-parsers";
-  version = "3.1.8-r2";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.8-2.tar.gz";
-    name = "3.1.8-2.tar.gz";
-    sha256 = "bd94a8175bc71f492b0d94c35909bf3385f5d69a999110e7e539044667b01bf8";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "80800aee3b054ae28be1ff504e02f493914fbd34fef742b8fd8c2a5b58ad82b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-info-manager/default.nix
+++ b/distros/humble/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager";
-  version = "3.1.8-r2";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.8-2.tar.gz";
-    name = "3.1.8-2.tar.gz";
-    sha256 = "4f1a6305e1d90494492407c0baa33d9533bb2e1fffe94a1dd7d442bd822de14d";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "68387148b569c7ff0ee9ffa381def0c544372bb834cc4867459b8ea8b2d5204e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fields2cover/default.nix
+++ b/distros/humble/fields2cover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-humble-fields2cover";
-  version = "1.2.1-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/1.2.1-2.tar.gz";
-    name = "1.2.1-2.tar.gz";
-    sha256 = "e88e84ed14b66ef8ec9a3dfcc7d60b5e63e193c9003254882766a4b4587a1a67";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "11ca6ae60cd6c395f357cfa4d29f79bce7efbea2defb4b1bc9696f749e02fdfd";
   };
 
   buildType = "cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "8ebc96c41da6e0491e644796bf19ef3f39c51a3765807698d4a56934a269d4db";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "bbd806c4e8d95a9c26caa0c979d58591cc77a244c904d2523a059c5a5c76af93";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "63754286d912717293f6d96333aa8218ac411b86e9b18701012e2123184391bd";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "0e5b7dd79bdaea12db49c676f5cb62d3ddb0b536c59c2225a6e45fa01334656e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -2754,6 +2754,8 @@ self: super: {
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
+ unitree-ros = self.callPackage ./unitree-ros {};
+
  ur = self.callPackage ./ur {};
 
  ur-bringup = self.callPackage ./ur-bringup {};

--- a/distros/humble/image-common/default.nix
+++ b/distros/humble/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-common";
-  version = "3.1.8-r2";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.8-2.tar.gz";
-    name = "3.1.8-2.tar.gz";
-    sha256 = "ce8b9198d007ab0c84d154fc2ae120540e6ba4ad4b5b59fe8210a6393196fda1";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "220959ac9c86065c387d7ca0e3d6c04aef9be478e6f53344d466451925374854";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport/default.nix
+++ b/distros/humble/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-transport";
-  version = "3.1.8-r2";
+  version = "3.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.8-2.tar.gz";
-    name = "3.1.8-2.tar.gz";
-    sha256 = "b35453f4f9445f290f6e8965eaf448c18f25f8fd5de8ce83d14f7c36d727668a";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.9-1.tar.gz";
+    name = "3.1.9-1.tar.gz";
+    sha256 = "a0070dab9e1759df86a54a63c92f3417dd09031cdd352bbf5c9c542243aa65b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a39e8f26939190a8bddd07db011ecf5c8b6edfbadf35028e0469c388835c3a92";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9d6430332bed6cae923ee1eed6fee296401c942d42fb30742cec29b39bc8ec95";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "39fe4a216483e142df966eae63112bbc2f7f62aa62cef0f3cdbe23f6a59fc6bd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "144638b71d4da49db25a8ed0438ba4299c31d0735e8db699acde6ed523e658a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "cbd6b32e8a8fbe817cb1d06446be0bec5d5d2b1af130af3474b34e1acdccfad0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "29e2cc62d3ea2dac3e94f935def20cdfc1b73e1832fa73affd07ebeafe7452e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "926ce9e9d7b39578b24d9fd6b2a8f2c53cb7bbff368427405c3bddd3cac7623e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "57793c2267466023287c1d4c67f496e9c9dfc37159e5acd478cd57352f36af08";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d306f1d7df8bcb5831165764b84b6195c0880e4b37945b1926c3c895fdf0b464";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3af468d73e269e2c02391365abfa2fb792a4fb6e542cc53c25f14495bf81fe45";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "312cbe0d95877583e8ab55c58bc3b3c4187b23914b482aae71c3e70f59dd738f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2cfd8bed9c9fe08e77d33214e35e94993bfc99f55f89f1caa2897d5a0a25b14d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "43816c3d6b449f9838e0ed65c94e4ef2f9f3c4d37d732cb41c79a7dc86815c7f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cc95c313bae078ca47bfc728da1de4ea89cbbbad5461c9c392d7e9cd0e439755";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "efe71b17c91d568eb2907d6848b55c6d1f1d4fdfc0977033401fc4cc2fa7b59f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a0f5ff6c73f174d875f8a351f706f64789d713aafa15fe8e5ddc905dc2290742";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a29be46eb85d06e1fee07bf7a0675fca14c42373ded626a57d663da07630c185";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ab839c59095ea73a79ba131111120d620e4c631c3532fd9e0ace7f1f1a2c5697";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ef800f9d1ae626bc385d3847fb12c00f8ac4f8dbdfc6e482e1d796006177274a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4bc6ee53f35c18cf1048f4b9239e983edd48606fd6abcbd53bdd6d826c6c43b1";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "212253a36740d8b5bceccadbb712326e2f8ecf5fbc3ad1b9b02eee0d552f3979";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "43946f395bb2eaf507c1cb368e0889639159f061e5a20b7df06756d75ba0ec98";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e1c1f401a36933d1f3b6094b3e5f582a9fd907645f7f20b8a43f5dba9dbf842b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "292921abca72c16750d55bc1c3672a3682077c8af341630e79ccb145c1f58165";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ad469125cee9151493592028d49415f0dcc6c33e06707042f41c7d2add9b63bc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "70e0c222cf293d91119bacd1902227eb0f53405903c676a305db20308735d369";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9a3647e6aac38b58b70e70c51f26f23c2ecd393988452a6abba0bdecf691e03c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5d1c7596b4d355714310c450bb73ca776115bf6140c62f44a32acc8f71bbdb0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-navstate-fuse/default.nix
+++ b/distros/humble/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fuse";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "fb537c2d504f9c31e97bf27916202393121144ba54283f6c6f6b9f162a365a29";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8f5317cbe17cad7c4ee82f65e0dacffb6fafa4e1911e1549164c3aac68aad4d4";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3ed881afaff174f103e8935c5b704b7211afd30aab74fed66e68f8b27cce3135";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "168991b7aba28e8fdf12e11a5957d88902df3859ca8d888d3dbee2f45e20ddca";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "4c8fded9eb1178068881a3770719c30f38eb7147e73808a5b4572ca20f1cd741";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "26906452072bfa97bb39d37023ef751f08d00279992f8b49ff360e33ffa0bb41";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3c4cd895b1d35cc9074813a7ec96d9f09a07a6433015c5b3eb7ebfca0c539c94";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "51ab93562afd2d23e4b4599d96ed65506252827b03cb8675e00471cc14d73419";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9adb6501a38adbe2f134c4237a5f93404746f99782a8d9e415efdc1e9731516c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3513b89e59246a3a53bf9971b884f888e1ffb74f567e87ddcfbdbdc1804653da";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "46df8506c5f91928b142add9bd7f12c1813cc8e768c2c94e6e7e7ad07e6f40be";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b57e0901aaa0fdfb334d0204ef6bc08dea905745bf9118ed3cefb006b1a1bf94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport-py/default.nix
+++ b/distros/humble/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport-py";
-  version = "1.0.16-r1";
+  version = "1.0.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.16-1.tar.gz";
-    name = "1.0.16-1.tar.gz";
-    sha256 = "48407a44a3d0e76d5a8377dce199f4004d2701b7306ec23079c517121047a774";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport_py/1.0.17-1.tar.gz";
+    name = "1.0.17-1.tar.gz";
+    sha256 = "16bdeb69b7a30d8eaf5ce75a0f040231e45229eb92a75273f2f097732ee367fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/point-cloud-transport/default.nix
+++ b/distros/humble/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-point-cloud-transport";
-  version = "1.0.16-r1";
+  version = "1.0.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.16-1.tar.gz";
-    name = "1.0.16-1.tar.gz";
-    sha256 = "71de8d112a99b55af2fc5307717f8ca50dbbc6006d358082e5f22e5d6ee59a4d";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/humble/point_cloud_transport/1.0.17-1.tar.gz";
+    name = "1.0.17-1.tar.gz";
+    sha256 = "b2b6dd5c15d3f3cdcf8644b5368ef2240da417cfcff6a9059474ac1059704fb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/psdk-interfaces/default.nix
+++ b/distros/humble/psdk-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-psdk-interfaces";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_interfaces/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ddc90f3d3639fea9c3e1ee61f3eaafc4963603daaeceb2f03137db27d52ecf09";
+    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_interfaces/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "8e871fd690dd6e61a14dd9ba26a8c261c09223ecce60de8d151faa0c5c0fb93c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/psdk-wrapper/default.nix
+++ b/distros/humble/psdk-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ffmpeg, geometry-msgs, libopus, libusb1, nav-msgs, nlohmann_json, psdk-interfaces, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-psdk-wrapper";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_wrapper/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "973899fe94f925c57d3a4db7c78ce4208c9966681c09b901efbc358dd73daff9";
+    url = "https://github.com/ros2-gbp/psdk_ros2-release/archive/release/humble/psdk_wrapper/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "282fd0a119b78d9e3de70d98a6ad8a81413b71cdbde0c9e01ab8ec1886c8e962";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "698b33537a6436ca22c96bea35c5e6f1736bcddf0705e0bd60e23d2e7baaff79";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "07d3cbf4aec8c51c1ceac9c661389731d95a0466ea434f968715d12457281f07";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "1ce81946eb284578e380a12dd1dd99e285ea14798cbe5e279ed025d5accf1652";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "4f2e33a3738ace7c6a9fe88e1a1415117e77048b62dc192fb8eaeab68ae877e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "9a22f60cf1430eba6185f6b28e1968651a4669fcc64465271c44aca23b1e6fcf";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "7fd4f808ebf47419f3124885fea760f73d08a2f109219d4e0eb1c46a69425ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "2e2bef887817e6b6b2c1e062b48412cbe9d4e4800d5f3ee97b29d90273144100";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "2b5516a7e79df148cda7d848fd9db79f6a02b272626fab6262965ef2c8f222a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "bcbe4cca0af775f94c69472edb48ccd3976879288c48c33720c6f132dfb1a26d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "87295176908ce2353e3b30fbf8e5b51c024af213cceb6ebd6e22a87145947706";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "1f195eaaf76556df11e65881b792403c03cc091df81411b0dfe4778586fd9783";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "73b4ea844314de5f0bc8aa5bd85d8c8a8d8203e7af2a4dd29ffd7f787f501e31";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "6c1b2e2ef6657fae4c2b76753af1c39fca832ad869ca41495b5b6d23d5d4b295";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "fc2659a8933adcab429377eadd0fe3ebd6dcc3be0e0c5aecc884e6cda9f6598f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.11-r1";
+  version = "11.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.11-1.tar.gz";
-    name = "11.2.11-1.tar.gz";
-    sha256 = "efd56ec1caf7c5fb61d9dd854f5b28219f69c36d5f691ee51e716771edb8201f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.12-1.tar.gz";
+    name = "11.2.12-1.tar.gz";
+    sha256 = "ed23ea0a0cb614117436d3c7339252f174d5a4d9b60fa535f06ab404670b325d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "f82181fd0d7bf5705921eeb3601e23f46063e0b7f85869ee7fe84bd9c6a7c88c";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "a494536d1bfa90fb6ef1b1c7285bcde570868206d39fec32b8bd474d0953fa11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "b9bf154de3f4addc2d95db68a4359cc2fc1056aed27689f4b6f719a99624c8fd";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "7a196b5eaf87390a5a8a6e1ec9e2a9ef53e8e4a23d9dad978ceddab0002efbd1";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake curl dpkg python3Packages.distro ];
+  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "ROS2 driver for flir spinnaker sdk";

--- a/distros/humble/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/humble/spinnaker-synchronized-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-synchronized-camera-driver";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_synchronized_camera_driver/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "3d5351b470dcdda66c859c177d47f71a472aabc26fa58e95d08bab2e3c39af53";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_synchronized_camera_driver/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "79a0d5fa4031d83a9c5af0d00b31d0a07185a8dfb171070f71c42fd27b91c6bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/unitree-ros/default.nix
+++ b/distros/humble/unitree-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-unitree-ros";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/unitree_ros-release/archive/release/humble/unitree_ros/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c07abefabddaf2bd438199ac9f375195a89dcead0ecb05958ebe4c2d68930622";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp rosidl-default-runtime sensor-msgs std-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Unitree ros package";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/iron/camera-calibration-parsers/default.nix
+++ b/distros/iron/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-camera-calibration-parsers";
-  version = "4.2.3-r1";
+  version = "4.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.3-1.tar.gz";
-    name = "4.2.3-1.tar.gz";
-    sha256 = "26bbe270df87c4a314f76441747756762892101ac3d1a04a2c6e2f2cbfd217fa";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_calibration_parsers/4.2.4-1.tar.gz";
+    name = "4.2.4-1.tar.gz";
+    sha256 = "71da8fbec6b1f45f43c560356c1a385b26f7e57eb9cf9f1d4fbe1afe9773e023";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/camera-calibration/default.nix
+++ b/distros/iron/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-camera-calibration";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/camera_calibration/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "95d3316ba87710174f32e9b2aabbd643c6409bdf06c84975bcd80496f98566de";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/camera_calibration/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "1f001d3c65c9f8252b517742a92ff223c1f9a4a7033cea19a15f1dcddca4049e";
   };
 
   buildType = "ament_python";

--- a/distros/iron/camera-info-manager/default.nix
+++ b/distros/iron/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-camera-info-manager";
-  version = "4.2.3-r1";
+  version = "4.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.3-1.tar.gz";
-    name = "4.2.3-1.tar.gz";
-    sha256 = "8654605dc1dbbb7df2c5c473f43735c11b0db38a0cac6413a626799139adee14";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/camera_info_manager/4.2.4-1.tar.gz";
+    name = "4.2.4-1.tar.gz";
+    sha256 = "5c64d7ba58ce7cb623ab4f57fc58992b4d0d208773a2ee2be7e94968da2fe25c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depth-image-proc/default.nix
+++ b/distros/iron/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-depth-image-proc";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/depth_image_proc/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "41c2dbe6b35bdedfb1c75926cd5f448bacf37a2bfb8a13af8caec4d6a92bd8bc";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/depth_image_proc/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "15eb3e0d1aab13e34540fa5ddb13b39365ea1bdc6b53692b7eebddd2f8e8fa79";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/fields2cover/default.nix
+++ b/distros/iron/fields2cover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-iron-fields2cover";
-  version = "1.2.1-r2";
+  version = "1.2.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/1.2.1-2.tar.gz";
-    name = "1.2.1-2.tar.gz";
-    sha256 = "c2e956c725c499fafd36d03ca150ec49ff2f34ed7e4cc371a3639d0f51911314";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/1.2.1-3.tar.gz";
+    name = "1.2.1-3.tar.gz";
+    sha256 = "ee0f4f72dac34530ed1983ab2f3832a1545f474a27c4b53b0d7fdcfd94fa57cf";
   };
 
   buildType = "cmake";

--- a/distros/iron/flir-camera-description/default.nix
+++ b/distros/iron/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-description";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "7cfea352fcca13681f399fe46ab0ab17598252ed7141b599201f494d4eb7abf9";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_description/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "af178b57d496578523a24c93d4374c87fc65c53884f48b8743ba9dee5b8808b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/flir-camera-msgs/default.nix
+++ b/distros/iron/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-flir-camera-msgs";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "aaa91f16feb1929f885a825acf02780828c492385a7ad6110af3b28c105e94d1";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/flir_camera_msgs/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "5b89f593b52b5147ed6ca2337679e636a1b9ae91104859c491a29194750e5259";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -2344,6 +2344,8 @@ self: super: {
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
+ unitree-ros = self.callPackage ./unitree-ros {};
+
  ur = self.callPackage ./ur {};
 
  ur-calibration = self.callPackage ./ur-calibration {};

--- a/distros/iron/image-common/default.nix
+++ b/distros/iron/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-iron-image-common";
-  version = "4.2.3-r1";
+  version = "4.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.3-1.tar.gz";
-    name = "4.2.3-1.tar.gz";
-    sha256 = "e95fca874ae1b2cbe4aa573222c90a276b0ddb2233cb8662d6300099c7c58d95";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_common/4.2.4-1.tar.gz";
+    name = "4.2.4-1.tar.gz";
+    sha256 = "8d40e0f792f1fafa32fed5a55eaf7a94e41f4a6d05b88b32db5bdffdf0a7ec57";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-pipeline/default.nix
+++ b/distros/iron/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-iron-image-pipeline";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_pipeline/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "65e40f61729b258ba47770f2f6c3d6e0d33d983472263ba160fba14ad0789d33";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_pipeline/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "e40811f74eeb978756e9309deed6036ebff3068ab9aee262deb1bc580b79cd03";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-proc/default.nix
+++ b/distros/iron/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-iron-image-proc";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_proc/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "dc6c5d0edac1630061cdb4970b95b53d7546f88b0d0401914d5456c6ef4dcdea";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_proc/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "72d474f8c554cdd05f833aff73dc6ea5b42dada4ef4f0629610cf7321aaa7778";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-publisher/default.nix
+++ b/distros/iron/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-image-publisher";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_publisher/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "d80565a23d93b702747d65de2b51cd01d688870965367abb7fd3531e83a65c80";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_publisher/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "f354f5abd82dc5062d63fa59f2ae8cb39f2753991f466fdb54fdb03ccdc132cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-rotate/default.nix
+++ b/distros/iron/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-image-rotate";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_rotate/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "ada8220cc3b76e2a0b2134a1ec963b0e1412a113177a590f36bf898416fa2a1c";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_rotate/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "6d64350d1afa9ede3dd196d49fad8f052f761d7fd34573c9b8cee9055b1fedbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-transport/default.nix
+++ b/distros/iron/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-image-transport";
-  version = "4.2.3-r1";
+  version = "4.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.3-1.tar.gz";
-    name = "4.2.3-1.tar.gz";
-    sha256 = "096bb06528635bbcb2b405c06ed2dc322a5acb022ef7c8524118c1d29253e575";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/iron/image_transport/4.2.4-1.tar.gz";
+    name = "4.2.4-1.tar.gz";
+    sha256 = "76c7624c9c9afc63e2e014cb59b0ec31a98d827306639c4f6fb20d3172f3d8a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-view/default.nix
+++ b/distros/iron/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, boost, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-iron-image-view";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_view/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "29ce096b84d1f6aca5245120260faeab797914bade1336fca503d5f96420dae6";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_view/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "97c5dfe2f6e60edf71d7b3ae4e6c46a2f3b9aee06c9d3b19b143a44fc63d590a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kitti-metrics-eval/default.nix
+++ b/distros/iron/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-kitti-metrics-eval";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e636539836ef1d0be216efa9b46e2faf6d1dc3b5629efea9f41fc3e804701c39";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "97423730676627bfc4f69cbd9d03321cdecd5954612bbdcd22315c86cac9542b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-bridge-ros2/default.nix
+++ b/distros/iron/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mola-bridge-ros2";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "79d0c578be046d862007fcc7c8df7d43e55c0b82d3ce308c9bd674b3198006bd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ca716c1a6cc1052a8f493373a853a8a4b4384f6aff9731a87e7767be48dc50f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-demos/default.nix
+++ b/distros/iron/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-demos";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "774a12c3d79a1281ee69b35be253f2d0c346323d934d10af009b8730729d1274";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "0700e51d6fad7a46d6d4344c088a4edf3cf9f130e1795f06d65baa35a0e3b477";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-imu-preintegration/default.nix
+++ b/distros/iron/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-imu-preintegration";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "24658102da265b527910c2f425a19b41daf0e3153ba72acf560020b025fcd418";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "1cbb712cadd4ac7d573717eebe217f463f022c6b45826af0b7a3297ad4a35fc4";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-euroc-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "6911ffdf8a806a4a8d2d50e7f5de32037c745906130a45a950ddd56cd2a5166b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9ec727179d39aab51aad026cf9d60f3dfdc4a1e9e447299eb51e65781efae626";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f8e21c9ff6382c2100b2d0edcf089f44765c74deb8f7a8e866e634c20d2f2b7e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b7ecc64eb36b1ca25de69611eda8a14a393364ac857933f32da0b3e4a8ef2d9e";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti360-dataset/default.nix
+++ b/distros/iron/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti360-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "3bb2a33f6f5174caa5d63822adbf055485ef97146f475c8dc35a230de4e893ed";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d940b3fb8933ab8507a5e24d522c51dd1c1933ba34e6518b101301def1dd4d8f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-mulran-dataset/default.nix
+++ b/distros/iron/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-mulran-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "39baf969f24ff1dbb3787bf5eadc702ee598bab788968bb523c861fe04decf57";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "365e66449061451da17bc1efd5d958479d7b0b14d0b57169acc6c26f710c9eb8";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-paris-luco-dataset/default.nix
+++ b/distros/iron/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-paris-luco-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "44c4f11901a17cfa84d9c817475dddb1de24f1f2220b5d2b48e12bba59946a4e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ab561b26462cb20750ea7e133e49c991d79c734f2c08c3fe2ccfcb3cd15a809f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rawlog/default.nix
+++ b/distros/iron/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rawlog";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e8eb1a5993542a77850d61136793e6967d7f179da6fbea977a5aa4f782fd8350";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f9b88aff2797b7166c474e2753c6b6eda37e369e0667c19a3412890063edc91c";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rosbag2/default.nix
+++ b/distros/iron/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rosbag2";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c111f74ab79bbba9cb72ae1a9d16499362bb2bb3686b41785f21fb08a9e3fe81";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "db7ed286d26006dbc7e908412fec97306a3fce2c8f4de6b6220f70fcaa89d7ec";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-kernel";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "edd0275ad083804c4f0f7d0a2f07ff73226e35fa6258c1bbd5a321e2e7e2116f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6fd113dd5bf814636ebc37cb2a4d16baf4faf8fb01266b88cd2da52f06af9979";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-launcher/default.nix
+++ b/distros/iron/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-launcher";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5fd141c2404a7bbb8ebe5af5365eb26501801229b21f7895ae53c4e647cbbc6b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "204db627c803390ca39d6297437948123ce92c019015ca84f9712fca0115ae57";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-metric-maps/default.nix
+++ b/distros/iron/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-metric-maps";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "23661a311409be6b2d18c5bcae7e0b3122022d7f76c2129409fceee10a702a91";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a7429b8fc4079cb24e03fb63aafa21f2ab62a055155c4f0f8310012cc32deeb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-navstate-fuse/default.nix
+++ b/distros/iron/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fuse";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "15f7f83ae875be8b7f33f51919a1dc3373df543a6b5582284e2c98112617685f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2e21ed05a5e11e12132937974606fb58c3a36b4bde7c3ffab5179949c5308ef1";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-pose-list/default.nix
+++ b/distros/iron/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-pose-list";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a3410d15d95a3c7e7e7843007130d9c35c2b8e75f156836122d933ed9b271372";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "83dbfb0caed89be8788363b5e0e1bbdc09b1f2fb09e18bc26651ff9b8e6675b2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-traj-tools/default.nix
+++ b/distros/iron/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-traj-tools";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "42dabcd65105f3488f475296212007d719eaefe085fd23835403f174974a8681";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "46d66bf008cc80873b6ef420e0d4e480a34fffb5df1c75ec6f4b033dd75dd4db";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-viz/default.nix
+++ b/distros/iron/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-viz";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "762b85aa0fcec3f1398ba342009dba39b1df4d1e9c9d639633ff8a598c0fee74";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b6a3412d8639a5a2cce837d3db87850acdd8c19a917dfb1fd1998649a586db9f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8611646d5b5c103308347139d690a464e4fe8417062d497ae88d6190ee11b943";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "39a9b309f2442097d4297044148a7341255b8f51a0b139dfb27f21f39702f86d";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola/default.nix
+++ b/distros/iron/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-iron-mola";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7c9b6c37c721be11c64ca1f0a538d4274954dc628e1ae3bc0261609e96dbd70b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cf59c7d35fafc63c30c3634d38492ac83f00a5f1d096d98eeeceb289529cbcde";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport-py/default.nix
+++ b/distros/iron/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport-py";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "b72740f7580f085ea4a5886028edc082656ce2ccf59793ecaf7991d854cc02f0";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport_py/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "646603f3cf9fecaace3e4d51970552f8a0e55ceea442d549eae96385825d5591";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/point-cloud-transport/default.nix
+++ b/distros/iron/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-point-cloud-transport";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "61146c914473da2d67cfaf8d0e3dd0947aa8f62088c006388c97a961ff44244e";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/iron/point_cloud_transport/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "9f336f696ee8a84a5e9358e9e00a300a5e523869945c028f2d5c8097467cc808";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-assimp-vendor/default.nix
+++ b/distros/iron/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-iron-rviz-assimp-vendor";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "44ab8d261ee236133e75d29b3427de7f17cc9ea84ecb854e1cb2a6aefed311c3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "b5d2f8c40d21e28a7a53bd53696494f722accda9708dc6c46e76127cb5be70fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-common/default.nix
+++ b/distros/iron/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-common";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "549ff1d26355d451c9136a30533351d01817fe9df7815ba1941b9c97fdfc24a7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "81d9791e97d2f19f53dff4fb14b16c035bcaf4579e2a19c780d80e76702fd4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-default-plugins/default.nix
+++ b/distros/iron/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz-default-plugins";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "0b709e75bae929946cece04b0e51f916ff465071848bbd2bd68fc1afd158618b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "4ee47e8e902b8604465d77480b7c3c5907c035f3ec44e583a6e463d527f6ae9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-ogre-vendor/default.nix
+++ b/distros/iron/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-iron-rviz-ogre-vendor";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "bff5ab6d14bf7af5375cdd1f0edeb5ed984ddcd1cb75606c3f8c568599a3925f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "33642e85795846cfdc0e5f6e8e0a1c5c9b5c23e6191c004ff68b7716ca6d47c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering-tests/default.nix
+++ b/distros/iron/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering-tests";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "d7f88aa1e581ba4f06569ffa37fe5a03bbcd3e86162954d51f1a6d82181c8b42";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "e7aab0cdddcf3e98ee85567bde5c156c2bbb391392227e7dcb78a58db6814a37";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering/default.nix
+++ b/distros/iron/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "0c9095e5e04bb5d9c3e3bc5d88629fc018f11e39d45780a90ce3ed5d3bff1e95";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "aabeac426b7862cf6656123e602229daa50a5dca55502532d6c3355d80db06a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-visual-testing-framework/default.nix
+++ b/distros/iron/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rviz-visual-testing-framework";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "b52e3ef6d901e788d3b3cb6961e59965323af834a26bdc2dad5e3536cf2542be";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "6f72a9f424122e819cd47993835919dee7b0cfd4a8eff33e3ec340ed7672d8c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz2/default.nix
+++ b/distros/iron/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz2";
-  version = "12.4.6-r1";
+  version = "12.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.6-1.tar.gz";
-    name = "12.4.6-1.tar.gz";
-    sha256 = "13696f45cdcbcee2138532d06de16c27ca81a7258215f95f7365d2affd3e30c8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.7-1.tar.gz";
+    name = "12.4.7-1.tar.gz";
+    sha256 = "221e64d5a03280ce006dc2765b6474399deff85729f2c24f23baf27c13d5d859";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/simple-launch/default.nix
+++ b/distros/iron/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-iron-simple-launch";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "d614e6f671bb2d71eab3236fb47d77a775e8d18886fe321740e0829ee143b54c";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/iron/simple_launch/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "eef7beceadd9e943e556fdf71ca26046590c05937ecc6e1b5e5d041c588de5c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/spinnaker-camera-driver/default.nix
+++ b/distros/iron/spinnaker-camera-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-spinnaker-camera-driver";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "4b693a2e29a369951194ddecefa9a7ee6d96b6e1f630b86208cab0f168de9f23";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_camera_driver/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "09fa5569a0c03c6e622494861b3c441addb5a7a34e12b2f97e430576222283e0";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake curl dpkg python3Packages.distro ];
+  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {
     description = "ROS2 driver for flir spinnaker sdk";

--- a/distros/iron/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/iron/spinnaker-synchronized-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-iron-spinnaker-synchronized-camera-driver";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_synchronized_camera_driver/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "8d2c865a17fe4a7cddbd71da0b0a07c6b97380a03b3b308ce339d1629ae133b9";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/iron/spinnaker_synchronized_camera_driver/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "ffe2c8a5f9d5ccef0330ccb7634774252a459fd5349ec2cd8ea5019b77ee47bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/stereo-image-proc/default.nix
+++ b/distros/iron/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-iron-stereo-image-proc";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/stereo_image_proc/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "8205055020cd26cab866ff3271e67270517b997eb10615156afd530363cf015a";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/stereo_image_proc/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "5da51c74a3575d80ec6f3dfed2ec109fe4b9d4209e8b68ffc9da1f3a45d6383d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tracetools-image-pipeline/default.nix
+++ b/distros/iron/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-iron-tracetools-image-pipeline";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/tracetools_image_pipeline/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "d732ef79bf506b36a1325ea1b8c4560a3f80d9337cbf72620a975c869e1653a3";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/tracetools_image_pipeline/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "860e21c1d482e7763b4f4891f3ac0c42dd59880f4b39475f277b2374f5306a1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/unitree-ros/default.nix
+++ b/distros/iron/unitree-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-unitree-ros";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/unitree_ros-release/archive/release/iron/unitree_ros/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "816668ac295408dbf008cd38e72e976bb2f4b02d330c07cd457eaedd7bdd3405";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake boost rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp rosidl-default-runtime sensor-msgs std-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Unitree ros package";
+    license = with lib.licenses; [ "GPL-3.0" ];
+  };
+}

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "6638533a0b883498d963232af07d4febf742667ec7a9c0c1bd985c5d0d48cca8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "068e841d65f1a28e76b99a24f2067fb8884202763ced83ac880abbe33d8f76e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "bcc95d6d7eb04deb042f6a16c1b665d7da10f3928535637df2973e4032bb668d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "6231c4fb784d0ce30ca57c4597a2bba83bf777d748683c457702b6dca2cbce74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "a9ed539186102070ab7d5b8045ceb9dc02a1c1d10a3827fc8d722a84173d24a3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "ed976b1c5e30d80a8b130a93d12af43fa578e7eb84c65a4fb59a3d938bebe451";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-2d";
-  version = "0.1.15-r1";
+  version = "0.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "b238ee5edf8d0fb460d5901b47582c88a5e558d7717400e7a509af5edfc94f41";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.16-1.tar.gz";
+    name = "0.1.16-1.tar.gz";
+    sha256 = "4cfae7eba9ac2671f275257766335c5789c15241d1e98dd0a36c18b4068eefb7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-3d";
-  version = "0.1.15-r1";
+  version = "0.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "45fb658de4d254e72b5d8166f1455fb4e8cfbed8b0b9387c19a0baf130316a0e";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.16-1.tar.gz";
+    name = "0.1.16-1.tar.gz";
+    sha256 = "a0c44a525f65e614e40e2aa3aa97a9f552a63e97a24b26257337db92ec65dcac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-graphslam-2d";
-  version = "0.1.15-r1";
+  version = "0.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "b4e3f94b04b943a132a13de09c63bd25df0c5cfc965139ef08584e1180d1b499";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.16-1.tar.gz";
+    name = "0.1.16-1.tar.gz";
+    sha256 = "8bd10c92eeef33540b3aabd95cac1f1d487db3ca58acee3bcf272956de6580f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-icp-slam-2d";
-  version = "0.1.15-r1";
+  version = "0.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "4a822f533518a530cc0a1930a8dbd0a47fb98f4ce7cee532cba5b3f83072c5b9";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.16-1.tar.gz";
+    name = "0.1.16-1.tar.gz";
+    sha256 = "abe2ea83b27bda932a26cb4344d23c818577f55e4512c1141fc791b1f9249d71";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rbpf-slam";
-  version = "0.1.15-r1";
+  version = "0.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "3f550d49fc10db0a71c8b0dc230162e2675135397ce3b1b61fe1a764845ca267";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.16-1.tar.gz";
+    name = "0.1.16-1.tar.gz";
+    sha256 = "d8e484c24824aab1c9401b1abb2bef1d60d7d13759abbdc389e2926606174116";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-slam";
-  version = "0.1.15-r1";
+  version = "0.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "03cd37d2b4de1dc86713b1718c95e56a5be89f8fda631f93403d0582fdd13b24";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.16-1.tar.gz";
+    name = "0.1.16-1.tar.gz";
+    sha256 = "c5e69f9df3ab01c324944053392d253237830bc4f7021828dad15458645c1f17";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, dynamic-reconfigure, gtest, mrpt2, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, rviz-plugin-tutorials, sensor-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.9.1-r2";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.9.1-2.tar.gz";
-    name = "0.9.1-2.tar.gz";
-    sha256 = "45ce15a4093e94b326f033d67615a526f63e11c92d9ddd1cabcc3e5c72bddfe9";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "8848f1576df055be318a657d1eb3c16aedb5be8563b5a7f96f747a69db0bb04a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "8f9a159760e41ddcc48fcf1a6187aaada183d6c10f82c6b531ff35589c9f238c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "6a9b0f6dc50fe8ce20ae5c678400fda2d0678823c787f6ff46f0d1add40c4084";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "dc1a438b8baa90512baa4b75cbd7cd1c0b8276d9f38fa0b6ca8dfe8d7a30eaed";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "f7a97e479f71c5fc22063419a81cd9c76a324d807bc493703b1350f808b092c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "c3f0d5020abcde46f31d776514a9389082297deb98aa9c98f31b4a2b7be401b8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "30d663234862c8c0830bc31a27b02a6e6d45aff4cf0c7e5f709cb85e8cb8c1dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "594ff2cec9cd00a309bb0b5dd923e2ba87c12621e88d7ec6a5846960ffc511e8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "c3527344b2b2c39655ca45f7dbe9b59f3290823a96dcdbbfe1c6bbccfa7f9fcb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/octomap-mapping/default.nix
+++ b/distros/noetic/octomap-mapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap-server }:
 buildRosPackage {
   pname = "ros-noetic-octomap-mapping";
-  version = "0.6.7-r1";
+  version = "0.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_mapping/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "ee74a243e61605b47a6e8444e0db6edcc84c5e4f4182f53fe42e555aa11ed8d6";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_mapping/0.6.8-1.tar.gz";
+    name = "0.6.8-1.tar.gz";
+    sha256 = "043e8ad5df165c8844dfdef8279ef0a498a091741fa09a52aa20ba114c1a3253";
   };
 
   buildType = "catkin";

--- a/distros/noetic/octomap-server/default.nix
+++ b/distros/noetic/octomap-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nav-msgs, nodelet, octomap, octomap-msgs, octomap-ros, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-octomap-server";
-  version = "0.6.7-r1";
+  version = "0.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_server/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "d85b080b98a1699bcd6423c97bc0807b9a7790d06aa745651622af0c478b2c7a";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/noetic/octomap_server/0.6.8-1.tar.gz";
+    name = "0.6.8-1.tar.gz";
+    sha256 = "38214a586b0dcc56a71bac14ccc727c008e4a0051ce5d89841aa95168b5468d2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "42a6dac6977283c15c41b66498306faa57f2d5715683c8ab38395e2df0f7304d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "d33892a848349dcafe07281bfe85dd81eb0ff5849c0ea41239a6185edf8ac803";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "cc2cb3ce12a5879b26f0bde148d4fdf5634c4dfde0565967716477e988af7ee9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "5beb3db53df3c47ebbe3d93ce2aab228d2cc34a0e73408ed403aec600b3bb68e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "82e5d3431e04eb994826a574cee62cff88a14d7bd147fad2a606c55fef82c393";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "ec60ba623584e21144250a95e3f5f501c71ddc677c25728a9fcfea13822ee213";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.17.0-r1";
+  version = "0.17.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.0-1.tar.gz";
-    name = "0.17.0-1.tar.gz";
-    sha256 = "8c4d8a5986d349efece748a71de8add6ce475409360fc9fe42333f288ac4737d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.1-1.tar.gz";
+    name = "0.17.1-1.tar.gz";
+    sha256 = "3179babaa006b39dd11f8e2f519c5f070d04f5e247ef5f6ab9ebe80650b2bf08";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur-ros/default.nix
+++ b/distros/noetic/ypspur-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ypspur }:
 buildRosPackage {
   pname = "ros-noetic-ypspur-ros";
-  version = "0.3.6-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/ypspur_ros-release/archive/release/noetic/ypspur_ros/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "2a95c1e89e2c0a14ae6b3b45813126afc2450a3a4dd5fe604e3692d9eb2e0d6f";
+    url = "https://github.com/openspur/ypspur_ros-release/archive/release/noetic/ypspur_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "fd7e719209d90f3a10da1957ad9ac983d79b5b9fcbedd6d300002f782a95469d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur/default.nix
+++ b/distros/noetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-noetic-ypspur";
-  version = "1.20.2-r1";
+  version = "1.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.20.2-1.tar.gz";
-    name = "1.20.2-1.tar.gz";
-    sha256 = "3b6048cde6a08aaa82eaea43e86ddcd1e1c2dfe9e68dcc3dfee93e45d215ea4d";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.21.0-1.tar.gz";
+    name = "1.21.0-1.tar.gz";
+    sha256 = "f1a5352bf7a63d0d23a0f2dfa4feaddd0b8131dda8bb9ef1624cd2b58fe66e1a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "db53e3fc46184980d5b10652d081d68ddd0b59cb21d265e806bed06b0b232184";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "acd6ed2cd10d64b2341505261f9df1885ff30c4f6f8b1d5cf3a65f29c3a9cc45";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-interfaces/default.nix
+++ b/distros/rolling/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-interfaces";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "51fca1dbb04fb7f286cffd4f8a165bde9576ebab6eff667856a53e84d17d45c9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "0f52e4c967c31c09cfe4ba497bd2432df21f9291c30cdab962ba840a9ca8b944";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "ef579be056100a912d8ddd74334034c3b75029996855068d342dbd2b67f0201f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "7af106cfa75cf19af3a9e8ba285d19eea0eb3d5f2bbe7864ac63fc76a5dfc20d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/actionlib-msgs/default.nix
+++ b/distros/rolling/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-actionlib-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "67d5cd144371316a87ef438043234b4961448b830cecbe0090518e98e3aaa03f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "9b4cac8603acd2bf1ce17a8098f169e2e8330eb82cc129a65217edc4146f1705";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "d165f5758d1f9082e67cbe970caa297c79d9dfabcb1c14b9e06c9202947bdbe3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "545a3053f74a082e24bf15c22c7378edf60c3baec6583148735c1ec418eb45c6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "ecb2f5639ed97de4f7e6bef874c3dcb0fe40dabb6a3e6c8e95ce189c4f09fc76";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "26a6430e435d2ebb23fc09dc80066145804187207bcc4852e48a4da0b9f026c8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-auto/default.nix
+++ b/distros/rolling/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-auto";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "1d21256014ab4a3cb97c6ffc53be6d163c46f5a0ae6152e8dd816362d80d394b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a24727fa30fa0ddb74b9507cf6edcc27e1e5fd21f8a554cb9a6408790c6359bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "e2c65308efec2ef06b4a1230fa97d428009adec01f95f360998aa43ed90a09e9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "a89bef76932eabedbaa6dd8c8a79b65511613a51df43ad1a5e23662fb6c34c16";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "92e5114371deba28d570da85d0310d42d5ab1263b04bf4b7b697ac82b309f369";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "d13c505ba602f13ef987421c97cdff30d2c664d67a6545b3336a3e2335e90004";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "b10b8d7ca536a0f7478aeedb02abbaae2469e1be9c7df2a178fd930c4e03d213";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "51786ae26dd5f2902df8e53433b0ba2bc136a82331a0fc7b1ef699b01e7a0b5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-core/default.nix
+++ b/distros/rolling/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-core";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "96c0e9cdcab3ad4b76888d034724b6d8a2de4fcf6c1fc72de09e24739a1ad613";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "2afc651d7bc3832370a037699acdb127a037eedd043c75fe16a4859f4f6f9f6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "71a6e386c8abbb3d34808f244b17e5e79f1938d54d6ffaa279346a0ca2936607";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "c9b7281d859bd3cddb8fcecacec2f096aaff2c6ba0fd150b446c8124c2111d5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "be933567845ada38e5b737de12c618ae0b13bd2d0d22f18b6f872580aa6e0c0d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "f964704a5d817957ceb387073161857e9d14a2365e356d4faa6ccbcd4fc44487";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-definitions/default.nix
+++ b/distros/rolling/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-definitions";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "43d1d9b5ed532eb5c4b577c1968b4f4e76fe81db07b38b357899514837bb3661";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0391c288809ce01074415a54f33a314f9c53bccae1e4cb2ac69497be9092cf95";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-dependencies";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "337744a46771cc78ee7ed99b20e059dd1f930b9e531a8d543f49ed9601cf3661";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "f2ebc56dc48369ca224400960c250466e8e903a07140d81f33ffc3c895446469";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-include-directories";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "4a9a5c07782701bdce4acc999d98c455743ed6f05eacc06f8d7199abcd45bff7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "140a2dd5078c526c5e2ffe1451314a7c5cf90286743c6dae861f170eebc7726b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-interfaces/default.nix
+++ b/distros/rolling/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-interfaces";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "fbaf677db576ed80ecee571e6b9afc8738dae04fc647a5ab20224dc4c4a33bf4";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "3c2a61e93cb2a05799bae56f6cb90d14ab3ff8262427b99c5024436b244f3ee1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-libraries/default.nix
+++ b/distros/rolling/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-libraries";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "560af853a9267b481195b93b6341ba1e56bfadaefed89e0c6b45292c56d7d07c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e6ed98662ea1d78d29954a9e8f8fd4db20edf445057d11a508412324417f2891";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-link-flags/default.nix
+++ b/distros/rolling/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-link-flags";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "fbcd6148c3f344ca0745572e81cc5dca583e2ae98931fd4f8400f8641d1226b9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "b750e22c5af1b70d8ce45d9a8fcf963d4fe9ecefc04de8d1dfaecedc2669c655";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-targets/default.nix
+++ b/distros/rolling/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-targets";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "4b77c2d2c07bfffc7a37d35db3e77a08f605a4400e7e7f56e1dc7d1d806eda60";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "92b16a0db2ca7ca39191b4eaa6691abb037f9810b1e18bae484b8692ffd02199";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "3a607d555b95b4abbd9be490c98f102a289de1eb81a994be2397fa24fd99bb0b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "f1ea4ba988de6ef852c5a7ab933afd56be327eae56c132a05ee488c38401b231";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gen-version-h/default.nix
+++ b/distros/rolling/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gen-version-h";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "ca68c0d4447bbe2057caeecc125ba9caf722a97fcf9aa97d6f509fc74d0533ac";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "4948097fc5095e1bbe88694d45ea9a59d0e590c6a149d2715e1c04025d5abe96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gmock/default.nix
+++ b/distros/rolling/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gmock";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "67173bbabcb3271be764843e8e806c41890f9c588775049120fb2cd866a81edc";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "9e48b6fc5581fee4f2429755199ec5dc098cbb9d3a3adc79bdd6e9a07b21b201";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-google-benchmark/default.nix
+++ b/distros/rolling/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-google-benchmark";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "e6d70aa41028b2520068e4dba0d0bfca86906e6027f2838e9a9a4f2d4954a183";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0a35242eaf8ea32174948a9adcd04b86aa0d1ed38c1b19a31e1d290e62d3a6dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gtest/default.nix
+++ b/distros/rolling/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gtest";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "c71247329a598613739b5d3b0e5df841bfe5727cbdddf16af67e602842594b7e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c87ba918907adbfce26f2ebdc8838ecce11662d1274f159b7a00e06278d30239";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-include-directories";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "c330fd2195611349c7ba4af099b8a5de10d830d2b9d4e5f63d19300d478acae2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "9d4d46a42feb20dcaa8a3c3ac6fb4f7013295c3b1d9d20df28cf7b417f4cd0da";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-libraries/default.nix
+++ b/distros/rolling/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-libraries";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "3a2b5142f188e211512ad29df18df877bb87bbc687f9bc8c7a15cd5c61a12551";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7c9d28e29157d27d9065a9cfb0ca6b30817518c8223fc01155e1b948812d1f00";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "f900ad0cc7cb8fdb6e645db7858f06d876e85003fe465cdd35fa93eba304c981";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "34785f52119bd10076a08d6f998bd8aab7088de4e2224771031bbee8ddb71c58";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "cbe4b8ae336fac6761233929c5f0ae0a638edbcc68c87731fdb376307da56245";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "8e35dd757b10e723c49175571aa54be1d64791ad7787186d8c53f54cdb37d944";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "b0007a5b2144e033716b43243a8188843cab648ac2134f1c601b8ca4bdd113af";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "c4c9e7f08a57c375360711f886018047c116460c1cbe3d47b824f17d942c50ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "5568239bc5fc10ff84fd9f04c237995b70f0c19b71f36647e05d37383b570a22";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "a3f7e101e86cebf07431428741f95af14a1558c2092fa437e0e1294f5226d3fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "fb5b9340e3bdbb490dbc822ad4f8affbf984cfc5d931e50b1c87159fe640e839";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "b16bb1826f69d5f4582b8e7ea4e79451c7268b3bb1208fb78ffb5fd1408ecdc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "108518f10b0fa65ddf1abf557926a49b72a8c1d4220c40c39311031209edc723";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "61db7395b5008bb516a921347c66c2ccd4662db39961adfc5a9eb4b53a33b294";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pytest/default.nix
+++ b/distros/rolling/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pytest";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "39658ccc3fdb69564e2df83c80380a33bd9be8e9adb9cacc49ad2253d53faa47";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "3565166d3c14ab7557a4df09cfff6316ae9a67662b911edec29ca25c800518c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-python/default.nix
+++ b/distros/rolling/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-python";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "689e95fd9775f304f2d2e170da8a476da6198dde2f0142fb55c4d877ff87ae26";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "1e6a95db8306503b441f2fea1993acd6ffef8ea0d8659d1e69d1ae219b944f5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-target-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-target-dependencies";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "818fe9241cde3476a4726a9af9f9c7c7ba5c8a6c860420a1ec4a10f69e2196e3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "88235bca721358b7f711ef82d070c81d66581027c5bb1865ec65c1e57db815ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-test/default.nix
+++ b/distros/rolling/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-test";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "a4b2bd973de0567c31c1414696ff3563e2fd382fd64753d3aafaf56a0f60959c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0338002c56e985471e7b90505808e23563b438b74528919152d708411eefcafd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "3f2f32538229d57fe7c0dd65f1f3f6d978ab25d1dde12b42daf72ec7782e5e58";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "2031a7a22b8fc537114359e580b130472cd08c047a492e2e3d61cea882d2a7f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-vendor-package/default.nix
+++ b/distros/rolling/ament-cmake-vendor-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-vendor-package";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "fee8eb53881a43a388f29709b0eb08760e96eb6294e02501033f7fcb36b19b3d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "6f063db1b572089d554228dc6be9e7fb2d05db3f38323a91f1fec44e02de7756";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-version/default.nix
+++ b/distros/rolling/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-version";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "90288b18d90802f8bd3321f9da8b1dce0e858727795c300390e312912344e307";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "02624eaa0fa9b5e98253e461ab495aba0e3113e7bd09ce2aea8a5a9bf82c2dca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "007a03cf8b851e077e95154c8fabb90106f0e45f16038aaeee41d0a1aae04192";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "47545e6cabb7c564f42c935dce1c725f8016f6f746a4ca2014115eea10799948";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake/default.nix
+++ b/distros/rolling/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake";
-  version = "2.3.2-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.3.2-3.tar.gz";
-    name = "2.3.2-3.tar.gz";
-    sha256 = "7982c301703457f2deb05084183ce4171cb22ff3795dd6bc98fdc71052190ebd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0092022a3aa56957a8a2789cf69f87dcee6fc5a1e030c9841d99ad6ebd9278e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "8b6d8eadbdb7e4d4d7db4eb1e7215a57b5e696206edf1478cb60b2d55d24857d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "ed3466d34c71330c94d4d657928e67fe6cce9756c713319a8af7a7c763c02a7e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, cppcheck, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "7bd60f1ad90d7f093d7bd696087fb61d9eb911333687faa6da08093835f46a37";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "03cef79923c23fae1cc4848a5e417a108a684af09616501fc523e1462c2e8c58";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "15e16a4b89aae64e94db6d7e319a2d5764af361f98c3ff90c6a213d7a33c3c80";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "9c7532619180af5c17cfd31bc94f536d507b414c5021a8f37fe5dc72b8e38277";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-index-cpp/default.nix
+++ b/distros/rolling/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-ament-index-cpp";
-  version = "1.7.0-r2";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_cpp/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "aa913d53f436db47cc7d70efda2031f603e8beb87435b35092f3ea0b49a58926";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_cpp/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "6b1d4faa181f10a5613b3239c459edd1ea8eefb3b53a1f67cb262620f6f145ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-index-python/default.nix
+++ b/distros/rolling/ament-index-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-index-python";
-  version = "1.7.0-r2";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_python/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "731728f6c849a16a2e45840945ad026cd1054942856e2c1bc07d370d1e8a3db7";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_python/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "9bc4aca2f92b4c7542e982818d8a096684c3c2f5239542a892700f393d36f5ba";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "4d4f6cc064df3f9a9f07adef3c0a4701db061e5d7aa64fcb8622cff44aed7adf";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "65266537613407e555dd1013bb0acaac70b75ffcb619df934e14eb191cd8a03b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "ac795ae8300d7be38d905b468c683cd557dbff75acc79bf970ed39b8f05d9f21";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "eca211e3da900715acc6d45ba4c3a00f959292be147874f6bd16d30a9ec5324d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "044b92867333530b64225515173613f570dc37b89ce050e220804f4c9ff30454";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "0b47a79c26f64e4bfa45a78a0065afb44eccc4834535283398439277fb7bcbad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "11487f7e46ecc233de96f3455cd70f6ab779eacbe589871a52023608d66094dd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "03f96a0661825d723f863ffea1d9a24d10c21c3fd8e6416965cd6dfd80c01f23";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "c164d4788456dd5ca0cff2769526d8d1e0f661aca1b7351cfcf0e2f3e162f8ab";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "307decd5e4954a6ad63754027e8de458fbc804c11c0f3db221fb6899b8178ef1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "d6be4dcf7174c421dd80abda6797aa35412465ef9dd32563a0d80c7369dbb6b9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "20dd7ab62d0bbb2dd62b083f9bf228fabfaff42f27d4610c04263301702305aa";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "0484485304b43f442dd7a9b78dd15899316046f9a51bc990e203631e56fb224a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "5e771419050edcdabb5cf71c718778aee4f76a2fb85d435379b63f54b588a7a3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "e0899e9356a463f186fbec36a5cca59ba8ef573c53d642abb169c384540370ad";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "8e193ec7f978b442df6a06876d91e2198acc3177abaab0c4839667e52ce31796";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "c24500ed897c7a69fc1c1be428ea7e042a7d209833f28497cee29bee53e577c6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "c6da57fb4a3a09b5fb49b871ef7965bd9f85d23a6f1e1356629578f6f7ef6c75";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "75be49437a0d91707335908fffccdf70e7af99f0900a7fa52056a47030402b96";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "cf7da6ff06b2b83cfd3228dac666c10c12787ba17a8ab0eaabaf1395026e94f2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.16.3-r2";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.3-2.tar.gz";
-    name = "0.16.3-2.tar.gz";
-    sha256 = "74a09ffb2e10ec6b48f568f895ca2018ee7019f503736b0f026db3629ee28bc7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "ab445c2b3154653abfc27366e3f6893750378a438a2cd0a766dfcd7680c59130";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "5.1.0-r2";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/5.1.0-2.tar.gz";
-    name = "5.1.0-2.tar.gz";
-    sha256 = "e4d92d2e73832a44abaed158dca501f6130cffa2c505820fb06a1088b3b90f96";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "89923cb854b7ceddcd928b94a956db8314d1a3e90da660aa46a99c73a87ce1e2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ rclcpp rcpputils sensor-msgs yaml-cpp-vendor ];
+  propagatedBuildInputs = [ rclcpp sensor-msgs yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/camera-calibration/default.nix
+++ b/distros/rolling/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "e838ba2bd899788b559054132188918f97027207d05ec64bbc34c461466b9974";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "46bfa50c8117fe76fffdd5b5b9911b7e34322e1af0559e73fab07a34cdf5729b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "5.1.0-r2";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/5.1.0-2.tar.gz";
-    name = "5.1.0-2.tar.gz";
-    sha256 = "f440803a53625270942aadaf9ba47c827f69340bf7551ca229df940d82e521c3";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "cc8ffaf07d003634311a6360cc2377af1ebfadb13fbec8e07e342d4bf878206e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "cb2a1701ced6998f0172bbf497674c414b256c7389f8b729122aabb7db867778";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "472a739eb2d456f73d161c21138dc87c6a827f91608cee5456fab4a75d34b513";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "f0bb5109b99a5ed215e7042c6db4ca8e9d09213d19b5400bba4b68d709fbe757";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "e6c2a3ce73a1e7c47ea4f7975717f41ff7454804a67c079f6c6e01304b7ad0d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "efea7f99baaae889228224f1da197c373d0c08be5f26fab981e2f099e263cca0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "1a107489b8f8a89197d3dc1e379c08e685b50e83d4e6b230c80b8c50c22a6c4a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake sensor-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h sensor-msgs ];
   checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
     description = "Description of controller_interface";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "9336a79f86b06d9cdbe79903a20a5f691125bb0532198c50a82d3e79d3cfdbe8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "634d6e9cf5923e521f2b9e9359250fe99f61223c7e3ae059bde1329ddda5bd17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "ab558de6e5e9262eacb9247d8c03f1b3db85d742075ad3f3c1916131ba9fc791";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "15998f2add22f309ec4a0aa315c2304c64ac19956dab8ec84a819139ebb81f17";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 
   meta = {
     description = "Description of controller_manager";

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "dc49354241e809d087516ba097441cd89dfc9b68a0daecb65e6ef838c572a5c9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "f7376d4437eb46d642367c244485b31cfe737364d70b091ef029d60fcf148f94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "f24f7b1e01e341a5d989afa532a5b3da123f60c7086051884883984ff66044c9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "6dc97e7e5435db429cffea473c9f6ba8af1cbf9e50a6972a412d9c932b55dafb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "e11c883d2638836e301b923350137d282c57f75790ed0a845b142839d2ef7848";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "0782aec61c31580f445d6725936b1ef06f8a5c5512b4834f5dd0507263b8ef49";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/depth-image-proc/default.nix
+++ b/distros/rolling/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-depth-image-proc";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "344a43f7896228600e87120b455be24cb8ed3372022999208b6ce650103684c0";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "845401521e9acb3f1121df06d46c4fe308fc36fa213f31883debe6c38ee2a628";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "54e2baa7b6996fbc80211f137470df3e0ac047a3656a67c6e37d29d9aaffb394";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "1b677045ff073ea9b867d1749406704bef81976f021d205717c3ae20d6ab7622";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "9d431324cf7b7077efbf3e89d1d5a0a3da013ec6dc8486f119d3bbd6ddf09b97";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "e69a68600f12a70db80485ffcb1604ca8626a47c8f26c9958b628d2ce8486486";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "bfbc739f846b4f487baa16528c7bb8df36534aa39f1b57b0d73bee8dd1fc6889";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "d857e81c2b45c91e343a829b1d4745b7b0e722d820d0392f4be2a548081b3805";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "c4bba7c1a495371a2df46aebe45687c43f5f4ab7543b7d62a4dd93b8e79861c7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "3df797374cedeaf17e4ff5eeb70c6f85ddb8156d746754d54b9681f5bd6d67d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-async-client/default.nix
+++ b/distros/rolling/examples-rclcpp-async-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-async-client";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_async_client/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "cc8012051f34c304c5d39728f82c520a8871be1dc8f1d61ae0b928a717ecc93f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_async_client/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "8ce0d0fc30ac0155c5ccd6304f804a9cfdf91cecdb05f84d470434d89d1355c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-cbg-executor/default.nix
+++ b/distros/rolling/examples-rclcpp-cbg-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-cbg-executor";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_cbg_executor/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "51bbc70cadab8b547069322ba28b192ee181406a64207908f9510d6b3ddbdfd9";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_cbg_executor/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "66b116d405400cade2fa382707e03847827ee11c2ac25c207c5c6a2b449ff370";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-action-client/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-action-client";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_client/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "49850ab8431c245b7ce54c7bbe368c5b924218a8294ce24c248fe5817a4cd0bd";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_client/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "5d6cb4b799a3010b292975a3b3b19d3cbe1f866e756a188a583a31c5b9ce84e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-action-server/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-action-server";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_server/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "c5b97c72ec20b4b52553459f9f2bed3ac40cec9527ae331610e95ea046f626d8";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_server/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "6a739dd0005cb06a70a4ef01f7dc908cee04c0c341e0e1dd68109271de7ea3b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-client/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-client";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_client/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "82b55ed4a5021a6c68589598e0d03af93dcf185c7c6f5053bb01953a135e9c1e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_client/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "7ab9faeedbd2eaff38114e67d48b7d6b08a87ccb669768ec3c5b9e23746f0c0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-composition/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-composition";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_composition/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "7c86432f9da091956441ac4453d908b2489b09458d352d935d6a528fff260df8";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_composition/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "52d8ade833dbfb3622603c11645ad4b6042b10feaabc6fe1e27b14e7a8e5d24a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-publisher/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-publisher";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_publisher/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "d3c7ea3c809b21c9645ef1fbc4e0c2432d72553846be02f8dcd61492749bf5d8";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_publisher/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "a1b81856aded7a3e56ed94b3ad6f07ee8008b58056d7de64a3fb2aa06a9a4435";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-service/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-service";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_service/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "717243fe4036871e354003bb0bf82660a0ea53e8021382bde8df148c626f8a10";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_service/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "13bd9cdb0ac3f7834def74a7d9faa5f1dc18395ae2cba28d5e8dbb519e892277";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-subscriber/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-subscriber";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_subscriber/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "ede51824ac34a71ae6cbdd25389d0e9e2c3f6a1a61cfe38d8777ba15abcd583f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_subscriber/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "9fb8ca33e0b812fdc441364a44cf34a78edf6e9025b243f49febefaa896e2d4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-timer/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-timer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-timer";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_timer/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "b25aaf05a1b355c9131555b3d65ff0cdf1468b30e4df74b2c88687af9f69c021";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_timer/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "02adc614dd5090d39166c8b9e407fcbceead5e6679a8a0986b86ee0df375fcf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-multithreaded-executor/default.nix
+++ b/distros/rolling/examples-rclcpp-multithreaded-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-multithreaded-executor";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_multithreaded_executor/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "791b9407de82c896b0cb3e7311de688b1c58a77963bf3eb9783fb9ce155f9979";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_multithreaded_executor/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "cca0d915c75d97c21cc3ced06ecd08bf7b90a8a1e4bfd822966bf850e56bb287";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-wait-set/default.nix
+++ b/distros/rolling/examples-rclcpp-wait-set/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-wait-set";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_wait_set/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "b80cc3210e2c43adc06fcb06d4657f5df60565f3548e03d9ccf0fb5ecb23a4c1";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_wait_set/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "e5ea618bb6973956b48398cbfe917810b45521694a388fdcf2f50faf62073a52";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclpy-executors/default.nix
+++ b/distros/rolling/examples-rclpy-executors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-executors";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_executors/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "a921513f818f08f4ec309e529121bccf2dd1ff6c4f5e1a67c7e5544025b0d354";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_executors/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "915f66eabd7c41b81b5d3da74e94cb57bf06b614053ce07aca7c797ad892bc75";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-guard-conditions/default.nix
+++ b/distros/rolling/examples-rclpy-guard-conditions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-guard-conditions";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_guard_conditions/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "45ea4abeacf635fea38f00df4ac248c154bccda054b0a78a88f4364355d6c1ab";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_guard_conditions/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "ea26b8f7f5f0a1dc18027cdb2261c34b27f5474be0b9b562a4ab9d2e9c3640c4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-action-client/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-action-client";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_client/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "8078f9a8159bc2be1d53c5ee71fab0072a0dfdc6ad57a726fd33e9a5e7c7174c";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_client/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "509d5c7012018284455e2410ce024b519c6ae390d42e41a6334e69d2c1984438";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-action-server/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-action-server";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_server/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "c3bab7b414719145b35e69247908f060f1bf07dd4d0c543ffa5933e21dd948da";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_server/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "a1fabe7f73fa60ba3ec28df43eba76aaeb8cd91cc70818ff7855fe748b6c8956";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-client/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-client";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_client/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "2dff3c78a34c05fa16e25ec87a62d4f53eb6da151b379eea5a160b34def63a0e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_client/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "ba82c69c4184f8345b6032278e937ae0770d834191a947c72464325028b1238e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-publisher/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-publisher";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_publisher/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "02c0bc0803da21fce14235855e07b54e731456366082495c19326370a20e2595";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_publisher/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "6d018e41116e097d74c12f58091dd12450146b0f352ad1fe7d99bc5b1725cc43";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-service/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-service";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_service/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "56c9923be15333f98fa4dcdbe6f2930a86431a1850631a3d7ada81bd7834eb2e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_service/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "ec41955b1aca05551bdaa427b79308b389f5d48b336379929ffcd27a4f18cbb5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-subscriber/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-subscriber";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_subscriber/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "6401a145dd2976c2ddcc4ac98fa12b87c2088e2f0f3fbe5b55b20d3118d552bb";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_subscriber/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "d6ca965afe4deea65717d9d359ec8c55feeb51b49fc6566bf0479b99ccbe636f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-pointcloud-publisher/default.nix
+++ b/distros/rolling/examples-rclpy-pointcloud-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-pointcloud-publisher";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_pointcloud_publisher/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "7f7e215d8850feb064649441c0ae93cf379355cfccb561fe39049f675e1ad490";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_pointcloud_publisher/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "1bc805a05067b43c425516396475394435782160b5fe6bb08bc2cbbd0f458fce";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "0d82bf41be293e4c32fec25ca64bb5cdac05dc7d9b5e511d77c7db52d76514f4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "6dc4447ac503be1a13402fac22804aef3b4e7ed2762af206262d377c6e72b5ba";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/fastcdr/default.nix
+++ b/distros/rolling/fastcdr/default.nix
@@ -2,23 +2,24 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
 buildRosPackage {
   pname = "ros-rolling-fastcdr";
-  version = "1.1.0-r3";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "efad3c7b6bc9887fc9b0f480b7f0038704f55d7543010d9070b915ce877a76e5";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "5987077b5ef6ac55c3a874df847201c162a6ef4862007bdf25710f9b36df2742";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
+  checkInputs = [ ament-cmake ament-cmake-gtest ];
   nativeBuildInputs = [ cmake ];
 
   meta = {
-    description = "CDR serialization implementation.";
+    description = "*eProsima Fast CDR* is a C++ serialization library implementing the Common Data Representation (CDR) mechanism defined by the Object Management Group (OMG) consortium. CDR is the serialization mechanism used in DDS for the DDS Interoperability Wire Protocol (DDSI-RTPS).";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/rolling/fastrtps-cmake-module/default.nix
+++ b/distros/rolling/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps-cmake-module";
-  version = "3.4.0-r2";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/fastrtps_cmake_module/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "62eb2afb74d54764ce78f83f5a4b4905b4d1981f11525d80473eb59073af05cc";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/fastrtps_cmake_module/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "413181feb19d47f873646e2ec8be85ad6319abac36f5c6e0fa0b3f01ac908a96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps";
-  version = "2.13.2-r3";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.13.2-3.tar.gz";
-    name = "2.13.2-3.tar.gz";
-    sha256 = "58d528748a348e45db6a55be99d8e6f0f587660b0cd251357c99a4062ec57c66";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "dc4c2b504a3cee8d80d155983e47a48733438f7af6f233a025c0532f46e0a492";
   };
 
   buildType = "cmake";

--- a/distros/rolling/fields2cover/default.nix
+++ b/distros/rolling/fields2cover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
 buildRosPackage {
   pname = "ros-rolling-fields2cover";
-  version = "1.2.1-r3";
+  version = "1.2.1-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/1.2.1-3.tar.gz";
-    name = "1.2.1-3.tar.gz";
-    sha256 = "383e2f60012181822f7510f1a3d207059cb020a99a08b8aa615af8d4a752bd18";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/1.2.1-5.tar.gz";
+    name = "1.2.1-5.tar.gz";
+    sha256 = "73d934a9ec9cff3468d8962712eabc5c8561c4bd5d99dc8ad1cd9f26d76c4ad2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/flir-camera-description/default.nix
+++ b/distros/rolling/flir-camera-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-flir-camera-description";
+  version = "2.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/rolling/flir_camera_description/2.0.15-1.tar.gz";
+    name = "2.0.15-1.tar.gz";
+    sha256 = "34ae4b598b6c20ba0bf1fc34dc600378692db2a2668592756e0a3f91aecd92cb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "FLIR camera Description package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/flir-camera-msgs/default.nix
+++ b/distros/rolling/flir-camera-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-flir-camera-msgs";
+  version = "2.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/rolling/flir_camera_msgs/2.0.15-1.tar.gz";
+    name = "2.0.15-1.tar.gz";
+    sha256 = "7d0ea1b240cc386d087edb86af4cffe8e83d3c410c31c634d7524e67e1993098";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "messages related to flir camera driver";
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -508,6 +508,10 @@ self: super: {
 
  find-object-2d = self.callPackage ./find-object-2d {};
 
+ flir-camera-description = self.callPackage ./flir-camera-description {};
+
+ flir-camera-msgs = self.callPackage ./flir-camera-msgs {};
+
  fluent-rviz = self.callPackage ./fluent-rviz {};
 
  fmi-adapter = self.callPackage ./fmi-adapter {};
@@ -607,6 +611,12 @@ self: super: {
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
  gtsam = self.callPackage ./gtsam {};
+
+ gz-cmake-vendor = self.callPackage ./gz-cmake-vendor {};
+
+ gz-math-vendor = self.callPackage ./gz-math-vendor {};
+
+ gz-utils-vendor = self.callPackage ./gz-utils-vendor {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
 
@@ -1827,6 +1837,10 @@ self: super: {
  spacenav = self.callPackage ./spacenav {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
+
+ spinnaker-camera-driver = self.callPackage ./spinnaker-camera-driver {};
+
+ spinnaker-synchronized-camera-driver = self.callPackage ./spinnaker-synchronized-camera-driver {};
 
  splsm-7 = self.callPackage ./splsm-7 {};
 

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "beb3c51b574e9c6918ddba2e88c9dcb7f585274620bc635d840a6ec19b268530";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "35cc53c3b13b5245d884749f04c25888ecf1ed02664810f773cd4a7b1dc94ab0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "9be3d8ec1cda49e32d3fc5436951002626f5140d69bc1a80069bed81ff9917ac";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "e4ef83facf16d57bec3eca69893c51bf194a55d543027bc42bc0797bebf770bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint }:
+buildRosPackage {
+  pname = "ros-rolling-gz-cmake-vendor";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "60337d17ee6d3f54c31e7243606bac2917b1a8ee6163672b9d1504f31383628a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-cmake3 3.5.0
+
+    Gazebo CMake : CMake Modules for Gazebo Projects";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, eigen, gz-cmake-vendor, gz-utils-vendor, pythonPackages }:
+buildRosPackage {
+  pname = "ros-rolling-gz-math-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "0e1e495871dd998bdc2db4b3bad20ba807cb7d331f0de447082e11dc7e9815de";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package pythonPackages.pybind11 ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ eigen gz-cmake-vendor gz-utils-vendor ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-math7 7.4.0
+
+    Gazebo Math : Math classes and functions for robot applications";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-utils-vendor/default.nix
+++ b/distros/rolling/gz-utils-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-gz-utils-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "a1617570aa92a2a50b57b81fd98bfc5a9962b95a77c56f0a8e7c93207237aefd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  propagatedBuildInputs = [ gz-cmake-vendor ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-utils2 2.2.0
+
+    Gazebo Utils : Classes and functions for robot applications";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "ddd63c0fd8cb6954246a4774efec2f19c7619d5b3163ccfe2173be403ed61daa";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "262ea9fc94298d7601775c2f9ef6945743f2c70c82dec2ddddb69c426a2c9adb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "bb0bba90ed989c5a260055fdd6db378b7a5db59148c9cb9e33645a1add1ad1a9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "e2d4cc061cb6e385d735cb2b9e02d8497cb402b0a3667b4198b28f153437c1ed";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
     description = "ros2_control hardware interface";

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "5.1.0-r2";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/5.1.0-2.tar.gz";
-    name = "5.1.0-2.tar.gz";
-    sha256 = "0667bdda6b1ce1436d3fad9e0a2d03e90de2a400fda3cde3575ba06efcdaa6fe";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "48b5761ab4b4052e3dcf68063d13af1623dfbed978a994174e23b0c6dd0dc0d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-pipeline/default.nix
+++ b/distros/rolling/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-rolling-image-pipeline";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "d6e6196c65704dc6cf4472933cd52d49fb511f01a8822ab8fb6a03b304c3dd00";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "6a6016f00753f45015b686615bb272cd95d1ed103a718aa750f72d2135d8fb90";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-proc/default.nix
+++ b/distros/rolling/image-proc/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, geometry-msgs, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-rolling-image-proc";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "c084aab8eca6f6da53c0111662f5703913106ec2d27fe3fce1c6817af5c4de09";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "3ada03999f6c7701383054ea9a77d9fceb311b616ccebe61b9e31bc16f2bde4a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge image-geometry image-transport opencv opencv.cxxdev rclcpp rclcpp-components rcutils sensor-msgs tracetools-image-pipeline ];
+  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge geometry-msgs image-geometry image-transport opencv opencv.cxxdev rclcpp rclcpp-components rcutils sensor-msgs tracetools-image-pipeline ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/rolling/image-publisher/default.nix
+++ b/distros/rolling/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-image-publisher";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "17c58f2c9dfa653e1ed1eacbfc0a41c1e5884952dad7026a658de55116f8cebf";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "b32f2b650a77a9bd21bcd36cef34bb0835c456d74f16de1a537504a87d0afd5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-rotate/default.nix
+++ b/distros/rolling/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-image-rotate";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "a4ab455c201aa48eb1fa8beefe41443faa15b423c86f01f4f8c124957a9090cb";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "011349d67f9f413b27589d70a2a23fd98b378539cf75edf46bd394449691e382";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "3e68e60914466987e2851e9f53089522b7baeac70deb55f9ead194067156a124";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "8f1cae702d70a1a25e4e8bc51468cbd33ea727b43423051ad02b43fb1b462f5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "5.1.0-r2";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/5.1.0-2.tar.gz";
-    name = "5.1.0-2.tar.gz";
-    sha256 = "cdd84bd28d0fbd00677b46146670e28d4809bc623cf10ced2619751fb51a7ac3";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "2cd3dce5809714e9134d72ab97cb95972b65087490d2f08e7cfc62fa9a09c365";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ message-filters pluginlib rclcpp sensor-msgs ];
+  propagatedBuildInputs = [ message-filters pluginlib rclcpp rclcpp-components sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/image-view/default.nix
+++ b/distros/rolling/image-view/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-view";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "11cfc13b135473bf9e056662b3d1246eb737cfcba3a102ee793eddb207c16f7f";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "581297520bc520efeb3e47765890311b1180e86f6280655911532a131a1231e5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge image-transport message-filters rclcpp rclcpp-components sensor-msgs std-srvs stereo-msgs ];
+  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge image-transport message-filters rclcpp rclcpp-components rclpy sensor-msgs std-srvs stereo-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/rolling/interactive-markers/default.nix
+++ b/distros/rolling/interactive-markers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rclcpp, rclpy, rcutils, rmw, std-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-interactive-markers";
-  version = "2.5.3-r2";
+  version = "2.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/interactive_markers-release/archive/release/rolling/interactive_markers/2.5.3-2.tar.gz";
-    name = "2.5.3-2.tar.gz";
-    sha256 = "d0fdc8baf799670e61d6bf91df0ce22f5186aed42b41e2f7aea64b3ebfe3896f";
+    url = "https://github.com/ros2-gbp/interactive_markers-release/archive/release/rolling/interactive_markers/2.5.4-1.tar.gz";
+    name = "2.5.4-1.tar.gz";
+    sha256 = "cb1317f6caf6bade6ea1b15bf9463bba20201ecae1286acf8fefa8dc21e55119";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "2c84c103642229fbdf6c8448ca7a7f7d29bac2b530b131a7945094384bca6121";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "b839eaa1498f926c8682f240cf63d6d4628933c11943878b6d49200e06dfe18d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "65aabf4e4cd52b8cbc131337a23a0b4afd60827f4726f635fb881bf438a94fbb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "da43df20d812b82b6909b784f704a5bd8762c4c93c1364614bbf4fbba2f87880";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gtest launch-testing-ament-cmake ];
   propagatedBuildInputs = [ rclcpp rclcpp-lifecycle urdf ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
     description = "Interfaces for handling of joint limits for controllers or hardware.";

--- a/distros/rolling/keyboard-handler/default.nix
+++ b/distros/rolling/keyboard-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-keyboard-handler";
-  version = "0.3.0-r2";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/keyboard_handler-release/archive/release/rolling/keyboard_handler/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "5212a677561f2688a0d52758f6772e1c360ff19ce59082dc17ca2c3adfc04505";
+    url = "https://github.com/ros2-gbp/keyboard_handler-release/archive/release/rolling/keyboard_handler/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "2ba4675ed24b88229494418a8b23a32d6dd92b18c639646ecd3e3bf508e4ef31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "6447c380cab184c236abc20b12966460a4c2286f617b44844f140876b280101e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "539ecf8c247762f864da08febc482903a41839f7b2ccccb7f80d7370284fa86e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.4.0-r2";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "0fb8ed25d5a8bfab6f8c10a84dba11c55014bcf0096df375d696938e8ec12570";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "49f8c60b42e720aa9c9c848dde6f3841c84442eccd1b3cc9e852be65378eabd9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-ros/default.nix
+++ b/distros/rolling/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-launch-ros";
-  version = "0.26.4-r2";
+  version = "0.26.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.26.4-2.tar.gz";
-    name = "0.26.4-2.tar.gz";
-    sha256 = "53a30afdb53510e05baaaf66f3f6918bb885916efd9f98e0ec2c9b40498d014d";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.26.5-1.tar.gz";
+    name = "0.26.5-1.tar.gz";
+    sha256 = "767f989a721474a2f907d28846e2dca566d94c0dfcaaceb94a60af24244b06c0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.4.0-r2";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "35ce706c2c6d1dfe393a0bd864deb2ca7de8c9aedd0b44e670bfbef6758430ef";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "84529852ee1f6dfe6d968024bf797753755d398a75ab7c7e7ac86f9f30fd6193";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-testing-examples/default.nix
+++ b/distros/rolling/launch-testing-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, rosbag2-transport, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-examples";
-  version = "0.19.1-r2";
+  version = "0.19.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/launch_testing_examples/0.19.1-2.tar.gz";
-    name = "0.19.1-2.tar.gz";
-    sha256 = "04c942c6f22a58151f772cab8ffad9be46b83af88a33ddab5d0128b2a88d2377";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/launch_testing_examples/0.19.2-1.tar.gz";
+    name = "0.19.2-1.tar.gz";
+    sha256 = "3d03451f5a53f077af02ea4219b85b34ce547d3c2767b2833d08bbc339a941f6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
-  propagatedBuildInputs = [ demo-nodes-cpp launch launch-ros launch-testing launch-testing-ros pythonPackages.pytest rcl-interfaces rclpy ros2bag rosbag2-transport std-msgs ];
+  propagatedBuildInputs = [ demo-nodes-cpp launch launch-ros launch-testing launch-testing-ros pythonPackages.pytest rcl-interfaces rclpy ros2bag std-msgs ];
 
   meta = {
     description = "Examples of simple launch tests";

--- a/distros/rolling/launch-testing-ros/default.nix
+++ b/distros/rolling/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ros";
-  version = "0.26.4-r2";
+  version = "0.26.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.26.4-2.tar.gz";
-    name = "0.26.4-2.tar.gz";
-    sha256 = "dbba85bd40de0d8a61161d39c065d007353b8aa64e7110e02d8a027a8e7d00f2";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.26.5-1.tar.gz";
+    name = "0.26.5-1.tar.gz";
+    sha256 = "aa40aebe06307a1a49825e3286a930ede2c99caefcf697eacce0364116d02c1d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.4.0-r2";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "41d666177c8fd03997b4f0ca72707db699a3ea342a86e9e1c34cb2d5beec5e6f";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "e286effcb52face371b413b574217043e86da05e174c61ead9db102ceb9de7c9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.4.0-r2";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "33d1f2e8f5a1e9676937b2805c3c49d996ad76ec8ec74075170f3468cbc12e72";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "e7f6fb1a02584b562a349ed06d67330f1b08db997d242c1da1203409d7f20dd9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.4.0-r2";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "be700735c25ff6aefa6cefeb0f66903ac66fd687c3690af0c0e1bec8e0b644c8";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "8a0d1f4713cc54c8676b6d5bd6d885583015907e8c50fe2718157f83e29d53a9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.4.0-r2";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "134aff319d0bc71bc1d05e28fb84eabcec1b9a181579b8fa3f6a869001f6de4c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "62786ff26f7067e6cf0b5ce5957d431d9913575a5bdbcc84e3faa46547341e59";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/libstatistics-collector/default.nix
+++ b/distros/rolling/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-libstatistics-collector";
-  version = "1.7.0-r2";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "672bf36c232c4175c948950827563db757fb64982e36431b553080c0019a286d";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "19922d2476ecb3b22122fe7314f4778a68ca8d4af2a8230ebc242fd9e8a3b3d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "fb7c632cee14d88cc7ac44f1152d7a2268ab48592bf3c2ebfdd77b9cbb8b152b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "194bbfccb63404baf7e21dd2766db0572e593957cc4af3d4e9d0e8ebcf19a21c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "e5b8c977fd47b86550a5fd0cc70fc7c4f3cde5c46e6264d765f09b2eee38a87b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "018e687bbdb435c92f183d905fb003d7b031c149486ff248b9e9941a7fe3d979";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "7d10c81a866a8ec284eff8fe098688d29c0165ac1dc0cfb3a68d867ea895c320";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "14dedab82c21a94108800a9b76932fab67a545f17886382328a130d971b2ddd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "52c589c9ff38c7a250ba0c99e6db4edb85d06c8c2262053fc3cc2a982b6a282e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "e2d80edbbdfb12f0fc233221d06927d72a50d25e540fca94ef1b98684435bfb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mimick-vendor/default.nix
+++ b/distros/rolling/mimick-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-mimick-vendor";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/rolling/mimick_vendor/0.6.0-3.tar.gz";
-    name = "0.6.0-3.tar.gz";
-    sha256 = "58ca397bd5bb614066ada32fa63ea17d3dddc43aff78104ed2e18f28976f00c6";
+    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/rolling/mimick_vendor/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "7d48a1988327a6ee759081a1551e1be3801b01c869e856c45c34377f0c3ac271";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b6ed47d2708fe389384e854e49d592a51711d912f241fbd7b02c49f90bc4fc3d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f4445ae986ac9842028231f61f641b44c41585139566b2725158463d9e6e2ffa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1ba38dd3868779259057e4c8862b373eeed3d2150148c22a769efa80688615c5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a35b0f2971613c5fe433d0aad54524e0a5ae04532dcedfe899a8af16a984650e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f95b63dfe01096e3db2860c500900f111aa900176220943a0ef0ab2f769e96c4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "be1a02f3f117c89636e966a3843d5cd3e4e8aa8342058765abd2e0d2a697a66c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a24b602e925d76963a1492ef5cb5f8b27f9877e6c45c2c6e8b2cbfe575902d41";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6dd648a6f6750ab3bc1cf8ddc074621b5b6f4186ffb7bb7a9c1d274e0235ad0b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "6d845442c9993a92a169b56041cf4501e154431403f344faf2271b2f98145f0c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9499d8934a67b8693180e1d3d732ea027c837b4e1ebf9ce0b8cb283b501c1873";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "34a21868f0761284c465e5894bb34e00793a0b49a5391ab5d46ebb5b29b1e298";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bcd2cf356954b35d3a472262c7730be5025468bc50b5d2d19f3d78d3a18e719a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9e65879e37c7507a616deb61071c2f051e23d356f429a23ffc26348ba9d901a0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d3edc78bac9d84b8de6c985e5f7d4e1e1c88432dfbd81894fe7e926a6163af1c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8bbee6da37597810fd0e720a37dfd605735de6a58b4a6ebad857ea677adc7f3e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f8ce2e7373c276484876bf4db98e4c337d6d128e2c18b0a056ac09fb9d2996ed";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ef733a69a853d6d36cf7a0a7ee84dd2bd78e5e6c87ba766f14c19c83982aded3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bc29179ef88925873c0167b2bd6dddce50a39fd7c6f87a3b69c29d135d8f7fb4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9382ad00b0d2bed9d2211de3ccb333c9fc9b1a7f21b537a5d5ec3023b3ecc978";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "188d214091205963fd69b50fe8d9904a621281d986d29238b984bc916fdfbae7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a83c59c7109bb65ad47938c215cff229d7803f301bf994623a09f477e9353260";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "de57c60e4ecf64234974c66a7fa194f91c289c2f4309add88f4c379c08c25444";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c713786a0de2bf9382c594b7ccdfbc3eea397162d129859c742eb582f9ce196f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5a981b24d97d8eee4b6ce6604696071a36247fedcb1e3678a6b96787f0c7b5c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c059c09c4d3f7b14db7d8de940a41fb86f1320e9fc8ceddf4db060c936ae0eca";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ca404b1ea387c8b3d3ea47ccc60a48501712849dafb948dd4e34fd4d7cd1561a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-navstate-fuse/default.nix
+++ b/distros/rolling/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fuse";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2483fde2c9f4f21265623fb57d70951e4eca5660c677f9b69d9f4a935064df6d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7429a54820b5a825e324add815f71cf7dad7c2f6053221f7d8551391fdf0ca94";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f34a35994e823a1d4838e5c0cb6e1ca8ac4d2d4bb72dca35841a08ea88139644";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a6de3295c52eb157b4ec6d44fd72455c45aca25f7c6a83119ede2165adac8918";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c30613162f912b1fdf6f10119d806c24c4dbe5ef360e934edbe5c054624abaab";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5abe71c969f37ad49944edba7479720eeb609d955097d20e596ac2f6f1c2c1fc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e4800bac705d57f43512a679a6142a37daf816c6f4e0037a07c320ff15efee0d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9755e30fcc5986f0023bbb872ec8dfbe6968f69ebf7f42be1890d2bec343e54e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8401a2a69f8943f6d04e49dd50243c133d94169772f4f69da9d0f7df1aaf4594";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "45b9f101ebeda7d96f12c176a117fd7eeea3390eb089907314346e89b80ae49e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2c2701500ac809f52a07dc40d1a3a8bde9292b22c63210376bb6d85bef1998f4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9d4a4c64f231d561db6956e18ed5e447563996a8d33a1cb29375a289b7adc23d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.12.0-r1";
+  version = "2.12.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "c4d50c688c4591880b1efaff8f0b7fd1443da778349601eb9ff6758363427903";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.12.0-2.tar.gz";
+    name = "2.12.0-2.tar.gz";
+    sha256 = "dbdd744263557a8b4c1242b0fd755f6b40fa0bedbc87361f4e5c04758e66f561";
   };
 
   buildType = "cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "7dd920c3361f26abb29d4c4ff4f828011c7da45abe63f9383b23082ede278b07";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "8d8b41fb69d21f32bbb904433e2860f11a20c423f5e53cc95d154e5d1b6f1292";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "cbc00646c80ef02c9907405fb7ee6c4bcaa6ed59308c1a09f0be304eeca373ff";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "f33196974bac070337fd36cfb9dae44fda36c2fa71b99d658f69051b338aa5b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "f62e78e5a551e433d6947ce2836563b37bb02988eaf8cdc135cdf23f91dec153";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "2404b01ef33279bbd46b2b7c93eacfbac714684fe774ccacf95ecccedc2c6348";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pluginlib/default.nix
+++ b/distros/rolling/pluginlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, class-loader, rcpputils, rcutils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-pluginlib";
-  version = "5.4.1-r2";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pluginlib-release/archive/release/rolling/pluginlib/5.4.1-2.tar.gz";
-    name = "5.4.1-2.tar.gz";
-    sha256 = "d7f710aefead00602cd4974e086ad4acca6673ec95c6b6c4df07f1c30c8dca78";
+    url = "https://github.com/ros2-gbp/pluginlib-release/archive/release/rolling/pluginlib/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "899c363a011ad122cc81c4df91e30913d7aa7dc8d20d88ea56b4d6954642996f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-cmake-module/default.nix
+++ b/distros/rolling/python-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, python3 }:
 buildRosPackage {
   pname = "ros-rolling-python-cmake-module";
-  version = "0.11.0-r2";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_cmake_module-release/archive/release/rolling/python_cmake_module/0.11.0-2.tar.gz";
-    name = "0.11.0-2.tar.gz";
-    sha256 = "d2f10e96af12d2792a103b560acf6e2c41bb3dfe55d917d340e3ef184d3916fe";
+    url = "https://github.com/ros2-gbp/python_cmake_module-release/archive/release/rolling/python_cmake_module/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "3cdfaaa339d1a39ebb2f0b395924ae7869aec5f6d1a012c33b685f1624023adb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-qt-binding/default.nix
+++ b/distros/rolling/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-rolling-python-qt-binding";
-  version = "2.1.1-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/rolling/python_qt_binding/2.1.1-2.tar.gz";
-    name = "2.1.1-2.tar.gz";
-    sha256 = "5e8367363a3cc1bc4520a5119ff1054199cc1854becfdc08bd3bb9cde27882f3";
+    url = "https://github.com/ros2-gbp/python_qt_binding-release/archive/release/rolling/python_qt_binding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ca9d31dd32ab98e0fc0e2c33b61dec6abe8e454a6b9b126094229167d0ed6878";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-dotgraph/default.nix
+++ b/distros/rolling/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-qt-dotgraph";
-  version = "2.7.2-r2";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/2.7.2-2.tar.gz";
-    name = "2.7.2-2.tar.gz";
-    sha256 = "d543dc8b5adfeb5254f4c186c5e7960c3344ec4396e1e0d1caaffbd20c67de16";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "5438763644890089bd1db01f2842e03ae0b6eab91756914e721fe1c5fc8d65d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-app/default.nix
+++ b/distros/rolling/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-app";
-  version = "2.7.2-r2";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/2.7.2-2.tar.gz";
-    name = "2.7.2-2.tar.gz";
-    sha256 = "7580c09547dec1e043ffb130bb857d55e349e3d90074acd187b5c2ff878c1723";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "8914647f8b6e42dd98978e6b965448da1d8803f402a4f25521059ce447ffc0c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-core/default.nix
+++ b/distros/rolling/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-core";
-  version = "2.7.2-r2";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/2.7.2-2.tar.gz";
-    name = "2.7.2-2.tar.gz";
-    sha256 = "d0614c40f2cb920cb746939ece7a147eb910b4d57b28996c4e0c99a55371559e";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "bef4b8589273d902c6cb1c851fc86f193f6001aa060ea60f6fab2d43514c402d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-cpp/default.nix
+++ b/distros/rolling/qt-gui-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, rcpputils, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-cpp";
-  version = "2.7.2-r2";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/2.7.2-2.tar.gz";
-    name = "2.7.2-2.tar.gz";
-    sha256 = "5b4ab49d5f61477753cfdd333d3e99787e4f3e6ed0dd93b470afd5b81611e935";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "bdc89cea23ad7773f4cf9eeca435f19d38af7d9abb85960c136b371cce7bdb82";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config python-qt-binding qt5.qtbase ];
   checkInputs = [ ament-cmake-pytest ];
-  propagatedBuildInputs = [ pluginlib qt-gui rcpputils tinyxml2-vendor ];
+  propagatedBuildInputs = [ pluginlib qt-gui tinyxml2-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/qt-gui-py-common/default.nix
+++ b/distros/rolling/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-py-common";
-  version = "2.7.2-r2";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/2.7.2-2.tar.gz";
-    name = "2.7.2-2.tar.gz";
-    sha256 = "d484dd90d05e982f86a47ecf3d6e05cd6eb1018105d1be32ecc58b587ba23a35";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "73e6542b8fe50d1a38d560279088f80ed1081f215d6760318ef0af5667b58b82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui/default.nix
+++ b/distros/rolling/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui";
-  version = "2.7.2-r2";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/2.7.2-2.tar.gz";
-    name = "2.7.2-2.tar.gz";
-    sha256 = "cbd7ed957f0aa5ee3bbaab52fb853bea2020052dca24e5fed2cbc45ac3fb686a";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "a6d207257f7eb2ae9bf8af6d9f3d5eedb4e9bd01cb7b33ab04a23ac6c301253d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "ed7269654973e7fe0b3114f76afbb2627c2aa67c09c744fd35809a1147c83241";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "34a2b4f18c94b1ae65ab304fc92acc5a707eae352ee29c8d9b1fa79cfd8b61e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "a02604cd84f3f44d4c5352931da39ee45b41f097890fc4bb4095fad9c163145c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "7454026cc7dc6cc583e27bb21df4cde3d044df06a8ee2f9cf3ec408880cdab49";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "9.1.0-r2";
+  version = "9.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/9.1.0-2.tar.gz";
-    name = "9.1.0-2.tar.gz";
-    sha256 = "8f5922d69cb8c26d2df322ea70fec31834977cbe5efcac9eae33d4b32bc2393d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/9.2.0-1.tar.gz";
+    name = "9.2.0-1.tar.gz";
+    sha256 = "41e388564cd233fd8144a032730dfa17293f20a1b958692737d81bd4d197ef1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "9.1.0-r2";
+  version = "9.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/9.1.0-2.tar.gz";
-    name = "9.1.0-2.tar.gz";
-    sha256 = "eb83d15eb014887ef935fe23d29050f47247caef44a1774b0fa0fc21d22fcc81";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/9.2.0-1.tar.gz";
+    name = "9.2.0-1.tar.gz";
+    sha256 = "12c4d190751dd5203756c296fb6dfa60a3c4785e162e016127b70c37f48489e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-interface/default.nix
+++ b/distros/rolling/rcl-logging-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-interface";
-  version = "3.0.0-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_interface/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "153d1b4eabf6fc1fac9c06500b8ea14600c5fed2db4f8f50848a5351d8248d29";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_interface/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a3cd324bd7b2abbf9944f5e4197ba61683e5c2536df0f39a256de23433ca75cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-noop/default.nix
+++ b/distros/rolling/rcl-logging-noop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, python3Packages, rcl-logging-interface, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-noop";
-  version = "3.0.0-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_noop/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "32239b119daf6e33a068605ae552d0209ee3fa33473a0e35194092e5ae650f35";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_noop/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a382af0fb30d5a7e850e3f034f40826c26e86eb078ecd18b077c95f3317a8903";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-spdlog/default.nix
+++ b/distros/rolling/rcl-logging-spdlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcl-logging-interface, rcpputils, rcutils, spdlog, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-spdlog";
-  version = "3.0.0-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_spdlog/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "105b87c81319ba6c2937d5c3761e923dcb73ee1705e744ff781f61001008450a";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_spdlog/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0b6cf197ac5d515d0081df4c1b8e1eceb1a7ca9a9c8444f03ae8c0e2cd919129";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "9.1.0-r2";
+  version = "9.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/9.1.0-2.tar.gz";
-    name = "9.1.0-2.tar.gz";
-    sha256 = "c49759edf1c2659b977b2c44a11fadbb3c5eb76ac715b8aae426531f2612cd3d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/9.2.0-1.tar.gz";
+    name = "9.2.0-1.tar.gz";
+    sha256 = "0aabb4c5e1c3afc98497a0c40747e61bebeef68d65cb54a0fa4267002933b350";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "9.1.0-r2";
+  version = "9.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/9.1.0-2.tar.gz";
-    name = "9.1.0-2.tar.gz";
-    sha256 = "cde7007b70ca9a637960aff5a0b00abb616ea5ecf5944e0d2c237c5a20523131";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/9.2.0-1.tar.gz";
+    name = "9.2.0-1.tar.gz";
+    sha256 = "de642ce5f508c1eea7784d9becf588d72f8e13a68817a5886f13b62e50eed38c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "27.0.0-r2";
+  version = "28.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/27.0.0-2.tar.gz";
-    name = "27.0.0-2.tar.gz";
-    sha256 = "a9d060d7d6cbc8d037b443eef6eaf875c95cf6ff69eb476a3e2b5ed0aa7a5f96";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/28.0.0-1.tar.gz";
+    name = "28.0.0-1.tar.gz";
+    sha256 = "db1cd7bc47b78a27503724c472c422580897d3dd93b3f1bc2ef21398ec0c5063";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "27.0.0-r2";
+  version = "28.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/27.0.0-2.tar.gz";
-    name = "27.0.0-2.tar.gz";
-    sha256 = "0de14e24fc25f8c575929df3bc33b4b098a3ead01946f37489404776b6284318";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/28.0.0-1.tar.gz";
+    name = "28.0.0-1.tar.gz";
+    sha256 = "6c5ac6b44bd7238dd5e7781949a500ba29aff0f69a387b899e6830847731848c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "27.0.0-r2";
+  version = "28.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/27.0.0-2.tar.gz";
-    name = "27.0.0-2.tar.gz";
-    sha256 = "31d2913d90dac0c8c13b1c6b817f599dbb06d214ab6de9bf78311052cae6169c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/28.0.0-1.tar.gz";
+    name = "28.0.0-1.tar.gz";
+    sha256 = "5e1f3ccd890a35a55f0b1d94e8b2a9a8cfb0de30a4d4488accf7c0ff16d4412b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "27.0.0-r2";
+  version = "28.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/27.0.0-2.tar.gz";
-    name = "27.0.0-2.tar.gz";
-    sha256 = "28fc19d392d17eecda03cf66759567e8898dd923b245ab3f689529745c4a4007";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/28.0.0-1.tar.gz";
+    name = "28.0.0-1.tar.gz";
+    sha256 = "8a670831c0e4f591c29efbb5095afca4493c98b1c397a89115fc8ac81b1e113c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, python3Packages, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "7.0.1-r2";
+  version = "7.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/7.0.1-2.tar.gz";
-    name = "7.0.1-2.tar.gz";
-    sha256 = "e07d3be0a04ccac0c2b1cc9c905eccf1d3ec77686c866776b11a39bc1eb9cc1d";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/7.1.0-1.tar.gz";
+    name = "7.1.0-1.tar.gz";
+    sha256 = "93eee722d5a9637a40e820accb78369de27002c13d5e2cf0bcd7f799b658e8c6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pybind11-vendor python-cmake-module rcpputils rcutils rmw-implementation-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common pythonPackages.pytest rosidl-generator-py test-msgs ];
-  propagatedBuildInputs = [ action-msgs ament-index-python builtin-interfaces lifecycle-msgs rcl rcl-action rcl-interfaces rcl-lifecycle rcl-logging-interface rcl-yaml-param-parser rmw rmw-implementation rosgraph-msgs rosidl-runtime-c rpyutils unique-identifier-msgs ];
+  propagatedBuildInputs = [ action-msgs ament-index-python builtin-interfaces lifecycle-msgs python3Packages.pyyaml rcl rcl-action rcl-interfaces rcl-lifecycle rcl-logging-interface rcl-yaml-param-parser rmw rmw-implementation rosgraph-msgs rosidl-runtime-c rpyutils unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake python-cmake-module ];
 
   meta = {

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.5.2-r2";
+  version = "6.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.5.2-2.tar.gz";
-    name = "6.5.2-2.tar.gz";
-    sha256 = "c2781320f53828a0465dc0c0ccb4deb62a956a443e6bc5559028b7cee5f25bf6";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.6.0-1.tar.gz";
+    name = "6.6.0-1.tar.gz";
+    sha256 = "26947d5532b0478b2440a1e0396b99ce3812e54a44644d004751f1e312751422";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.20.1-r1";
+  version = "0.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "dc61a234fbae21fc6814e5d80b90e7b50a5f9af1758df1748b3e6f58225e43dc";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.21.0-1.tar.gz";
+    name = "0.21.0-1.tar.gz";
+    sha256 = "d90f43081253b38b8a46029070f138e1efe24cefe82109910e10d43c1378706d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.20.1-r1";
+  version = "0.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "2e259b78b3260deb8279c4870790d4cfddeabb9d2d03a31402d901c982935420";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.21.0-1.tar.gz";
+    name = "0.21.0-1.tar.gz";
+    sha256 = "98374ca387a1ff12634ddfe29649ae3e67eb4f8ce40934dc6e38c0ae7c17f39d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "2.1.0-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "4c3022a1720df9f171da691cf2d367329252e7bc3ac603f12c377302808bc636";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e590073b3bc279501adfbd14707ce976cc994436f5896705c84e6635d2fe7896";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "8.2.0-r2";
+  version = "8.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/8.2.0-2.tar.gz";
-    name = "8.2.0-2.tar.gz";
-    sha256 = "2bd6e6165885be6c6dbf4dfe6aae6a634cf790c851a7c6175ee418d5fe08075f";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/8.3.0-1.tar.gz";
+    name = "8.3.0-1.tar.gz";
+    sha256 = "1e5477aebbc6fd8ee9b3b1d8d9887e6885372e18933aa6648400140e6b2a17d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "8.2.0-r2";
+  version = "8.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/8.2.0-2.tar.gz";
-    name = "8.2.0-2.tar.gz";
-    sha256 = "8c0cc0e5a34195f5f8c00805335e251bfd4e15f68a33e6d325f2d9c001aa3949";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/8.3.0-1.tar.gz";
+    name = "8.3.0-1.tar.gz";
+    sha256 = "e76e737f1fec3ae6b27b0a0066092d529d5647f234071c98ac4bd03f921f77a4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
 
   meta = {

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "8.2.0-r2";
+  version = "8.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/8.2.0-2.tar.gz";
-    name = "8.2.0-2.tar.gz";
-    sha256 = "03156b0ad119f5423da18ab8ee1e67f6e98317fc380e8388d56a4239f486615d";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/8.3.0-1.tar.gz";
+    name = "8.3.0-1.tar.gz";
+    sha256 = "23c14ec04877eeba212cdda0709ba42cf148c72786aef3215f6fb707fa56d257";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation/default.nix
+++ b/distros/rolling/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation";
-  version = "2.15.0-r3";
+  version = "2.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/2.15.0-3.tar.gz";
-    name = "2.15.0-3.tar.gz";
-    sha256 = "527a0a7a6cbca95f0a342a0030fc3134081bd9a92d8f01945947fc8484e12329";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/2.15.1-1.tar.gz";
+    name = "2.15.1-1.tar.gz";
+    sha256 = "aea695e0e4265427fb42eee6b1aa6b27c5ada444f2cf5ddcfab8e41271b8c356";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "d252bf42ff4e5d60946b48f579ad6328aa80d9dd3e90cfc089ce9da545e22562";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "5b0e00b3a0dd9b9316fa8cd202d1da50812f716f6626feedbe1c3b00f6118b6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "9a1ba59a6f1aff7e36ece35f03fd7528ba7e410d1c3bc0b8a80becf12ba199af";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "f3eaa8fb4b30e4d113159c4a19d3cb2de6774ba22669721eff5c0b0001e5aed7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "6dc87e5bf2773e14f578cad37f8278c64e80e9377e921c4d7508d5969411816d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "234f9969d8e7133f8c9a78836b3962901825221f9121d48b60a2ffaad50e20c2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "488cd2eb4c106503d2fbe6c8385b4f959f2513f9365bc04488133777a5147f14";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "fd4c57c6657d86da798c4ad29f626f14779b458459d53453671be5cde2663c2f";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-testing launch-testing-ros pythonPackages.pytest rosbag2-storage-default-plugins rosbag2-test-common ];
-  propagatedBuildInputs = [ ament-index-python rclpy ros2cli rosbag2-py ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml rclpy ros2cli rosbag2-py ];
 
   meta = {
     description = "Entry point for rosbag in ROS 2";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "cf93c086b1074eef92380a4c5282995fcf7dad03db2b3e346d6aae04cf581a21";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "dd7e36bdb8d52fd52215305f9b140cec5235274d5fa27c0635e8883a5164aac8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "573963a3d7be0aa9e47f2143f1d99491488558b5e758f42cb826447c950c80e8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "38f8c5a9726615ff8941e0618e321f73e88dbabfb0bb41f81110a0a70451f8d6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "2014d6ee47ff1ec82227ed4ce1c1bc531a299959246992b3fcea6031f8516460";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "583f9795e8d9c5cd92a0f8a4908a35b5ceabdbd6e09c8a9f4b88a4ef5d3d9cbc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "ae95b24599b91eda4d13461290e1c2d523e39bf748e76445f5245d3c2084b3bb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "c32559256a058fd1a13c3b3a1d297a119b84cdd6a9ce1397850246b26bbcb89e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "a095387c0386620a943e5a18c2db08c144c31bb6a3af52236f55ff5bf50835de";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "9bd890e616669aa8af28bf491a8a8793f385aa6b57ff6a597372ddb511a0e9eb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "7048c5a0d43fb471d4a7678ca8a19de4b47fe4095a940e5f10aac4fec99874fd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "2024ec80a6769e59c592b08ad0c83a9107011951b97f3421b86ed8c5f59d5917";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2launch/default.nix
+++ b/distros/rolling/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2launch";
-  version = "0.26.4-r2";
+  version = "0.26.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.26.4-2.tar.gz";
-    name = "0.26.4-2.tar.gz";
-    sha256 = "03b2eec57439200b2d32313d8c33a5bb7eeeec43836db58b83acfd5580d51171";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.26.5-1.tar.gz";
+    name = "0.26.5-1.tar.gz";
+    sha256 = "b6dd8af7009e91a2182cd40d29bc545a880aebacfc690ed35c223d3493e89aaf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "1ddf9e91accf498f35050c21d7fb084773ca582823e699cd931df8d5acfa6d11";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "b99aa24873c026fb315bb149b964769c5426a41ab91a13c96d87a27b5348e319";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "a43c86345fa01bb8a3a189f38d4a82df5535b58ea5550b28fd8c0697fb986254";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "41d1e84e0d0e279b4a903a77e343664795725ac1dd6009216a864b38f1b4a7a1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "f9ace3cb06776abdee49afa91955e282fe27a80e49ddd45d89d8ee248e855fe6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "def5cf5d0cae577f8a44d00d8dbc93b6eef692e14ec5c5b824798adc83015a1e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "376e192a96f8639827310e100ef177e0d7c2fd299f7f5844d14773165b02a641";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "e20d1565c2485f4519695a34891fa592ddd8f4dd7854ed4a9ea1789235c1de21";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "ce56d84eb631692417bbd25c02170b8db0400a1e89144b88d244a8273ddac304";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "c5ca86735c01c8e0ceb9aa38a44664b37381741a495a5650b89dee8fe77d00e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "b11a457660591d90cb1c8f150650711f1b602fb62c412b524e7b56d85ad7cf3e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "584ab48f0da281dd2e559bf90628f716e04ae7891fdf7db2d4cb0a7306f0b0d7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "ae4471aa288cad6fc4e61762377128bd857591d1ab6fc41cffbe74ce614ab7e3";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "579a296f3e54c6034bec86e56262ab4e9b88ebf4ca85a8432f6aadd775aa2e67";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "16f7637ee840ca83be7c21af59966e314d658ecfe17ebd783bb22b2132197c6e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "e681bf37a60da3e7d05daedd071e4d4b10946efa5755c0066dcc0273a2c215fe";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.31.1-r2";
+  version = "0.31.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.31.1-2.tar.gz";
-    name = "0.31.1-2.tar.gz";
-    sha256 = "daeafcd3a6b2de3122f9fd1c1d875628b7cc715453a5f6f154036cc2d1bda3bd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.31.2-1.tar.gz";
+    name = "0.31.2-1.tar.gz";
+    sha256 = "fab6ab2ddc9f65684e247f31af63cac4c22f4b5d652cc1c2a46169468ac78166";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2trace/default.nix
+++ b/distros/rolling/ros2trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages, ros2cli, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-ros2trace";
-  version = "8.0.0-r2";
+  version = "8.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/ros2trace/8.0.0-2.tar.gz";
-    name = "8.0.0-2.tar.gz";
-    sha256 = "07ede99d592a0f34b46e4d3e831f679d719e157062f320588f778dd69b5a246a";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/ros2trace/8.1.0-1.tar.gz";
+    name = "8.1.0-1.tar.gz";
+    sha256 = "83f45419ca422767b78509d86e699667721bc272d295a7a246943b6a3a149e59";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "7219700f24b3120eb721d96f093339e635d56424c2ecd4aa0de06d624beae0f1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "e48a83ca88144d1d70746271968fdd6ea77e9c05092e3716e774b8f3a9681616";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp rosbag2-test-common ];
-  propagatedBuildInputs = [ pluginlib rcpputils rcutils rosbag2-compression zstd-vendor ];
+  propagatedBuildInputs = [ pluginlib rcutils rosbag2-compression zstd-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "c162b8251b80a4ea63ac84af6c09e0f000dfbe8e137fa9cd6850c849b2973507";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "0222c1ee7d62ce0a2e4cb8912639a8f0c1680de1f2e54f856875d259f9df2712";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "3ad81229fbd930e16226c3d1ee497e02c888c51b848146a00d4c2fbe882646ec";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "f4361d935d1afe748045bff6949c1e4e2682b678add98923a3fd955bf23180aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "ceb9462ffccfd0ebe7839496c6ff765d869511c6715fdf27f9da9da71e848a1c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "44b589899ef983cbf3daa19e97b42ec65ec6286da7f64091359ad3f6a589ee33";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "485ff76dfd4b2696eb62c1cb89191e980c981002d69ee8d12c1c9de482cf12e5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "4c8f6a4f604ce6150efcb4fbe26d9e5eeb2eed4b6c9a0c94af76cfd586c776cc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "b3fc5564853f3798965361d7a7c22557e87d04faa05de78138ab7150b3656340";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "2178704ca466b3f79e61c1b1960d491945310e005d5e961501a3596b338b8d29";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "682aa6fc9b5e709d19b45e7a5943c4573851fd9050db612fbc22d9137aab94d6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "a4e1cfb33c00cde1197048b35fb3002621d6564a76d288471d2dd5a2b6ce9332";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "120fcd88d4e8d80b5ca1703ad6de64c39ac4c7e7e17621c5b928ff03ae120941";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "0456b01be16059369b1dbe026a489b706ff37e3d58a5d217b0a3f4f3dd85897d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "0f73c29758843795d0fe97defed33c8781091e833e4d004544714f7a812006ca";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "8fc362703dac25f0fb68a5fd82112bbcc42836e8c984467d4cac38e78ff06edc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
-  checkInputs = [ ament-lint-auto ament-lint-common pythonPackages.pytest rcl-interfaces rclpy rosbag2-storage-default-plugins rosbag2-test-common rosidl-runtime-py std-msgs ];
+  checkInputs = [ ament-lint-auto ament-lint-common pythonPackages.pytest rcl-interfaces rclpy rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ pybind11-vendor rosbag2-compression rosbag2-cpp rosbag2-storage rosbag2-transport rpyutils ];
   nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
 

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "1b9af46452155e33b111fbec745401c81e4ee7dbc35c995f6293e1a59f85d87e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "9072ed9f49709b8e2dfecbe8152d9fa63a52523036ac5d1344c65d678fce5b7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "193ae009ac8fb23120d34b11624da7cd05241f2bc27664022af8093e6b040fc8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "ec52bfb3dceaac5fdf3752b9cabfd59aa2f891f7b31376d6497cc9fdc783e21f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rcpputils rosbag2-test-common std-msgs ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-test-common std-msgs ];
   propagatedBuildInputs = [ ament-index-cpp mcap-vendor pluginlib rcutils rosbag2-storage ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "3cbff9b3eaeee4840d48bc59fc04196d142a866614551cc7da28877660379ad9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "8622be2fb96bbc38c4e1f5f63ce2d18e656b9501739efdc8bf6197864727265a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rmw, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "0b49339957e1526755106bb79a2a74616c52d5cceb80f237e6546c3f7b1d56b6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "cf09abd0927d679cc1f8c85b0d020bf6904f4ac15fe2039a6434c3e799167e10";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common rosbag2-test-common ];
-  propagatedBuildInputs = [ pluginlib rcpputils rcutils yaml-cpp-vendor ];
+  propagatedBuildInputs = [ pluginlib rclcpp rcutils rmw yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "381c2345d5d95b8c17c568805dce363998682c9c950ead9b5f2c2dff853d7285";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "b63dfc38f6e54f1c72d8efa78cf97f5aa7813a353e4e1e78ca40fd1d0a4e3126";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "6fdb6c74f3f87c1176c3529028de1117a6de8fff9d89e492f6a57248f413e4e3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "12c86590a270b2fbaad801e051c78424dff5bda35f10260454a3690bb8d8693c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "0eaabcd341f10c86c3aa213faa02f4507f5a4cc93e971c4468aa8644817a8781";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "cded224909de53b3c0b29410062b74398b5d0ddf324402d427faf2c9f4088a7f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp rcpputils ros2bag rosbag2-compression rosbag2-compression-zstd rosbag2-cpp rosbag2-interfaces rosbag2-storage rosbag2-storage-default-plugins rosbag2-test-common std-msgs test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp rcpputils ros2bag rosbag2-compression rosbag2-compression-zstd rosbag2-cpp rosbag2-interfaces rosbag2-storage rosbag2-storage-default-plugins rosbag2-test-common rosbag2-transport std-msgs test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-components, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "1532bcbefa8a5f3c6bbb69291442938ce31e39e0a80b95477211b8d6b74f6fa1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "472ef9236e4c0c814f7d19e76c9f586220392525129ac4b0bf55bcb45380907b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gmock ament-index-cpp ament-lint-auto ament-lint-common rmw-implementation-cmake rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common test-msgs ];
-  propagatedBuildInputs = [ keyboard-handler rclcpp rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage shared-queues-vendor yaml-cpp-vendor ];
+  checkInputs = [ ament-cmake-gmock ament-index-cpp ament-lint-auto ament-lint-common composition-interfaces rmw-implementation-cmake rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common test-msgs ];
+  propagatedBuildInputs = [ keyboard-handler rclcpp rclcpp-components rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage shared-queues-vendor yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "66e5636eb14e89a6617609f228fc98616256eca38eb52e01b9b749ae51071987";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "5bfb92176027cbb51c41562684ca62bf7834d0fe373dd2833bfd350a9a38179c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "feb9bd0d9a408472d42d50a1f792d791dc009370cb2b3682f7985c8f6456ac1f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "1be5a90d7e3f92630b9f5311e44c03fb39c65081a9fc1b242a22861a6b531de0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "9ab0f190b78f5e232ef4a946e9a739ce5441d37c52eb71aa58baf34b80b42bf6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "4e52320b0c080a76d80b323caaf2ffe579c3b8559955f0cfebd52cdd379630e9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "343d8106200323e960c42c0db6af3375a543622a401c8d8e4003107bf2df9267";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "73f8fdbee80aa9fcf4315d334411bedfa91248c682a37dbf3e1d2626213cd692";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "a8ca4dab422f1e6902de787ed73fd67d5fb116de8d5553306ef337924abb2591";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "304a488e6f7f56d83689fe95f3e5809b108015b6bc08235a15390b5edeb41e47";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "b4463c1457ab7e3c44dc167234265176d2470258ac004345067b00b90565e710";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "d9802984481156628a4e38a048f0ded9cbd8c2e28ceb98830db0d86420931936";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-py/default.nix
+++ b/distros/rolling/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-pytest, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-py";
-  version = "0.21.1-r2";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.21.1-2.tar.gz";
-    name = "0.21.1-2.tar.gz";
-    sha256 = "cf4f1a6ff882a8277c22f801681957512b02e815a672478eeac5e1862125589d";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "d9508933c3eea7717befff82d40cb09441562e156d87a1b9ae1965501c0451b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "690fc1fbbf1e8246648e3aed0f89862344157f0c5e10cbe2767891511eb869a3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "c0c0588c314385182216c8b1aa5ea759de9f015b6272acdc5c073ef1c3343671";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "b847a7191070121d3bf73f70c0abcbac17b408f64749f15e48d7816bfd02169b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "e2c807c478f7e4ec3d49c4e06e96fb66689b89d30442a67ecbce6a6dd1b66609";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "211b06cf274b4a882ad7bc29d213409356af1f22f47f4057527b75eec06aaa01";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "a4129df0234659f97b2c75f8624e952be5570179b44bf679a90233658dbb8c30";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "9426d77ccf533abbfdd44329164fbdbb13ca8377b87f4d3715657cecafc21b20";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "a51658e3b92a46b8a12359bfade43565db5fafff0451a690dba1b4dd9c5501c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "d9b39b445d304e4bbb72f1e43e38c99ee9b7b40d40d155ed88d5738ab9c56c10";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "c42052d6ffbc98c192c00bdf43092ad14c4e7804e0c64a2745591227a862a453";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-py/default.nix
+++ b/distros/rolling/rosidl-runtime-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rosidl-parser, std-msgs, std-srvs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-py";
-  version = "0.13.0-r2";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_runtime_py-release/archive/release/rolling/rosidl_runtime_py/0.13.0-2.tar.gz";
-    name = "0.13.0-2.tar.gz";
-    sha256 = "f91f210dda3944a5777fd71bb2e66617207e4b17a69ad0bfddc66697049c2d65";
+    url = "https://github.com/ros2-gbp/rosidl_runtime_py-release/archive/release/rolling/rosidl_runtime_py/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "30df0ddfb7090f66ad9b6d1a78e2df2b72f563b2c3ed37df1d5bdb8ef38bc554";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-typesupport-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-c";
-  version = "3.2.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_c/3.2.0-2.tar.gz";
-    name = "3.2.0-2.tar.gz";
-    sha256 = "b7ada9f8619c7fb4a25b3123709c7e9ab2de2d027e92981fd02d0fca378514fc";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_c/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "94ec4223abaa35783a0f4f12ff923d7b6c5d9c73503e2243ed191e82ae102c31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-cpp";
-  version = "3.2.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_cpp/3.2.0-2.tar.gz";
-    name = "3.2.0-2.tar.gz";
-    sha256 = "7edadcb96bea3552aef3cbca6e0aa89f49ce5f71d4de530b3a06d1e245008772";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_cpp/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "7a9a359f266946886d6299366a00f24590cce2acdd4e0412486681990d389e09";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-c";
-  version = "3.4.0-r2";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "e636ab0ac0ef869c81417d022af76465f7b5454564a3a6fdb3592df7616e19ae";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "51635c963c25a80c600df3ae65c51da166ac47adbcdbb4cb9f7e44c277a62c4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-cpp";
-  version = "3.4.0-r2";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "7bccab572deaf50bfbe30c069930ffd25db47d6b85654e62b9e6669694496053";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "ecda03fd59c8a750b6febf39008d3d0ecd4c02350e4c110c86d96920e65c65a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "765d5a05de3e8d01a76091817d891855874b99929a383081439eeecbc36bedb1";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "0dec5e902e46eeb61316c15d86ff2daae31bc7f3823e3c3e8c8a24436a03f99a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "c2428d7a7f77b1017c9c06793f761f7991098bd82fb65994b82f844ebeda259f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "9968999235c9150f613957ffb6bf52da50dc3ae7a59e50c08aa42e1aad7f84fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.5.1-r2";
+  version = "4.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.5.1-2.tar.gz";
-    name = "4.5.1-2.tar.gz";
-    sha256 = "54508e0fad656f58f59323fa91494b4c5834a88392459fb3664ca6b775276a02";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.5.2-1.tar.gz";
+    name = "4.5.2-1.tar.gz";
+    sha256 = "765ce531be81f1fe2926aac4d20de7408ec18b8fdf6f1fc82797a8b585321170";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-bag-plugins/default.nix
+++ b/distros/rolling/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, pythonPackages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag-plugins";
-  version = "1.5.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/1.5.1-2.tar.gz";
-    name = "1.5.1-2.tar.gz";
-    sha256 = "53d636051fafe5f00f77b6aff804e41f916d0ff44a549992f2148916d5c19d39";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "e53810b9590d64f571d7694619f804342a38deddc8f1bb4a7715ad10e4405c89";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-bag/default.nix
+++ b/distros/rolling/rqt-bag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, pythonPackages, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, python-qt-binding, pythonPackages, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag";
-  version = "1.5.1-r2";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/1.5.1-2.tar.gz";
-    name = "1.5.1-2.tar.gz";
-    sha256 = "94c94aef392b3d428386b096272d532a73d866730d3911b6c32b9f1cb9c49777";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "ea58b11ea39438b92d7697cfadd5e82c50907e8a3895fd54f7b2cdf6bc01d72e";
   };
 
   buildType = "ament_python";
-  checkInputs = [ pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ python-qt-binding rclpy rosbag2-py rqt-gui rqt-gui-py ];
 
   meta = {

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "ddd4da82dfd93dc128cdec3cb6526d6e1d6987a92ef12626856d236824fcbad6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "40ce66292127247efa0ae702d8ea9a9e05568ca961a968f31ea1108ce807f246";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ controller-manager-msgs rclpy rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs rclpy rqt-gui rqt-gui-py ];
 
   meta = {
     description = "Graphical frontend for interacting with the controller manager.";

--- a/distros/rolling/rqt-gui-cpp/default.nix
+++ b/distros/rolling/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pluginlib, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-cpp";
-  version = "1.5.0-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "e2d73eda84cf8f3b7356754539e30e35f810eb4a03f27170a64ad0edcc516a1b";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "17419302ca12b909d8b0639d8a480fd68d4b571c03bb78590efe68086243efc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gui-py/default.nix
+++ b/distros/rolling/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-py";
-  version = "1.5.0-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "8f4a77909e1a50660255d1262cd50f991126bfd30e218d70cbd7d532f0b243b5";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "3966fce220c6342f02233d51341bd1e59e9376403ba045b5ee1e050c4cbb268d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gui/default.nix
+++ b/distros/rolling/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui";
-  version = "1.5.0-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "d2a1a2262a2a3486578015591aaf2920a5019d2c4519d55bbbc98357477c1a7f";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "566afbcb969f102bed0dd4b4d653806ce7657b7c53cdad7684dfec425b44a66d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-plot/default.nix
+++ b/distros/rolling/rqt-plot/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, pythonPackages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, python-qt-binding, python3Packages, pythonPackages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-plot";
-  version = "1.3.2-r2";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/rolling/rqt_plot/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "0516310dc7ca345d6211caa6e706475cb330b31d0bbc1e853598d0bb021d62e9";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/rolling/rqt_plot/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "99ec63fa2e0ce643940f2129eb30ce62f11b2fe1e280f7ef28d6d81e3b7ac795";
   };
 
   buildType = "ament_python";
-  checkInputs = [ pythonPackages.pytest ];
+  checkInputs = [ ament-copyright pythonPackages.pytest ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg python3Packages.matplotlib python3Packages.numpy qt-gui-py-common rclpy rqt-gui rqt-gui-py rqt-py-common std-msgs ];
 
   meta = {

--- a/distros/rolling/rqt-publisher/default.nix
+++ b/distros/rolling/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, python3Packages, pythonPackages, qt-gui-py-common, rclpy, rosidl-runtime-py, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-publisher";
-  version = "1.7.1-r2";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/rolling/rqt_publisher/1.7.1-2.tar.gz";
-    name = "1.7.1-2.tar.gz";
-    sha256 = "414bec61911c41978687996081e6738772eaabce13686d8b252c622fc5bb8524";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/rolling/rqt_publisher/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "1592d6c2346c985a84cec4bb7bd77e0ad0617d5fab5c85d59fe46e001303cb80";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-py-common/default.nix
+++ b/distros/rolling/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-common";
-  version = "1.5.0-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "dc69c6649389a6343b5b3d079ea84d1b950abb6a1bb0363d0614650f22e76b80";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "91e3ec67dbd42ba59f7ddad0b495abf227e34f5c588900e193eb2154a282cef4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-topic/default.nix
+++ b/distros/rolling/rqt-topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python-qt-binding, pythonPackages, rclpy, ros2topic, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-topic";
-  version = "1.7.1-r2";
+  version = "1.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/rolling/rqt_topic/1.7.1-2.tar.gz";
-    name = "1.7.1-2.tar.gz";
-    sha256 = "700ef8d314e0c580ca61e2fe9a3ef62fe73569bf2f379c46f4276371d4d0dfce";
+    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/rolling/rqt_topic/1.7.2-1.tar.gz";
+    name = "1.7.2-1.tar.gz";
+    sha256 = "c330982cfc2014aa2ccd663a9f932c0f73efea41a4859adcc524b58a82257738";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt/default.nix
+++ b/distros/rolling/rqt/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, pythonPackages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt";
-  version = "1.5.0-r2";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "c64160ff1c4c54c36cab8d6e06a3ff7b2b397c4d9bc672eb56e68bb9e266bdcf";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "cf767418ee62faf72356f3b501b6e44f360d4c3a02127223d4fd544b9df6d4a1";
   };
 
   buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
   propagatedBuildInputs = [ rqt-gui rqt-gui-cpp rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.20.1-r1";
+  version = "0.21.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "5b3b9a88e1a1ea439e88e4feeb161a18a838f84a8beb00d5dbe09ef16951f0f2";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.21.0-1.tar.gz";
+    name = "0.21.0-1.tar.gz";
+    sha256 = "f1cda55e091a991bc4868106176bcc786cf52f2eacd5031f1849b75f9b24b231";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "1e0b81888cd9dd591bc651963d84315f275b7ef7eeb74df5c287ae7e5091680c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "fc8d6995d55cc9a1d48d3bf97aa026f2da39227ad40fcba3dfb23f4e350337db";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "5ff7a521bbaf2a3a7551cd36accb589dbdd851b46ba19269085d42804f9f8d71";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "5c3a534062e7e1b838765edf8bc35c07c05085906624c14618f179cef340e570";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "46a4d39dff9f04b026599007c2ef75d33521673a8da81ef280df909ba066d044";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "a7c7a23415ff2d43e20d4dcfcbbf6d171476932e6d325e2cf8b307fab9af8610";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-index-cpp ament-lint-auto rviz-rendering-tests rviz-visual-testing-framework ];
-  propagatedBuildInputs = [ geometry-msgs ignition-math6-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib qt5.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs ignition-math6-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt5.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "ce583f5c2deac7af762f46c57a199fe9f901c68a22223f7b49ac500ad3dce762";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "e37011167f4eae6bb22a21d1892cb2d290d454d6122d233a27bbaf39b0934a00";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "d71dd1de63b136767fa800a59c6ea268fc3e3e81ee161b2ac19e616602df9a31";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "34a8ab26df07ac7323ad88efe70bd67909cccd919f25cded9e10009b51e4347a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "0e45b3355b4319cf3e7199d2a7e42668609bbe75e0f02735a71567c37d6346e5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "105b7bdcb65c60292861f4a724bc3382c767da46886d1098e54bfc285326f010";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "d0f312f6ef6b97ef0a45dccaf55af12e7fa688849f7be22aee3232bf8754b873";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "1dfe11024fcbed5bb9328d39e76cc1c6dfbbdeecf6f79626dddda65e3a6cb329";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.4.0-r2";
+  version = "13.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.4.0-2.tar.gz";
-    name = "13.4.0-2.tar.gz";
-    sha256 = "afcef75ede14ae865cb818f33fd8d7023d21ba49302293d4353cc24c1f43da14";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.4.2-1.tar.gz";
+    name = "13.4.2-1.tar.gz";
+    sha256 = "ba261f3b89ba86f842484634e5f27e347b514b779855c41a08c95bee1c08b4a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "ee6797acf3b0d5b9c1116aaf5ee5d314bf925641f4d69b00d5133f1503630409";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "cb2bed1c94ca40fb2bf2350eefa702219b11e500eab86d8b82ad2f22cb0d97ad";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "de80c41187e666d42a8d95333697c5f0a177c6f10b23663ccc7499ebb6482899";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "7c324dc755968d005817e4f9884407d04d094fd67177a4bbc21b61a3c3b9cf38";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "57908b2870dc359dff3e91ef5921148fb3bb0d85c0b42a400731339fe5f72098";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "95c29d68c8f655d94b3fabad14be1a254c60e76960574e81d5924749657c4789";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shared-queues-vendor/default.nix
+++ b/distros/rolling/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-shared-queues-vendor";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "1b4c422f4f70af93cb56355cc9bdead94ae61abccf08b4c6d2ba5054871772c3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "5debd1f194e6a08e2de37f2359235254b05837835743c2efebd14257d499eba1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/spinnaker-camera-driver/default.nix
+++ b/distros/rolling/spinnaker-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-rolling-spinnaker-camera-driver";
+  version = "2.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/rolling/spinnaker_camera_driver/2.0.15-1.tar.gz";
+    name = "2.0.15-1.tar.gz";
+    sha256 = "6eeb8f5f862362acf6ed92bd7ad1a7a1d1bfeecfdd034240e3ac880202855552";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+
+  meta = {
+    description = "ROS2 driver for flir spinnaker sdk";
+    license = with lib.licenses; [ "Apache-2" bsdOriginal ];
+  };
+}

--- a/distros/rolling/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/rolling/spinnaker-synchronized-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
+buildRosPackage {
+  pname = "ros-rolling-spinnaker-synchronized-camera-driver";
+  version = "2.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/rolling/spinnaker_synchronized_camera_driver/2.0.15-1.tar.gz";
+    name = "2.0.15-1.tar.gz";
+    sha256 = "72cd9345638df395d4b5ddf34f936d673965f42791844be84c76b1bfc4b7dd0c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-black ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components spinnaker-camera-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS2 driver for synchronized flir cameras using the Spinnaker SDK";
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/rolling/sqlite3-vendor/default.nix
+++ b/distros/rolling/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-sqlite3-vendor";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "0adef19b281d113f7f61c00d1d2d3bbbee1f7c317cb4747bd72ea86eb8a2d99f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "44c8ae1a96a10f3fb0e60fc973c76be54b30f54ff649532fc6a70e58ac17453e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "be21f83b0f0a39139e9cc61d3323e2d7395ddb91e29061087ce5c9123e86fe33";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "8691f3f3d6de82fa44c5fd4915b65d531c9b29a699e011ca9327d2cf2346cf20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "f99de8e376b0bf5f0f3ab1886164ef3e44a394b1e3ceb603fc8c146c96d04bcd";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "97c0ca907d9f38343d87cfecc8f751f62a7f5a0c1d97bb9b7d004ebc2f505a4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-image-proc/default.nix
+++ b/distros/rolling/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-image-proc";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "b64428f60fc9282abf9a0fe23db7c5c01b5af0ad04c3328cd0342c68b597e73d";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "0f77a222d655538746a921cd98e9111da6baf8779c2094706cce19dd80df7940";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "035bfc3f2b26c198ab8f6702302cbf4b3d22730b0f2a68f44ef952630a2524ee";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "aae8acd381fd6a914f80e0cdc99292025db71760d15982bf78daf86e94a6a81c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "d4751ccbc1c448cb2599971a30dbc8fd98da8bedef916f8c88a619e817c2d312";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "c33a0801e3ab10dbf09597b1be6fb55e9388e13661306351d76b26db5e3753f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "0785366db2811e01b646a4d7f959205ff2bc9cb9f6662c78e5ade007ade9f17e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "44934c6d2487c53d0a9a9b391c01d9590ed722416b0eff92dfe5ba01a2d77069";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "42d159474a60cbc2ec5c438990a715da8801f16c8addec5d104e4655187739e0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "8d60668961f9cc91470057bddc577fda0e8d6c654905df049aad9ac30b896508";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "c59e1b8cc22753c415b5a88e3e6c2d6f1cfa1b54daabfa79bb18a78c2a406373";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "76c465029e7505abb96aa3da2f3c4edaebef77f642e4909472a29734c4f5b33a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "ddfb95a3856503355f6143417b6735cbb9e49745f190d78ac5bc41720d2ef03a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "dbc68ef9e055cf0f6a4d4caf9d94dd435762bcef687d23ebedc6f08857aa461e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "037d1a14c9d68f71703d3ff8f3e51e8ff0a3f1e8eeb80255f5766d84dffde1ae";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "59d6a0a73681d1bb4fb146e2cb084fcc1bfb16eb41dd9b3a025cb0616fe78ee3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "4b06be02368eefd025790b45456f94268425bca1273176e5934783497179856d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "efee756a54ffa561d1ae5e9ae854c8ed5d063a113a7e59a00cd432600f476d91";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "94415671df00cba6b87c763f81a0acb44410b6ceb0c49687389e91029d5c10d4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "c3f84e4644b17ebb637ab8a1b1a0bebe6c33755e8ed07478be12b7fa1394a890";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "196bd9a89db6e621726a36fb470c3a0612f66d04b2e9a149225568480fe4e379";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "07646ab602f1f170c80949fb973becced84059f517e8d25f01fc080026d91060";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "44278ede241d0cf051e37615ee28ef23baaa2d894bfb8e95d1639ddbcd1f7ce5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "eec61f1d16f95e687c0ba845abe4fb870ae41fd3cb1d3e4021b1ad3cf75f8946";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "2dc7af6467d9681f9d428b077e97cdf73605f365faaab38d4a5a2a9ccd6af199";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "093bb99c049115c8206734ce0a14cd17766f37b4023623b980b00dbecaf2f686";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.36.0-r2";
+  version = "0.36.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.36.0-2.tar.gz";
-    name = "0.36.0-2.tar.gz";
-    sha256 = "6993fbfbe2d63088d2e6b611765a6d31cbbdc009848c99524ee6eda25e52cd4b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.36.1-1.tar.gz";
+    name = "0.36.1-1.tar.gz";
+    sha256 = "04ac38052de1adadfa1585788164c5a954501f78c6356bcedf77ffaf9116e943";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
   checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ];
-  propagatedBuildInputs = [ builtin-interfaces console-bridge console-bridge-vendor geometry-msgs rcutils rosidl-runtime-cpp ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rcutils rosidl-runtime-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "4b622162c7c30126b38c4e0d0aa31f555366ae55b18ad823e6e80ec2483e782a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "b5e3ba5a4a1c4c8f04230029eeccb07a15b339d8c49b7779d431d081227dcd76";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.33.1-r2";
+  version = "0.33.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.33.1-2.tar.gz";
-    name = "0.33.1-2.tar.gz";
-    sha256 = "c92228611606e760d90cfe63ce57356c5d3804bbd1725b52a93dff185252881b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.33.2-1.tar.gz";
+    name = "0.33.2-1.tar.gz";
+    sha256 = "bc18524a35af1530d6833776c064fa82cb1f3d2d61c99757bf84af7f40c7abae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-image-pipeline/default.nix
+++ b/distros/rolling/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-image-pipeline";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "df73a3ac5fb583bb06d558db26c82d9d129ae7608ab8335c536d2565d96328d5";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "3ab76d19cc3f91eb9ce2195f2499f9d39cf3e1191b651e6acf18cedb715ef9f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-launch/default.nix
+++ b/distros/rolling/tracetools-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-launch";
-  version = "8.0.0-r2";
+  version = "8.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_launch/8.0.0-2.tar.gz";
-    name = "8.0.0-2.tar.gz";
-    sha256 = "f50264d8e72a32ea304890caf6eaac127ca3529821a155b78d3dd9c17bb928ad";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_launch/8.1.0-1.tar.gz";
+    name = "8.1.0-1.tar.gz";
+    sha256 = "a6363e1fb33b9e6dcfd49da446327394797e982f5791300832d5da731225b75b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools-test/default.nix
+++ b/distros/rolling/tracetools-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-launch, tracetools-read, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-test";
-  version = "8.0.0-r2";
+  version = "8.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_test/8.0.0-2.tar.gz";
-    name = "8.0.0-2.tar.gz";
-    sha256 = "a8d1ca19961cbd5b759e4c1ff64da8b72698a11a2ee0528e5b23aeb76a98a179";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_test/8.1.0-1.tar.gz";
+    name = "8.1.0-1.tar.gz";
+    sha256 = "c273ce4064bb6ec1b0ea12cbea76948dc3163d240df458458af316641f023927";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools-trace/default.nix
+++ b/distros/rolling/tracetools-trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, lttngpy, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-trace";
-  version = "8.0.0-r2";
+  version = "8.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_trace/8.0.0-2.tar.gz";
-    name = "8.0.0-2.tar.gz";
-    sha256 = "26d2563c722ec900ef8cf5d59f186f56370f6d560a5fb49d075524a815ddebf1";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_trace/8.1.0-1.tar.gz";
+    name = "8.1.0-1.tar.gz";
+    sha256 = "c62eda9189aaa88841788f22d64b3f06fdf64d05e5f471ebaa48c7402e325761";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools/default.nix
+++ b/distros/rolling/tracetools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lttng-tools, lttng-ust, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-tracetools";
-  version = "8.0.0-r2";
+  version = "8.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools/8.0.0-2.tar.gz";
-    name = "8.0.0-2.tar.gz";
-    sha256 = "5cfd2ea120c43c61d5d61836b2622b3673afd90630c4b32637f41749124b7e56";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools/8.1.0-1.tar.gz";
+    name = "8.1.0-1.tar.gz";
+    sha256 = "dd3f76fbe8aef0bc2ed24fba3cb09d1d59d79b128ad691c8fcd8ae018189807c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "a672d567db256cf08c20884a72eba7424d21317ef11e7f55ec9c609437e9a9fb";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "513fe0c274c15d5a8b60d20e4ecda6c86e78f690af7bda1480f8b268abe3205d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "55c880ffe4fdfba37e8a9195fcc1ef351d66e492af98ab8d30c40a3c46db5330";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "1e9679287044a5a5a8544b135e411d7f3dcc570f1ffd85335372cf265feaedcc";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ hardware-interface pluginlib ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
     description = "transmission_interface contains data structures for representing mechanical transmissions, methods for propagating values between actuator and joint spaces and tooling to support this.";

--- a/distros/rolling/turtlesim/default.nix
+++ b/distros/rolling/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rcl-interfaces, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-turtlesim";
-  version = "1.8.1-r2";
+  version = "1.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.8.1-2.tar.gz";
-    name = "1.8.1-2.tar.gz";
-    sha256 = "ce3762d588b077906ce39b14e9cff515372645e3954bd0fac71261c791d4a140";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/rolling/turtlesim/1.8.2-1.tar.gz";
+    name = "1.8.2-1.tar.gz";
+    sha256 = "7182e6027257beabb07884127e024a55b2a5fa8453da6052c6cc58d61ec114f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.3.0-r2";
+  version = "5.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.3.0-2.tar.gz";
-    name = "5.3.0-2.tar.gz";
-    sha256 = "ca2e58e10c0d4e8f7ae70abaf786f64004072bb27ee0044e6cc9c96013858468";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.3.1-1.tar.gz";
+    name = "5.3.1-1.tar.gz";
+    sha256 = "22d1a13b3d6109849fe806a4b0b5d6d05d8918b2a61d23ccc6008691f7c2d0c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/yaml-cpp-vendor/default.nix
+++ b/distros/rolling/yaml-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-yaml-cpp-vendor";
-  version = "8.3.1-r2";
+  version = "8.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yaml_cpp_vendor-release/archive/release/rolling/yaml_cpp_vendor/8.3.1-2.tar.gz";
-    name = "8.3.1-2.tar.gz";
-    sha256 = "8cf0d1c01d63e8f9673b27c8cb3f096827f47015fb6af2933fb226ffc865adda";
+    url = "https://github.com/ros2-gbp/yaml_cpp_vendor-release/archive/release/rolling/yaml_cpp_vendor/8.3.2-1.tar.gz";
+    name = "8.3.2-1.tar.gz";
+    sha256 = "d44531ec33e038f0a54f43033353adab7c623e3104b8e070182f2064a6a94e76";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-vendor/default.nix
+++ b/distros/rolling/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-vendor";
-  version = "0.24.0-r3";
+  version = "0.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.24.0-3.tar.gz";
-    name = "0.24.0-3.tar.gz";
-    sha256 = "e2a9b32171b7d0d3ae316b426e3810f8dcb7d7055534b245b4b59e9ade3d163a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.25.0-1.tar.gz";
+    name = "0.25.0-1.tar.gz";
+    sha256 = "fa95479cf1dc1968db44b0506b3a846e2db4b05123ecabd4d1ddb6404d18258e";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit 1b9585ae8f529b2b392203f2dda6fb96311621a9.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aerostack2 1.0.8-r1 --> 1.0.9-r1*
* *as2-alphanumeric-viewer 1.0.8-r1 --> 1.0.9-r1*
* *as2-behavior 1.0.8-r1 --> 1.0.9-r1*
* *as2-behavior-tree 1.0.8-r1 --> 1.0.9-r1*
* *as2-behaviors-motion 1.0.8-r1 --> 1.0.9-r1*
* *as2-behaviors-perception 1.0.8-r1 --> 1.0.9-r1*
* *as2-behaviors-platform 1.0.8-r1 --> 1.0.9-r1*
* *as2-behaviors-trajectory-generation 1.0.8-r1 --> 1.0.9-r1*
* *as2-cli 1.0.8-r1 --> 1.0.9-r1*
* *as2-core 1.0.8-r1 --> 1.0.9-r1*
* *as2-gazebo-classic-assets 1.0.8-r1 --> 1.0.9-r1*
* *as2-keyboard-teleoperation 1.0.8-r1 --> 1.0.9-r1*
* *as2-motion-controller 1.0.8-r1 --> 1.0.9-r1*
* *as2-motion-reference-handlers 1.0.8-r1 --> 1.0.9-r1*
* *as2-msgs 1.0.8-r1 --> 1.0.9-r1*
* *as2-platform-crazyflie 1.0.8-r1 --> 1.0.9-r1*
* *as2-platform-dji-osdk 1.0.8-r1 --> 1.0.9-r1*
* *as2-platform-gazebo 1.0.8-r1 --> 1.0.9-r1*
* *as2-platform-tello 1.0.8-r1 --> 1.0.9-r1*
* *as2-realsense-interface 1.0.8-r1 --> 1.0.9-r1*
* *as2-state-estimator 1.0.8-r1 --> 1.0.9-r1*
* *as2-usb-camera-interface 1.0.8-r1 --> 1.0.9-r1*
* *camera-calibration-parsers 3.1.8-r2 --> 3.1.9-r1*
* *camera-info-manager 3.1.8-r2 --> 3.1.9-r1*
* *fields2cover 1.2.1-r2 --> 1.2.1-r3*
* *flir-camera-description 2.1.14-r1 --> 2.1.15-r1*
* *flir-camera-msgs 2.1.14-r1 --> 2.1.15-r1*
* *image-common 3.1.8-r2 --> 3.1.9-r1*
* *image-transport 3.1.8-r2 --> 3.1.9-r1*
* *kitti-metrics-eval 1.0.0-r1 --> 1.0.1-r1*
* *mola 1.0.0-r1 --> 1.0.1-r1*
* *mola-bridge-ros2 1.0.0-r1 --> 1.0.1-r1*
* *mola-demos 1.0.0-r1 --> 1.0.1-r1*
* *mola-imu-preintegration 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-euroc-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-kitti-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-kitti360-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-mulran-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-paris-luco-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-rawlog 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-rosbag2 1.0.0-r1 --> 1.0.1-r1*
* *mola-kernel 1.0.0-r1 --> 1.0.1-r1*
* *mola-launcher 1.0.0-r1 --> 1.0.1-r1*
* *mola-metric-maps 1.0.0-r1 --> 1.0.1-r1*
* *mola-navstate-fuse 1.0.0-r1 --> 1.0.1-r1*
* *mola-pose-list 1.0.0-r1 --> 1.0.1-r1*
* *mola-traj-tools 1.0.0-r1 --> 1.0.1-r1*
* *mola-viz 1.0.0-r1 --> 1.0.1-r1*
* *mola-yaml 1.0.0-r1 --> 1.0.1-r1*
* *point-cloud-transport 1.0.16-r1 --> 1.0.17-r1*
* *point-cloud-transport-py 1.0.16-r1 --> 1.0.17-r1*
* *psdk-interfaces 1.1.0-r1 --> 1.1.1-r1*
* *psdk-wrapper 1.1.0-r1 --> 1.1.1-r1*
* *rviz-assimp-vendor 11.2.11-r1 --> 11.2.12-r1*
* *rviz-common 11.2.11-r1 --> 11.2.12-r1*
* *rviz-default-plugins 11.2.11-r1 --> 11.2.12-r1*
* *rviz-ogre-vendor 11.2.11-r1 --> 11.2.12-r1*
* *rviz-rendering 11.2.11-r1 --> 11.2.12-r1*
* *rviz-rendering-tests 11.2.11-r1 --> 11.2.12-r1*
* *rviz-visual-testing-framework 11.2.11-r1 --> 11.2.12-r1*
* *rviz2 11.2.11-r1 --> 11.2.12-r1*
* *simple-launch 1.9.1-r1 --> 1.9.2-r1*
* *spinnaker-camera-driver 2.1.14-r1 --> 2.1.15-r1*
* *spinnaker-synchronized-camera-driver 2.1.14-r1 --> 2.1.15-r1*
* *unitree-ros 1.1.0-r1*

Iron Changes:
-------------
* *camera-calibration 4.0.0-r1 --> 4.0.1-r1*
* *camera-calibration-parsers 4.2.3-r1 --> 4.2.4-r1*
* *camera-info-manager 4.2.3-r1 --> 4.2.4-r1*
* *depth-image-proc 4.0.0-r1 --> 4.0.1-r1*
* *fields2cover 1.2.1-r2 --> 1.2.1-r3*
* *flir-camera-description 2.2.14-r1 --> 2.2.15-r1*
* *flir-camera-msgs 2.2.14-r1 --> 2.2.15-r1*
* *image-common 4.2.3-r1 --> 4.2.4-r1*
* *image-pipeline 4.0.0-r1 --> 4.0.1-r1*
* *image-proc 4.0.0-r1 --> 4.0.1-r1*
* *image-publisher 4.0.0-r1 --> 4.0.1-r1*
* *image-rotate 4.0.0-r1 --> 4.0.1-r1*
* *image-transport 4.2.3-r1 --> 4.2.4-r1*
* *image-view 4.0.0-r1 --> 4.0.1-r1*
* *kitti-metrics-eval 1.0.0-r1 --> 1.0.1-r1*
* *mola 1.0.0-r1 --> 1.0.1-r1*
* *mola-bridge-ros2 1.0.0-r1 --> 1.0.1-r1*
* *mola-demos 1.0.0-r1 --> 1.0.1-r1*
* *mola-imu-preintegration 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-euroc-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-kitti-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-kitti360-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-mulran-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-paris-luco-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-rawlog 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-rosbag2 1.0.0-r1 --> 1.0.1-r1*
* *mola-kernel 1.0.0-r1 --> 1.0.1-r1*
* *mola-launcher 1.0.0-r1 --> 1.0.1-r1*
* *mola-metric-maps 1.0.0-r1 --> 1.0.1-r1*
* *mola-navstate-fuse 1.0.0-r1 --> 1.0.1-r1*
* *mola-pose-list 1.0.0-r1 --> 1.0.1-r1*
* *mola-traj-tools 1.0.0-r1 --> 1.0.1-r1*
* *mola-viz 1.0.0-r1 --> 1.0.1-r1*
* *mola-yaml 1.0.0-r1 --> 1.0.1-r1*
* *point-cloud-transport 2.0.4-r1 --> 2.0.5-r1*
* *point-cloud-transport-py 2.0.4-r1 --> 2.0.5-r1*
* *rviz-assimp-vendor 12.4.6-r1 --> 12.4.7-r1*
* *rviz-common 12.4.6-r1 --> 12.4.7-r1*
* *rviz-default-plugins 12.4.6-r1 --> 12.4.7-r1*
* *rviz-ogre-vendor 12.4.6-r1 --> 12.4.7-r1*
* *rviz-rendering 12.4.6-r1 --> 12.4.7-r1*
* *rviz-rendering-tests 12.4.6-r1 --> 12.4.7-r1*
* *rviz-visual-testing-framework 12.4.6-r1 --> 12.4.7-r1*
* *rviz2 12.4.6-r1 --> 12.4.7-r1*
* *simple-launch 1.9.1-r1 --> 1.9.2-r1*
* *spinnaker-camera-driver 2.2.14-r1 --> 2.2.15-r1*
* *spinnaker-synchronized-camera-driver 2.2.14-r1 --> 2.2.15-r1*
* *stereo-image-proc 4.0.0-r1 --> 4.0.1-r1*
* *tracetools-image-pipeline 4.0.0-r1 --> 4.0.1-r1*
* *unitree-ros 1.1.0-r1*

Noetic Changes:
---------------
* *costmap-cspace 0.17.0-r1 --> 0.17.1-r1*
* *joystick-interrupt 0.17.0-r1 --> 0.17.1-r1*
* *map-organizer 0.17.0-r1 --> 0.17.1-r1*
* *mrpt-ekf-slam-2d 0.1.15-r1 --> 0.1.16-r1*
* *mrpt-ekf-slam-3d 0.1.15-r1 --> 0.1.16-r1*
* *mrpt-graphslam-2d 0.1.15-r1 --> 0.1.16-r1*
* *mrpt-icp-slam-2d 0.1.15-r1 --> 0.1.16-r1*
* *mrpt-rbpf-slam 0.1.15-r1 --> 0.1.16-r1*
* *mrpt-slam 0.1.15-r1 --> 0.1.16-r1*
* *mvsim 0.9.1-r2 --> 0.9.2-r1*
* *neonavigation 0.17.0-r1 --> 0.17.1-r1*
* *neonavigation-common 0.17.0-r1 --> 0.17.1-r1*
* *neonavigation-launch 0.17.0-r1 --> 0.17.1-r1*
* *obj-to-pointcloud 0.17.0-r1 --> 0.17.1-r1*
* *octomap-mapping 0.6.7-r1 --> 0.6.8-r1*
* *octomap-server 0.6.7-r1 --> 0.6.8-r1*
* *planner-cspace 0.17.0-r1 --> 0.17.1-r1*
* *safety-limiter 0.17.0-r1 --> 0.17.1-r1*
* *track-odometry 0.17.0-r1 --> 0.17.1-r1*
* *trajectory-tracker 0.17.0-r1 --> 0.17.1-r1*
* *ypspur 1.20.2-r1 --> 1.21.0-r1*
* *ypspur-ros 0.3.6-r1 --> 0.4.0-r1*

Rolling Changes:
----------------
* *action-tutorials-cpp 0.33.1-r2 --> 0.33.2-r1*
* *action-tutorials-interfaces 0.33.1-r2 --> 0.33.2-r1*
* *action-tutorials-py 0.33.1-r2 --> 0.33.2-r1*
* *actionlib-msgs 5.3.0-r2 --> 5.3.1-r1*
* *ament-clang-format 0.16.3-r2 --> 0.16.4-r1*
* *ament-clang-tidy 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-auto 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-clang-format 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-clang-tidy 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-copyright 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-core 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-cppcheck 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-cpplint 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-export-definitions 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-export-dependencies 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-export-include-directories 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-export-interfaces 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-export-libraries 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-export-link-flags 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-export-targets 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-flake8 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-gen-version-h 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-gmock 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-google-benchmark 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-gtest 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-include-directories 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-libraries 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-lint-cmake 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-mypy 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-pclint 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-pep257 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-pycodestyle 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-pyflakes 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-pytest 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-python 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-target-dependencies 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-test 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-uncrustify 0.16.3-r2 --> 0.16.4-r1*
* *ament-cmake-vendor-package 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-version 2.3.2-r3 --> 2.4.0-r1*
* *ament-cmake-xmllint 0.16.3-r2 --> 0.16.4-r1*
* *ament-copyright 0.16.3-r2 --> 0.16.4-r1*
* *ament-cppcheck 0.16.3-r2 --> 0.16.4-r1*
* *ament-cpplint 0.16.3-r2 --> 0.16.4-r1*
* *ament-index-cpp 1.7.0-r2 --> 1.8.0-r1*
* *ament-index-python 1.7.0-r2 --> 1.8.0-r1*
* *ament-lint 0.16.3-r2 --> 0.16.4-r1*
* *ament-lint-auto 0.16.3-r2 --> 0.16.4-r1*
* *ament-lint-cmake 0.16.3-r2 --> 0.16.4-r1*
* *ament-lint-common 0.16.3-r2 --> 0.16.4-r1*
* *ament-mypy 0.16.3-r2 --> 0.16.4-r1*
* *ament-pclint 0.16.3-r2 --> 0.16.4-r1*
* *ament-pep257 0.16.3-r2 --> 0.16.4-r1*
* *ament-pycodestyle 0.16.3-r2 --> 0.16.4-r1*
* *ament-pyflakes 0.16.3-r2 --> 0.16.4-r1*
* *ament-uncrustify 0.16.3-r2 --> 0.16.4-r1*
* *ament-xmllint 0.16.3-r2 --> 0.16.4-r1*
* *camera-calibration 5.0.0-r2 --> 5.0.1-r1*
* *camera-calibration-parsers 5.1.0-r2 --> 5.1.1-r1*
* *camera-info-manager 5.1.0-r2 --> 5.1.1-r1*
* *common-interfaces 5.3.0-r2 --> 5.3.1-r1*
* *composition 0.33.1-r2 --> 0.33.2-r1*
* *controller-interface 4.7.0-r1 --> 4.8.0-r1*
* *controller-manager 4.7.0-r1 --> 4.8.0-r1*
* *controller-manager-msgs 4.7.0-r1 --> 4.8.0-r1*
* *demo-nodes-cpp 0.33.1-r2 --> 0.33.2-r1*
* *demo-nodes-cpp-native 0.33.1-r2 --> 0.33.2-r1*
* *demo-nodes-py 0.33.1-r2 --> 0.33.2-r1*
* *depth-image-proc 5.0.0-r2 --> 5.0.1-r1*
* *diagnostic-msgs 5.3.0-r2 --> 5.3.1-r1*
* *dummy-map-server 0.33.1-r2 --> 0.33.2-r1*
* *dummy-robot-bringup 0.33.1-r2 --> 0.33.2-r1*
* *dummy-sensors 0.33.1-r2 --> 0.33.2-r1*
* *examples-rclcpp-async-client 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-cbg-executor 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-action-client 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-action-server 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-client 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-composition 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-publisher 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-service 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-subscriber 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-minimal-timer 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-multithreaded-executor 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclcpp-wait-set 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-executors 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-guard-conditions 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-minimal-action-client 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-minimal-action-server 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-minimal-client 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-minimal-publisher 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-minimal-service 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-minimal-subscriber 0.19.1-r2 --> 0.19.2-r1*
* *examples-rclpy-pointcloud-publisher 0.19.1-r2 --> 0.19.2-r1*
* *examples-tf2-py 0.36.0-r2 --> 0.36.1-r1*
* *fastcdr 1.1.0-r3 --> 2.2.1-r1*
* *fastrtps 2.13.2-r3 --> 2.14.0-r1*
* *fastrtps-cmake-module 3.4.0-r2 --> 3.5.0-r1*
* *fields2cover 1.2.1-r3 --> 1.2.1-r5*
* *flir-camera-description 2.0.15-r1*
* *flir-camera-msgs 2.0.15-r1*
* *geometry-msgs 5.3.0-r2 --> 5.3.1-r1*
* *geometry2 0.36.0-r2 --> 0.36.1-r1*
* *gz-cmake-vendor 0.0.3-r1*
* *gz-math-vendor 0.0.2-r1*
* *gz-utils-vendor 0.0.2-r1*
* *hardware-interface 4.7.0-r1 --> 4.8.0-r1*
* *hardware-interface-testing 4.7.0-r1 --> 4.8.0-r1*
* *image-common 5.1.0-r2 --> 5.1.1-r1*
* *image-pipeline 5.0.0-r2 --> 5.0.1-r1*
* *image-proc 5.0.0-r2 --> 5.0.1-r1*
* *image-publisher 5.0.0-r2 --> 5.0.1-r1*
* *image-rotate 5.0.0-r2 --> 5.0.1-r1*
* *image-tools 0.33.1-r2 --> 0.33.2-r1*
* *image-transport 5.1.0-r2 --> 5.1.1-r1*
* *image-view 5.0.0-r2 --> 5.0.1-r1*
* *interactive-markers 2.5.3-r2 --> 2.5.4-r1*
* *intra-process-demo 0.33.1-r2 --> 0.33.2-r1*
* *joint-limits 4.7.0-r1 --> 4.8.0-r1*
* *keyboard-handler 0.3.0-r2 --> 0.3.1-r1*
* *kitti-metrics-eval 1.0.0-r1 --> 1.0.1-r1*
* *launch 3.4.0-r2 --> 3.4.1-r1*
* *launch-pytest 3.4.0-r2 --> 3.4.1-r1*
* *launch-ros 0.26.4-r2 --> 0.26.5-r1*
* *launch-testing 3.4.0-r2 --> 3.4.1-r1*
* *launch-testing-ament-cmake 3.4.0-r2 --> 3.4.1-r1*
* *launch-testing-examples 0.19.1-r2 --> 0.19.2-r1*
* *launch-testing-ros 0.26.4-r2 --> 0.26.5-r1*
* *launch-xml 3.4.0-r2 --> 3.4.1-r1*
* *launch-yaml 3.4.0-r2 --> 3.4.1-r1*
* *libstatistics-collector 1.7.0-r2 --> 1.7.1-r1*
* *lifecycle 0.33.1-r2 --> 0.33.2-r1*
* *lifecycle-py 0.33.1-r2 --> 0.33.2-r1*
* *logging-demo 0.33.1-r2 --> 0.33.2-r1*
* *mcap-vendor 0.24.0-r3 --> 0.25.0-r1*
* *mimick-vendor 0.6.0-r3 --> 0.6.1-r1*
* *mola 1.0.0-r1 --> 1.0.1-r1*
* *mola-bridge-ros2 1.0.0-r1 --> 1.0.1-r1*
* *mola-demos 1.0.0-r1 --> 1.0.1-r1*
* *mola-imu-preintegration 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-euroc-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-kitti-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-kitti360-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-mulran-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-paris-luco-dataset 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-rawlog 1.0.0-r1 --> 1.0.1-r1*
* *mola-input-rosbag2 1.0.0-r1 --> 1.0.1-r1*
* *mola-kernel 1.0.0-r1 --> 1.0.1-r1*
* *mola-launcher 1.0.0-r1 --> 1.0.1-r1*
* *mola-metric-maps 1.0.0-r1 --> 1.0.1-r1*
* *mola-navstate-fuse 1.0.0-r1 --> 1.0.1-r1*
* *mola-pose-list 1.0.0-r1 --> 1.0.1-r1*
* *mola-traj-tools 1.0.0-r1 --> 1.0.1-r1*
* *mola-viz 1.0.0-r1 --> 1.0.1-r1*
* *mola-yaml 1.0.0-r1 --> 1.0.1-r1*
* *mrpt2 2.12.0-r1 --> 2.12.0-r2*
* *nav-msgs 5.3.0-r2 --> 5.3.1-r1*
* *pendulum-control 0.33.1-r2 --> 0.33.2-r1*
* *pendulum-msgs 0.33.1-r2 --> 0.33.2-r1*
* *pluginlib 5.4.1-r2 --> 5.4.2-r1*
* *python-cmake-module 0.11.0-r2 --> 0.11.1-r1*
* *python-qt-binding 2.1.1-r2 --> 2.2.0-r1*
* *qt-dotgraph 2.7.2-r2 --> 2.7.3-r1*
* *qt-gui 2.7.2-r2 --> 2.7.3-r1*
* *qt-gui-app 2.7.2-r2 --> 2.7.3-r1*
* *qt-gui-core 2.7.2-r2 --> 2.7.3-r1*
* *qt-gui-cpp 2.7.2-r2 --> 2.7.3-r1*
* *qt-gui-py-common 2.7.2-r2 --> 2.7.3-r1*
* *quality-of-service-demo-cpp 0.33.1-r2 --> 0.33.2-r1*
* *quality-of-service-demo-py 0.33.1-r2 --> 0.33.2-r1*
* *rcl 9.1.0-r2 --> 9.2.0-r1*
* *rcl-action 9.1.0-r2 --> 9.2.0-r1*
* *rcl-lifecycle 9.1.0-r2 --> 9.2.0-r1*
* *rcl-logging-interface 3.0.0-r2 --> 3.1.0-r1*
* *rcl-logging-noop 3.0.0-r2 --> 3.1.0-r1*
* *rcl-logging-spdlog 3.0.0-r2 --> 3.1.0-r1*
* *rcl-yaml-param-parser 9.1.0-r2 --> 9.2.0-r1*
* *rclcpp 27.0.0-r2 --> 28.0.0-r1*
* *rclcpp-action 27.0.0-r2 --> 28.0.0-r1*
* *rclcpp-components 27.0.0-r2 --> 28.0.0-r1*
* *rclcpp-lifecycle 27.0.0-r2 --> 28.0.0-r1*
* *rclpy 7.0.1-r2 --> 7.1.0-r1*
* *rcutils 6.5.2-r2 --> 6.6.0-r1*
* *rmw-connextdds 0.20.1-r1 --> 0.21.0-r1*
* *rmw-connextdds-common 0.20.1-r1 --> 0.21.0-r1*
* *rmw-cyclonedds-cpp 2.1.0-r2 --> 2.1.1-r1*
* *rmw-fastrtps-cpp 8.2.0-r2 --> 8.3.0-r1*
* *rmw-fastrtps-dynamic-cpp 8.2.0-r2 --> 8.3.0-r1*
* *rmw-fastrtps-shared-cpp 8.2.0-r2 --> 8.3.0-r1*
* *rmw-implementation 2.15.0-r3 --> 2.15.1-r1*
* *ros2-control 4.7.0-r1 --> 4.8.0-r1*
* *ros2-control-test-assets 4.7.0-r1 --> 4.8.0-r1*
* *ros2action 0.31.1-r2 --> 0.31.2-r1*
* *ros2bag 0.24.0-r3 --> 0.25.0-r1*
* *ros2cli 0.31.1-r2 --> 0.31.2-r1*
* *ros2cli-test-interfaces 0.31.1-r2 --> 0.31.2-r1*
* *ros2component 0.31.1-r2 --> 0.31.2-r1*
* *ros2controlcli 4.7.0-r1 --> 4.8.0-r1*
* *ros2doctor 0.31.1-r2 --> 0.31.2-r1*
* *ros2interface 0.31.1-r2 --> 0.31.2-r1*
* *ros2launch 0.26.4-r2 --> 0.26.5-r1*
* *ros2lifecycle 0.31.1-r2 --> 0.31.2-r1*
* *ros2lifecycle-test-fixtures 0.31.1-r2 --> 0.31.2-r1*
* *ros2multicast 0.31.1-r2 --> 0.31.2-r1*
* *ros2node 0.31.1-r2 --> 0.31.2-r1*
* *ros2param 0.31.1-r2 --> 0.31.2-r1*
* *ros2pkg 0.31.1-r2 --> 0.31.2-r1*
* *ros2run 0.31.1-r2 --> 0.31.2-r1*
* *ros2service 0.31.1-r2 --> 0.31.2-r1*
* *ros2topic 0.31.1-r2 --> 0.31.2-r1*
* *ros2trace 8.0.0-r2 --> 8.1.0-r1*
* *rosbag2 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-compression 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-compression-zstd 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-cpp 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-examples-cpp 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-examples-py 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-interfaces 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-performance-benchmarking 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-performance-benchmarking-msgs 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-py 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-storage 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-storage-default-plugins 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-storage-mcap 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-storage-sqlite3 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-test-common 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-test-msgdefs 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-tests 0.24.0-r3 --> 0.25.0-r1*
* *rosbag2-transport 0.24.0-r3 --> 0.25.0-r1*
* *rosidl-adapter 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-cli 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-cmake 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-generator-c 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-generator-cpp 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-generator-py 0.21.1-r2 --> 0.21.2-r1*
* *rosidl-generator-type-description 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-parser 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-pycommon 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-runtime-c 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-runtime-cpp 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-runtime-py 0.13.0-r2 --> 0.13.1-r1*
* *rosidl-typesupport-c 3.2.0-r2 --> 3.2.1-r1*
* *rosidl-typesupport-cpp 3.2.0-r2 --> 3.2.1-r1*
* *rosidl-typesupport-fastrtps-c 3.4.0-r2 --> 3.5.0-r1*
* *rosidl-typesupport-fastrtps-cpp 3.4.0-r2 --> 3.5.0-r1*
* *rosidl-typesupport-interface 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-typesupport-introspection-c 4.5.1-r2 --> 4.5.2-r1*
* *rosidl-typesupport-introspection-cpp 4.5.1-r2 --> 4.5.2-r1*
* *rqt 1.5.0-r2 --> 1.6.0-r1*
* *rqt-bag 1.5.1-r2 --> 1.5.2-r1*
* *rqt-bag-plugins 1.5.1-r2 --> 1.5.2-r1*
* *rqt-controller-manager 4.7.0-r1 --> 4.8.0-r1*
* *rqt-gui 1.5.0-r2 --> 1.6.0-r1*
* *rqt-gui-cpp 1.5.0-r2 --> 1.6.0-r1*
* *rqt-gui-py 1.5.0-r2 --> 1.6.0-r1*
* *rqt-plot 1.3.2-r2 --> 1.4.0-r1*
* *rqt-publisher 1.7.1-r2 --> 1.7.2-r1*
* *rqt-py-common 1.5.0-r2 --> 1.6.0-r1*
* *rqt-topic 1.7.1-r2 --> 1.7.2-r1*
* *rti-connext-dds-cmake-module 0.20.1-r1 --> 0.21.0-r1*
* *rviz-assimp-vendor 13.4.0-r2 --> 13.4.2-r1*
* *rviz-common 13.4.0-r2 --> 13.4.2-r1*
* *rviz-default-plugins 13.4.0-r2 --> 13.4.2-r1*
* *rviz-ogre-vendor 13.4.0-r2 --> 13.4.2-r1*
* *rviz-rendering 13.4.0-r2 --> 13.4.2-r1*
* *rviz-rendering-tests 13.4.0-r2 --> 13.4.2-r1*
* *rviz-visual-testing-framework 13.4.0-r2 --> 13.4.2-r1*
* *rviz2 13.4.0-r2 --> 13.4.2-r1*
* *sensor-msgs 5.3.0-r2 --> 5.3.1-r1*
* *sensor-msgs-py 5.3.0-r2 --> 5.3.1-r1*
* *shape-msgs 5.3.0-r2 --> 5.3.1-r1*
* *shared-queues-vendor 0.24.0-r3 --> 0.25.0-r1*
* *spinnaker-camera-driver 2.0.15-r1*
* *spinnaker-synchronized-camera-driver 2.0.15-r1*
* *sqlite3-vendor 0.24.0-r3 --> 0.25.0-r1*
* *std-msgs 5.3.0-r2 --> 5.3.1-r1*
* *std-srvs 5.3.0-r2 --> 5.3.1-r1*
* *stereo-image-proc 5.0.0-r2 --> 5.0.1-r1*
* *stereo-msgs 5.3.0-r2 --> 5.3.1-r1*
* *tf2 0.36.0-r2 --> 0.36.1-r1*
* *tf2-bullet 0.36.0-r2 --> 0.36.1-r1*
* *tf2-eigen 0.36.0-r2 --> 0.36.1-r1*
* *tf2-eigen-kdl 0.36.0-r2 --> 0.36.1-r1*
* *tf2-geometry-msgs 0.36.0-r2 --> 0.36.1-r1*
* *tf2-kdl 0.36.0-r2 --> 0.36.1-r1*
* *tf2-msgs 0.36.0-r2 --> 0.36.1-r1*
* *tf2-py 0.36.0-r2 --> 0.36.1-r1*
* *tf2-ros 0.36.0-r2 --> 0.36.1-r1*
* *tf2-ros-py 0.36.0-r2 --> 0.36.1-r1*
* *tf2-sensor-msgs 0.36.0-r2 --> 0.36.1-r1*
* *tf2-tools 0.36.0-r2 --> 0.36.1-r1*
* *topic-monitor 0.33.1-r2 --> 0.33.2-r1*
* *topic-statistics-demo 0.33.1-r2 --> 0.33.2-r1*
* *tracetools 8.0.0-r2 --> 8.1.0-r1*
* *tracetools-image-pipeline 5.0.0-r2 --> 5.0.1-r1*
* *tracetools-launch 8.0.0-r2 --> 8.1.0-r1*
* *tracetools-test 8.0.0-r2 --> 8.1.0-r1*
* *tracetools-trace 8.0.0-r2 --> 8.1.0-r1*
* *trajectory-msgs 5.3.0-r2 --> 5.3.1-r1*
* *transmission-interface 4.7.0-r1 --> 4.8.0-r1*
* *turtlesim 1.8.1-r2 --> 1.8.2-r1*
* *visualization-msgs 5.3.0-r2 --> 5.3.1-r1*
* *yaml-cpp-vendor 8.3.1-r2 --> 8.3.2-r1*
* *zstd-vendor 0.24.0-r3 --> 0.25.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libxkbcommon-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-smbus
 * [ ] qml-module-qtquick-extras
 * [ ] qtbase5-private-dev
 * [ ] rmf_building_map_tools
 * [ ] rmf_building_sim_common
 * [ ] rmf_building_sim_gz_classic_plugins
 * [ ] rmf_building_sim_gz_plugins
 * [ ] rmf_robot_sim_common
 * [ ] rmf_robot_sim_gz_classic_plugins
 * [ ] rmf_robot_sim_gz_plugins
 * [ ] rmf_traffic_editor
 * [ ] rmf_traffic_editor_assets
 * [ ] rmf_traffic_editor_test_maps
 * [ ] ros_gz_bridge
 * [ ] ros_gz_sim
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] ros_ign_gazebo_demos
 * [ ] ros_ign_image
 * [ ] ros_ign_interfaces
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

