### PR TITLE
README: Update example flake.nix to use buildEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ Using the overlay in your `flake.nix`-based project could look like this:
       in {
         devShells.default = pkgs.mkShell {
           name = "Example project";
-          packages = with pkgs.rosPackages.humble; [
+          packages = [
             pkgs.colcon
-            ros-core
-            # ...
+            # ... other non-ROS packages
+            (with pkgs.rosPackages.humble; buildEnv {
+                paths = [
+                    ros-core
+                    # ... other ROS packages
+                ];
+            })
           ];
         };
       });


### PR DESCRIPTION
Currently, quite a few things are broken when ROS packages are used directly without buildEnv.

Closes #396 #401
Related #362