### PR TITLE
uncrustify-vendor: Fix vendor URL patching

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -382,8 +382,9 @@ let
     });
 
     uncrustify-vendor = patchVendorUrl rosSuper.uncrustify-vendor {
-      url = "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.68.1.tar.gz";
-      sha256 = "04ndwhcn9iv3cy4p5wgh5z0vx2sywqlydyympn9m3h5458w1aijh";
+      originalUrl = "https://github.com/uncrustify/uncrustify.git";
+      url = "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.72.0.tar.gz";
+      hash = "sha256-1v/3C8eCP6xMdwEwVTM7eaSDmQkJTo7uihTujxd3N04=";
     };
 
     urdf = patchBoostPython rosSuper.urdf;


### PR DESCRIPTION
Fixes #433

This is just a "quick fix" which works mostly by accident. Different version of `uncrustify-vendor` (in different distros) use not only different versions of uncrustify but also different patching mechanisms.

If time allows, I'll try to change this to patching for different versions of the package (although in case of uncrustify it's probably not that important to use exactly the same version as upstream). At the same time, it might be useful to improve `patchExternalProjectGit` and `patchAmentVendorGit` to fail if upstream changes the version to be patched. To do this, I'll need to resuscitate my Hydra to check the results of these changes. And this will take me some time.