### PR TITLE
Python qt bindings support both

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -178,12 +178,23 @@ let
 
     pr2-tilt-laser-interface = patchBoostSignals rosSuper.pr2-tilt-laser-interface;
 
-    python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
-      propagatedNativeBuildInputs ? [], ...
+    python-qt-binding = (rosSuper.python-qt-binding.override {
+      python3Packages = rosSelf.python3Packages.overrideScope (pyFinal: pyPrev: {
+        pyqt5 = pyPrev.pyqt5.overrideAttrs ({
+          patches ? [], ...
+        }: {
+          patches = patches ++ [ (self.fetchpatch {
+            url = "https://aur.archlinux.org/cgit/aur.git/plain/restore-sip4-support.patch?h=python-pyqt5-sip4&id=6e712e6c588d550a1a6f83c1b37c2c9135aae6ba";
+            hash = "sha256-NfMe/EK1Uj88S82xZSm+A6js3PK9mlgsaci/kinlsy8=";
+          }) ];
+        });
+      });
+    }).overrideAttrs ({
+      propagatedBuildInputs ? [], ...
     }: {
-      propagatedNativeBuildInputs = propagatedNativeBuildInputs ++ (with rosSelf.pythonPackages; [
-        shiboken2
+      propagatedBuildInputs = propagatedBuildInputs ++ (with rosSelf.pythonPackages; [
         pyside2
+        sip4
       ]);
 
       dontWrapQtApps = true;
@@ -194,6 +205,14 @@ let
           rm -rf devel/lib
         }
         preFixupHooks+=(_pythonQtBindingPreFixupHook)
+      '';
+
+      postPatch = ''
+        sed -e "1 i\\import PyQt5" \
+            -e "s#sipconfig\._pkg_config\['default_mod_dir'\], 'PyQt5'#PyQt5.__path__[0]#" \
+            -e "s#with open(os.path.join(tmpdirname, 'QtCore', 'QtCoremod.sip'), 'w') as outfp:##" \
+            -e "s#outfp.write(output)##" \
+            -i cmake/sip_configure.py
       '';
     });
 

--- a/distros/ros1-overlay.nix
+++ b/distros/ros1-overlay.nix
@@ -155,35 +155,7 @@ rosSelf: rosSuper: with rosSelf.lib; {
     '';
   });
 
-  # rviz does not support shiboken/pyside2 and SIP4 is broken with the latest
-  # pyqt5. This applies a patch to make pyqt5 compatible with SIP 4 and uses
-  # SIP 4 with python-qt-binding for rviz only.
-  rviz = (rosSuper.rviz.override {
-    python-qt-binding = (rosSuper.python-qt-binding.override {
-      python3Packages = rosSelf.python3Packages.overrideScope (pyFinal: pyPrev: {
-        pyqt5 = pyPrev.pyqt5.overrideAttrs ({
-          patches ? [], ...
-        }: {
-          patches = patches ++ [ (self.fetchpatch {
-            url = "https://aur.archlinux.org/cgit/aur.git/plain/restore-sip4-support.patch?h=python-pyqt5-sip4&id=6e712e6c588d550a1a6f83c1b37c2c9135aae6ba";
-            hash = "sha256-NfMe/EK1Uj88S82xZSm+A6js3PK9mlgsaci/kinlsy8=";
-          }) ];
-        });
-      });
-    }).overrideAttrs({
-      propagatedNativeBuildInputs ? [],
-      postPatch ? "", ...
-    }: {
-      propagatedNativeBuildInputs = with rosSelf.pythonPackages;
-        (rosSelf.lib.subtractLists [ shiboken2 pyside2 ] propagatedNativeBuildInputs)
-        ++ [ sip_4 ];
-      postPatch = ''
-        sed -e "1 i\\import PyQt5" \
-            -e "s#sipconfig\._pkg_config\['default_mod_dir'\], 'PyQt5'#PyQt5.__path__[0]#" \
-            -i cmake/sip_configure.py
-      '' + postPatch;
-    });
-  }).overrideAttrs ({
+  rviz = rosSuper.rviz.overrideAttrs ({
     nativeBuildInputs ? [],
     postFixup ? "", ...
   }: {


### PR DESCRIPTION
I have been bounding around trying to get all of the pyqt stuff to work across all of the distros for a while now... and I think this is my final solution. It seems to keep everything happy, and works even for the most current versions of everything, without requiring any huge overrides, or any patches that will break when files are updated upstream.

Some packages need specifically pyqt or pyside to be loaded by python-qt-binding. This changes the overrides to support both.

Annoyingly, in recent python-qt-binding releases, sip_configure.py, the cmake helper script, rewrites QtCoremod.sip, which is outside of the nix build area and causes a build failure. See https://github.com/ros-visualization/python_qt_binding/commit/e78372fd63eda527c9fad5fcdab8ca31eb3f36d2

This is the same patch that is applied from the AUR here. So sed patch out these changes. Then move the ros1 rviz patch to distro-overlay.nix to apply to everything.

Tested with:
 - ROS2 rolling using rqt_image_viewer
 - ROS2 humble using rqt_image_viewer
 - ROS1 noetic using rqt_image_viewer and rziv
 
 See #404