### PR TITLE
ros2 python-qt-binding sip4 patch to fix apps like rqt

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -112,8 +112,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
     postPatch ? "", ...
   }: {
     propagatedNativeBuildInputs = with rosSelf.pythonPackages;
-      (rosSelf.lib.subtractLists [ shiboken2 pyside2 ] propagatedNativeBuildInputs)
-      ++ [ sip_4 ];
+      propagatedNativeBuildInputs++ [ sip_4 ];
     postPatch = ''
       sed -e "1 i\\import PyQt5" \
           -e "s#sipconfig\._pkg_config\['default_mod_dir'\], 'PyQt5'#PyQt5.__path__[0]#" \

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -113,11 +113,11 @@ rosSelf: rosSuper: with rosSelf.lib; {
   }: {
     propagatedNativeBuildInputs = with rosSelf.pythonPackages;
       propagatedNativeBuildInputs++ [ sip_4 ];
-    postPatch = ''
-      sed -e "1 i\\import PyQt5" \
-          -e "s#sipconfig\._pkg_config\['default_mod_dir'\], 'PyQt5'#PyQt5.__path__[0]#" \
-          -i cmake/sip_configure.py
-    '' + postPatch;
+    # postPatch = ''
+    #   sed -e "1 i\\import PyQt5" \
+    #       -e "s#sipconfig\._pkg_config\['default_mod_dir'\], 'PyQt5'#PyQt5.__path__[0]#" \
+    #       -i cmake/sip_configure.py
+    # '' + postPatch;
   });
 
   rcutils = rosSuper.rcutils.overrideAttrs ({


### PR DESCRIPTION
Without this patch, on WSL, and I believe all non-darwin systems, rqt will be unable to load the image_viewer plugin. See #404 and https://github.com/lopsided98/nix-ros-overlay/issues/404#issuecomment-2092797850

This could be selectively applied to rqt, similar to the ros1 overlay rviz patch. But I think it would be best to patch for all dependencies. This should not break anything, as it does not affect whether or not pyside or pyqt is chosen as the backend. It will simply allow the pyqt backend to function.

An alternative approach could be taken (and also works) where python-qt-bindings is patched to always choose pyside, but I actually see better framerate with the image_viewer plugin with pyqt (at least on WSL2).

I have tested this with rqt in ros2/humble.