### PR TITLE
buildRosPackage: default separateDebugInfo to true

### DIFF
--- a/distros/build-ros-package/default.nix
+++ b/distros/build-ros-package/default.nix
@@ -13,12 +13,13 @@
 , CXXFLAGS ? ""
 , postFixup ? ""
 , passthru ? { }
+, separateDebugInfo ? true
 , ...
 }@args:
 
 (if buildType == "ament_python" then pythonPackages.buildPythonPackage
 else stdenv.mkDerivation) (args // {
-  inherit doCheck dontWrapQtApps;
+  inherit doCheck dontWrapQtApps separateDebugInfo;
 
   # Disable warnings that cause "Log limit exceeded" errors on Hydra in lots of
   # packages that use Eigen


### PR DESCRIPTION
If the user has `services.nixseparatedebuginfod.enable=true` in their configuration this should allow `gdb` and friends to pull down symbols and source.

Closes #431