### PR TITLE
Fix jsk-recognition-msgs on noetic

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -66,9 +66,12 @@ let
     image-cb-detector = patchBoostSignals rosSuper.image-cb-detector;
 
     jsk-recognition-msgs = rosSuper.jsk-recognition-msgs.overrideAttrs ({
-      buildInputs ? [], ...
+      buildInputs ? [], postPatch ? "", ...
     }: {
       buildInputs = buildInputs ++ [ rosSuper.ros-environment ];
+      postPatch = ''
+        substituteInPlace CMakeLists.txt --replace "catkin_python_setup()" ""
+      '';
     });
 
     laser-cb-detector = patchBoostSignals rosSuper.laser-cb-detector;

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -65,6 +65,12 @@ let
 
     image-cb-detector = patchBoostSignals rosSuper.image-cb-detector;
 
+    jsk-recognition-msgs = rosSuper.jsk-recognition-msgs.overrideAttrs ({
+      buildInputs ? [], ...
+    }: {
+      buildInputs = buildInputs ++ [ rosSuper.ros-environment ];
+    });
+
     laser-cb-detector = patchBoostSignals rosSuper.laser-cb-detector;
 
     libfranka = rosSuper.libfranka.overrideAttrs ({


### PR DESCRIPTION
This contains two fixes:

1. The first is that `ROS_DISTRO` is read from the environment in `CMakeLists.txt`. The variable is only available when `ros-environment` is included as a build input. I'm not sure how this worked before. (https://github.com/jsk-ros-pkg/jsk_recognition/pull/2836)

1. The second build fix is removing `catkin_python_setup` from `CMakeLists.txt` (https://github.com/jsk-ros-pkg/jsk_recognition/pull/2829)


Fixes #406 