### PR TITLE
Allow building ros-core for humble on MacOS

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -88,9 +88,10 @@ rosSelf: rosSuper: with rosSelf.lib; {
 
   python-cmake-module = rosSuper.python-cmake-module.overrideAttrs ({ ... }: let
     python = rosSelf.python;
+    libExt = if self.stdenv.isDarwin then "dylib" else "so";
   in {
     pythonExecutable = python.pythonOnBuildForHost.interpreter;
-    pythonLibrary = "${python}/lib/lib${python.libPrefix}.so";
+    pythonLibrary = "${python}/lib/lib${python.libPrefix}.${libExt}";
     pythonIncludeDir = "${python}/include/${python.libPrefix}";
     setupHook = ./python-cmake-module-setup-hook.sh;
     outputs = [ "out" "dev" ];

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -119,13 +119,18 @@ rosSelf: rosSuper: with rosSelf.lib; {
   };
 
   rmw-implementation = rosSuper.rmw-implementation.overrideAttrs ({
-    propagatedBuildInputs ? [], ...
+    propagatedBuildInputs ? [], buildInputs ? [], ...
   }: {
     # The default implementation must be available to all dependent packages
     # at build time.
     propagatedBuildInputs = with rosSelf; [
       rmw-fastrtps-cpp
     ] ++ propagatedBuildInputs;
+    # rmw-cyclonedds-cpp fails to build on MacOS.
+    buildInputs = if self.stdenv.isDarwin then
+      builtins.filter (p: p.pname != "ros-${p.rosDistro}-rmw-cyclonedds-cpp") buildInputs
+    else
+      buildInputs;
   });
 
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({


### PR DESCRIPTION
This fixes build issues on MacOS identified in #419. With these commits, it's possible to build `humble.ros-core` on MacOS. Unfortunately, building `ros-core` still fails on iron and rolling due to `lttng` being a dependency of `fastrtps`. I think this can be fixed, but will require more work, maybe in other repositories, so I don't try to fix it here.