### PR TITLE
Fix sophus build errors for humble and iron

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -134,6 +134,18 @@ in with lib; {
     sha256 = "1iv6k0dwdzg5nnzw2mcgcl663q4f7p2kj7nhs8afnsikrzxxgsi4";
   };
 
+  sophus = rosSuper.sophus.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Remove -Werror from the compile flags.
+      (self.fetchpatch {
+        url = "https://github.com/clalancette/sophus/commit/13339e883e627dc62e5a3e8d13919173051ea139.patch";
+        hash = "sha256-vY99tXRcrWxcztva+wQiOw50PwLePrvaSVZ/lerX1Kg=";
+      })
+    ];
+  });
+
   urdfdom = rosSuper.urdfdom.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/iron/overrides.nix
+++ b/distros/iron/overrides.nix
@@ -118,6 +118,18 @@ in with lib; {
     '';
   });
 
+  sophus = rosSuper.sophus.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Remove -Werror from the compile flags.
+      (self.fetchpatch {
+        url = "https://github.com/clalancette/sophus/commit/13339e883e627dc62e5a3e8d13919173051ea139.patch";
+        hash = "sha256-vY99tXRcrWxcztva+wQiOw50PwLePrvaSVZ/lerX1Kg=";
+      })
+    ];
+  });
+
   urdfdom = rosSuper.urdfdom.overrideAttrs ({
     patches ? [], ...
   }: {

--- a/distros/noetic/overrides.nix
+++ b/distros/noetic/overrides.nix
@@ -83,4 +83,12 @@ rosSelf: rosSuper: with rosSelf.lib; {
     url = "https://github.com/fmtlib/fmt/releases/download/9.1.0/fmt-9.1.0.zip";
     sha256 = "sha256-zOtMuTZuGKV0ISjLNSTOX1Doi0dvHlRzekf/3030yZY=";
   };
+
+  sophus = rosSuper.sophus.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    postPatch = postPatch + ''
+      substituteInPlace CMakeLists.txt --replace-fail " -Werror" ""
+    '';
+  });
 }


### PR DESCRIPTION
We apply the patch from the rolling version, which builds fine already now. The patch does not apply to foxy and noetic versions so we don't patch them. Foxy is EOL. If someone needs noetic version, more effort is needed.

Fixes #393