### PR TITLE
Allow gazebo to build against graphviz 10

### DIFF
--- a/pkgs/gazebo/default.nix
+++ b/pkgs/gazebo/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchurl, cmake, pkg-config, ronn, libGL
+{ lib, mkDerivation, fetchpatch, fetchurl, cmake, pkg-config, ronn, libGL
 , openal, hdf5, curl, tinyxml, tinyxml-2, libtar, gts, libusb1, qtbase, gdal
 , libuuid, graphviz, libsForQt5, freeimage, boost, protobuf, sdformat, tbb
 , ogre1_9, ffmpeg, ignition, ignition-cmake ? ignition.cmake0
@@ -17,6 +17,15 @@ mkDerivation rec {
     url = "https://osrf-distributions.s3.amazonaws.com/gazebo/releases/${pname}-${version}.tar.bz2";
     hash = "sha256-fphCwEbJ4HVTVbJ0wkCoq79Olivnznt/WRlOX0tYT0U=";
   };
+
+  patches = [
+    # Allow building with graphviz 10+
+    (fetchpatch {
+      name = "fix-build-against-graphviz-10.patch";
+      url = "https://github.com/gazebosim/gazebo-classic/commit/660ae15f4af1f5ea8d9d50d4a24e4d91a94f9c2d.patch";
+      hash = "sha256-KPwuDdTEWMDbLF/FQACM/huCYlXDg43cd8QBt3E859A=";
+    })
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Unstable ships with graphviz 10 instead of 9. Allow gazebo to compile against the newer version as well.