### PR TITLE
rosdistro sync, Fri Apr 12 13:51:24 2024

### DIFF
--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "20920a67c66b20be897ea2fc842b6d7872a08e26b8a7a725051a9fbab4d55ea7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "7f820768e1a657d3349fc2aa8e41070dc19e41ce1ecb4ab6edd67bc3548dd7e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.2.5-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "7b80d458f997b338545edc3fa04857f348d4b084095391ca35c28de36c8e8c3e";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "aa149e789805b81ffd2fc16d46b3c0858e81072b66e728d4c4ecb69d97ad624c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "b752d17b133f4c90a23a97dbb4e4c790e91d2c636f8bcac49c740b6b5a0f9c4a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "e65002c38ec188d5b50e48ffe1c4a3867cae265f7f7714d346cd43633d1bed6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-customization";
+  version = "0.2.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "1648339720d4bd2c2b2f405412aa87b930b1c6d077c701a79c0ca1bdedc854ff";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath customization packages.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "93a6ad2dd329cf0cefdc79fa0cd052e075cbe398d30b2571544484eaa8d9c7c3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "a41b168ebda1f4756b3719d3242c9ace11b767cc39bfbc599be4b81f232ee61b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "e80ade17556a719375e62ec98818df3dd0bef8bb14a673ca39ae5e0beb1eff3c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "497207e11e6ea63429f70e2afe63a38e238eabfdb87e88449d7682795e833a21";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "ca8a1dc3b1b2e4b051afac956568f4707638f3a29e4c7b7c66a40ad94a5e454f";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "9a27fe317a37927c59d9fe12f15332f062266e27cd9faa82a2df6ba45da0ab85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "e3fe25f9673ef25140e94fb243911a7b43b206ab083fb2af0e8139b041790ddd";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "ba3cd39cd2f1759cfe01505fc856424c2ce2f497656edfc757e59f187703cb74";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "70c989520c3a98b694f17bf45a304d13dbba7ae45bd8179835493ff4e82627f0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "dbf3ac982d6d7dea22be12166e0d149382dceb8a6539dc2eed227715d3fb250b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.2.6-r1";
+  version = "0.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "11a78521277689e0a081f7a84af141bf12f5f3017fe8499899af8323cc7ad572";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.2.7-1.tar.gz";
+    name = "0.2.7-1.tar.gz";
+    sha256 = "47e6597ec345ec530aa3719d4c2105cead7634178a19fa42d0035535e3c5a701";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "9bbf7c447d46a8a6821ff424426f52eebc756f1857006bb363d84678e2552cbc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "8f585b5b455d6e10784e67bf911ba53022e4094e7340150f83b13994d410bdda";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "3c5b4f67044a92e8e1637217f315e48279efe0546aac0973acdd1064d7122cf9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "660301e9b34fbbd7819409581882cf70035e8d564d4c7c51767bddc8ff9b99b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "00fc6fc331b97bef240e77c6772a697b472a871f62d7d7a80f43b740bf67a817";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "503b31abc6599069157ad616c62a450459d21d460b06a3970f1fb081b5fc035c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "43b992e8427b56020ca979ffca56390ad9271bc4a2f081adc02d76c0a3108f82";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "02f4dbe2ca698c48a106e56fd8558f6d1b759b5b3914fb290d5f876823371b92";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "f383a6541e981b829e3d137d3e20c30d351d4debb71d1df5f4e4f2b6d759f767";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "728732cf65743cdb5e838367ce59a99bf4ccb1577179c18c4f35fa1ded54536e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fields2cover/default.nix
+++ b/distros/humble/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, nlohmann_json, python3, python3Packages, tbb_2021_8, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fields2cover";
-  version = "1.2.1-r3";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/1.2.1-3.tar.gz";
-    name = "1.2.1-3.tar.gz";
-    sha256 = "11ca6ae60cd6c395f357cfa4d29f79bce7efbea2defb4b1bc9696f749e02fdfd";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9b73ada0478b6f919e5df366ecc11681bc2c1e138f8081d0770fbbc44c12d922";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ eigen gdal git gtest python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 ];
+  propagatedBuildInputs = [ eigen gdal git gtest nlohmann_json python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -334,6 +334,8 @@ self: super: {
 
  clearpath-control = self.callPackage ./clearpath-control {};
 
+ clearpath-customization = self.callPackage ./clearpath-customization {};
+
  clearpath-description = self.callPackage ./clearpath-description {};
 
  clearpath-desktop = self.callPackage ./clearpath-desktop {};
@@ -1448,6 +1450,8 @@ self: super: {
 
  nav2-dwb-controller = self.callPackage ./nav2-dwb-controller {};
 
+ nav2-graceful-controller = self.callPackage ./nav2-graceful-controller {};
+
  nav2-lifecycle-manager = self.callPackage ./nav2-lifecycle-manager {};
 
  nav2-map-server = self.callPackage ./nav2-map-server {};
@@ -2553,6 +2557,8 @@ self: super: {
  test-interface-files = self.callPackage ./test-interface-files {};
 
  test-msgs = self.callPackage ./test-msgs {};
+
+ test-ros-gz-bridge = self.callPackage ./test-ros-gz-bridge {};
 
  tf2 = self.callPackage ./tf2 {};
 

--- a/distros/humble/geodesy/default.nix
+++ b/distros/humble/geodesy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, geographic-msgs, geometry-msgs, python3Packages, sensor-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-geodesy";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/humble/geodesy/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "fa05af8d16df4be6cc8f6a71d9009933d293d9054c3177fae791cc998e3e70da";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/humble/geodesy/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "01c23b3da7cd520ad52cf0482ea62578a00ce47ade4793a79f484affa989532b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/geographic-info/default.nix
+++ b/distros/humble/geographic-info/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geodesy, geographic-msgs }:
 buildRosPackage {
   pname = "ros-humble-geographic-info";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/humble/geographic_info/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c602139fab33140b9333ca07d78d3e5ffb401c36713edec21427df7aa34a8628";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/humble/geographic_info/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "1a899289d143c388be120854f654f5bbe36fed4317d31b7d062dcf5215c7e745";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/geographic-msgs/default.nix
+++ b/distros/humble/geographic-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-geographic-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/humble/geographic_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "5faf8b0fc6ca7585c3392c095872f95bcd17b8a2db35d929302278c40b4357dd";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/humble/geographic_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "faf54d859fe67cfd307b4ca8248c74f42498ccacc05f0dc78e596939de0a66b6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/ign-ros2-control-demos/default.nix
+++ b/distros/humble/ign-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-ign-gazebo, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control-demos";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "bac8b751eafe2f8eb06584f51230d58c3c64fa72be326a4c90085b099feb54d1";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "cd15d60be5d1cb0c4d52309d2466c87ebf59f944caa91617a36054f2a9a05873";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-description/default.nix
+++ b/distros/humble/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-description";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_description/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "a6d92a2ca3be297bb512c760094fd327711fcc62c0737643f2ae225ed1c121f9";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_description/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "bfd21f08775eca0eecd49b22eb2c0937acf3b6019b41f990de938a531f383654";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-driver/default.nix
+++ b/distros/humble/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-driver";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "e7adf667044658d8af22440b8d53a28a0620cd2c4829d331f8c8777134774323";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "8fcd6789c61a3fac395307693815952415241ecd816bf2a42ca69a140fb0beee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-examples/default.nix
+++ b/distros/humble/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-examples";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "cf0b307dc77767657fcbb5dfe36f5a5dfc347da447ddb16bf24391e8ba8f3d70";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "bc459df536af086358bc6e4d165b084a3c25ccc75d941b83a08552e48a741db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-msgs/default.nix
+++ b/distros/humble/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-msgs";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "0a083ed7c4f27d1ce5a2cbe2082dddc61be29f8fd4c994cb53299d0d038ba608";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "32d04ef73576016dd6951e458b57cabd57a04fb4b16c03c3555d975c2b000a3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-rqt/default.nix
+++ b/distros/humble/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-rqt";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "d6d5ffc663acc3c94fc7154fd4845fa2ca65d3f50ac13c231e1a10b7519ea976";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "1c584570ea57cc79bcae5ccd51c584dce7b859654fbac47183f5a9084177d139";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "11edfed1f060d405fd097646d2ebec36453793859dd58a16cabbd6d57ccfa06e";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "87ecd15270cc110c4dcc6ddb7f9ae796536ee4af9f4fe7100d26e7f0ec009a16";
   };
 
   buildType = "cmake";

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "750db10a58650b5e99de68690412c914ab06cda8ad22e590f9099ae83b9e59ed";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "5f7b986906422871aad86ec723f3ffb28304b8b33f81fb1eaf3060ca32acff84";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "1baa16c50a8124f7022e2dab167845d30882958beec509c737e9bc3faf6d72a8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "61e6386568ddeacdbd2260182b9cce8cde4b7766080f0a465924b1d728cda7b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "bc53782b577609f52ca2c88ea1edd863ac26ad6ab52f9a341314b14d4d655d53";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "be63326f76c28962f588521d0c39fe1f1243c64aa9c1cbdf303dffbca844d52d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "4c597fc8cb54bb50409fd2f4914aa682252242d23aeed84c9309c52efd089483";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "ce8b983a557c99fb3eb7e6572ffc2a307feb4c9f8a8bcd362e6774d803649910";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "29a42604cba8f541159e645afef396680adbdda9ac2503cbf1808525c5ce3f24";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "2279bdf1e0de56eef1fa507e2f73fedbb2abfb0c3332c3d0bc32c57a03294330";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "33da10c4315d1b09c38df9f56f7212dab72ab3de3863af88cdbdeb9111e8f5b0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "222d5410d197a84541af081b9ef0f07f366a9df00e9922e09d647d6f76134eec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "cc67d9161dc8501d8cc7789aa395c1295d0ea43b31a71f22bab3cfaf048de708";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "1546c50ca55a0fe93890c6f3884f36f101c2ff9f669e528027fb4b7a157773e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "a9661c8e3696468b043008475b54d925db97715e94bbfd9008bcb900502c4793";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "e3240a16f0be6f1ee63cea3c7f7d9ca17e81b9fa161aa484cafff8774d90ae61";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "e1fa964d3c3f5389c751d5ba7c92af7f0979436bdaab131c25beba5bf17ba5a1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "fde5372d57075e8d42e021e10839601b1c5874f287b3785d182879cb271d1c6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "ca2b4648d1a8b9686ab9a8a7c0dde529d25ef853400ed15a450fd062fabefbbe";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "1ae72733572205e23f9641f43f4a1096370e5b7dccc5e716540ee5556f684175";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "c21c7050eadccbc4ec717edf0c694082c0a7dc2478e6d6b29c0e54c8e17d6c40";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "f9d1c5a922940eb494b15d6dddb1df9e18c5cfce4f9f02d8415c6b906278512e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "5ebb48c595958a1264771480ee3d8c82b2dd1c835639042148484cf3b0594c78";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "5db201f1e31583e02e54be69773cde5b3f63c945313bb98914933b8b2a70b69d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "31d7eb734a931cf311811cf3aab2d7d7d47badac041168b17ba5a1c3d79ce322";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "5cb7450e85c40a5880eacb6814a3362dc89ffd0cd2935e3e313c7fd124c9acd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "53ee10e52152ff6b543621d8beb0e051ee7c7543e7ff20db480f48b200e8c3fe";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "d591822b033264d4a3c3a1a2bf4380d92ed793f25a9f3ec53a0d6037e435e6cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-graceful-controller/default.nix
+++ b/distros/humble/nav2-graceful-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-2d-utils, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-humble-nav2-graceful-controller";
+  version = "1.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_graceful_controller/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "816499c61b36d1413e9160ede10c91c015ea35889ba7a9fce4cc85ff06779c60";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common nav2-controller ];
+  propagatedBuildInputs = [ angles geometry-msgs nav-2d-utils nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Graceful motion controller";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "76ba416ee0c3bd859d653134cf919625db28d5c311a15cd3a862bfd3612551ee";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "908d0a688dc5e0c592ff22555c453ef0e36d75334707f7459305c8626a4af2cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "110dce88311319dcfc84a7649ce7d485b4d1cf57443e34361582cc823b6185d5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "f1465a9720b9d908c3fe33e7fd464ed7221701e7a019b38ae24c5bf0d9a1d41c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-mppi-controller/default.nix
+++ b/distros/humble/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-humble-nav2-mppi-controller";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "022d5d675576b8463c00bb984deeb9702b66cce39b3949f49c566a7eb9f03188";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "f327ebc35f00097d245d7f572da0ad4ea38cc88edf7592bbdbb419e37a95b5a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "89ce4ebd4a120ce7f8a1d706de6b834f97e427985632fa0e06d14b461b917e25";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "1153a3f51db63711838b9168ce96c56d42688d59ca63be4b0338bdb0254190ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "e6250856919fc3b516f408e32dbb25a96edb42430d58394e4ba87e8b89811594";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "d00c9fa5b09282ba0e2108929e369502816abe0b02ae3642543ff1367090f694";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "69613d3097453933e03fda4ed66e6d753e4184d80e8b04ce1de59528c4eafcfc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "30fbc98ad9db85f41a234b1eb31d83e064b5a8783667dd402afd806e30ca9298";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "45c4401d48a180e6fa2273bbedd20eec30f262769126289e76bb009c9938583b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "2c1deb9d3c1f203bc751f715f82139b1084f84eb695651880f5b6516c05a5f74";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "b1e0eb2061fb3f12f344aefe790c7ee8659c3439155ea5d0302131b8436f71d5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "13a1fb64ec5c34a759065b4234b5b3018a32da914c6b8b23c3eff41a35d7fe26";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "a1fe501dd4f86e8c77265077b8449ffd9cf32297ab54825036646703a24694cf";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "e3d43f79c843a48a3437794860390d0bf5c8272e38d823184baf348b2d904bb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "378503d035374423cc5420d94b1e95e0240a6c983751cf0bc4c20ea83d0251ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "aa4d6c11c5a68ce310e9bfce62de24e0d6efb99cfe84efa380d8f4612dbf14ec";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "ec48131b66a48805aecde7c81d9526b039ada95a46505776e25d09c8dc2f6152";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "309bfd870686759bc307221780073758dbddd7cfb0d2c809261e27a0385e566d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "a82700efdf73a2b76cba58fed0b4eff46f07f013f1972179c70e26224c83659e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "80bc9453c9f1ab4d7ca8cbd8bdfe2abc11d6cda3fd9d3074ab7d6ce60fe057da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "26f2e610dc31d28cb75ef88c86062bf25ed25af9675e3017a57006dcf5906a96";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "0e3b5e993faba783c93b141e3262a539454cf0b73ee6c3bcc4627fd5bfb96246";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "6f0f1e34858fea6694f580bedb4dfafd7011b6225a8c3a41ff42ceb8b5006994";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "17d5e7e1380278c76b60627202978cd3341bfb04bc56bbcc2a7ab4f1f3588ab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "e933363b46af8da149a713231e0cf486ac5634d6b371ea5c9bc2284abad5611b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "bf50cc4a7abf379da1b933de2e8173997b2f8a0c86a13059261d9bc22bb13be2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "7d5476e168d4ccd920d7c84fad1a6883a83d2068c2a470346ac778db7fdb0089";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "60dd50c81d5a7878f20bfb756ecf42637ce257a6329f320dee14805d91500fd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "ebcdca0e94b6d80fee828b8e6a39674396f1c48cc049fd9609c95a838dd0d66e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "702f12e3a9a7475f23694678c50ac015f51d13adcc49d47a68127cee06231a66";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "736dcd80a25f5bf2093069c5d57045b905f3771d9bfbfada166a3308d8261303";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "91e0700df49d68db9f1dd7a3bbf486f4aea93fbe28b45bc091402126f0897afd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.13-r1";
+  version = "1.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.13-1.tar.gz";
-    name = "1.1.13-1.tar.gz";
-    sha256 = "244b4b7a81d62d80fa68f58ae0492ecc5b24dc2f4b817b5ff8d5c605b965d39d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.14-1.tar.gz";
+    name = "1.1.14-1.tar.gz";
+    sha256 = "8cfb21c2185073d35b8756df716d0574b22fd7a08c1dca8da8ff0432920b84f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pcl-conversions/default.nix
+++ b/distros/humble/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pcl-conversions";
-  version = "2.4.0-r6";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.0-6.tar.gz";
-    name = "2.4.0-6.tar.gz";
-    sha256 = "dee51fc73a0875ced007e7bcab00eea6b5240327bc6bf5179a51b3aa70b1d87c";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "377a23bbd3be62a60799380ff31461d17546d38e3b7e82557f5a632d59539c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pcl-ros/default.nix
+++ b/distros/humble/pcl-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-pcl-ros";
-  version = "2.4.0-r6";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.0-6.tar.gz";
-    name = "2.4.0-6.tar.gz";
-    sha256 = "c05c0597712030197c8b1c5266e6587038c86694823565e8aaa89c275c2565dc";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "954f8b0e4cbe5089d29542886f02ce2b1aba3b3f0b287857dcebb7095d22d802";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/perception-pcl/default.nix
+++ b/distros/humble/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-humble-perception-pcl";
-  version = "2.4.0-r6";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.0-6.tar.gz";
-    name = "2.4.0-6.tar.gz";
-    sha256 = "665287fc0bdf50f3f21d77ba6b5633a43fee2da6d0e0d334bd7f9f6dac380eb2";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "b1ed8e8ab56cb10cde1d820115eebfe7eb2de199a59aee768b85db0ac3ab822e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz-interfaces/default.nix
+++ b/distros/humble/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-interfaces";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_interfaces/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "94911294036be70b53c063e3760e3ee32eaf626aca61f6f426256a7def807074";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_interfaces/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "8065ef8ad792cc66f6f0f0ac25773475843f27fe7c949fa94fe549c0a88a0f4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz/default.nix
+++ b/distros/humble/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-humble-ros-gz";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "179f6a3d4db654757ac2aa081a1f0de3bab0252a340867dee3c64484f0189fd2";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "3df8bd73c666d97fde77943c893d5559f1f01553861ecdc5412e9c8eaa2fa183";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-bridge/default.nix
+++ b/distros/humble/ros-ign-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-bridge";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_bridge/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "fea13274a985f0953243b890f1b8efbabb7c6340a3b6b9bbed36dfb8e9716b31";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_bridge/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "351a86dec32f66ca297f7778a1e3850d20a3f348452f8f0f354e16229723f1b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-gazebo-demos/default.nix
+++ b/distros/humble/ros-ign-gazebo-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-gazebo-demos";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo_demos/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "dd29188edc08e8a6b2b4a9902c5caf3c8416715f4fe34fda31d67ae846ca0adb";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo_demos/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "278eb3db0f1cfbc2ce11fc9c189084951c2bb946ca433dbed0d85d44460b04dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-gazebo/default.nix
+++ b/distros/humble/ros-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-sim }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-gazebo";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "90a325380f6e061cb9e38a948e91b3278de1d40949df9d78126447898b8173da";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "c2bb6cfc5d790de248f48fef3b7dd5c0883b0cd067f214517efb06e59d89d10a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-image/default.nix
+++ b/distros/humble/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-image }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-image";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_image/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "aa2d9ca6f064984d29f801ec7c3be5370968b443b1d4eb9ec3c0359da974f7a3";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_image/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "de9a53961fc30e545861a68a3de9f50a9521acb7506148b04c28e8d4619955e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-interfaces/default.nix
+++ b/distros/humble/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, ros-gz-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-interfaces";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_interfaces/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "0b1fc3c645254db5d0fb99ca000829270c9df2b3d929a420c5b21d0cea8c1346";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_interfaces/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "704d9849ba33aea36868368fa9de03ed74b3d79e18cf82c456c0ad56c5e85325";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign/default.nix
+++ b/distros/humble/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-humble-ros-ign";
-  version = "0.244.13-r1";
+  version = "0.244.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign/0.244.13-1.tar.gz";
-    name = "0.244.13-1.tar.gz";
-    sha256 = "0049c71a769c7943e27cb52de67b74e2179e24a230095bff8864714d2371f0fa";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "ae545b6c5ebf6d3c6afa53b0c2f2071aa94dd4b0ffc24aeb4595bb9c08f3c2af";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/test-ros-gz-bridge/default.nix
+++ b/distros/humble/test-ros-gz-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
+buildRosPackage {
+  pname = "ros-humble-test-ros-gz-bridge";
+  version = "0.244.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/test_ros_gz_bridge/0.244.14-1.tar.gz";
+    name = "0.244.14-1.tar.gz";
+    sha256 = "ee86fd9c1f10321dfd917a4291dd0d16c86df12a34459965931827e418484663";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ ros-gz-bridge ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Bridge communication between ROS and Gazebo Transport";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.10-r1";
+  version = "2.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.10-1.tar.gz";
-    name = "2.2.10-1.tar.gz";
-    sha256 = "e6d6b58fba33b55eaab9ee44c02f0689b6de9b163fcceb7f2b68f8813cd095a9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.11-1.tar.gz";
+    name = "2.2.11-1.tar.gz";
+    sha256 = "3a582d391dac2ce05d49a895ddbf98063951912e3c4de32ecd72e80d602a5b24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.10-r1";
+  version = "2.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.10-1.tar.gz";
-    name = "2.2.10-1.tar.gz";
-    sha256 = "8de475042d321442bac093a8cb0ff6f15ce5d615de9493024dd8543cd6f9c48a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.11-1.tar.gz";
+    name = "2.2.11-1.tar.gz";
+    sha256 = "2f8ddead58e04011b40599d75375648ca0e02e20f785d9717893bf3f006be142";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.3.5-r1";
+  version = "1.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.5-1.tar.gz";
-    name = "1.3.5-1.tar.gz";
-    sha256 = "394de316eb48762148dec817eebeebde09f38b493c5936b29466f05ce763b9fd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.3.6-1.tar.gz";
+    name = "1.3.6-1.tar.gz";
+    sha256 = "a2c6f0b5bd3d51bb4703060348aebf520477fd8e25ac0dfe90c63043fe3997ba";
   };
 
   buildType = "cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.10-r1";
+  version = "2.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.10-1.tar.gz";
-    name = "2.2.10-1.tar.gz";
-    sha256 = "d96f20445fcb82ad6851d87c16f59c46ecfe014f774690f0ae7c59afd9f51301";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.11-1.tar.gz";
+    name = "2.2.11-1.tar.gz";
+    sha256 = "6aa9520365e59a5a9eb101611e598ad98702ed1906a9531808272585b672884f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.10-r1";
+  version = "2.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.10-1.tar.gz";
-    name = "2.2.10-1.tar.gz";
-    sha256 = "22d90dc17958b274d9db99666afb043a62f8825d4eb0315e8dc785c6d43d680d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.11-1.tar.gz";
+    name = "2.2.11-1.tar.gz";
+    sha256 = "22aa56e87a7a5e09a521b13ddccc85c083d3e028aa13e6fcd8e613bb68aca83f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.10-r1";
+  version = "2.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.10-1.tar.gz";
-    name = "2.2.10-1.tar.gz";
-    sha256 = "8fb4c48abdb4b0a314b3e6c772864e69c38c3d20ecad99705d3e3243b00354ed";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.11-1.tar.gz";
+    name = "2.2.11-1.tar.gz";
+    sha256 = "109da6367a96d3c126b68b3615181d38c9f35fb6b178322e5a2208a5c6063e4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.10-r1";
+  version = "2.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.10-1.tar.gz";
-    name = "2.2.10-1.tar.gz";
-    sha256 = "d3018aa4394d3efeb7fba38d48509a9bd68d9a45d54a21ffad8275dea21cd8d1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.11-1.tar.gz";
+    name = "2.2.11-1.tar.gz";
+    sha256 = "8bc4d4759c64dcb2d245dddb731160f49e517d9791b7b5e08236a40ea5c564b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "8cb585237a3a4d35c43ce2ea8c79ac8f431b7f23c280a9cfbda2a0f91d4b52ad";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "1c80accf2f9f4f75b3d61b057431ef225dc3df1572564c26695bccd9525aec83";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "356ab68445bb7a1303f5ecc264e44d34d89e41c062da63731e0e564c19dbe22a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "66bbe24ed436544edba7e5c866648e034ddc1819ddfb61f6c5cbbe0206a1e2f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "32ea34d91bbec806e5bcadcad021d15b973e22e21b299b38f76cf5eec26f707d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "6913b792e5fd3b20507920173162a9c908bd8a664d9344433faf4308e48a6e49";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "56c2ac406cd39012342f10a457911185d007b9dbfb379f397f7a63c5fa23e6e0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "02b493e3c804d76edb81c7c703bbe7ef71138f0d1c6854135ceee06d01d00673";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "dc40ba781d21bee3e6629904afe143aa15ccafdb9c73f23a7b83da1dfa631213";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "5e8cb759b5e2c32bb8e511bda111871a843e40c86084894420d023e3a3f09338";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "852687c6bb39b61111915589583d2f8fce3647f8478975165d88c88bbd90b2b1";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "fd339582ae24021c2ccd468d0a225aa7e4e914a781881aa899b111df744e5183";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "537cec542f2f73343589075eb530dff61c9330932b1559c2b8cc1129b7f34b2b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "98163129d29d1ad7ad8fc0d9546fb1f7adc8627c68a57b22ba638213a927c756";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "4f78ad72d1649c432e18b28ffc04d64d848a1228dcaa55c1218ec19682b12f28";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "b31742a532868a1250853f3d22e19677e07f5f0bc138a502041876a74c82cde3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "56a6b951f962857c8ce20a244ea159ecc5cb73d9dd115fdf15ff759a3866aea7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "8cc879a979762eb860220c3dd35e64e6cd46cd6e2f5348e64b72f7325d182c70";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "c0ec2d713d234035f7ab55244eaeba1e58b22cd6d96bb6093dd5850b8982f335";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "7c9629a218e21fd9a7b2eeba6754916baedc3d3755b0b66ceb2d0795c5111188";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "9de204d5ffce4715b74f4410ac331d1c50b44bc93370a446e3c895584679ce0e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "7da393a95153f7913d82858fa831a74e2d208c10cd2c44608da875877daf86ee";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "981c3533191989d32b5027b0dfe5d82f13b94f118f328a00461502b7c410d3d4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "1808685478aa5b5650ba97e4a4451bfb534535c02789f7e2651608f741b4ed32";
   };
 
   buildType = "ament_python";

--- a/distros/iron/cascade-lifecycle-msgs/default.nix
+++ b/distros/iron/cascade-lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-cascade-lifecycle-msgs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/cascade_lifecycle_msgs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "63b073f2cac4c5b729d550691d7073a2474a812a662357394a0687322d6668b6";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/cascade_lifecycle_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7f5726bdd3bbdfacbdfb84f311917432a81aa9ca5a5822d8e56097757c459417";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cmake-generate-parameter-module-example/default.nix
+++ b/distros/iron/cmake-generate-parameter-module-example/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
+buildRosPackage {
+  pname = "ros-iron-cmake-generate-parameter-module-example";
+  version = "0.3.8-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/cmake_generate_parameter_module_example/0.3.8-3.tar.gz";
+    name = "0.3.8-3.tar.gz";
+    sha256 = "0924770703586da3cda0973928b5f255242ff82732e9cf0d2e2f4e58c399cb0c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ generate-parameter-library rclpy ];
+  nativeBuildInputs = [ ament-cmake-python ];
+
+  meta = {
+    description = "Example usage of generate_parameter_library for a python module with cmake.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/iron/control-msgs/default.nix
+++ b/distros/iron/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-control-msgs";
-  version = "5.0.0-r1";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/iron/control_msgs/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "5de25a5aba43871feabe47038c60805eebf4d44172e969d6c08113c3bc7901af";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/iron/control_msgs/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "956b4a3c1e4a85265f8e11207dc6c9b985a6133974fb1eb63ebd0922f5f832a4";
   };
 
   buildType = "ament_cmake";
@@ -23,6 +23,6 @@ buildRosPackage {
     description = "control_msgs contains base messages and actions useful for
     controlling robots.  It provides representations for controller
     setpoints and joint and cartesian trajectories.";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/iron/costmap-queue/default.nix
+++ b/distros/iron/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-costmap-queue";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/costmap_queue/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "9c95e607e3902551ae49a335fe0840ba918286d47afb4f51db8e2f8d105e8c0a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/costmap_queue/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "78f585c94a708fa936031d1ad343d0517347b9868dac71151bf6770a7d54f700";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-core/default.nix
+++ b/distros/iron/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-core";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_core/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "cca9620b194ade98803137658c21ca5bf7d1d888b0f90a3bbca858713bcf6149";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_core/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "7b1db4b51e68da6074e58bb7c1e408043cc123fe96bdeec5e78e5d997cb299fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-critics/default.nix
+++ b/distros/iron/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-critics";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_critics/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "a34190ef0a2328127603b01f47daa7d3dd29236259d409ad9da8f6053d385abe";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_critics/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "0074c66b50bddce9b597283dc6b80c62ff34994dd5351c5d19698e0e12e4b78a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-msgs/default.nix
+++ b/distros/iron/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-dwb-msgs";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_msgs/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "0cbb6bc60210c95479cb88c352784c574046610ae2207548962570e4c99f2cbd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "0097de44763e7b5f942e2d32c59e67d286d9f508eeb9e2db6c75bb24b892cc6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/dwb-plugins/default.nix
+++ b/distros/iron/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-dwb-plugins";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_plugins/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "e2522876c490708a6b050a2ae0bfb5a6045cbfc74130e292b2460f304bba097d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/dwb_plugins/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "455254dd4330c0b68a6b177723cebd5a45352d85e1abda1cae94780dc8b894ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/fields2cover/default.nix
+++ b/distros/iron/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, nlohmann_json, python3, python3Packages, tbb_2021_8, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-iron-fields2cover";
-  version = "1.2.1-r3";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/1.2.1-3.tar.gz";
-    name = "1.2.1-3.tar.gz";
-    sha256 = "ee0f4f72dac34530ed1983ab2f3832a1545f474a27c4b53b0d7fdcfd94fa57cf";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d7b1a60215a6d54c853ca32044f320336ff59232ce2292c79a5191f72c4ae506";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ eigen gdal git gtest python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 ];
+  propagatedBuildInputs = [ eigen gdal git gtest nlohmann_json python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/generate-parameter-library-example/default.nix
+++ b/distros/iron/generate-parameter-library-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "3170753249cde8bcbe014651292b45965f71a2eadd1637aac24e5fd50accc940";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_example/0.3.8-3.tar.gz";
+    name = "0.3.8-3.tar.gz";
+    sha256 = "0a111e6d491f92ede777fd9d905f92dd7cc086419616e611805f83ea1a54b6a3";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-core ];
 
   meta = {
-    description = ''Example usage of generate_parameter_library.'';
+    description = "Example usage of generate_parameter_library.";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/iron/generate-parameter-library-py/default.nix
+++ b/distros/iron/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library-py";
-  version = "0.3.7-r1";
+  version = "0.3.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "34d0686416877e62693352cd77d7490ccec6ac2fc2ac56d15ce9bc846dbfac62";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library_py/0.3.8-3.tar.gz";
+    name = "0.3.8-3.tar.gz";
+    sha256 = "0ebd06334a1ceda8e5801c23bb02c991fbeb74ea022d29deec0d1afd6633834f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/generate-parameter-library/default.nix
+++ b/distros/iron/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-library";
-  version = "0.3.7-r1";
+  version = "0.3.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "7bad8adac3783a4181d99dcf688b89c6f1ab8ef6176d20cacaac22034e181d68";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_library/0.3.8-3.tar.gz";
+    name = "0.3.8-3.tar.gz";
+    sha256 = "ec4c68c6ceedcd8cb25f8faba0afd1939c92f74c2f7da4d584fee77378b6ab37";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generate-parameter-module-example/default.nix
+++ b/distros/iron/generate-parameter-module-example/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2023 Open Source Robotics Foundation
+# Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-generate-parameter-module-example";
-  version = "0.3.6-r1";
+  version = "0.3.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "72475cf5472ce06e4f391a2a601e8bfe55adafa28bb1b5aec03e08770a2e72c8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/generate_parameter_module_example/0.3.8-3.tar.gz";
+    name = "0.3.8-3.tar.gz";
+    sha256 = "3560a9d74dfafcd184d563bccf8615a65bf7e6713175b89272686a03fafafad5";
   };
 
   buildType = "ament_python";
@@ -18,7 +18,7 @@ buildRosPackage {
   propagatedBuildInputs = [ generate-parameter-library generate-parameter-library-py rclpy ];
 
   meta = {
-    description = ''Example usage of generate_parameter_library for a python module'';
+    description = "Example usage of generate_parameter_library for a python module";
     license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -238,6 +238,8 @@ self: super: {
 
  classic-bags = self.callPackage ./classic-bags {};
 
+ cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
+
  color-names = self.callPackage ./color-names {};
 
  color-util = self.callPackage ./color-util {};
@@ -640,7 +642,11 @@ self: super: {
 
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
 
+ generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
+
+ generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
 
  geodesy = self.callPackage ./geodesy {};
 
@@ -1035,6 +1041,8 @@ self: super: {
  mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};
 
  mola-pose-list = self.callPackage ./mola-pose-list {};
+
+ mola-relocalization = self.callPackage ./mola-relocalization {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 
@@ -2215,6 +2223,8 @@ self: super: {
  test-interface-files = self.callPackage ./test-interface-files {};
 
  test-msgs = self.callPackage ./test-msgs {};
+
+ test-ros-gz-bridge = self.callPackage ./test-ros-gz-bridge {};
 
  tf2 = self.callPackage ./tf2 {};
 

--- a/distros/iron/geodesy/default.nix
+++ b/distros/iron/geodesy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, geographic-msgs, geometry-msgs, python3Packages, sensor-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-iron-geodesy";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/iron/geodesy/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "125c88baf26e8ac54a393fe20b04fa88c873a85e6095d66434073aa02d903550";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/iron/geodesy/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "252b8b13c89b705d8e3a5ec74c9ac4b2ca56f519943ab5103b27b7b88d9fbc28";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/geographic-info/default.nix
+++ b/distros/iron/geographic-info/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geodesy, geographic-msgs }:
 buildRosPackage {
   pname = "ros-iron-geographic-info";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/iron/geographic_info/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "fb878cc265efbbc069c13a141a28c339e48c39f76b0956b2da9d11f412eff76f";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/iron/geographic_info/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "5286525ecb9794b8f41fec44e0a42ca5385d36251b65548f340aacc31b6c01cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/geographic-msgs/default.nix
+++ b/distros/iron/geographic-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-iron-geographic-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/iron/geographic_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "5d7c9fdf89d99b133141e57e278837d8dc910679abb7a6916742c77a867b73c2";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/iron/geographic_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "baa14425948b5bce721dcdb79af24a6752677eac4b32d74e0240a2efe0620edd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/gz-ros2-control-demos/default.nix
+++ b/distros/iron/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-gz-ros2-control-demos";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/iron/gz_ros2_control_demos/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "1ec0622439436ad15ae0eea23368b15acb56e4e102e979d0180cbdfef55b1340";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/iron/gz_ros2_control_demos/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "e541e393680d487c3b831598d0957e9fed1428407dd019644a9f394cb419a4e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kitti-metrics-eval/default.nix
+++ b/distros/iron/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-kitti-metrics-eval";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "97423730676627bfc4f69cbd9d03321cdecd5954612bbdcd22315c86cac9542b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a63b8ea9f233a4acad8b323b7a5b027d0dd25607da72688f4d3d669430f77a60";
   };
 
   buildType = "cmake";

--- a/distros/iron/microstrain-inertial-description/default.nix
+++ b/distros/iron/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-description";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_description/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "aa4d1ad69cce3991d46410d01f420dcf3bfe396bc7ede581d206248141e4e86b";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_description/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "3abdc6748c483c4f714726dd46479059089d5f14ffb92ba64951077a59691942";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-driver/default.nix
+++ b/distros/iron/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-driver";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_driver/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "24e76d53ad2e9eb225e34d9095d1cf04ab1ad80f016f0dc5502159855a451950";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "00031d35aa8e5bc27749eb804e5bd1cadbad6932a5c9c44043876e0c35c576f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-examples/default.nix
+++ b/distros/iron/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-examples";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_examples/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "f976ccbaaa64ecbec5beb5c3a788db7e95ff3f1eb450ff65133852fe6207e06b";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_examples/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "d04cadc8f33a64ee7f84f77036acb8f2449e15310dc5533b4a356f279e9a1a49";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-msgs/default.nix
+++ b/distros/iron/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-msgs";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_msgs/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "ffa19749fadcede33ca5c43f4d86a514ae04d493aba9727354cd64c054edc36c";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "a05240c3ee69f3a5535b82ec3f13bd1977dafcbb341b5859a9729a582bef872c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-rqt/default.nix
+++ b/distros/iron/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-rqt";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_rqt/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "aa2aba7fc88f62b9052b5071788c357db64a9945c2dedb9c4be0be8c88fc3689";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_rqt/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "9c164198152dcf4ffe483f5db207920115a6d19477c8e49d10bf49bcb8e87123";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mola-bridge-ros2/default.nix
+++ b/distros/iron/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mola-bridge-ros2";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ca716c1a6cc1052a8f493373a853a8a4b4384f6aff9731a87e7767be48dc50f2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "b0ab5f4e92419f2d23c4c5893dadf3e0c61b8dfaefdab33680e63b024e4d05af";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-demos/default.nix
+++ b/distros/iron/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-demos";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "0700e51d6fad7a46d6d4344c088a4edf3cf9f130e1795f06d65baa35a0e3b477";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "b5171dfbf235363d0e753198a492fbb31c696625a0eb8c385434362caeba12a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-imu-preintegration/default.nix
+++ b/distros/iron/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-imu-preintegration";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "1cbb712cadd4ac7d573717eebe217f463f022c6b45826af0b7a3297ad4a35fc4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "42989a921d490290381b16e5acce2e43280f84926ed4b6f381655819732910e7";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-euroc-dataset";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "9ec727179d39aab51aad026cf9d60f3dfdc4a1e9e447299eb51e65781efae626";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "17a54f13b0ccbb9f570e64eb35e40755271be63cfb8f806f2a0a0697385a97d9";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti-dataset";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b7ecc64eb36b1ca25de69611eda8a14a393364ac857933f32da0b3e4a8ef2d9e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d9e615c8169f649cf2f6d492ad31e526ac357642e303ffe91e267aa3db2bc00e";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti360-dataset/default.nix
+++ b/distros/iron/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti360-dataset";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d940b3fb8933ab8507a5e24d522c51dd1c1933ba34e6518b101301def1dd4d8f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "7592f413ef4e8552eba8ade0c54785c794b258433edcceb35be1a5c863627835";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-mulran-dataset/default.nix
+++ b/distros/iron/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-mulran-dataset";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "365e66449061451da17bc1efd5d958479d7b0b14d0b57169acc6c26f710c9eb8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "aaab3aec76cdfdf48b452cadf7d986cfe21222ce19fa971bcda046edc549d8f8";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-paris-luco-dataset/default.nix
+++ b/distros/iron/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-paris-luco-dataset";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ab561b26462cb20750ea7e133e49c991d79c734f2c08c3fe2ccfcb3cd15a809f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d4a02464e581676fa3a108f8e22ecfd31457010bb8a508e500d4dfed4a9503b1";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rawlog/default.nix
+++ b/distros/iron/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rawlog";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f9b88aff2797b7166c474e2753c6b6eda37e369e0667c19a3412890063edc91c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "66b0ff9006b0d052f9f67a1c53802b16310540243fdc9b6fc0ace39fa6057562";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rosbag2/default.nix
+++ b/distros/iron/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rosbag2";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "db7ed286d26006dbc7e908412fec97306a3fce2c8f4de6b6220f70fcaa89d7ec";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "381e354833d11036760b5cc25db006f27986523c56e8ca1d9a1aed0a2b1a031d";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-kernel";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6fd113dd5bf814636ebc37cb2a4d16baf4faf8fb01266b88cd2da52f06af9979";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "219b61e693dd66f6082d71e0d2cc1f006f7c0a8e546343141dfc6fdbbd2d43f7";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-launcher/default.nix
+++ b/distros/iron/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-launcher";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "204db627c803390ca39d6297437948123ce92c019015ca84f9712fca0115ae57";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "4156770edc3138459dc9d73caaa20c233650a83188954a53e1b2755ea6a949e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-metric-maps/default.nix
+++ b/distros/iron/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-metric-maps";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "a7429b8fc4079cb24e03fb63aafa21f2ab62a055155c4f0f8310012cc32deeb3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d825215b38eb8bcd01b4c88046a4b09a9e9953e677bfb1a355b0e03e5816ff52";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-navstate-fuse/default.nix
+++ b/distros/iron/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fuse";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "2e21ed05a5e11e12132937974606fb58c3a36b4bde7c3ffab5179949c5308ef1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d910279ecdcf4d589d155b5a94b6b6fcaa97f24888708fe112b47268d8ec18d1";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-pose-list/default.nix
+++ b/distros/iron/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-pose-list";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "83dbfb0caed89be8788363b5e0e1bbdc09b1f2fb09e18bc26651ff9b8e6675b2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "afda192e5f0d3c7e70709aca64cd171cc34aab7762591303f0bbcfb8833eac36";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-relocalization/default.nix
+++ b/distros/iron/mola-relocalization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-test-datasets, mp2p-icp, mrpt2 }:
+buildRosPackage {
+  pname = "ros-iron-mola-relocalization";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "48edac8a2f2fa19cb42f0f58f8ec468a81c9e4bde4a36f78cc512142c9523fc3";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-test-datasets mp2p-icp mrpt2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "C++ library with algorithms for relocalization, global localization, or pose estimation given a large initial uncertainty";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-traj-tools/default.nix
+++ b/distros/iron/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-traj-tools";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "46d66bf008cc80873b6ef420e0d4e480a34fffb5df1c75ec6f4b033dd75dd4db";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "baf7733e0392f69a31a99386ec9f0619ac2e9b709b04bd4d24f556eae057b848";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-viz/default.nix
+++ b/distros/iron/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-viz";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "b6a3412d8639a5a2cce837d3db87850acdd8c19a917dfb1fd1998649a586db9f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "5272cc219f75b3792d32f25656e6d5e291b4c06445b35c25a2a628d308f37d97";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "39a9b309f2442097d4297044148a7341255b8f51a0b139dfb27f21f39702f86d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "185a13f12cfaeb248c7201cd5a9065a046f9de3e469af05a6461ab034efa7fd7";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola/default.nix
+++ b/distros/iron/mola/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-traj-tools, mola-viz, mola-yaml }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-iron-mola";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "cf59c7d35fafc63c30c3634d38492ac83f00a5f1d096d98eeeceb289529cbcde";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "9ddd847c803e817d2835dbeb430e5c1886e98e9f1b52a55f76057e2b55cb92a8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fuse mola-pose-list mola-traj-tools mola-viz mola-yaml ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "ecc0a9a724da3ca500affd9e089d4124c953144a8fe5781754f9529dca25eab9";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "0938b93a9717e1d0658b351f9add2bdaa83f60249127f9b385998e4076e0df91";
   };
 
   buildType = "cmake";

--- a/distros/iron/nav-2d-msgs/default.nix
+++ b/distros/iron/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav-2d-msgs";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_msgs/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "7418c6031e780eaaf73a58b19404e159b1248a2eb668c4f3a58148ae87e9a480";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "c5e33ae345a2258dd98f59bcab07be1f2493b3338de62834fb97170e62d573e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav-2d-utils/default.nix
+++ b/distros/iron/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav-2d-utils";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_utils/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "ac8ecd12132474848d65b5e36ae8a7302390c32787c8c6d5d0e64a703c557da2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav_2d_utils/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "51bbc26d50b5e578d63b9367bc185af8f7dd17da64cdd665b17c32c484782e69";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-amcl/default.nix
+++ b/distros/iron/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-amcl";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_amcl/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "0adf690d91571dda26530124eb2b48d9f4f5c89b0b77875c4162196a7c9d0d18";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_amcl/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "ed4918e36bed02996866b534490abb27a2b518422dd9f92e02140bef70ad9df6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-behavior-tree/default.nix
+++ b/distros/iron/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-behavior-tree";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behavior_tree/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "5d0c6d78c4458d712ffdf755885bc3a2d5d26ae3b61fe4a7bb84700f242fe8d1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behavior_tree/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "3d95be8c75ac824c94885b3b4f16095a68c6d34631fbc8a79a797b00c7728949";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-behaviors/default.nix
+++ b/distros/iron/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-behaviors";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behaviors/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "88fa7ef2ac6d8ee69b4182c1557767e036832f7a69ba3ec0ef88daff67ddc6b3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_behaviors/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "0e1bab82296101f235cbcf8cae8fb7d5e8c5443abdfccfd675c14d60d3bd2d0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-bringup/default.nix
+++ b/distros/iron/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-iron-nav2-bringup";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bringup/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "bdf9b7193b97fad88572a5cbddd41cb6915ee87d6c5b5e0a50ae7ca4238eda96";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bringup/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "57940223d09903f4535c4a42e841428e54f45b9ba36b334ed1547291c3dec4d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-bt-navigator/default.nix
+++ b/distros/iron/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-bt-navigator";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bt_navigator/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "a1aa3fd96aaecb63d1fc5be21537dd7987f6e9a336583c0aa6bd6a6a65509bee";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_bt_navigator/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "19f016018f319d92cecbeade9e9a3dbd0b0e445f4a5c129d39cab0e28d89d84b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-collision-monitor/default.nix
+++ b/distros/iron/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-collision-monitor";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_collision_monitor/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "4604da23420fcb1aa8f501162cf90a07ac5f42a608bd60db6b8096f1577811c1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_collision_monitor/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "e79e66b21e64fb7ea950f26ac0f97a5dde88064f895e4daa2f7657748fe225e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-common/default.nix
+++ b/distros/iron/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-nav2-common";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_common/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "8b6aeda6294f46b3bc74a067d665c3e9c73e6a4e4afa7973599a525b5b540fa9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_common/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "002af5f98d2b2c6b8bcbf4b74753a3f26226a3102261d91009bb9ca32c690611";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-constrained-smoother/default.nix
+++ b/distros/iron/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-nav2-constrained-smoother";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_constrained_smoother/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "17bed96d197d813e47170f648ec4eabb05b8087c7eb885d2e603a20f8ecf6b1f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_constrained_smoother/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "2e7315eae0eb0c4267056ec96b5138ea13f99b874e5111b5552328304760cd9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-controller/default.nix
+++ b/distros/iron/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-controller";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_controller/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "3ef12b701fa8034e9dc7bd68fb95d9a791dc431ed5ccae4252d7477eb99f96e5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_controller/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "2a993ffc9f651261cdd028f19ae6120332f6dd07fb82cebced9cc9bcde0f2014";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-core/default.nix
+++ b/distros/iron/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-core";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_core/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "83b172aa3f2abc351a2b3d5ab308127ae24353b43bf53cab559850a8ae848925";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_core/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "a79af511b0ce4ea2a1f7ed884f346678ed7a9ac61e7ff98d0f1d2542bff27205";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-costmap-2d/default.nix
+++ b/distros/iron/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-costmap-2d";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_costmap_2d/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "3d69a95f1f7c94fbdeb71bfc7adc0e10891a0294212797ec695afe4ab7d0818c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_costmap_2d/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "38397a0ff215e6d52c39ff8a1f78b7476e4701d12e42f592faac1fb43c3b2406";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-dwb-controller/default.nix
+++ b/distros/iron/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-iron-nav2-dwb-controller";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_dwb_controller/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "384b0f9c6bb2af764fdce6d3271c579976a99817a70b834e249aa2469a7bcc9f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_dwb_controller/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "3967da1c895629dd693d48c4eaf901a572a55a466584b51bfc70484adf155549";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-lifecycle-manager/default.nix
+++ b/distros/iron/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-lifecycle-manager";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_lifecycle_manager/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "f286e7b2ec36f70bfd870ee6a5685ed706cae86e298e80d43f4214d97f9790be";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_lifecycle_manager/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "701475a15b185acbac71e41e98c99727ac4ae085bde847a805afe463da2e0574";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-map-server/default.nix
+++ b/distros/iron/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-nav2-map-server";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_map_server/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "7c03f458309fbc42a919b53f4551180c2f9c7e632083f487062763d0705c79c8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_map_server/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "f370d02c5848d7fd09a1841e6ebe178ea99d2d12b33b0d18e82d5a5342357bef";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-mppi-controller/default.nix
+++ b/distros/iron/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-iron-nav2-mppi-controller";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_mppi_controller/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "944d69ff5cc3febf7449ee7b76080daa94b21fddda390d107c04b6f938f8149b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_mppi_controller/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "fb2fd57a6b2b908f3383f6bd2b7fd269e30b225e584bf4292c8c7674cfdc5aa1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-msgs/default.nix
+++ b/distros/iron/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-msgs";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_msgs/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "6d6e16db581c6956c586a8b379720931e9b0053e11982bfb3cc28b1147ec8907";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "f529fc8cc6c4728a6be35a151d8b297a3e0dec78ce0ea256ab1772345a8505ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-navfn-planner/default.nix
+++ b/distros/iron/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-navfn-planner";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_navfn_planner/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "f121091eee0ce781bcfe89a3f739a48e262ca0e0f81eabcf911448a8042edaf0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_navfn_planner/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "6b5d3d73cff4fb01dde1be157fa7fbc316e1f35f0189e0ab83decd153f2d66f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-planner/default.nix
+++ b/distros/iron/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-planner";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_planner/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "f0ca45f4b0792a26954d808298af372064a96dd749088d2e1fbc634c8cdca058";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_planner/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "cfc19050cc4f1f1f57f0e5ac963835fbd55340c94ffa7289304a1ad78a1385f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/iron/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-regulated-pure-pursuit-controller";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_regulated_pure_pursuit_controller/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "2908fa26645a973d0d01986e19754f1bdb7cecb651b5417222b026fc534aed3a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_regulated_pure_pursuit_controller/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "66366530494e0ce0d4c7ca8c699f6ffda05867037efeb67e000567139b38e473";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-rotation-shim-controller/default.nix
+++ b/distros/iron/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-nav2-rotation-shim-controller";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rotation_shim_controller/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "c12c8b0d5f006bb21c6ea5eab029a68cb82a4d960b0484135aead2471827bcde";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rotation_shim_controller/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "5ed549906bc98124524c49807addd821f91f737ad679eecf26533816a31d030d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-rviz-plugins/default.nix
+++ b/distros/iron/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-nav2-rviz-plugins";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rviz_plugins/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "7191bc97902dadb0977d44bb034063737bbf51abacc290544ec89f5fe70f4f71";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_rviz_plugins/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "4e983093cd5e95253442541098c93d47a90ea84b171e077209c3c5ca99a37123";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-simple-commander/default.nix
+++ b/distros/iron/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-nav2-simple-commander";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_simple_commander/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "f1ef46a6e22ba3cf1b54a061cdaf7b3ca18060fa000827868f89cc3a6ceae882";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_simple_commander/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "17f283c500230cd76c721094cbc49c379a8e6b937ce1f64906fccc5397060082";
   };
 
   buildType = "ament_python";

--- a/distros/iron/nav2-smac-planner/default.nix
+++ b/distros/iron/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-smac-planner";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smac_planner/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "32106a7b9519e15a3d6b3a5aff2b9bfe55b74e19d65a8bcb1cfee7ea9e5c1b62";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smac_planner/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "1906772ab1ec0a227ee5dc1530a1916bbf98705768e665a21ed4b2be396f0a3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-smoother/default.nix
+++ b/distros/iron/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-smoother";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smoother/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "6a48224cfe38e68980caf7deae43e7cf158f8cbf144d1017033dd331c0ef01c5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_smoother/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "16f499e17dbe4a0d5282751d3ac8d354679a42805da4aa625ea061a7f7dfe015";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-system-tests/default.nix
+++ b/distros/iron/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-nav2-system-tests";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_system_tests/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "97760405e54da64e5671262f1e8e890738e6425d13f4a14f47d02f1bed6d2ad7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_system_tests/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "d778f77b80a72c594cba6353d8994525cf3f04c7a95447d16652f9a55b3e17be";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-theta-star-planner/default.nix
+++ b/distros/iron/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-theta-star-planner";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_theta_star_planner/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "bbf6021a9499af0adbe8167f11ffb030a417b0d9d59fbd582bc7d62cb6cb10eb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_theta_star_planner/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "d9efc98b4683efb6d3649d79bce800720336ff7e9eaf5eb5933ac9aecfcf7617";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-util/default.nix
+++ b/distros/iron/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-util";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_util/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "285d813ccbe0345210a66644ba2ae59904f8345d1922662f9dc391920a30419a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_util/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "9571986a82cfbd9d04800eb467f1e66fc33981810cb980488a773254a98618e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-velocity-smoother/default.nix
+++ b/distros/iron/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-nav2-velocity-smoother";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_velocity_smoother/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "48ead0329d65cf62d468f43c9f999033a888873ed3d7bea85d9c87b3816608d1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_velocity_smoother/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "72733332dd4a14e28e05930a1d7312cc2f1cdc647ee02b7b4481ba9ef5253609";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-voxel-grid/default.nix
+++ b/distros/iron/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-nav2-voxel-grid";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_voxel_grid/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "ca76a281a625ea75c211104349ec6ad5cffc009f421ee9a00cb6d50af5437582";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_voxel_grid/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "00d07e852f1858e90c1e51d58a6a121c30636ad7b7025fe14a09809f5e08bc67";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/nav2-waypoint-follower/default.nix
+++ b/distros/iron/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, geographic-msgs, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-localization, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-nav2-waypoint-follower";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_waypoint_follower/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "e2422d4370307ee88ea7f70034c6d936990ca6e850cf12f6bc791162fd95ed6a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/nav2_waypoint_follower/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "7433587adfaae03d62cb2393c8458dc98f29bf0c2c5aa603da6f360a8b36afec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/navigation2/default.nix
+++ b/distros/iron/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-iron-navigation2";
-  version = "1.2.6-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/navigation2/1.2.6-1.tar.gz";
-    name = "1.2.6-1.tar.gz";
-    sha256 = "5d4d70a7cd1b18f47395f75126d08a3344d67521fc9f8d0fbe0465688024296b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/iron/navigation2/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "d97e9b9dc64ec2b5e3bb05ce22d554548e5391bcf49711cce5a23916eef035e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/parameter-traits/default.nix
+++ b/distros/iron/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-iron-parameter-traits";
-  version = "0.3.7-r1";
+  version = "0.3.8-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "cdc317d58b65c57998ea590802e13fbd36dcec5309f6d698afbfe7063ac18e55";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/iron/parameter_traits/0.3.8-3.tar.gz";
+    name = "0.3.8-3.tar.gz";
+    sha256 = "697ca5dd7b19743a5dee2559a59b1c534654dd773cbfc4aff0392ef50408804c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/pcl-conversions/default.nix
+++ b/distros/iron/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-pcl-conversions";
-  version = "2.4.0-r5";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/iron/pcl_conversions/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "5d5d1d4abe918ec220110e22c4f014cbc50d56464a7b940a4ce2738bd27d138e";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/iron/pcl_conversions/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "6e19bab6bfb4c04294ee30453cf0f26048b135523e41271e85176fd1b793501d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/pcl-ros/default.nix
+++ b/distros/iron/pcl-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-pcl-ros";
-  version = "2.4.0-r5";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/iron/pcl_ros/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "82be48e41542f9185429ea2e2d8646f6e3e3441640a0735af840017ebf3dc9e5";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/iron/pcl_ros/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "51d370ef3b3bcdebd08f7c02b4062937fa6ad401de0be6352cde03dc9adc9e86";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/perception-pcl/default.nix
+++ b/distros/iron/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-iron-perception-pcl";
-  version = "2.4.0-r5";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/iron/perception_pcl/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "563d0db90de514a487a7a00ef8eb180bdb25b930a0d1e98ec17787cf48d3e89a";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/iron/perception_pcl/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "b9d3905e435eae3b70cf30993bc675163b747b301769beffad8edf64d17cccea";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/iron/rclcpp-cascade-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-cascade-lifecycle";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/rclcpp_cascade_lifecycle/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "938948c178767f26c23f6f4e43a4eb206dc82cfca4e14df7cdd02c7f37fe9da8";
+    url = "https://github.com/ros2-gbp/cascade_lifecycle-release/archive/release/iron/rclcpp_cascade_lifecycle/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "350d9a6af1fbdbb5b6ad6b6d6c5d570848bd08091d6ef4b691fcea083519753e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-gz-interfaces/default.nix
+++ b/distros/iron/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros-gz-interfaces";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz_interfaces/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "9b87e97d9df91834a48e2059b39ae7addc948f35952ef38bbc7a849af6f59cb2";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz_interfaces/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "ac973aed5646e9b8b02a7818ea90faa17c168a381d67437c430512c6c86d5052";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-gz/default.nix
+++ b/distros/iron/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-iron-ros-gz";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "2551995a579a9630310b64efbcdcd92f99b865e2c2202144d6d9de22deb03c9a";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_gz/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "3fc3fd494f540bc82f1f6b7c0c3914496affc745280b68a1dfc1a60a0e973ff7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-bridge/default.nix
+++ b/distros/iron/ros-ign-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-bridge";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_bridge/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "b7a0f6c8a8e65df66aab78c15f4d2871396cfe25b3383a40bdd9786aed2bb658";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_bridge/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "fb22cdace78dbabd72690fed6d1a8d981ef607acb1e98267533e72ad2e30b55f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-gazebo-demos/default.nix
+++ b/distros/iron/ros-ign-gazebo-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-gazebo-demos";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo_demos/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "9c0278a371ad598b78f9e376aea97c7a374a80bcc49b5fcc076188b2b9ee477c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo_demos/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "2db772c66d510dc66ad0a768058ad352af87ed6100cf70c94ff3e131ca3e9a83";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-gazebo/default.nix
+++ b/distros/iron/ros-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-sim }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-gazebo";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "7177c9b0e7218de20017922070b8f866170fdecfefce84d3464271cdf29711b4";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_gazebo/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "b6507e24611302199087c445aeba78a39d345d00666c275cdd011b4be1d9d4e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-image/default.nix
+++ b/distros/iron/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-image }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-image";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_image/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "a1f456174a1cd4625a2327cf5a1d64d5e30164633e0c0ffd7224418535d29960";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_image/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "2fc71c6f306920826a7163f49d9265f7eb6b30fc17b6417438bf5366a9605ec6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign-interfaces/default.nix
+++ b/distros/iron/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, ros-gz-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros-ign-interfaces";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_interfaces/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "88cfcbb04f7de7717de5bbe195bb35cf519968eb8b7d2e8c769fb545d2fc144c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign_interfaces/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "c6dc63f9fad36a4448236baf8378d3bc8824b6501beefa795363c8265ad6eea7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros-ign/default.nix
+++ b/distros/iron/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-iron-ros-ign";
-  version = "0.254.0-r1";
+  version = "0.254.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign/0.254.0-1.tar.gz";
-    name = "0.254.0-1.tar.gz";
-    sha256 = "2c6a917189bfb608368a86db580a4ebfdf59b1e561715367787a1d049f60b691";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/ros_ign/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "7d8526bc25258da1e325ac1bdcb291e90639f661b04fa350bd6e7e9496105f16";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/test-ros-gz-bridge/default.nix
+++ b/distros/iron/test-ros-gz-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
+buildRosPackage {
+  pname = "ros-iron-test-ros-gz-bridge";
+  version = "0.254.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/iron/test_ros_gz_bridge/0.254.1-1.tar.gz";
+    name = "0.254.1-1.tar.gz";
+    sha256 = "c54b90b85c7b5b229428cf78c918ebaf28de9bdcf087117907cff031234344f4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ ros-gz-bridge ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Bridge communication between ROS and Gazebo Transport";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/ur-calibration/default.nix
+++ b/distros/iron/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-ur-calibration";
-  version = "2.3.5-r1";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.5-1.tar.gz";
-    name = "2.3.5-1.tar.gz";
-    sha256 = "b470e928030f90c05ceec77fab36a38b8cab9d38565e233d27f8ea2e2fbe6dc9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "f5e9ecaf72960bf4f9a71fe86cb925a127ce853ce5fff2afb12344277b9de6fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-client-library/default.nix
+++ b/distros/iron/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-iron-ur-client-library";
-  version = "1.3.5-r1";
+  version = "1.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.5-1.tar.gz";
-    name = "1.3.5-1.tar.gz";
-    sha256 = "962cc2773eaa3038bd8124e2e5be06021dfccef42dd2babbae88a19617fd9539";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/iron/ur_client_library/1.3.6-1.tar.gz";
+    name = "1.3.6-1.tar.gz";
+    sha256 = "f45bab2559fa3379371c41124425654d41bfb3ac94ea1ceac6f60a7e8769c0e2";
   };
 
   buildType = "cmake";

--- a/distros/iron/ur-controllers/default.nix
+++ b/distros/iron/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-iron-ur-controllers";
-  version = "2.3.5-r1";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.5-1.tar.gz";
-    name = "2.3.5-1.tar.gz";
-    sha256 = "456ca7e78dffa23c0fa0c3de1d25dae38a24c7f9c8e23cfbc84cdbc2892590d3";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "37327fee6ba4e97439d7ae102c1f49bef77e5d1b7064c5c9780a7b630a3559b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-dashboard-msgs/default.nix
+++ b/distros/iron/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ur-dashboard-msgs";
-  version = "2.3.5-r1";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.5-1.tar.gz";
-    name = "2.3.5-1.tar.gz";
-    sha256 = "bfdfe6604b1b34d3ea20523ff4a785efdaa0d1987ba0e45e8b6534a016020ba5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "cdbd0d8512037e4c3b93b5e6ee6ae8e63c53fe094d489b2b6d09a669819055c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-description/default.nix
+++ b/distros/iron/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-description";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/iron/ur_description/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "9f47be9bb7c26c6337422d8f624ee713eab06cc56d3b10d12d923d293987b146";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/iron/ur_description/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "7bf9a3f625f51470a5bb25238ad6415936dd23664e4060c50e86a256159c106a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-moveit-config/default.nix
+++ b/distros/iron/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-moveit-config";
-  version = "2.3.5-r1";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.5-1.tar.gz";
-    name = "2.3.5-1.tar.gz";
-    sha256 = "b69bc73ec619e201ab0badd0ee8e1561994c1f5cabbec8fa8109472e7a26c6f9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "c2651ab0fb4e5cfd5ce5a08a4ee6dd00dd0b02440701f410c5522ab0c7811a0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur/default.nix
+++ b/distros/iron/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-iron-ur";
-  version = "2.3.5-r1";
+  version = "2.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.5-1.tar.gz";
-    name = "2.3.5-1.tar.gz";
-    sha256 = "9f812e3d5a8921e56b48d8cc9e810f060a5938733ab1903dcd4a08f09dcd489a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.6-1.tar.gz";
+    name = "2.3.6-1.tar.gz";
+    sha256 = "3ee7ababd079710589a2c8be20d369a38795d2afea5f9f44c06dfef16e25efb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-control/default.nix
+++ b/distros/iron/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-control";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_control/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "c43cf5d50fc6e279b11c447230da23553cb90b08409c345ae9be237ebc3ab4ea";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_control/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "b858ec78168a1c15de12c868f4edc1ccced9eb2159da35b0f3f3ffa45497c868";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-driver/default.nix
+++ b/distros/iron/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-driver";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_driver/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "64fccdd7f85b354b94338844720b7d4f12a4bc64c5cd0d71e5cde7883357b3ed";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_driver/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "7efe097ec02443f87d79a69db9f60078695cf32523944e085157b20e2e5a4710";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-epuck/default.nix
+++ b/distros/iron/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-epuck";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_epuck/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "d546ddab11fa4fcd71fa52af4014241380e88877505caf95b954034b749e1318";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_epuck/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "f2311b5d88107a6e1c5691fc5cb6c2e5ea6ba22fc9c34c967f5dec8532f2fc21";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-importer/default.nix
+++ b/distros/iron/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-importer";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_importer/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "113950243dfa7dd9a978d55d313e9202f5e9df5be2ead46ed77fada95d9ea9e8";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_importer/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "c1910778e48a06b8e2f62ba03d7e0019ced4b301aa9eb30ccd12353e2a39386d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-mavic/default.nix
+++ b/distros/iron/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-mavic";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_mavic/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "352eb11d4b9c8bf0d936dac23451bf110a7c771e47871e1807046ec296324d18";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_mavic/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "643f286eddeb9e12d962b920dcae183c62bc948f0eb51c936c86500a3251ae2b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-msgs/default.nix
+++ b/distros/iron/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-msgs";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_msgs/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "3e69f8dd2256c2f2e4cface2975a67843a259b79658e266b35088b71fe84c016";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_msgs/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "7fce8948c614dfd22a9bd8ffa862c746973ee3779299e37e72cd18cdc7fe5ea1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/webots-ros2-tesla/default.nix
+++ b/distros/iron/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tesla";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tesla/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "e927abf95a989c2bd26ecd17eb2c179d146084d2faf7ec53c2049dc82c4ec259";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tesla/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "5fabb9cfb8e39a2abac2d9cc8b1340871fda7c4f03af63e654c13f7314a2c238";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-tests/default.nix
+++ b/distros/iron/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tests";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tests/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "7aec1a0351bfefd0177ecee3cd6fdf67b61ad6d7ff64c42cca7f041f4a62f4c3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tests/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "cefd4aade87958ae1bb70a7d385aa0bc06a339a173828abd684260206f303b9a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-tiago/default.nix
+++ b/distros/iron/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-tiago";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tiago/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "25fe1835d28c1f033045b91a3cfca6637b854f9788f948478f16003b3b63a442";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_tiago/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "bda8beb4b797348e2abb727679bfbae5ee3e1948622ec714306d91dddd7919e9";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-turtlebot/default.nix
+++ b/distros/iron/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-turtlebot";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_turtlebot/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "3c40d599d1260c525df83aaaf039690e7366e3c05fe9300116e470cb62263275";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_turtlebot/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "3454f47602dfc75b254777fcf0bdea113b8338a0fc32c21846afd92c8b7c7042";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2-universal-robot/default.nix
+++ b/distros/iron/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2-universal-robot";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_universal_robot/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "cb217fe2963c49d6c9fc66e5fc69fc12637ddd65ebf75965d3bca5ff938b20fb";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2_universal_robot/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "c5de8ea0e488a2dfabf8b8dba38626c550468d4d43e85cbae4838b12d52043d1";
   };
 
   buildType = "ament_python";

--- a/distros/iron/webots-ros2/default.nix
+++ b/distros/iron/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-iron-webots-ros2";
-  version = "2023.1.1-r2";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2/2023.1.1-2.tar.gz";
-    name = "2023.1.1-2.tar.gz";
-    sha256 = "e805536276880a90b984b3c598ba7501b034117b54f46a03db1ec3262c5561a7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/iron/webots_ros2/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "c09812388d5d626d3602601b39e93374fd2716ce22688fa6bd74a7ee8af7d930";
   };
 
   buildType = "ament_python";

--- a/distros/noetic/fields2cover/default.nix
+++ b/distros/noetic/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, nlohmann_json, python3, python3Packages, tbb_2021_8, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-fields2cover";
-  version = "1.2.1-r3";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/Fields2Cover/fields2cover-release/archive/release/noetic/fields2cover/1.2.1-3.tar.gz";
-    name = "1.2.1-3.tar.gz";
-    sha256 = "1657143af02bfc8c0dfa841de2f91ef9ee79312be3e03095fd487fbfe9bc2ccc";
+    url = "https://github.com/Fields2Cover/fields2cover-release/archive/release/noetic/fields2cover/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "68fe33ca8feb4079dca56639d1740c7aa271cd72973e0ece24eb82c742b5829d";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ eigen gdal git gtest python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 ];
+  propagatedBuildInputs = [ eigen gdal git gtest nlohmann_json python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -3794,6 +3794,8 @@ self: super: {
 
  ur20-moveit-config = self.callPackage ./ur20-moveit-config {};
 
+ ur30-moveit-config = self.callPackage ./ur30-moveit-config {};
+
  ur3-moveit-config = self.callPackage ./ur3-moveit-config {};
 
  ur3e-moveit-config = self.callPackage ./ur3e-moveit-config {};

--- a/distros/noetic/microstrain-inertial-description/default.nix
+++ b/distros/noetic/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-description";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_description/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "0dae86c43cedd54e8b998960e8681e1408320ce73f59adc6b9339137ea50d9fb";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_description/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "51b3546731b48a06301dcb2ee1e8b46405d232da9d3c4ae752d68f41ec620a57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "3671ba5e9a8496e9e09f9b7621f7f70eb9d058a6511629f3995b914277014cde";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "28e3a5b1a6071cbbd718e92cc209d1463f3373484c5a707e31f8c0639ebf77d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, microstrain-inertial-driver, rviz, rviz-imu-plugin, tf }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "ddc402ca6d23d9eb084a5cea11d6585e54414fe3333dd1c38e9eede9d8cbb48f";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "5c8eb7e277bb6c667d392a0b67467c91b522bb0bc350137deb9d51368d3730a6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "052007a62ad99126a889119d5d44984fb4552429eaec09d8b169473586d3f224";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "9c37bb1cda46ce391806651f1f4bad1227024947b7ba7b300aafb362491d71a0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-rqt/default.nix
+++ b/distros/noetic/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-rqt";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "504a1178e81a672622857c8dbb26ec9a5144a06b3339712190d248cede592e56";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "711ea25a3b53a5db415e30b69b4fac10c8d2ffac3a9df498513a87d4d7ae2c3d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-geometry-msgs, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.12.0-r1";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "dc7eba761f89db0e68290a5041b6f3622549fbebf05864dd4711c965beeb96af";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "bea58fee0a790167ddae644b42ba407a2dfa10fa4a5a3f3d9a138a453c49e2cf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/openrtm-aist/default.nix
+++ b/distros/noetic/openrtm-aist/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automake, catkin, cmake, doxygen, libtool, omniorb, pkg-config, pythonPackages, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-openrtm-aist";
-  version = "1.1.2-r4";
+  version = "1.1.2-r5";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/openrtm_aist-release/archive/release/noetic/openrtm_aist/1.1.2-4.tar.gz";
-    name = "1.1.2-4.tar.gz";
-    sha256 = "61a7a22fbfbf87fff5685a08bde398fc1523e543865f24fe3bacc6f83afc341b";
+    url = "https://github.com/tork-a/openrtm_aist-release/archive/release/noetic/openrtm_aist/1.1.2-5.tar.gz";
+    name = "1.1.2-5.tar.gz";
+    sha256 = "c41cfdf69cd365e435dca2379bcfcb8c5f0e317fc97f43671c47627399608d54";
   };
 
   buildType = "cmake";

--- a/distros/noetic/static-transform-mux/default.nix
+++ b/distros/noetic/static-transform-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-static-transform-mux";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/static_transform_mux-release/archive/release/noetic/static_transform_mux/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "87ab7e2def917975a8972fb4a1d38e9758b6116b5905c7168ade03de68ed6250";
+    url = "https://github.com/peci1/static_transform_mux-release/archive/release/noetic/static_transform_mux/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "1e144c9a7be2cc7f3271f923e88e88f79a7506067857ec9e0115a60313237056";
   };
 
   buildType = "catkin";

--- a/distros/noetic/universal-robots/default.nix
+++ b/distros/noetic/universal-robots/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ur-description, ur-gazebo, ur10-moveit-config, ur10e-moveit-config, ur16e-moveit-config, ur20-moveit-config, ur3-moveit-config, ur3e-moveit-config, ur5-moveit-config, ur5e-moveit-config }:
+{ lib, buildRosPackage, fetchurl, catkin, ur-description, ur-gazebo, ur10-moveit-config, ur10e-moveit-config, ur16e-moveit-config, ur20-moveit-config, ur3-moveit-config, ur30-moveit-config, ur3e-moveit-config, ur5-moveit-config, ur5e-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-universal-robots";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/universal_robots/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "db4847a64a1129d0de12dc9a3e2e150d08c3deb25f94b9cda09652ab29152ac5";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/universal_robots/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "121c3dbe823e3235a573def84b447bae2547bd7c373b0f71307892fb3e2871f3";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ ur-description ur-gazebo ur10-moveit-config ur10e-moveit-config ur16e-moveit-config ur20-moveit-config ur3-moveit-config ur3e-moveit-config ur5-moveit-config ur5e-moveit-config ];
+  propagatedBuildInputs = [ ur-description ur-gazebo ur10-moveit-config ur10e-moveit-config ur16e-moveit-config ur20-moveit-config ur3-moveit-config ur30-moveit-config ur3e-moveit-config ur5-moveit-config ur5e-moveit-config ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ur-calibration/default.nix
+++ b/distros/noetic/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, rosunit, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-ur-calibration";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_calibration/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "b9e73509f4c590a8908cc9473a6e53dd0be9161ce24fbf33f6dd3b4be904256d";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_calibration/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "8588c4b720799fcf10fd29b9f1a4e3b1ae2ad9ec7d670262defee1a8eb983f03";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.3.5-r1";
+  version = "1.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.5-1.tar.gz";
-    name = "1.3.5-1.tar.gz";
-    sha256 = "4ae5278bf8c1731ba04066a9947220b5f78c2d1f55eb4a35b557f93eed8b2b45";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.3.6-1.tar.gz";
+    name = "1.3.6-1.tar.gz";
+    sha256 = "1b42c47b20ac6eee54e809bd6c6305dbbe41701292274130f91f924e73974258";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ur-dashboard-msgs/default.nix
+++ b/distros/noetic/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ur-dashboard-msgs";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_dashboard_msgs/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "091218910619c635daa906f5f2693a4c9ba73388ba17c8c14d2bc742f45210dd";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_dashboard_msgs/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "d00a860c1019e33fa0baad5ede4ca0b57d802eac0258392d6e7da6f8245b0d75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-description/default.nix
+++ b/distros/noetic/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur-description";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_description/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "a325902df04bd741be68e8df82a97dbeec78d551379bf30e51181a7a5c72e450";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_description/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "27695dd079d7b005f3e0ed09ac2b3604af7df1c531ba7c22a795659af3784ba9";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = "URDF description for Universal UR3(e), UR5(e), UR10(e), UR16e and UR20 robots";
-    license = with lib.licenses; [ bsdOriginal "Universal-Robots-A-S'-Terms-and-Conditions-for-Use-of-Graphical-Documentation" ];
+    description = "URDF description for Universal UR3(e), UR5(e), UR10(e), UR16e, UR20 and UR30 robots";
+    license = with lib.licenses; [ bsdOriginal "Universal-Robots-A-S'-Terms-and-Conditions-for-Use-of-Graphical-Documentation" "Universal-Robots-A-S'-Terms-and-Conditions-for-Use-of-Graphical-Documentation" ];
   };
 }

