### PR TITLE
ament-cmake-vendor-package: don't 'fix' cmake files

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -12,6 +12,13 @@ rosSelf: rosSuper: with rosSelf.lib; {
     outputs = [ "out" "dev" ];
   });
 
+  ament-cmake-vendor-package = rosSuper.ament-cmake-vendor-package.overrideAttrs ({
+    # the regular cmake fixing replaces <snip>/opt<snip> with /var/empty, even within
+    # the local ros2 install folder, which completely breaks vendoring, since the
+    # cmake_prefix_path will no longer point the where the files are.
+    dontFixCmake = true;
+  });
+
   cyclonedds = rosSuper.cyclonedds.overrideAttrs ({
     cmakeFlags ? [], ...
   }: {


### PR DESCRIPTION
the ament cmake vendoring works by downloading files into the `ros2_ws/install/opt/<package>` folder, which is a *local* path. It then sets the `CMAKE_PREFIX_PATH` to point into this directory. However, the normal nixpkgs cmake setup renames the /opt/ chunk with /var/empty, which then breaks the CMAKE_PREFIX_PATH setup. since this is a local install, just dont "fix" the cmake paths.

I noticed this by trying to build https://github.com/ros2/rmw_zenoh, which uses the ament cmake vendoring, and therefore just simply does not build without this patch.

I had to apply this in the distro overlay files, as the vendoring package does not exist in foxy.