### PR TITLE
update foonathan-memory to fix memory allocation error on macOS

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -18,12 +18,14 @@ in with lib; {
   });
 
   # This is a newer version than the build system tries to download, but this
-  # version doesn't try to run host platform binaries on the build platform.
+  # version doesn't try to run host platform binaries on the build platform
+  # and fixes "Allocator foonathan::memory::memory_pool received invalid size"
+  # error on MacOS
   foonathan-memory-vendor = patchExternalProjectGit rosSuper.foonathan-memory-vendor {
     url = "https://github.com/foonathan/memory.git";
     originalRev = "v0.7-1";
-    rev = "v0.7-2";
-    fetchgitArgs.hash = "sha256-5nJNW0xwjSCc0Egq1zv0tIsGvAh1Xbnu8190A1ZP+VA=";
+    rev = "v0.7-3";
+    fetchgitArgs.hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
   };
 
   gazebo = self.gazebo_11;


### PR DESCRIPTION
fixes [foonathan::memory] Allocator foonathan::memory::memory_pool error, mentioned in https://github.com/lopsided98/nix-ros-overlay/issues/419#issuecomment-2196472985, see https://github.com/RoboStack/ros-humble/issues/32#issuecomment-2227591674

Tested on macOS 15.0-beta, needs to be verified on other versions and platforms