--- a/distros/noetic/ur-gazebo/default.nix
+++ b/distros/noetic/ur-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, effort-controllers, gazebo-ros, gazebo-ros-control, joint-state-controller, joint-trajectory-controller, position-controllers, robot-state-publisher, roslaunch, ur-description }:
 buildRosPackage {
   pname = "ros-noetic-ur-gazebo";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_gazebo/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "6b090db8d84e6381d49252a8a2405c7c20e54d9912b69134ecd8367d87dd041e";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_gazebo/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "55217f5a8a222feb7798e9d5be15609d533c3c8effd32eeb83c1e5a5d6c63f72";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-robot-driver/default.nix
+++ b/distros/noetic/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, boost, cartesian-trajectory-controller, catkin, control-msgs, controller-manager, controller-manager-msgs, force-torque-sensor-controller, geometry-msgs, hardware-interface, industrial-robot-status-controller, industrial-robot-status-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pass-through-controllers, pluginlib, robot-state-publisher, roscpp, rostest, scaled-joint-trajectory-controller, sensor-msgs, socat, speed-scaling-interface, speed-scaling-state-controller, std-srvs, tf, tf2-geometry-msgs, tf2-msgs, trajectory-msgs, twist-controller, ur-client-library, ur-dashboard-msgs, ur-description, ur-msgs, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ur-robot-driver";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_robot_driver/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "30e970fbf77f500094fdb39c780eac809068161d0f9a8cc214ddd1289f792019";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_robot_driver/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "e838e24744cd8acca0128fee966b17a635bd7bbef2b9194c397c22a81c0d77fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur10-moveit-config/default.nix
+++ b/distros/noetic/ur10-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur10-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "8ddab9f30e0439793fc0bfc036d21d9f5efe0530d2bf979ecfa0f6af7f278021";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "1662543b514e7b0677cae3a24c69c036ff7d372e8f597a9baca4811621ab3297";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur10e-moveit-config/default.nix
+++ b/distros/noetic/ur10e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur10e-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10e_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "afdd791077c9bda9e5b0eb301e2f8a197fe2afaa890da87dce5ec995dea7f82a";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10e_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "88cfe6a084835c3e33de3b4849fa6b88baf530d502ea7cd0738e9abcdca3e7b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur16e-moveit-config/default.nix
+++ b/distros/noetic/ur16e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur16e-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur16e_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "62cd4adfc1d20b0fc2ad65fe5cfb02de75f1b46c2633859e876da4e723425747";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur16e_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "3208e6aea2292592a82025704cfc6edd6022880c68c3e5627113f4dd90b0e2b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur20-moveit-config/default.nix
+++ b/distros/noetic/ur20-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur20-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur20_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "625a6bdfcca25e664e6d9e436001fd77d5b2990f38a510021a3c852a1388c89e";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur20_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "3ceb7472473cc25ca1ec42692ce7664b038fc59b8fac7698d81ff4c3dccba06f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur3-moveit-config/default.nix
+++ b/distros/noetic/ur3-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur3-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "09f4ac4b58b6d8b5a9527b0ffe3b169df6a662f7c9c70505ae8482c0f05ccc3a";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "8746b956ca182345f66e0f9a19038a480a24c6cc889f53f47e034c36de310c7e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur30-moveit-config/default.nix
+++ b/distros/noetic/ur30-moveit-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-ur30-moveit-config";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur30_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "a68bcdc970c5dc2d94eed8091d85d3a296b83ed7989fda668b9a8e7aa967ce52";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-fake-controller-manager moveit-planners-ompl moveit-ros-benchmarks moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz tf2-ros trac-ik-kinematics-plugin ur-description warehouse-ros-mongo xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the ur30 with the MoveIt Motion Planning Framework";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ur3e-moveit-config/default.nix
+++ b/distros/noetic/ur3e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur3e-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3e_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "c44f45212d6f6aa22c747686f6d3607b2dec1bb993cfd6f7bbf39fd53f3ce7c4";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3e_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "5a4ea71067c0a6fa69b203ff9be2a169c904964e73069251a6f9c794bf1f9946";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur5-moveit-config/default.nix
+++ b/distros/noetic/ur5-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur5-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "4477c88820b48b04dd96f3b5a0af64d10a9ea1a012a821d8a789dfa42dd17e6d";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "07604a2f515aad5055031008c425ac8b1f6b1578e6f4b9e3fafd8c98543eec1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur5e-moveit-config/default.nix
+++ b/distros/noetic/ur5e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur5e-moveit-config";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5e_moveit_config/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "ee858de6aa40269157581e0ae25789b3986fc41a7b83c25d1d967d022f716913";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5e_moveit_config/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "fdee6c6a3b6576ad5514321db3bcb7714ed12a39e9d0d30be99661569b3cf92d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur/default.nix
+++ b/distros/noetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-noetic-ypspur";
-  version = "1.22.0-r1";
+  version = "1.22.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.22.0-1.tar.gz";
-    name = "1.22.0-1.tar.gz";
-    sha256 = "e21f4016be794ee812912bf881e9ca6c3e3e4b932429e5487837a84bce1e3035";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.22.2-1.tar.gz";
+    name = "1.22.2-1.tar.gz";
+    sha256 = "be1fa7487f451a50cdc77956566bc751736372ce7aa15d75ac527024e505833f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/actionlib-msgs/default.nix
+++ b/distros/rolling/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-actionlib-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "9b4cac8603acd2bf1ce17a8098f169e2e8330eb82cc129a65217edc4146f1705";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "f2097b1bda9271a81aa833beee9edc8d97491afe01d409bcc5136626ef43c099";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/aruco-opencv-msgs/default.nix
+++ b/distros/rolling/aruco-opencv-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-aruco-opencv-msgs";
-  version = "4.1.1-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv_msgs/4.1.1-2.tar.gz";
-    name = "4.1.1-2.tar.gz";
-    sha256 = "2157dd004b1766364c7280551dea758fef002ba5cae08f166192fa2d4f4fa319";
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "95ff22e673634eddb3add1ee496ff5281a72b5d06a01e0622dfbb3f6f0d0db41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/aruco-opencv/default.nix
+++ b/distros/rolling/aruco-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, aruco-opencv-msgs, cv-bridge, image-transport, python3Packages, rclcpp, rclcpp-components, rclcpp-lifecycle, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-aruco-opencv";
-  version = "4.1.1-r2";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv/4.1.1-2.tar.gz";
-    name = "4.1.1-2.tar.gz";
-    sha256 = "bb0920ded7898f81c91519a814d53b6efb995455c5b02563581c8a1054e154e0";
+    url = "https://github.com/ros2-gbp/aruco_opencv-release/archive/release/rolling/aruco_opencv/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "fd2a473c5680a86c12f949bb12b5d1825ba43298620f891d57e666b422334d9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "472a739eb2d456f73d161c21138dc87c6a827f91608cee5456fab4a75d34b513";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "74878b9106e5932d1388565bdef2daaf8e2ed9d1c2d84f97ed570904c69d1e7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-msgs/default.nix
+++ b/distros/rolling/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-control-msgs";
-  version = "5.0.0-r2";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "ab3a8752da8b0df90570decc6dd78e839e1f7b07c62f51ff4ad96ea9e87bfe6d";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "ddf332e88cab63dbc1fe5d44b213e883ce21317e929c10f0386c1e2d53fea468";
   };
 
   buildType = "ament_cmake";
@@ -23,6 +23,6 @@ buildRosPackage {
     description = "control_msgs contains base messages and actions useful for
     controlling robots.  It provides representations for controller
     setpoints and joint and cartesian trajectories.";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "1b677045ff073ea9b867d1749406704bef81976f021d205717c3ae20d6ab7622";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "e56a6c34b6e5c70c30d3e9e32eed22f208c2abfba705e09530582c0f73b286b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "6dc4447ac503be1a13402fac22804aef3b4e7ed2762af206262d377c6e72b5ba";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "9a7fc519c73955d0063127a2e276428d2c97791f49aabecdeb46cd2a5119d601";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/fields2cover/default.nix
+++ b/distros/rolling/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, python3, python3Packages, tbb_2021_8 }:
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gdal, git, gtest, lcov, nlohmann_json, python3, python3Packages, tbb_2021_8, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fields2cover";
-  version = "1.2.1-r5";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/1.2.1-5.tar.gz";
-    name = "1.2.1-5.tar.gz";
-    sha256 = "73d934a9ec9cff3468d8962712eabc5c8561c4bd5d99dc8ad1cd9f26d76c4ad2";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "0b3281130cda2430a6c4438bc9469f2d18154280c9b44ab3aa4ae05138c8ea15";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ eigen gdal git gtest python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 ];
+  propagatedBuildInputs = [ eigen gdal git gtest nlohmann_json python3 python3Packages.matplotlib python3Packages.tkinter tbb_2021_8 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -624,6 +624,16 @@ self: super: {
 
  gz-math-vendor = self.callPackage ./gz-math-vendor {};
 
+ gz-msgs-vendor = self.callPackage ./gz-msgs-vendor {};
+
+ gz-physics-vendor = self.callPackage ./gz-physics-vendor {};
+
+ gz-plugin-vendor = self.callPackage ./gz-plugin-vendor {};
+
+ gz-sensors-vendor = self.callPackage ./gz-sensors-vendor {};
+
+ gz-transport-vendor = self.callPackage ./gz-transport-vendor {};
+
  gz-utils-vendor = self.callPackage ./gz-utils-vendor {};
 
  hardware-interface = self.callPackage ./hardware-interface {};

--- a/distros/rolling/geodesy/default.nix
+++ b/distros/rolling/geodesy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, geographic-msgs, geometry-msgs, python3Packages, sensor-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geodesy";
-  version = "1.0.5-r2";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geodesy/1.0.5-2.tar.gz";
-    name = "1.0.5-2.tar.gz";
-    sha256 = "804e5d7c003d49bdea9419398b036af29f95fc0fa01e28d0ddb29387fdaaf2a6";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geodesy/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "9dccfb0c5f595b86f0c2c695b597a8119538c8866a803b85c53ac9a5441025d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geographic-info/default.nix
+++ b/distros/rolling/geographic-info/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geodesy, geographic-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geographic-info";
-  version = "1.0.5-r2";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_info/1.0.5-2.tar.gz";
-    name = "1.0.5-2.tar.gz";
-    sha256 = "2e1757e449ed2857d5044e939db1afb4ae7a870168b84274855e9da72fd3b82f";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_info/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "c71ef5be0339e35ef5044647e356a23d105c1b1a14ef82ec2f99a86158e08041";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geographic-msgs/default.nix
+++ b/distros/rolling/geographic-msgs/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geographic-msgs";
-  version = "1.0.5-r2";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_msgs/1.0.5-2.tar.gz";
-    name = "1.0.5-2.tar.gz";
-    sha256 = "7901d1e58339646d7be1be410bb3a2a08c1504a5a2dd277a465d49336f84507c";
+    url = "https://github.com/ros2-gbp/geographic_info-release/archive/release/rolling/geographic_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "4a2de75e12520519ffbeea5d4ce3b114be126877413aa35057be629d91405102";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "35cc53c3b13b5245d884749f04c25888ecf1ed02664810f773cd4a7b1dc94ab0";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "fb6a943b2fd2926d3809e537af4a4c7962d3fc601739bc7cd375cfb97ca508be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "e4ef83facf16d57bec3eca69893c51bf194a55d543027bc42bc0797bebf770bb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "9d5da141e26f44086a73dcba1191cb7e382ff02d8c149d9802adccbe45ebeb62";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gmock-vendor/default.nix
+++ b/distros/rolling/gmock-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gmock-vendor";
-  version = "1.11.9000-r2";
+  version = "1.14.9000-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/googletest-release/archive/release/rolling/gmock_vendor/1.11.9000-2.tar.gz";
-    name = "1.11.9000-2.tar.gz";
-    sha256 = "4bbcee514276e50cf1293ba0ec4ff9e09620962ad9ce3022a94565795e7557f0";
+    url = "https://github.com/ros2-gbp/googletest-release/archive/release/rolling/gmock_vendor/1.14.9000-1.tar.gz";
+    name = "1.14.9000-1.tar.gz";
+    sha256 = "82a7a497f6f54384134e7b934c81c02b3a8807407299dcac0b6b98580388237b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/gtest-vendor/default.nix
+++ b/distros/rolling/gtest-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-rolling-gtest-vendor";
-  version = "1.11.9000-r2";
+  version = "1.14.9000-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/googletest-release/archive/release/rolling/gtest_vendor/1.11.9000-2.tar.gz";
-    name = "1.11.9000-2.tar.gz";
-    sha256 = "3a80c0855bccd88896d9e5200450a2daa774b24a7e68fe9f470d0e3dc734c4a3";
+    url = "https://github.com/ros2-gbp/googletest-release/archive/release/rolling/gtest_vendor/1.14.9000-1.tar.gz";
+    name = "1.14.9000-1.tar.gz";
+    sha256 = "90aaa9ea824a705f8711140e1f377db2b3b73c2f2304c5477d63b096a6e176b0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "c1a4690f6bc7ea94c2c466c4e33e12cea77e3e1e7cb88a497b0c089baf0b0414";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "2c90ea40899922e11bdded2f9e620a6a28970c3486f14ee50981d00e46e5cc32";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint cmake ];
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-cmake3 3.5.1
+    description = "Vendor package for: gz-cmake3 3.5.2
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, eigen, gz-cmake-vendor, gz-utils-vendor, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-gz-math-vendor";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "ee7eef25401d8735b8b85fd7827933f606a9464a0bf9d1906e141fd2c009189d";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "d784be7f504301220354ff6b16b46b450b1d712a728b59db3953fcd87c7848ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-msgs-vendor/default.nix
+++ b/distros/rolling/gz-msgs-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, pythonPackages, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-rolling-gz-msgs-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "1b032e66dde8e2b7897ed32f46772e61ee53904ee3c60c16f2bc6eee17bd39b3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ gz-cmake-vendor gz-math-vendor gz-tools-vendor protobuf python3 python3Packages.protobuf tinyxml-2 ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-msgs10 10.1.2
+
+    Gazebo Messages: Protobuf messages and functions for robot applications";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-gz-physics-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "ab11ad76e3485a84952de6447e2bd98029d406fb5159b806f80b50eef01a955a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  propagatedBuildInputs = [ bullet eigen gbenchmark gz-cmake-vendor gz-common-vendor gz-dartsim-vendor gz-math-vendor gz-plugin-vendor gz-utils-vendor sdformat-vendor ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-physics7 7.2.0
+
+    Gazebo Physics : Physics classes and functions for robot applications";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-plugin-vendor/default.nix
+++ b/distros/rolling/gz-plugin-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-tools-vendor, gz-utils-vendor }:
+buildRosPackage {
+  pname = "ros-rolling-gz-plugin-vendor";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "f07ae56e1102e86122258204f3f481efae2db40471b4a78a09bdf20785f24561";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  propagatedBuildInputs = [ gz-cmake-vendor gz-tools-vendor gz-utils-vendor ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-plugin2 2.0.3
+
+    Gazebo Plugin : Cross-platform C++ library for dynamically loading plugins.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-sensors-vendor/default.nix
+++ b/distros/rolling/gz-sensors-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
+buildRosPackage {
+  pname = "ros-rolling-gz-sensors-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "85c678c00233b4dac4c2830f5a502e5461543ec62ee9de906d2d8fdd3c4a14b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
+  propagatedBuildInputs = [ gz-cmake-vendor gz-common-vendor gz-math-vendor gz-msgs-vendor gz-rendering-vendor gz-tools-vendor gz-transport-vendor sdformat-vendor ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-sensors8 8.0.1
+
+    Gazebo Sensors : Sensor models for simulation";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-transport-vendor/default.nix
+++ b/distros/rolling/gz-transport-vendor/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, pythonPackages, sqlite, util-linux }:
+buildRosPackage {
+  pname = "ros-rolling-gz-transport-vendor";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "d469720bda8a063cb13cbeec267522230d79a81924c4be60100e992661d957d3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  propagatedBuildInputs = [ cppzmq gz-cmake-vendor gz-math-vendor gz-msgs-vendor gz-tools-vendor gz-utils-vendor pkg-config protobuf python3 python3Packages.psutil pythonPackages.pybind11 pythonPackages.pytest sqlite util-linux ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for: gz-transport13 13.2.0
+
+    Gazebo Transport: Provides fast and efficient asynchronous message passing, services, and data logging.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/gz-utils-vendor/default.nix
+++ b/distros/rolling/gz-utils-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-utils-vendor";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "a1617570aa92a2a50b57b81fd98bfc5a9962b95a77c56f0a8e7c93207237aefd";
+    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "83c6cb47fae95ba55679b18c0f9b951771dd5ddf5b9f7fbacd2358e0949ea87e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-description/default.nix
+++ b/distros/rolling/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-description";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_description/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "01933a92e8f374e7d8b8f4696ff5ee953d6cd0fa7a39c39367d872e6568f73e1";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_description/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "c340b2add56ee94ed9cc1ad78db496c7a51bcad296f34845a43e73afb5e23d0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-driver/default.nix
+++ b/distros/rolling/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-driver";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "e81bb16720e9998adbfa5e4a1a683c3e7cce05faf01997bfd2c860465d0b7dbe";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "d8854abb3c233e145224cff993f9afb84dfa2c931aaa13af846714c71682b6aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-examples/default.nix
+++ b/distros/rolling/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-examples";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "9334c0f93c07e2de36b208a7fc5b386122164312d795f83359aa70d1a34d140a";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "58b784177d0a18c120fb4bdb7dd3420f337cdd63dd13ae0bdea52b33e3760e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-msgs/default.nix
+++ b/distros/rolling/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-msgs";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "041318a21d2ef6cac674dd0a95ffc0b7f77b094bf99084db41ae50aeb68c2ace";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "a33a95584ee79887c591f4e87fd595c5cceb4c9c76a6715ef9191da067199e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-rqt/default.nix
+++ b/distros/rolling/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-rqt";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "6ac78ef14bc36bd3a7cb6e035a211bf97a371b4d14b033538cf7120b27eefb00";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "2556c17ec3969e7fb550619f77656ef02295a0f3acbdca84bf9b3e8d2ad69590";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, opencv, openni2, pkg-config, python3Packages, pythonPackages, qt5, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.12.0-r2";
+  version = "2.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.12.0-2.tar.gz";
-    name = "2.12.0-2.tar.gz";
-    sha256 = "dbdd744263557a8b4c1242b0fd755f6b40fa0bedbc87361f4e5c04758e66f561";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.12.1-1.tar.gz";
+    name = "2.12.1-1.tar.gz";
+    sha256 = "7e1003648fc3b44d6b285de42b1f7aca7f2e60a52d0d579e7fefbb9aa7327a5d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "8d8b41fb69d21f32bbb904433e2860f11a20c423f5e53cc95d154e5d1b6f1292";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "d91964e63f0bb790294e0e2842b1877cad5d1f1f6a873aafb365f270d8e877c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pcl-conversions/default.nix
+++ b/distros/rolling/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pcl-conversions";
-  version = "2.4.0-r5";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_conversions/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "bf9d711654d8cf99fa6cbf8f36d1957a4fb42bdf3793befeefdf3d0526ecb0b0";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_conversions/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "637a95bb12503cfd650a77fe3ea232024ad4e0ab984ee148b77d57e8b03cd568";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pcl-ros/default.nix
+++ b/distros/rolling/pcl-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-pcl-ros";
-  version = "2.4.0-r5";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_ros/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "d03b0ff9fc74265be477bd874e96af0a1e5bcda4dc828f1f90b8a5a59707fdf6";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_ros/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "ed24afb43e183514e90387323d629cc25624a64d380185c2325201b0f0488644";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ros sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/perception-pcl/default.nix
+++ b/distros/rolling/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-rolling-perception-pcl";
-  version = "2.4.0-r5";
+  version = "2.6.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/perception_pcl/2.4.0-5.tar.gz";
-    name = "2.4.0-5.tar.gz";
-    sha256 = "3aec0c49cdbf221737dfead1e9805c60b962e947851d47e98dc9d98075b4d6c8";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/perception_pcl/2.6.1-2.tar.gz";
+    name = "2.6.1-2.tar.gz";
+    sha256 = "9ab3eb288134591265b2053b11b26bc5236bbefff8830bf9258ed81e1903e082";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.21.0-r1";
+  version = "0.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "d90f43081253b38b8a46029070f138e1efe24cefe82109910e10d43c1378706d";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.22.0-1.tar.gz";
+    name = "0.22.0-1.tar.gz";
+    sha256 = "f08fdfba8084324532a2e763301f654f8cda4a6c755c23b75633486bc0f92f4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.21.0-r1";
+  version = "0.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "98374ca387a1ff12634ddfe29649ae3e67eb4f8ce40934dc6e38c0ae7c17f39d";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.22.0-1.tar.gz";
+    name = "0.22.0-1.tar.gz";
+    sha256 = "e0c48c46adcc2b3f6a04c398e4213c30c864850e4724f9bca4e4ebe48261cc3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "2.1.1-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "e590073b3bc279501adfbd14707ce976cc994436f5896705c84e6635d2fe7896";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b7d8d64cf537e5c226be3e316535fd1f1732eb7a09a5fef340a8c716dbb86550";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-dds-common/default.nix
+++ b/distros/rolling/rmw-dds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-dds-common";
-  version = "3.0.0-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "15730a08a52693a1dea77e3dd7dcc0f8327a46307e35987d6133ddc061b40327";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2c068f1fe9903ae7f49a7cba7e8d4d79827de67d06467d34171247f219e025ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "8.3.0-r1";
+  version = "8.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/8.3.0-1.tar.gz";
-    name = "8.3.0-1.tar.gz";
-    sha256 = "1e5477aebbc6fd8ee9b3b1d8d9887e6885372e18933aa6648400140e6b2a17d2";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/8.4.0-1.tar.gz";
+    name = "8.4.0-1.tar.gz";
+    sha256 = "e0295976b526bbce681cb8b44530ae3dbab76a92e9f6155967dcef2a2050981f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "8.3.0-r1";
+  version = "8.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/8.3.0-1.tar.gz";
-    name = "8.3.0-1.tar.gz";
-    sha256 = "e76e737f1fec3ae6b27b0a0066092d529d5647f234071c98ac4bd03f921f77a4";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/8.4.0-1.tar.gz";
+    name = "8.4.0-1.tar.gz";
+    sha256 = "044ef2f3c6eaabb9866a7547d0679f953f769c76a9a36ea8945fb76fe881774f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "8.3.0-r1";
+  version = "8.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/8.3.0-1.tar.gz";
-    name = "8.3.0-1.tar.gz";
-    sha256 = "23c14ec04877eeba212cdda0709ba42cf148c72786aef3215f6fb707fa56d257";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/8.4.0-1.tar.gz";
+    name = "8.4.0-1.tar.gz";
+    sha256 = "4ee0ce76fd98a073af93885cf1552aefd6f39200b254cdb85a0fbf77bdf2e613";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.21.0-r1";
+  version = "0.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.21.0-1.tar.gz";
-    name = "0.21.0-1.tar.gz";
-    sha256 = "f1cda55e091a991bc4868106176bcc786cf52f2eacd5031f1849b75f9b24b231";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.22.0-1.tar.gz";
+    name = "0.22.0-1.tar.gz";
+    sha256 = "7638c414cc776d3e089b53a4f70325d5b492bb509b946b2cecdda6b4b23fd763";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "fc8d6995d55cc9a1d48d3bf97aa026f2da39227ad40fcba3dfb23f4e350337db";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "e58bbc97820bd8a362983ed46ba840593df63c5948294c592cd664309b62586d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "5c3a534062e7e1b838765edf8bc35c07c05085906624c14618f179cef340e570";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "eb822e42049030591a04fa0822595bfb1e83b7563660dd79fea72af07c943849";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "a7c7a23415ff2d43e20d4dcfcbbf6d171476932e6d325e2cf8b307fab9af8610";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "be298411bf91b5cf3437072f322d71ca857058f5f0cfcf2dd5945e983908cd60";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-index-cpp ament-lint-auto rviz-rendering-tests rviz-visual-testing-framework ];
-  propagatedBuildInputs = [ geometry-msgs ignition-math6-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt5.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs gz-math-vendor image-transport interactive-markers laser-geometry map-msgs nav-msgs pluginlib point-cloud-transport qt5.qtbase rclcpp resource-retriever rviz-common rviz-ogre-vendor rviz-rendering tf2 tf2-geometry-msgs tf2-ros urdf visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "e37011167f4eae6bb22a21d1892cb2d290d454d6122d233a27bbaf39b0934a00";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "4bdbb584581fa3abae798c412376376a6e18a1e14508322a94dd8985af85f377";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "34a8ab26df07ac7323ad88efe70bd67909cccd919f25cded9e10009b51e4347a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "f6560caf1a8177a90e03258af65b581b8a4f6f99f6b7d45dc64445adf5e37251";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "105b7bdcb65c60292861f4a724bc3382c767da46886d1098e54bfc285326f010";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "9f7f696baca1b2a37d17aea20795731d09007214ff8428f70344f1aa1e654817";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "1dfe11024fcbed5bb9328d39e76cc1c6dfbbdeecf6f79626dddda65e3a6cb329";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "7e2e4ba70a8848791e5dfd921d8c932c3469b5e704d21782e36c03532834e53c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "13.4.2-r1";
+  version = "14.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/13.4.2-1.tar.gz";
-    name = "13.4.2-1.tar.gz";
-    sha256 = "ba261f3b89ba86f842484634e5f27e347b514b779855c41a08c95bee1c08b4a2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.0.0-1.tar.gz";
+    name = "14.0.0-1.tar.gz";
+    sha256 = "b044025c0947db96afe463bc2f455c48824472e9c61b224c360e5546ffd5ba74";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sdformat-vendor/default.nix
+++ b/distros/rolling/sdformat-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, pythonPackages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-sdformat-vendor";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "ddf79213bfa26b7a7dd643d7dc78b91c4360458afe8190326ac675a1be5abd0b";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "cfc77de1be6942ab74649bafb91a9a68e272edc8c4492765d7a61945438639b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "cb2bed1c94ca40fb2bf2350eefa702219b11e500eab86d8b82ad2f22cb0d97ad";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "8ce699f5357db4038d38bc82b3b5c5ca273ed9b07b94072e8f889d7ea783e48a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "7c324dc755968d005817e4f9884407d04d094fd67177a4bbc21b61a3c3b9cf38";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "9ff40838fa331bdd7d5b59bf5a37358ce4fa4bcf0b77a712b582c8074b02b209";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "95c29d68c8f655d94b3fabad14be1a254c60e76960574e81d5924749657c4789";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "0687bbf2775c237fb5102d0a096d9108cb17972882d67f0a1a966e8d9f541350";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "8691f3f3d6de82fa44c5fd4915b65d531c9b29a699e011ca9327d2cf2346cf20";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "51a1e42d74e87a3c47a2faab4fa9605e7fc68a4808789057b526deded1fd2919";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "97c0ca907d9f38343d87cfecc8f751f62a7f5a0c1d97bb9b7d004ebc2f505a4b";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "3cc4f3ac14e551d2074b85b05be95c7c986cccf94ac6333e9164af2760db38fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "aae8acd381fd6a914f80e0cdc99292025db71760d15982bf78daf86e94a6a81c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "a24efcab544b92be07c4fc297a84365f698aa0c8fba4778a54d1f324bf5a5999";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "c33a0801e3ab10dbf09597b1be6fb55e9388e13661306351d76b26db5e3753f5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "30ab35f86f3701a5c1b661453b709a9faf9d181b71e16fbae30986af5e37f3b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "44934c6d2487c53d0a9a9b391c01d9590ed722416b0eff92dfe5ba01a2d77069";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "4b8ba2ef7531a0f003c3f1d9fc477c5a62c2cfac7e21026e1eb07451405765c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "8d60668961f9cc91470057bddc577fda0e8d6c654905df049aad9ac30b896508";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "b1bd6606c7a815d8ac240ce355ac12074c274aae40686bc9240bc8eae26b0782";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "76c465029e7505abb96aa3da2f3c4edaebef77f642e4909472a29734c4f5b33a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "e67b1b8f69e025d706099c7ececa93edd440d0fa10885ad849dd365feb29a640";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "dbc68ef9e055cf0f6a4d4caf9d94dd435762bcef687d23ebedc6f08857aa461e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "f437f53fb6a5a666d166de1ee13a2e78150ac019c7434e7108240416523642dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "59d6a0a73681d1bb4fb146e2cb084fcc1bfb16eb41dd9b3a025cb0616fe78ee3";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "aeae3a5be8a469637b0ecd9c385b4fb270d17a28cc832268a8515317ad08984d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "efee756a54ffa561d1ae5e9ae854c8ed5d063a113a7e59a00cd432600f476d91";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "67905f4d40737a7cd911fa64c01edb1ed29d9dd5cc11f65e7ecdc70ef7046f0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "c3f84e4644b17ebb637ab8a1b1a0bebe6c33755e8ed07478be12b7fa1394a890";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "6389ecf080d86f76714d6da79cf230e7cb3adf77903a49b329ba0707bf1e3a3a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "07646ab602f1f170c80949fb973becced84059f517e8d25f01fc080026d91060";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "d36d0bc06591ae3f7147d6f0faccc7fe1e7ca883b6e7ed58b1bd9a40bb3c4415";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "eec61f1d16f95e687c0ba845abe4fb870ae41fd3cb1d3e4021b1ad3cf75f8946";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "1117d0b7296e4cd19491f41406abe3f87a7294b10631565843aef31f96aa8df2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "093bb99c049115c8206734ce0a14cd17766f37b4023623b980b00dbecaf2f686";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "406ec2a8ee3864dd16d089b65a22ca48415149a514ae78325f01785716fec22b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.36.1-r1";
+  version = "0.36.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "04ac38052de1adadfa1585788164c5a954501f78c6356bcedf77ffaf9116e943";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.36.2-1.tar.gz";
+    name = "0.36.2-1.tar.gz";
+    sha256 = "e7558d26a979dbeba621fad4c1c1db756cb5973818818472390df59cd6296337";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "513fe0c274c15d5a8b60d20e4ecda6c86e78f690af7bda1480f8b268abe3205d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "5eb20e77a1807e4e7d50a944506893b18eadcf225dec956e78eeec8f0555e65c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "2.4.3-r2";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.3-2.tar.gz";
-    name = "2.4.3-2.tar.gz";
-    sha256 = "ba897f072e1415b2d1967bbfe633201407db1096e66b574db24f9accc46333cb";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "9d32f195acd7406a880a623cc7e9e352b846ed5f49e5a6ca0a1fc64bcb69fd60";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.3.5-r2";
+  version = "1.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.5-2.tar.gz";
-    name = "1.3.5-2.tar.gz";
-    sha256 = "d55be6885af8f753580ea33b7d931753a700e1d295d3b877cc62ce787ea40fdc";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.3.6-1.tar.gz";
+    name = "1.3.6-1.tar.gz";
+    sha256 = "f8d6671644dc9fafcab3bacb9a27575881e0d9f421a710ad1e5cd19955c182c2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "2.4.3-r2";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.3-2.tar.gz";
-    name = "2.4.3-2.tar.gz";
-    sha256 = "62bdf71f53b5e2a5dc5bc3e913c7dbee6b36fb219b452bbd13cd572e645243c8";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "d982bc8599fdd959c7430d1b56ac4110b054af2091b10c53d6c392f6616e03e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "2.4.3-r2";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.3-2.tar.gz";
-    name = "2.4.3-2.tar.gz";
-    sha256 = "6c75c0580422962c1a284ed588bf072f244d5f8df5a1184fd219fad7fc358716";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "59ee8ff9b1e2bed1c1ba193d2c0a7a2e4494f7934fc78378f34127a1386269b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-description/default.nix
+++ b/distros/rolling/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-description";
-  version = "2.2.4-r2";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/2.2.4-2.tar.gz";
-    name = "2.2.4-2.tar.gz";
-    sha256 = "b8a558486a649c96211e7ad313b7fcf37bb08ebce77b1935c4722006372394ab";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "c10aa03371795e710a6502b065ad384016193b0eab84709e2f32df14f1537f2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "2.4.3-r2";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.3-2.tar.gz";
-    name = "2.4.3-2.tar.gz";
-    sha256 = "ce6aa5404c6a8b3b70c7b33cab8ba31fc1447b703a86633d365ee579424ee814";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "10a734079d8cbad1cd10d454b4561b811e726f2424ba39c0767b273722c409ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "2.4.3-r2";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.3-2.tar.gz";
-    name = "2.4.3-2.tar.gz";
-    sha256 = "b87809c91ea452cc734e152bf42dd887206655f9e31e4f15ee4cf0c68655a87b";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "48e4c668f6c36b411d18fafda166cd931a581556a97f03feb6b2c4c576773e75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.3.1-r1";
+  version = "5.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "22d1a13b3d6109849fe806a4b0b5d6d05d8918b2a61d23ccc6008691f7c2d0c0";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.3.3-1.tar.gz";
+    name = "5.3.3-1.tar.gz";
+    sha256 = "ff357cfe9efd00b7104e72c16fd435040c3d72c6a9f856a9d800059210b6b755";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "92de4ea8b96e6b69ac46fe13d103a04e7de7b46e13712908a0119f6fdc571537";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "3dccd1c2e991a7da8a16636b4dabfe7ec3f2c0da3770f4cffacd5da1f4c5e51a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "4a822680354c1b1a9fdae5149779c38fd231bef566aade0775d6547aa918797b";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "e71f9fcb468ef3538ed4984b84c8621dfff6662a948615df6bb22c80a85c6571";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "36d9382ba8519874dcc7b9b6f2570e1b6bb12af3afebf49943fa88d7cef87a80";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "d8720fb401fb8073acbdb7cc7596391a8a16ea59dc85f29934f42540d18d0472";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "dd135e3262507109ad27771ac2853df843fa6cb814aea730335fd36dcf1a0c9c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "4166ec5320069a7ceceaaff1318a0276103e8fcb4c398682d0aea46398fc527e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "b362c097df0ce806aeb50b070c10f25014882d9067ad02c975708119ecfc046c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "0cdf88e2747568a1927d85d57885700e2802dc8bce986f13505f9a9191dd3c9e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "b83792559ca35c2573d7140ae18ca9fadff553e56798c1042ba5f1c03deef528";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "80a2f48af7c144a57a95f1ce73f90d101623c4bee53e401544f37ba8bc34d2aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "e127fd177ea7f9db8e60b0a2f5a583fea95513945a43d16463d715eadacda6ae";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "c16c0344775d0b1ac91013e563515f70bd052618431eac9e2e76f27283e1f2c3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "053062a96173aad5a977726b9ae0fc0619dd52b8685193205152bf7bac1df51c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "062d86d80742df334c1a6e15b8da46480b8e1e5d56d7a23173b9cfb6a55fb33a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "fbda6505379ee3e5d273260a08d62084950e5c2a11d242304f1978f8460dd941";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "d1091c2310bc280585766fe8671d6da9241b9e38423f3ec2720306a0ae564a97";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "d11b9d2e1e7fbd9eca670601390e32500c19c7b33ab67cfff6febd2ee04c502a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "d53910ae47930f24eec3dbf7c6b578e74422109a94a0b02bca909e5376962211";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "844272be0c9dc62c9006ca55c1eedf648636b738849795f027dc446fe7a37e3a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "7225468b946a023616125e25da57646ccc9368da328a575a3dae7b5229af6fdc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.1.1-r3";
+  version = "2023.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.1-3.tar.gz";
-    name = "2023.1.1-3.tar.gz";
-    sha256 = "958f3e65201a4a327815d05f65fc71bbcd37d6ff5013ede5901006a9c528306a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.2-1.tar.gz";
+    name = "2023.1.2-1.tar.gz";
+    sha256 = "6f061b8b89060b79d464e0feca835cc69fb0bd68018adef7931bced2bbb6de41";
   };
 
   buildType = "ament_python";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'noetic', 'rolling'] from nix-ros-overlay commit e239e71fd2ce40ce1f7499328a4c92e9473fec88.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-config 0.2.5-r1 --> 0.2.7-r1*
* *clearpath-control 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-customization 0.2.7-r1*
* *clearpath-description 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-generator-common 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-mounts-description 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-platform 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-platform-description 0.2.6-r1 --> 0.2.7-r1*
* *clearpath-sensors-description 0.2.6-r1 --> 0.2.7-r1*
* *costmap-queue 1.1.13-r1 --> 1.1.14-r1*
* *dwb-core 1.1.13-r1 --> 1.1.14-r1*
* *dwb-critics 1.1.13-r1 --> 1.1.14-r1*
* *dwb-msgs 1.1.13-r1 --> 1.1.14-r1*
* *dwb-plugins 1.1.13-r1 --> 1.1.14-r1*
* *fields2cover 1.2.1-r3 --> 2.0.0-r1*
* *geodesy 1.0.5-r1 --> 1.0.6-r1*
* *geographic-info 1.0.5-r1 --> 1.0.6-r1*
* *geographic-msgs 1.0.5-r1 --> 1.0.6-r1*
* *ign-ros2-control-demos 0.7.6-r1 --> 0.7.7-r1*
* *microstrain-inertial-description 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-driver 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-examples 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-msgs 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-rqt 4.1.0-r1 --> 4.2.0-r1*
* *mrpt2 2.12.0-r1 --> 2.12.1-r1*
* *nav-2d-msgs 1.1.13-r1 --> 1.1.14-r1*
* *nav-2d-utils 1.1.13-r1 --> 1.1.14-r1*
* *nav2-amcl 1.1.13-r1 --> 1.1.14-r1*
* *nav2-behavior-tree 1.1.13-r1 --> 1.1.14-r1*
* *nav2-behaviors 1.1.13-r1 --> 1.1.14-r1*
* *nav2-bringup 1.1.13-r1 --> 1.1.14-r1*
* *nav2-bt-navigator 1.1.13-r1 --> 1.1.14-r1*
* *nav2-collision-monitor 1.1.13-r1 --> 1.1.14-r1*
* *nav2-common 1.1.13-r1 --> 1.1.14-r1*
* *nav2-constrained-smoother 1.1.13-r1 --> 1.1.14-r1*
* *nav2-controller 1.1.13-r1 --> 1.1.14-r1*
* *nav2-core 1.1.13-r1 --> 1.1.14-r1*
* *nav2-costmap-2d 1.1.13-r1 --> 1.1.14-r1*
* *nav2-dwb-controller 1.1.13-r1 --> 1.1.14-r1*
* *nav2-graceful-controller 1.1.14-r1*
* *nav2-lifecycle-manager 1.1.13-r1 --> 1.1.14-r1*
* *nav2-map-server 1.1.13-r1 --> 1.1.14-r1*
* *nav2-mppi-controller 1.1.13-r1 --> 1.1.14-r1*
* *nav2-msgs 1.1.13-r1 --> 1.1.14-r1*
* *nav2-navfn-planner 1.1.13-r1 --> 1.1.14-r1*
* *nav2-planner 1.1.13-r1 --> 1.1.14-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.13-r1 --> 1.1.14-r1*
* *nav2-rotation-shim-controller 1.1.13-r1 --> 1.1.14-r1*
* *nav2-rviz-plugins 1.1.13-r1 --> 1.1.14-r1*
* *nav2-simple-commander 1.1.13-r1 --> 1.1.14-r1*
* *nav2-smac-planner 1.1.13-r1 --> 1.1.14-r1*
* *nav2-smoother 1.1.13-r1 --> 1.1.14-r1*
* *nav2-system-tests 1.1.13-r1 --> 1.1.14-r1*
* *nav2-theta-star-planner 1.1.13-r1 --> 1.1.14-r1*
* *nav2-util 1.1.13-r1 --> 1.1.14-r1*
* *nav2-velocity-smoother 1.1.13-r1 --> 1.1.14-r1*
* *nav2-voxel-grid 1.1.13-r1 --> 1.1.14-r1*
* *nav2-waypoint-follower 1.1.13-r1 --> 1.1.14-r1*
* *navigation2 1.1.13-r1 --> 1.1.14-r1*
* *pcl-conversions 2.4.0-r6 --> 2.4.3-r1*
* *pcl-ros 2.4.0-r6 --> 2.4.3-r1*
* *perception-pcl 2.4.0-r6 --> 2.4.3-r1*
* *ros-gz 0.244.13-r1 --> 0.244.14-r1*
* *ros-gz-interfaces 0.244.13-r1 --> 0.244.14-r1*
* *ros-ign 0.244.13-r1 --> 0.244.14-r1*
* *ros-ign-bridge 0.244.13-r1 --> 0.244.14-r1*
* *ros-ign-gazebo 0.244.13-r1 --> 0.244.14-r1*
* *ros-ign-gazebo-demos 0.244.13-r1 --> 0.244.14-r1*
* *ros-ign-image 0.244.13-r1 --> 0.244.14-r1*
* *ros-ign-interfaces 0.244.13-r1 --> 0.244.14-r1*
* *test-ros-gz-bridge 0.244.14-r1*
* *ur 2.2.10-r1 --> 2.2.11-r1*
* *ur-bringup 2.2.10-r1 --> 2.2.11-r1*
* *ur-calibration 2.2.10-r1 --> 2.2.11-r1*
* *ur-client-library 1.3.5-r1 --> 1.3.6-r1*
* *ur-controllers 2.2.10-r1 --> 2.2.11-r1*
* *ur-dashboard-msgs 2.2.10-r1 --> 2.2.11-r1*
* *ur-moveit-config 2.2.10-r1 --> 2.2.11-r1*
* *webots-ros2 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-control 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-driver 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-epuck 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-importer 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-mavic 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-msgs 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-tesla 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-tests 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-tiago 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-turtlebot 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-universal-robot 2023.1.1-r2 --> 2023.1.2-r1*

Iron Changes:
-------------
* *cascade-lifecycle-msgs 1.0.4-r1 --> 1.0.5-r1*
* *cmake-generate-parameter-module-example 0.3.8-r3*
* *control-msgs 5.0.0-r1 --> 5.1.0-r1*
* *costmap-queue 1.2.6-r1 --> 1.2.7-r1*
* *dwb-core 1.2.6-r1 --> 1.2.7-r1*
* *dwb-critics 1.2.6-r1 --> 1.2.7-r1*
* *dwb-msgs 1.2.6-r1 --> 1.2.7-r1*
* *dwb-plugins 1.2.6-r1 --> 1.2.7-r1*
* *fields2cover 1.2.1-r3 --> 2.0.0-r1*
* *generate-parameter-library 0.3.7-r1 --> 0.3.8-r3*
* *generate-parameter-library-example 0.3.6-r1 --> 0.3.8-r3*
* *generate-parameter-library-py 0.3.7-r1 --> 0.3.8-r3*
* *generate-parameter-module-example 0.3.6-r1 --> 0.3.8-r3*
* *geodesy 1.0.5-r1 --> 1.0.6-r1*
* *geographic-info 1.0.5-r1 --> 1.0.6-r1*
* *geographic-msgs 1.0.5-r1 --> 1.0.6-r1*
* *gz-ros2-control-demos 1.1.5-r1 --> 1.1.6-r1*
* *kitti-metrics-eval 1.0.1-r1 --> 1.0.2-r1*
* *microstrain-inertial-description 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-driver 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-examples 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-msgs 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-rqt 4.1.0-r1 --> 4.2.0-r1*
* *mola 1.0.1-r1 --> 1.0.2-r1*
* *mola-bridge-ros2 1.0.1-r1 --> 1.0.2-r1*
* *mola-demos 1.0.1-r1 --> 1.0.2-r1*
* *mola-imu-preintegration 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-euroc-dataset 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-kitti-dataset 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-kitti360-dataset 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-mulran-dataset 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-paris-luco-dataset 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-rawlog 1.0.1-r1 --> 1.0.2-r1*
* *mola-input-rosbag2 1.0.1-r1 --> 1.0.2-r1*
* *mola-kernel 1.0.1-r1 --> 1.0.2-r1*
* *mola-launcher 1.0.1-r1 --> 1.0.2-r1*
* *mola-metric-maps 1.0.1-r1 --> 1.0.2-r1*
* *mola-navstate-fuse 1.0.1-r1 --> 1.0.2-r1*
* *mola-pose-list 1.0.1-r1 --> 1.0.2-r1*
* *mola-relocalization 1.0.2-r1*
* *mola-traj-tools 1.0.1-r1 --> 1.0.2-r1*
* *mola-viz 1.0.1-r1 --> 1.0.2-r1*
* *mola-yaml 1.0.1-r1 --> 1.0.2-r1*
* *mrpt2 2.12.0-r1 --> 2.12.1-r1*
* *nav-2d-msgs 1.2.6-r1 --> 1.2.7-r1*
* *nav-2d-utils 1.2.6-r1 --> 1.2.7-r1*
* *nav2-amcl 1.2.6-r1 --> 1.2.7-r1*
* *nav2-behavior-tree 1.2.6-r1 --> 1.2.7-r1*
* *nav2-behaviors 1.2.6-r1 --> 1.2.7-r1*
* *nav2-bringup 1.2.6-r1 --> 1.2.7-r1*
* *nav2-bt-navigator 1.2.6-r1 --> 1.2.7-r1*
* *nav2-collision-monitor 1.2.6-r1 --> 1.2.7-r1*
* *nav2-common 1.2.6-r1 --> 1.2.7-r1*
* *nav2-constrained-smoother 1.2.6-r1 --> 1.2.7-r1*
* *nav2-controller 1.2.6-r1 --> 1.2.7-r1*
* *nav2-core 1.2.6-r1 --> 1.2.7-r1*
* *nav2-costmap-2d 1.2.6-r1 --> 1.2.7-r1*
* *nav2-dwb-controller 1.2.6-r1 --> 1.2.7-r1*
* *nav2-lifecycle-manager 1.2.6-r1 --> 1.2.7-r1*
* *nav2-map-server 1.2.6-r1 --> 1.2.7-r1*
* *nav2-mppi-controller 1.2.6-r1 --> 1.2.7-r1*
* *nav2-msgs 1.2.6-r1 --> 1.2.7-r1*
* *nav2-navfn-planner 1.2.6-r1 --> 1.2.7-r1*
* *nav2-planner 1.2.6-r1 --> 1.2.7-r1*
* *nav2-regulated-pure-pursuit-controller 1.2.6-r1 --> 1.2.7-r1*
* *nav2-rotation-shim-controller 1.2.6-r1 --> 1.2.7-r1*
* *nav2-rviz-plugins 1.2.6-r1 --> 1.2.7-r1*
* *nav2-simple-commander 1.2.6-r1 --> 1.2.7-r1*
* *nav2-smac-planner 1.2.6-r1 --> 1.2.7-r1*
* *nav2-smoother 1.2.6-r1 --> 1.2.7-r1*
* *nav2-system-tests 1.2.6-r1 --> 1.2.7-r1*
* *nav2-theta-star-planner 1.2.6-r1 --> 1.2.7-r1*
* *nav2-util 1.2.6-r1 --> 1.2.7-r1*
* *nav2-velocity-smoother 1.2.6-r1 --> 1.2.7-r1*
* *nav2-voxel-grid 1.2.6-r1 --> 1.2.7-r1*
* *nav2-waypoint-follower 1.2.6-r1 --> 1.2.7-r1*
* *navigation2 1.2.6-r1 --> 1.2.7-r1*
* *parameter-traits 0.3.7-r1 --> 0.3.8-r3*
* *pcl-conversions 2.4.0-r5 --> 2.5.1-r1*
* *pcl-ros 2.4.0-r5 --> 2.5.1-r1*
* *perception-pcl 2.4.0-r5 --> 2.5.1-r1*
* *rclcpp-cascade-lifecycle 1.0.4-r1 --> 1.0.5-r1*
* *ros-gz 0.254.0-r1 --> 0.254.1-r1*
* *ros-gz-interfaces 0.254.0-r1 --> 0.254.1-r1*
* *ros-ign 0.254.0-r1 --> 0.254.1-r1*
* *ros-ign-bridge 0.254.0-r1 --> 0.254.1-r1*
* *ros-ign-gazebo 0.254.0-r1 --> 0.254.1-r1*
* *ros-ign-gazebo-demos 0.254.0-r1 --> 0.254.1-r1*
* *ros-ign-image 0.254.0-r1 --> 0.254.1-r1*
* *ros-ign-interfaces 0.254.0-r1 --> 0.254.1-r1*
* *test-ros-gz-bridge 0.254.1-r1*
* *ur 2.3.5-r1 --> 2.3.6-r1*
* *ur-calibration 2.3.5-r1 --> 2.3.6-r1*
* *ur-client-library 1.3.5-r1 --> 1.3.6-r1*
* *ur-controllers 2.3.5-r1 --> 2.3.6-r1*
* *ur-dashboard-msgs 2.3.5-r1 --> 2.3.6-r1*
* *ur-description 2.1.3-r1 --> 2.1.4-r1*
* *ur-moveit-config 2.3.5-r1 --> 2.3.6-r1*
* *webots-ros2 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-control 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-driver 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-epuck 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-importer 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-mavic 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-msgs 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-tesla 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-tests 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-tiago 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-turtlebot 2023.1.1-r2 --> 2023.1.2-r1*
* *webots-ros2-universal-robot 2023.1.1-r2 --> 2023.1.2-r1*

Noetic Changes:
---------------
* *fields2cover 1.2.1-r3 --> 2.0.0-r1*
* *microstrain-inertial-description 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-driver 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-examples 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-msgs 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-rqt 4.1.0-r1 --> 4.2.0-r1*
* *mrpt2 2.12.0-r1 --> 2.12.1-r1*
* *openrtm-aist 1.1.2-r4 --> 1.1.2-r5*
* *static-transform-mux 1.1.1-r1 --> 1.1.2-r1*
* *universal-robots 1.3.2-r1 --> 1.3.3-r1*
* *ur-calibration 2.1.3-r1 --> 2.1.4-r1*
* *ur-client-library 1.3.5-r1 --> 1.3.6-r1*
* *ur-dashboard-msgs 2.1.3-r1 --> 2.1.4-r1*
* *ur-description 1.3.2-r1 --> 1.3.3-r1*
* *ur-gazebo 1.3.2-r1 --> 1.3.3-r1*
* *ur-robot-driver 2.1.3-r1 --> 2.1.4-r1*
* *ur10-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur10e-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur16e-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur20-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur3-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur30-moveit-config 1.3.3-r1*
* *ur3e-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur5-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ur5e-moveit-config 1.3.2-r1 --> 1.3.3-r1*
* *ypspur 1.22.0-r1 --> 1.22.2-r1*

Rolling Changes:
----------------
* *actionlib-msgs 5.3.1-r1 --> 5.3.3-r1*
* *aruco-opencv 4.1.1-r2 --> 4.2.0-r1*
* *aruco-opencv-msgs 4.1.1-r2 --> 4.2.0-r1*
* *common-interfaces 5.3.1-r1 --> 5.3.3-r1*
* *control-msgs 5.0.0-r2 --> 5.1.0-r1*
* *diagnostic-msgs 5.3.1-r1 --> 5.3.3-r1*
* *examples-tf2-py 0.36.1-r1 --> 0.36.2-r1*
* *fields2cover 1.2.1-r5 --> 2.0.0-r1*
* *geodesy 1.0.5-r2 --> 1.0.6-r1*
* *geographic-info 1.0.5-r2 --> 1.0.6-r1*
* *geographic-msgs 1.0.5-r2 --> 1.0.6-r1*
* *geometry-msgs 5.3.1-r1 --> 5.3.3-r1*
* *geometry2 0.36.1-r1 --> 0.36.2-r1*
* *gmock-vendor 1.11.9000-r2 --> 1.14.9000-r1*
* *gtest-vendor 1.11.9000-r2 --> 1.14.9000-r1*
* *gz-cmake-vendor 0.0.4-r1 --> 0.0.6-r1*
* *gz-math-vendor 0.0.3-r1 --> 0.0.4-r1*
* *gz-msgs-vendor 0.0.2-r1*
* *gz-physics-vendor 0.0.2-r1*
* *gz-plugin-vendor 0.0.3-r1*
* *gz-sensors-vendor 0.0.2-r1*
* *gz-transport-vendor 0.0.2-r1*
* *gz-utils-vendor 0.0.2-r1 --> 0.0.3-r1*
* *microstrain-inertial-description 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-driver 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-examples 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-msgs 4.1.0-r1 --> 4.2.0-r1*
* *microstrain-inertial-rqt 4.1.0-r1 --> 4.2.0-r1*
* *mrpt2 2.12.0-r2 --> 2.12.1-r1*
* *nav-msgs 5.3.1-r1 --> 5.3.3-r1*
* *pcl-conversions 2.4.0-r5 --> 2.6.1-r2*
* *pcl-ros 2.4.0-r5 --> 2.6.1-r2*
* *perception-pcl 2.4.0-r5 --> 2.6.1-r2*
* *rmw-connextdds 0.21.0-r1 --> 0.22.0-r1*
* *rmw-connextdds-common 0.21.0-r1 --> 0.22.0-r1*
* *rmw-cyclonedds-cpp 2.1.1-r1 --> 2.2.0-r1*
* *rmw-dds-common 3.0.0-r2 --> 3.1.0-r1*
* *rmw-fastrtps-cpp 8.3.0-r1 --> 8.4.0-r1*
* *rmw-fastrtps-dynamic-cpp 8.3.0-r1 --> 8.4.0-r1*
* *rmw-fastrtps-shared-cpp 8.3.0-r1 --> 8.4.0-r1*
* *rti-connext-dds-cmake-module 0.21.0-r1 --> 0.22.0-r1*
* *rviz-assimp-vendor 13.4.2-r1 --> 14.0.0-r1*
* *rviz-common 13.4.2-r1 --> 14.0.0-r1*
* *rviz-default-plugins 13.4.2-r1 --> 14.0.0-r1*
* *rviz-ogre-vendor 13.4.2-r1 --> 14.0.0-r1*
* *rviz-rendering 13.4.2-r1 --> 14.0.0-r1*
* *rviz-rendering-tests 13.4.2-r1 --> 14.0.0-r1*
* *rviz-visual-testing-framework 13.4.2-r1 --> 14.0.0-r1*
* *rviz2 13.4.2-r1 --> 14.0.0-r1*
* *sdformat-vendor 0.0.2-r1 --> 0.0.3-r1*
* *sensor-msgs 5.3.1-r1 --> 5.3.3-r1*
* *sensor-msgs-py 5.3.1-r1 --> 5.3.3-r1*
* *shape-msgs 5.3.1-r1 --> 5.3.3-r1*
* *std-msgs 5.3.1-r1 --> 5.3.3-r1*
* *std-srvs 5.3.1-r1 --> 5.3.3-r1*
* *stereo-msgs 5.3.1-r1 --> 5.3.3-r1*
* *tf2 0.36.1-r1 --> 0.36.2-r1*
* *tf2-bullet 0.36.1-r1 --> 0.36.2-r1*
* *tf2-eigen 0.36.1-r1 --> 0.36.2-r1*
* *tf2-eigen-kdl 0.36.1-r1 --> 0.36.2-r1*
* *tf2-geometry-msgs 0.36.1-r1 --> 0.36.2-r1*
* *tf2-kdl 0.36.1-r1 --> 0.36.2-r1*
* *tf2-msgs 0.36.1-r1 --> 0.36.2-r1*
* *tf2-py 0.36.1-r1 --> 0.36.2-r1*
* *tf2-ros 0.36.1-r1 --> 0.36.2-r1*
* *tf2-ros-py 0.36.1-r1 --> 0.36.2-r1*
* *tf2-sensor-msgs 0.36.1-r1 --> 0.36.2-r1*
* *tf2-tools 0.36.1-r1 --> 0.36.2-r1*
* *trajectory-msgs 5.3.1-r1 --> 5.3.3-r1*
* *ur 2.4.3-r2 --> 2.4.4-r1*
* *ur-calibration 2.4.3-r2 --> 2.4.4-r1*
* *ur-client-library 1.3.5-r2 --> 1.3.6-r1*
* *ur-controllers 2.4.3-r2 --> 2.4.4-r1*
* *ur-dashboard-msgs 2.4.3-r2 --> 2.4.4-r1*
* *ur-description 2.2.4-r2 --> 2.2.5-r1*
* *ur-moveit-config 2.4.3-r2 --> 2.4.4-r1*
* *visualization-msgs 5.3.1-r1 --> 5.3.3-r1*
* *webots-ros2 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-control 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-driver 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-epuck 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-importer 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-mavic 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-msgs 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-tesla 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-tests 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-tiago 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-turtlebot 2023.1.1-r3 --> 2023.1.2-r1*
* *webots-ros2-universal-robot 2023.1.1-r3 --> 2023.1.2-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] docker.io
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros_pkgs
 * [ ] glslang-dev
 * [ ] glslc
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libavdevice-dev
 * [ ] libcoin80-dev
 * [ ] libdraco-dev
 * [ ] libfreeimage-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] liblttng-ctl-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] libshaderc-dev
 * [ ] libxkbcommon-dev
 * [ ] libzip-dev
 * [ ] ocl-icd-opencl-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-colorcet
 * [ ] python3-flake8-builtins
 * [ ] python3-flake8-comprehensions
 * [ ] python3-flake8-docstrings
 * [ ] python3-flake8-import-order
 * [ ] python3-flake8-quotes
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pydantic
 * [ ] python3-pymap3d
 * [ ] python3-rosdep
 * [ ] python3-smbus
 * [ ] qml-module-qt-labs-folderlistmodel
 * [ ] qml-module-qt-labs-platform
 * [ ] qml-module-qt-labs-settings
 * [ ] qml-module-qtcharts
 * [ ] qml-module-qtgraphicaleffects
 * [ ] qml-module-qtlocation
 * [ ] qml-module-qtpositioning
 * [ ] qml-module-qtquick-controls
 * [ ] qml-module-qtquick-controls2
 * [ ] qml-module-qtquick-dialogs
 * [ ] qml-module-qtquick-extras
 * [ ] qml-module-qtquick-layouts
 * [ ] qml-module-qtquick-templates2
 * [ ] qml-module-qtquick-window2
 * [ ] qml-module-qtquick2
 * [ ] qtbase5-private-dev
 * [ ] qtquickcontrols2-5-dev
 * [ ] rmf_building_map_tools
 * [ ] rmf_building_sim_common
 * [ ] rmf_building_sim_gz_classic_plugins
 * [ ] rmf_building_sim_gz_plugins
 * [ ] rmf_robot_sim_common
 * [ ] rmf_robot_sim_gz_classic_plugins
 * [ ] rmf_robot_sim_gz_plugins
 * [ ] rmf_traffic_editor
 * [ ] rmf_traffic_editor_assets
 * [ ] rmf_traffic_editor_test_maps
 * [ ] ros_gz_bridge
 * [ ] ros_gz_sim
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] ros_ign_gazebo_demos
 * [ ] ros_ign_image
 * [ ] ros_ign_interfaces
 * [ ] rubocop
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] simde
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wayland
 * [ ] wayland-dev
 * [ ] wiimote

