### PR TITLE
rosdistro sync, Fri Aug  2 13:27:09 2024

### DIFF
--- a/distros/humble/action-tutorials-cpp/default.nix
+++ b/distros/humble/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-action-tutorials-cpp";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_cpp/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "3b27b0739059449a829c873b9f45d169e47f85e87bdee4b9a00ebb1562adcb7c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_cpp/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "5b0e6640ad5ea37a4f24e58cab50945abcda6abd41e6cf5e1459bee7a7b46d76";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/action-tutorials-interfaces/default.nix
+++ b/distros/humble/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-action-tutorials-interfaces";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_interfaces/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "66e0b6679092deffdf14a43bf5d4c46d45e4f8ecac0ef58e6d5a80de332d832c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_interfaces/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "d0206e68051e4b9ad215a8dc95242b9303f9a91ace9f57f974ebb59bb568b96d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/action-tutorials-py/default.nix
+++ b/distros/humble/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-lint-auto, ament-lint-common, rclpy }:
 buildRosPackage {
   pname = "ros-humble-action-tutorials-py";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_py/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "ee991cebbc4bbf4cc24796f3fbf7ac0fbb0bc93333a78da965155d677ef9e4e7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/action_tutorials_py/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "7a2dd8a9899f9a8760a64c8f30ccec84c0bd1b1d0cb2fd37205414f8901b48d8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-black/default.nix
+++ b/distros/humble/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-black";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_black/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "e6b57aa1868bd6ff6b3a6da574019fa6ad1f23a9df1715609d7275fa86de8f33";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "630b19024c714b71ebed940babfdb2a19d75e6551936fa720ffe232c2ec87d2c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cmake-auto/default.nix
+++ b/distros/humble/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-auto";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "76a9b55d84afc660f3e04794dc35a00bc2670cd03add98fed71a26aa7b8e2afd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "d435be1af9ee2702e35c454b077fc18cfbbb6094e5a15be3f9a7b7a80744d5f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-black/default.nix
+++ b/distros/humble/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-black";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_cmake_black/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "bfd3f48c7861ac8e5eaaf7381e5cb57615f2f90a2afb9c242e47bc905d142c26";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_cmake_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "2cc92498e7bd66d1ebb137c49b55390e8149b813669bf5546c7fb6c6c4631f2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-core/default.nix
+++ b/distros/humble/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-core";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "d88a21844dcfcbb9368f1181c996a3b15935e106c98b9c53e2498d69ce299e0e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "e1dc7ca030acbf5789240e5da5c1ac151f531aa76902dead8987a6ab31fe626f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-definitions/default.nix
+++ b/distros/humble/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-definitions";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "5c7118615071925edb80fd55ebd4ff183629b7f22d62fdcf9bde337dad15b110";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "1768af9dab66522b38c40cb8b5de930479d6749db4b52ec7811dd59fde1e2aad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-dependencies/default.nix
+++ b/distros/humble/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-dependencies";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "0112ab210ed06c4bfdf3589365078176af42e97d27b7ee4bb8acd0fb9fc75ed7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "2ded3649235337226aa2f26486a015a5195b318587a5addd1d615a1ddd168010";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-include-directories/default.nix
+++ b/distros/humble/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-include-directories";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "7f54c40148ef56f2aaae9240ed8cb71ea566c1e289444975b60658fbb2896c89";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "309780fe9db71104b4c5bddad049502c3b59b50a8b9277c567903f07502e42b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-interfaces/default.nix
+++ b/distros/humble/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-interfaces";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "307f8a41f33bb03e78a48e82e97b43a8f369ca58d85804131b8a6266c0bb94ff";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "403ab5ba78c3f15531ccfa4ebdd22a72ed4e2955e1e641a5e524f24e33d88db6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-libraries/default.nix
+++ b/distros/humble/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-libraries";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "e80a35505dbf0ccf39d00dfccc6c3119a5a441d985a0b48c8a18f10cc44a2794";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "159235d2a02f9852cab61ea32ac16bf7f126c8b267785151528155fde33ee701";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-link-flags/default.nix
+++ b/distros/humble/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-link-flags";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "ecac9ac3e2936876e6540a45d1c9e14158562d3cd0306544b668035cda063509";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "cd1b04d561d1b9644e18a370de3901e15120db0d02c8d64e06dc602cbd912365";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-targets/default.nix
+++ b/distros/humble/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-targets";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "90d7f5e9fa2fe539f429ab4937f003a344ac3036eafc6b3f1290324e756f8fc6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "f751dded95b0fb809bd41233d89cc0b19aac204cd2cf660813c4ea254a91e806";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gen-version-h/default.nix
+++ b/distros/humble/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gen-version-h";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "683d7d751ae16511a366e774bc7429eb23a0aaecd6f25735e65b38c6bf62c96c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "a40c8afbae1dadb2affe881e35cc786f7bf85c788c2cea6f9fdfa92996c8d4fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gmock/default.nix
+++ b/distros/humble/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gmock";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "bb40f09fb12c687223d83d488a35c84a17f6c554d3e95f35f596d0863cc79eeb";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "494f3bfc95ec6ee5f3ec91b16023090af17bda0f143c5438cbd8adc4494baae2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-google-benchmark/default.nix
+++ b/distros/humble/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-google-benchmark";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "e102a743608592335a4ddec70b9486124500ff146e0160cab710c167799d2860";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "dbe284153d0355699731fcf8456ec631a9233a5f7a0a00c12ca80309750d1191";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gtest/default.nix
+++ b/distros/humble/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gtest";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "2009c2faa79e05d4e03283d0a182cd24c6ab04c8be30dbf8d02f2a98a907bc2b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "133d16ea7d5dbf9b563fcee55c4ae585a4971c5802cb59f4fa69c5e15ae33051";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-include-directories/default.nix
+++ b/distros/humble/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-include-directories";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "d675b9a622df39cbea2825b131e0d64a8a56e434bb3146c47c6cfe84929b5859";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "b30070499487db06c44c6ba6502665153c14bc309ace0ebb5673785ffe3cc17f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-libraries/default.nix
+++ b/distros/humble/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-libraries";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "b2e64b530e4effbc81ff253a001437faa1716c5c0daf7fec38ccfe53b5fef54d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "9f259d51ea16519126a9346e51894fd311d7902f7f77a8655b636d7102441fe4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-nose/default.nix
+++ b/distros/humble/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-nose";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "a0436bc67174118e4ed7a07b57e3063e8f49b6dda5259f5dfc4629829dc63c95";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "2058e91a6ca6be919b912c7f99c0fbd05299001001722c775a8d15c069f789c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pytest/default.nix
+++ b/distros/humble/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pytest";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "454ef2dc9a4b8a2d0b7eccb520ceb7939be3446aab95579b83da1269037cc2bb";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "af703cfe993ceb3adfdba48ee3fc6a9ad661eac5f1e6e9e80fb5e9c8e394722d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-python/default.nix
+++ b/distros/humble/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-python";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "b45f74a0c44931ec8542022e95743ee3066544cd8df7f178983657fa7bd74bca";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "22dfaafc6abd04638dfc160f705b6cd2861a258335ffeb42c1e787853d9fe12f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-target-dependencies/default.nix
+++ b/distros/humble/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-target-dependencies";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "42121657dcb6597151b99dc44d4dc6f3077ed3c27dd99c6d86baee707bffbca1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "92923a98880f7821d64c463b885f6df5182985c016d931834e93c48cadaf7524";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-test/default.nix
+++ b/distros/humble/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-test";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "fc13bcd2baa012f73ffc15022354e384f4b2bd81d36adf08293989d0a9f182e0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "ef20c8002bed0b34a98277af122254d813a81a67231cbb7a66367aa8197ecd1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-vendor-package/default.nix
+++ b/distros/humble/ament-cmake-vendor-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-vendor-package";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "1aa1c7acefce533f6f16935be738d0cedf9845c2f128f11f3946927d5454053e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "99a5bbb41355ccfbf00a53b22fe5da8741a9046301344864681dfe259b376794";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-version/default.nix
+++ b/distros/humble/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-version";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "221450f70b4ae53c763216e74609a65824a05afbb2522096989a0590f2ce4c4d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "2f22ca79ff00237236189f56f0558490196604fdcab743317db9ee00e3898c58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake/default.nix
+++ b/distros/humble/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake";
-  version = "1.3.9-r1";
+  version = "1.3.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.9-1.tar.gz";
-    name = "1.3.9-1.tar.gz";
-    sha256 = "8b63c7b7b8594c875f98f69c1df7d6ac101ed05b960c5a8f52b21c8cc81983ff";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.10-1.tar.gz";
+    name = "1.3.10-1.tar.gz";
+    sha256 = "0dff90d2d2365f726407a6e91851aa5ee0bb9762030c172a99f858d9234c76a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-socketcan-interface/default.nix
+++ b/distros/humble/clearpath-socketcan-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, console-bridge, linuxHeaders, pluginlib }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-socketcan-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/clearpath_socketcan_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "098c5c8f4b05701bd1579127e3a4dc887ace3f337254cae4ad6d29cd18c64454";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost console-bridge linuxHeaders pluginlib ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "Clearpath's CAN interface description with helpers for filtering and driver implementation. Further a socketcan implementation based on boost::asio is included.";
+    license = with lib.licenses; [ lgpl3Only ];
+  };
+}

--- a/distros/humble/composition/default.nix
+++ b/distros/humble/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-composition";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/composition/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "54001d702c0ac6cad0c5333860558b22ffa50c1745a72322d39092eea457892b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/composition/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "68e9cbbecb1ca5f517893d5a541779c5d831b6f42d3b0d8c89744aab88e6d01b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/demo-nodes-cpp-native/default.nix
+++ b/distros/humble/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-demo-nodes-cpp-native";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp_native/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "b3e9c5ed992e3e25f9955482cc168da0dd3367e1e66952a3033815a6bafd56f7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp_native/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "d3eb1e849f1c2f5aca6fffa7551a70aa4fd6dc35c264e93f2ead971200e986f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/demo-nodes-cpp/default.nix
+++ b/distros/humble/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-demo-nodes-cpp";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "acabc0c25cdd3a13c965a3f832825df7740fe9436e12389450d13262fabf2165";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_cpp/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "bae26eb92b56f6fba90320852fc970b58d2b0bbf5ff0962a255e0c74e43b60b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/demo-nodes-py/default.nix
+++ b/distros/humble/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-demo-nodes-py";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_py/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "5ca42db70fe6c8add39a2417ae7f5646db08aeb149d09e794b1ca84b6d90aad3";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/demo_nodes_py/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "91702a23a43ff2e49a0ef50b12edd171a8e9564cb83354b2a6cccbd2017a0b4d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/dummy-map-server/default.nix
+++ b/distros/humble/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dummy-map-server";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_map_server/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "4be15539008a389dce16c8fc745ca9927faac06027d1d3db405165abd49f3490";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_map_server/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "aba096049cc3e550597106f7a2989369d75635e5d8b4c1404c125c1f73c30e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dummy-robot-bringup/default.nix
+++ b/distros/humble/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-humble-dummy-robot-bringup";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_robot_bringup/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "3f98438b18b1bf8278a1ce26b9cd75bd85c0b3a45bfd89d9e34097abb25c040c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_robot_bringup/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "5c0b4bb9fefcb8ee8d53e7a7a21cf3ae4b427286d507aa0d2c09ae044ed4f600";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dummy-sensors/default.nix
+++ b/distros/humble/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dummy-sensors";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_sensors/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "3c649fa19409e4ea388d638679b49aeb8e9877744536198337d6302b3a7066ca";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/dummy_sensors/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "e9dadf78c7f46e887d7db63d142f3a6f6ac938a7531a7e56b93bf4f7f172eb97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-async-client/default.nix
+++ b/distros/humble/examples-rclcpp-async-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-async-client";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_async_client/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "96e8f19c8a8b92bfaa42a60a1664cf7a9c8b14fc004a6c66824051a73955c162";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_async_client/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "7bc2cd95b109347900925742d36cd746eda42f2b5962deef63b025abf96372bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-cbg-executor/default.nix
+++ b/distros/humble/examples-rclcpp-cbg-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-cbg-executor";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_cbg_executor/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "c1dfc968aae3056001cc56a646e68ec89d6dad2903e3c92dab8d53bff8fc8482";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_cbg_executor/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "6e7a61f72fdf406995e1360de12a17c7f2cdc404f965164ff0767ac3dc909529";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-action-client/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-action-client";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_client/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "f8958ab937873bd8064834da5cbd74783f496557d5c3488a0e1ea0f2f37300d1";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_client/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "0e9e3c1a58605a094ded959ce405055bf8954224c1a8395fe9fc87565376ef9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-action-server/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-action-server";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_server/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "2c8fa1fec9b36c6d53cbf35f3462f590c28143270bc8387b5565e61fb0d5b3f8";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_server/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "ef67f18f41667633b39ff597ead9148b5d9dbbc6ac8aa21588c09b224ed1f60f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-client/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-client";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_client/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "535ff29d2ecd5c04cbf6799e5a2746455afaae94046e02428ab49273c4312b71";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_client/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "7d92c12f193e97c771b5c6d5cbb5f535a930992c9bb44fded1bd6fc922c33fd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-composition/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-composition";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_composition/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "4f06a2a1726484437fab7188605870ae3213bab37ec75df60906f0430f927f30";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_composition/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "cd6c40c5dfa28026daf8e3cc790f85e68907074bf1e6f85a352371ddfaffbc4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-publisher/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-publisher";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_publisher/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "94db60d17bdbacc694011fda09958aad41cbecea5bc5773bf72431aff6d48345";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_publisher/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "f52bec619741364cb4a0c2a7c030d8fb8b01ba93b0af5531feec5c0e814de937";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-service/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-service";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_service/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "097f96f2eaddab3d5fe34b8d9604ec49521e28707341d9699485ff76c97d5626";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_service/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "6ba92c519586bf35be9a6627a4a2dd2ce0b149051cf0b0e11e6b78c1e615de46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-subscriber/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-subscriber";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_subscriber/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "ade2413d7ba7b7f850047be47af5ff05133928358eb278d9bc75ce9c8bbd8fe2";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_subscriber/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "018389c190d5b8024f0099b09f3da91c6f6d8dae0dc65c9e7d7b60648ca9bdf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-timer/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-timer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-timer";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_timer/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "4c1b5104a0e7a51ec3f396c5edb01e94c6304b88d0f88ec0c48a684c1c5c3533";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_timer/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "91a5ee75d0445ca4d038fd73d1e6147638b3d850d27f15812e5ff239d2de4c11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-multithreaded-executor/default.nix
+++ b/distros/humble/examples-rclcpp-multithreaded-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-multithreaded-executor";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_multithreaded_executor/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "164fa840b1db4a30980433c94a4a468441c0213c07806027ef3900747fdb9725";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_multithreaded_executor/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "ec7e60d9b39938886baf59cbb1611d29495318f93f0e2aa4b3e3ad4c358cda6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-wait-set/default.nix
+++ b/distros/humble/examples-rclcpp-wait-set/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-wait-set";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_wait_set/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "0e088de926b40717d0c2dbed352183ea3c023947146d1659f5341ba36905fb46";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_wait_set/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "96cd1334aba21f6c9e3c00625ee980d17be123d46dab9af63f8a6e82573a8b80";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclpy-executors/default.nix
+++ b/distros/humble/examples-rclpy-executors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-executors";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_executors/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "a65b0be8abe0f770b24f47bb28ab5f185f7b5a48db8037806b56e5944f551a78";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_executors/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "e3e7d6b8b52fe4b6b38ab4f51f0604cf41c3955cc5fefe9f15d929b089c40472";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-guard-conditions/default.nix
+++ b/distros/humble/examples-rclpy-guard-conditions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-guard-conditions";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_guard_conditions/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "f6d0d58b4dd6f7bec82bb19430bc0aa184dd2c9f8d45f9fe0290540e6a595daf";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_guard_conditions/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "6d7afecddf113c57fc1dfde2281ecef535dd31d442904e57dfef3cf12ec97302";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-action-client/default.nix
+++ b/distros/humble/examples-rclpy-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-action-client";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_client/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "4868882ae72f76f4bfede6ccca79b7011e3d7f4b56110ca57fecf66555fcf2f0";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_client/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "28a8cfa804509e5d670225b6493542ce1e68b778a60e011b1d0c1fd86f43e5ba";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-action-server/default.nix
+++ b/distros/humble/examples-rclpy-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-action-server";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_server/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "fc30e95fcb858116f888e39fbf09f369b64b303fb0444bcd0dbd0d915a614840";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_server/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "debe2b6e339881cb974ff26a065709c6e372e1bc5fb24c1075553810165a1703";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-client/default.nix
+++ b/distros/humble/examples-rclpy-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-client";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_client/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "d6d2944c4b38b15f2d90506b5f88106c0157cc5569ec03cab217c6e7f8a833ba";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_client/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "add427eeca042ff203095f2c51e2142fac92eed036d553cbf2f8187c9820612a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-publisher/default.nix
+++ b/distros/humble/examples-rclpy-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-publisher";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_publisher/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "c46e281cfc1340197f440f0f7db6455ed921ae8499830c7e94f209b4f336c433";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_publisher/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "366d1da6c3a2621c9751911b8611a2804da6bd2e62822988c0b208293a3e0d1c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-service/default.nix
+++ b/distros/humble/examples-rclpy-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-service";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_service/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "c169cd515788386ad3fd45e3e4f20f619531fd36b2ae4c8aaa6aa287f7d74bef";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_service/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "135d1341e5f6f980f813b3f55c273feb3d46705c9e2e728bef61c073ef9e5a67";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-subscriber/default.nix
+++ b/distros/humble/examples-rclpy-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-subscriber";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_subscriber/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "8fbf6183d06e13ee0238db759624676739c77dac226b17c8991bf18c517f69d6";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_subscriber/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "399f00b056cacf54e3b1a63ff7ed26243d263877fd88e3c992607e536337eb68";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-pointcloud-publisher/default.nix
+++ b/distros/humble/examples-rclpy-pointcloud-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-pointcloud-publisher";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_pointcloud_publisher/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "f105c56892a928d70e00ead663c8255adcd0ebd37593387b0a2ec571b3cc650b";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_pointcloud_publisher/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "a38407edd63ed333d688899297917ceb28a8055a5a784191ea61ee330bbb45fb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.7.9-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "08599bb4760170f184dd05f26f5e6ef808fcb99488c57703297af8355c18ccb0";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ca480317afe7f6db7490635a041b68e4d518993d191db43cc49f4e53b925bc3d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs zlib ];
+  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -448,6 +448,8 @@ self: super: {
 
  clearpath-simulator = self.callPackage ./clearpath-simulator {};
 
+ clearpath-socketcan-interface = self.callPackage ./clearpath-socketcan-interface {};
+
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
  cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
@@ -1528,6 +1530,8 @@ self: super: {
 
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
 
+ mola-msgs = self.callPackage ./mola-msgs {};
+
  mola-navstate-fg = self.callPackage ./mola-navstate-fg {};
 
  mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};
@@ -2101,6 +2105,10 @@ self: super: {
  psdk-interfaces = self.callPackage ./psdk-interfaces {};
 
  psdk-wrapper = self.callPackage ./psdk-wrapper {};
+
+ puma-motor-driver = self.callPackage ./puma-motor-driver {};
+
+ puma-motor-msgs = self.callPackage ./puma-motor-msgs {};
 
  py-binding-tools = self.callPackage ./py-binding-tools {};
 

--- a/distros/humble/gmock-vendor/default.nix
+++ b/distros/humble/gmock-vendor/default.nix
@@ -5,17 +5,18 @@
 { lib, buildRosPackage, fetchurl, cmake, gtest-vendor }:
 buildRosPackage {
   pname = "ros-humble-gmock-vendor";
-  version = "1.10.9004-r4";
+  version = "1.10.9006-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/googletest-release/archive/release/humble/gmock_vendor/1.10.9004-4.tar.gz";
-    name = "1.10.9004-4.tar.gz";
-    sha256 = "efe60aaf74a6119bea8bacd12ca53ec5d4f4b7fb1e2e21f5785071385afed28a";
+    url = "https://github.com/ros2-gbp/googletest-release/archive/release/humble/gmock_vendor/1.10.9006-1.tar.gz";
+    name = "1.10.9006-1.tar.gz";
+    sha256 = "cbc87b003ed0fed24f465cbd8a8a76d2daf0b804ccef81a58cad0fc1b2520b34";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   propagatedBuildInputs = [ gtest-vendor ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "The package provides GoogleMock.";

--- a/distros/humble/gtest-vendor/default.nix
+++ b/distros/humble/gtest-vendor/default.nix
@@ -5,16 +5,17 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-humble-gtest-vendor";
-  version = "1.10.9004-r4";
+  version = "1.10.9006-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/googletest-release/archive/release/humble/gtest_vendor/1.10.9004-4.tar.gz";
-    name = "1.10.9004-4.tar.gz";
-    sha256 = "ae16d684d1edfd58c42d6ae250d16d07c888c789a601ab56bb964d23f90990c4";
+    url = "https://github.com/ros2-gbp/googletest-release/archive/release/humble/gtest_vendor/1.10.9006-1.tar.gz";
+    name = "1.10.9006-1.tar.gz";
+    sha256 = "912593c99ddf9072c2a60b9fe0ae7f2356b935aee723702a4bf6a397d5f4d263";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "The package provides GoogleTest.";

--- a/distros/humble/hpp-fcl/default.nix
+++ b/distros/humble/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-hpp-fcl";
-  version = "2.4.4-r1";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "ce66e8a41433a61be77daa7e4cb6969c5e4eb075e6bd1eec4b10b4ead25d1486";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/humble/hpp-fcl/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "4bc60d22a2f72da95027da3cc2911ac0cbcda45898a1ad9a18dca36bb1d23ce1";
   };
 
   buildType = "cmake";

--- a/distros/humble/image-tools/default.nix
+++ b/distros/humble/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-tools";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/image_tools/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "edc7de87884657dddf7943dc3e5692a0f0276d1e40596ac49a22945732b8b24a";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/image_tools/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "ab27561faea037b3f4590881de1691b196e19699f501ba42e031bbeee2d5c678";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/intra-process-demo/default.nix
+++ b/distros/humble/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-intra-process-demo";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/intra_process_demo/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "69cf3b6aec85144f89c2e49906420d2e102dd469095ac06c3f4097727340f06c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/intra_process_demo/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "a042d7073957db92f9d833e267933075905f2e9c647665f03d162a139f17fe2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "41cac131b9008ba6634e7a4e1760417e12ba1f407f95bdf7476fd01e1c988660";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d4eb59d99dca5e48353d090a1d2a7aaeda78785fb5d062f4f7defb2a1b669bfa";
   };
 
   buildType = "cmake";

--- a/distros/humble/launch-testing-examples/default.nix
+++ b/distros/humble/launch-testing-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-transport, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-examples";
-  version = "0.15.1-r1";
+  version = "0.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/launch_testing_examples/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "76ec4b6913e2080b9adde1497f8ec286edc8b0bb9272d303553d8be93a32337d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/launch_testing_examples/0.15.2-1.tar.gz";
+    name = "0.15.2-1.tar.gz";
+    sha256 = "106b547189ed144baa6a536a7a8818072262ed63e2925dcc417e4fb01e216d70";
   };
 
   buildType = "ament_python";

--- a/distros/humble/libstatistics-collector/default.nix
+++ b/distros/humble/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-libstatistics-collector";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/humble/libstatistics_collector/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "2a05584b95e02dc80716324f183566028689cfeea04e2834fbe535efce2264eb";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/humble/libstatistics_collector/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "e725e6f3bfaf74e4936377fcd403ef4dbe5e7b3b0e45574009fc6b7be57fe4e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/lifecycle-py/default.nix
+++ b/distros/humble/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-lifecycle-py";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle_py/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "ab478f0e19b58cbd60e9c7946c7bced9ce0fec060b04a74eebbf38dd261c3b4b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle_py/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "3bddccd8026629d7a3e7cc1d684790ac7e14c2f7f6de4dc4872a18e1437af061";
   };
 
   buildType = "ament_python";

--- a/distros/humble/lifecycle/default.nix
+++ b/distros/humble/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-lifecycle";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "727f6fa98a80f78105fb7d912234f73f6d6e7905be0756ee073a25eec9461df1";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/lifecycle/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "de63d716016530dbfd4ada49dfc16940d25722165a22b7617f5c7a4b1bf76cc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/logging-demo/default.nix
+++ b/distros/humble/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-logging-demo";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/logging_demo/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "24b3b24ac87c9b45eaeacf389acd1f08c0025af68fd91594c2128fdd5766d7bd";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/logging_demo/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "fa7f1d65d9cfe6717c73ff3386cf190f6dcb843253fb269e7c8f879f33438982";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "4ea5f0d1ad288c01e03e801806931c9e5da6f854b82bec60a5766b78671816c5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "9f8ccc697a345ec85db7821ef9eee4d0bfadfd2630b990b760ed2e3aa2f25ab7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e83ff19fc5e80a8d7e79ed375f913f05769c02f712ea0517cc89723f92b7eb9d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "831359bce286a7a3d0a3f00556a772e66893bf052f642ebfb745ffb19aee9e73";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b741b399911c6930a21a4101d0f38391be3263e190da57dd8ffb1f84bfef2500";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0b81a0ba6a99b1b7aaebc53958ae4705593e6e6a6b49444402773ff1591e02fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a8b0d3d68f6dedc3879282689467bf2ee11cb189a272e3bc3a0eed219f6612fe";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f3f7fa0974ca0d3082023a6f29a817d68ce5d5cc27a7b1803751a8fffb2d8e25";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "944edff50ce1be6365a72b9fe0f3a47eb7b7c67e2f28ec928a6dbc514ef37ca0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "1bc2450b49f91b818f05c6c0b3ff62fe54977376a649ddc0fa5407f2b7cfe9fe";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6db16452f26c75110f431bb2312206ca121c17be7005dab54b702a97ff626608";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "07ecdfac91596a7df8e93267b7c491cb0418025c3929e34feed792f0dd98f354";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "369a9c69cd199f621dcc9dce72bf38d387062f0f25280b9191a3ef9fd227f891";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3bea460f6789da6d23da8ba119fb432b190017397cdccbff3e0cdc2cbc0ea4c3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "cedb9e4f68e5bd1414d12c9656c53d83f4a2273d210de12bf569b36962748e72";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9616e80cc99c2a06caa188de342ee10d41a9bddd1767e9494e86946abb951a9e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0737ed1510507917a4fccc58a1708e309e03a40e794b0c7ffae5593db70454c6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b9c06392a4b46302d66f18e5fc5d723bd0719f2fa310de4df8be4a4dc6956751";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "ef94c97268e2383299f6b56cd6eda09ad52cd2a2e2e6bb162255e87a141f2fbb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e70502a549078ce41710bc504d2788d2925a9d5ae1a60c1f3f40045020b25daa";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3fd5f4ffd7aebeb2150273c77eb550df795ebb6f7398951880eb939d4ff77624";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0c744f18fb4404c92d20d18d65ef5267b6c34ecb018046423102645a3e9dde3f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "25e81183e7ddf716499cd7232b2aa81754eb97ee859afd798056630a0b57a651";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "61f3dff05f09df7321d34d21951099b6f066b5787445b6d91621d6ca5473211d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e913c1446d8c316906da9f4b6cff2fe5e18c09efbe43157708c09b0e14aee051";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3ce5209aa468a724985bbc845423f779758ef48108e04e643bd791eaec1e25dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2f4487a05ed6eaccf0eeb4277c67df26dbb16ee784759c992e3209acd6bfc9d0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9e8404ceff185a9545a1c8b54035e7cf10cf9f11c8c89b21d18a1714ee7fb5bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-mola-msgs";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5f93714cfcbecb3f4b5b4d8dce60f092aac79fd93de2eafd35d61b753fbf3d78";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs mrpt-msgs nav-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS message, services, and actions used in other MOLA packages.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-navstate-fg/default.nix
+++ b/distros/humble/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fg";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fg/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5261bb36d4dcf065b6abff580ad4aecfa037d17e29160c3f12e0f39ab7a25ee9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fg/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f23cc54114304dcbda72a269dfdb5285c6c57ad4e1be7cdf6aec3002c81b4768";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-navstate-fuse/default.nix
+++ b/distros/humble/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fuse";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "283b3094361dccfa2a9201ddd287a4329ef7d8281096b556d9abbcb523f3c8e8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "11c1818cef50c8ee2985ae713eb6e601a752f560c3b7d7f04e057b0107003ef8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "fc94376abb477c8ca63b1579be5e5fdac8ae1396bd8c36e1a574c3174091d557";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a06728bfedac8a19f5d50c111d27eee68da7cb1db8f159a3c7333e85c468b590";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "29d55e319a3f9d6446cff3f3b7953fc083c0ff0bbe8f45e1f99811c33799eb3f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b789fcae216936709e575f13b0ade6ae7f63f0f9e69a84f4ca65c036493e4dd7";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-test-datasets/default.nix
+++ b/distros/humble/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-test-datasets";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/humble/mola_test_datasets/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "7d1f9cdd1b769b859c1f8b6fc63f4ba01e7282aaf88dd1ac0244e23c1100f59a";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/humble/mola_test_datasets/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "3a70674ad0d2cac97bfee8df35383e2e5eae9b1859859099c480e91024428e1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "acfdcb1aacdf03d3994131c517dd296b9354784b4ed229cc2af8759917e939f7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e2ec40b60db187d7829b0926b5bd5f91814dd0491dc2676ce81b4d2071a56dc9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d7b71a627255b9253abe8a716e44239b96f87d2d4578f91b06b5c006e335dc42";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6aac2e0087bad278f0ea0e4afd3c9fdce8ffe199d7ee53a215b1a5669dd6e54f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "607b9564965f05fb8712cf107cb669d6ec7ad3ec3005a22fc1e9f334cab50f80";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b50fa1b7c81e7967936c75264493b11f974cd1af747c038c966db6bae866b8c3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "ad1106e1f33a5d7a43e67d36254901c9911097c0c4cbdde5ee05ea9220a8d2da";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b91341c40e17396ce71f54a3a102e31f53b7b3b45f4e76b075cc0e8916049129";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pendulum-control/default.nix
+++ b/distros/humble/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-humble-pendulum-control";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_control/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "b57caf63516614464874d48f436b3d48dd698ac85cfc7c5039d368bbc006d3d6";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_control/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "ff1e5528f687d44c8ee4c468fc7308b3a31cfabfa2a33345d777902b227083a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pendulum-msgs/default.nix
+++ b/distros/humble/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-pendulum-msgs";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_msgs/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "e5763fb3b585651f7bfcf8c651febd12c60fb0d6f8c1821d7d84c56402b47388";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/pendulum_msgs/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "70dfb77ce939d96a6eb85776d458345cbb7159d6a61d3f1555c3a3f1a36dc62e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/puma-motor-driver/default.nix
+++ b/distros/humble/puma-motor-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, can-utils, clearpath-socketcan-interface, diagnostic-updater, joy, puma-motor-msgs, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-puma-motor-driver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/puma_motor_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f21374b241ad1792c1f5e82135d038d24621972a8ca3d5a818b31a9c8002d71c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ can-utils clearpath-socketcan-interface diagnostic-updater joy puma-motor-msgs rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ROS driver for Puma single-channel motor control board.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/puma-motor-msgs/default.nix
+++ b/distros/humble/puma-motor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-puma-motor-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/puma_motor_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "81d584c594ce8844be527942d710ffe1ed8fb1b65f635709bc388428935da7c7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Messages specific to Puma.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/quality-of-service-demo-cpp/default.nix
+++ b/distros/humble/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-quality-of-service-demo-cpp";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_cpp/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "bdab3547a86115bc12ddec5a489d854a180ea03624dcf332b377d2ea669d2678";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_cpp/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "3d01fb8a7e7c276910c989c6400a0de48ed9d8a3c14ccba7a5e63013dd3baf5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/quality-of-service-demo-py/default.nix
+++ b/distros/humble/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-quality-of-service-demo-py";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_py/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "e602f5a77c4b2b16335f3c00beed79853557d29c93f8b5f3154232af6b96820c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/quality_of_service_demo_py/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "9e2ab6657ab69d00a2c0eadf09c790ae305258d068709b81d17698ea79ac3f43";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rcl-action/default.nix
+++ b/distros/humble/rcl-action/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rcl-action";
-  version = "5.3.8-r1";
+  version = "5.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.8-1.tar.gz";
-    name = "5.3.8-1.tar.gz";
-    sha256 = "404efb03848affedb8e21f6cbbbe579e22d90fc2c44d0d1967600ccef39b9d65";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_action/5.3.9-1.tar.gz";
+    name = "5.3.9-1.tar.gz";
+    sha256 = "6c97a0fb44a521c09198e1f05cd8e3db9c56cae425d369cd504b011026890ff2";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp rmw-implementation-cmake test-msgs ];
   propagatedBuildInputs = [ action-msgs rcl rcutils rmw rosidl-runtime-c ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Package containing a C-based ROS action implementation";

--- a/distros/humble/rcl-lifecycle/default.nix
+++ b/distros/humble/rcl-lifecycle/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl-lifecycle";
-  version = "5.3.8-r1";
+  version = "5.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.8-1.tar.gz";
-    name = "5.3.8-1.tar.gz";
-    sha256 = "86045ad222e7bb9b431683db4a9517bd1f9a17cd533b7ba6caae8293a4269d0b";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_lifecycle/5.3.9-1.tar.gz";
+    name = "5.3.9-1.tar.gz";
+    sha256 = "451f34e6b435fb0ccb15fbdaf309d27da2accd0b503119bdbcf85b82a9c1feb0";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
   propagatedBuildInputs = [ lifecycle-msgs rcl rcutils rmw rosidl-runtime-c tracetools ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Package containing a C-based lifecycle implementation";

--- a/distros/humble/rcl-yaml-param-parser/default.nix
+++ b/distros/humble/rcl-yaml-param-parser/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-humble-rcl-yaml-param-parser";
-  version = "5.3.8-r1";
+  version = "5.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.8-1.tar.gz";
-    name = "5.3.8-1.tar.gz";
-    sha256 = "15987387ad7037cd9c2ccf73f503cdf27e1b762af5f7d87707a2b7baf8db12e6";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl_yaml_param_parser/5.3.9-1.tar.gz";
+    name = "5.3.9-1.tar.gz";
+    sha256 = "ada6426ee889aa803a1fe27477e0b1f7699e024c59b73295942af0bfc7dd68e7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros rcutils ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros rcutils ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor osrf-testing-tools-cpp performance-test-fixture rcpputils ];
   propagatedBuildInputs = [ libyaml libyaml-vendor rmw ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "Parse a YAML parameter file and populate the C data structure.";

--- a/distros/humble/rcl/default.nix
+++ b/distros/humble/rcl/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rcl";
-  version = "5.3.8-r1";
+  version = "5.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.8-1.tar.gz";
-    name = "5.3.8-1.tar.gz";
-    sha256 = "ccd495d814a4e318bf0f2da8d41c69c41a5b0a09d5dd3a363f02d07a8762d7c7";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/humble/rcl/5.3.9-1.tar.gz";
+    name = "5.3.9-1.tar.gz";
+    sha256 = "917ec138f94522f7d66944507ec0ab7e73be749810db7860d056e163064c21c8";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-ros ];
+  buildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
   propagatedBuildInputs = [ rcl-interfaces rcl-logging-interface rcl-logging-spdlog rcl-yaml-param-parser rcutils rmw rmw-implementation rosidl-runtime-c tracetools ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake-gen-version-h ament-cmake-ros ];
 
   meta = {
     description = "The ROS client library common implementation.

--- a/distros/humble/rclcpp-action/default.nix
+++ b/distros/humble/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-action";
-  version = "16.0.9-r1";
+  version = "16.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.9-1.tar.gz";
-    name = "16.0.9-1.tar.gz";
-    sha256 = "22fc872acdbb86aaee634d75645c2813f998080ccd3d1e21834d58c7c1c2a248";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.10-1.tar.gz";
+    name = "16.0.10-1.tar.gz";
+    sha256 = "24b21fc234d14886c4fd91d67614cf6cefe3303276bfc31f78bb4589b7b6505f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-components/default.nix
+++ b/distros/humble/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-components";
-  version = "16.0.9-r1";
+  version = "16.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.9-1.tar.gz";
-    name = "16.0.9-1.tar.gz";
-    sha256 = "82f1dcb850d6af5278a605e5ec1ff1e85d680a7fe767d67aa5f791b0fd8174a0";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.10-1.tar.gz";
+    name = "16.0.10-1.tar.gz";
+    sha256 = "0ddecd759ae682ff6d79576aeb68254c8bc8a2cd48ec940af54ac58c5616685c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-lifecycle/default.nix
+++ b/distros/humble/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-lifecycle";
-  version = "16.0.9-r1";
+  version = "16.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.9-1.tar.gz";
-    name = "16.0.9-1.tar.gz";
-    sha256 = "5e1ad0544b6ad041f42c461cba62d32ab467c9db5bc1b81bb5539ea1fe7b8358";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.10-1.tar.gz";
+    name = "16.0.10-1.tar.gz";
+    sha256 = "c22b5f38c962fa65d78b445ade3f38cf36dbc89530912b332f6a79fba985f809";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp/default.nix
+++ b/distros/humble/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rclcpp";
-  version = "16.0.9-r1";
+  version = "16.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.9-1.tar.gz";
-    name = "16.0.9-1.tar.gz";
-    sha256 = "2271db5f23e3c3aa8487a5e5dadd57fc5d5af8ce7cd6b8f5b0e14cb38110dbf0";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.10-1.tar.gz";
+    name = "16.0.10-1.tar.gz";
+    sha256 = "b42cfb57707511c016512fa95a1910e8c77e378b4660ced3e3ce72eadf3d37e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclpy/default.nix
+++ b/distros/humble/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclpy";
-  version = "3.3.13-r1";
+  version = "3.3.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.13-1.tar.gz";
-    name = "3.3.13-1.tar.gz";
-    sha256 = "86da771bc364bcbb36262ed36c0e7f928e88a97b0d5428ce402dc76b90d91c97";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.14-1.tar.gz";
+    name = "3.3.14-1.tar.gz";
+    sha256 = "0ba3bee35a4514180f47226c13f0db3ef6708bba3d4b7742860ce27870e01455";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-cpp";
-  version = "6.2.6-r1";
+  version = "6.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.6-1.tar.gz";
-    name = "6.2.6-1.tar.gz";
-    sha256 = "a68c990361c2783a3e6a36310956ee0bee777f2ce64e7a5b6f4f7cab6c82caf6";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_cpp/6.2.7-1.tar.gz";
+    name = "6.2.7-1.tar.gz";
+    sha256 = "451b62736e424f549c1d96a53eaec8d83323bef8a3f1901a935436641d2ddf5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-dynamic-cpp";
-  version = "6.2.6-r1";
+  version = "6.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.6-1.tar.gz";
-    name = "6.2.6-1.tar.gz";
-    sha256 = "61391a107bf3c0461e2810fce0071486f75276ddf9204eff8bb36a91fac2d3f5";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_dynamic_cpp/6.2.7-1.tar.gz";
+    name = "6.2.7-1.tar.gz";
+    sha256 = "a5768dcb9bb1a5f5073fc19469f8871d3312868ab7482d6cf32ce2184571cd6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/humble/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rmw-fastrtps-shared-cpp";
-  version = "6.2.6-r1";
+  version = "6.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.6-1.tar.gz";
-    name = "6.2.6-1.tar.gz";
-    sha256 = "90d70ebc9ef8a8e0bb982ee5e468d23f785ef24883e69322b5b2370d0ff4126e";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/humble/rmw_fastrtps_shared_cpp/6.2.7-1.tar.gz";
+    name = "6.2.7-1.tar.gz";
+    sha256 = "de32df66167ffc8ab9dfd673779d9badeff671f0302cd92a66c9f87241e87055";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-implementation/default.nix
+++ b/distros/humble/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-humble-rmw-implementation";
-  version = "2.8.3-r1";
+  version = "2.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/humble/rmw_implementation/2.8.3-1.tar.gz";
-    name = "2.8.3-1.tar.gz";
-    sha256 = "e151b3c97619563e8c33e6e9f190769428929a94eec8839d526b89faf96c41bd";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/humble/rmw_implementation/2.8.4-1.tar.gz";
+    name = "2.8.4-1.tar.gz";
+    sha256 = "ccaa7c0583c3d54eebc9368db40a81f467e082d5ecea3cd8c5f3bfea925cecc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz-interfaces/default.nix
+++ b/distros/humble/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-gz-interfaces";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_interfaces/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "8057045bf9efd58f39d4899007897c2db3e33d78e6fa690cc1e61fd20d6dc6ef";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz_interfaces/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "eef1b2a2bf6dfceb018ccceed81615413249da2c44badb6f6e4a1aa2ade74c16";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-gz/default.nix
+++ b/distros/humble/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-humble-ros-gz";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "61e56ba77b2706f4863c2b9a600e06a0c4a26153e227e3566ad7150ef70793b5";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_gz/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "1cd42424dd2266acd95b5d3c5beecde977d0e5b769fae989b750f2c60f39bbb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-bridge/default.nix
+++ b/distros/humble/ros-ign-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-bridge";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_bridge/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "784d6638dcd913ab8b8a0d360ed24cb9d7d6187c1b85bef5ce4d452d27de13aa";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_bridge/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "4a9e84a18a4e5d26bf3eaf0b7f9056c3885db87c295692b8184579d687764d03";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-gazebo-demos/default.nix
+++ b/distros/humble/ros-ign-gazebo-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-gazebo-demos";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo_demos/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "dccf7adbb99880c766646f476b5a4255564803bcff22e8f7b4d90ef85ee83651";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo_demos/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "7dbcdd4c8f5103937d14a25c43daf1fc53c19f7a790fceafa85c090bf86a26ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-gazebo/default.nix
+++ b/distros/humble/ros-ign-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-sim }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-gazebo";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "9439c427599d1cd7bccb2dcc046d775e4cea9f54808abd86f08c8c2ecffb37f6";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_gazebo/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "c09106b7782bafac288e7c4f9a640364094ef5877d73cb12fc4ed116aee6e01c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-image/default.nix
+++ b/distros/humble/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ros-gz-image }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-image";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_image/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "62aa2d96bc86f9b562987fcb5f3dd16f71da4cf00cc40bca8890f58413b25f43";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_image/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "d642646429a630afaf14fb3cb3af402a2c88e3bf7f7bbdc5cd618a76069f11d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign-interfaces/default.nix
+++ b/distros/humble/ros-ign-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, ros-gz-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-ign-interfaces";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_interfaces/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "e977686f7f2d0b98670b4057dd3a24079d550969b5e867fda511371552145b90";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign_interfaces/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "0226cc8ebb7ae61d0aeb7e2de3f003da64e2b6b3fa0990b209b28b53377ac5e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-ign/default.nix
+++ b/distros/humble/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-humble-ros-ign";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "7e364e89c17461f1c5cf3edbf73a9627a4a38612eb668e80d8f8751ff644e54c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/ros_ign/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "e7e1fad1fe23ef70b0bd77b8d3a6791f04de751e64f56a232f2a67689f08ecc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2action/default.nix
+++ b/distros/humble/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2action";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "35e029e33d07d697ea2c4a3619b71d2adfccfa5d95c8e1fba8d41dcd58bdc514";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "3ef9993e8118dad249f9e86b5172d5c0ef06efdbe402dd84d512861f97b5083a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2bag/default.nix
+++ b/distros/humble/ros2bag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins }:
 buildRosPackage {
   pname = "ros-humble-ros2bag";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "a80f8fae8b4810374ecbc7268bc444290c835b58719cac4cd4b04d118dd66052";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "21d8d58f37a7737b648d4a5262c7d58e46e0ca93b05cb3e9ff379b0109f1c9c3";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-testing launch-testing-ros pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-testing launch-testing-ros pythonPackages.pytest rosbag2-storage-default-plugins ];
   propagatedBuildInputs = [ ament-index-python rclpy ros2cli rosbag2-py ];
 
   meta = {

--- a/distros/humble/ros2cli-test-interfaces/default.nix
+++ b/distros/humble/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2cli-test-interfaces";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "525f49cc1687da1d98fd9ba4319e029281c88d5fa19de80cc507639884b06431";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "6c416b0ebac68fd782758a79e9c324be06be98b4ef28d65a6495710de9f34d70";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2cli";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "385566b82a89966392c01a0adea0b48e2affee5b11879bd38e77e5ea805ca586";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "66d21e05b5af229f19c03acfe769dbeeb22db45cb65ccb55bfca740631dd2213";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2component/default.nix
+++ b/distros/humble/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2component";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "62494b4a15564d8d59739e35f080c1f5d2729a574df8703ede5cc29f4d554038";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "a52d58a4b5bf2a61aa3e108b006144f622dd98249ae608adc047b944c6da215f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2doctor/default.nix
+++ b/distros/humble/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2doctor";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "a08c5d73dc0346817aeb67c28de4146de49bf282cd4981248f11d792573b4e1d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "2b486383cde6d5560321f22b873e016d763ca88d906fd4769aab666ea1531f3b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2interface/default.nix
+++ b/distros/humble/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2interface";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "492b14e621ad24d8f585810bbae351a1d0b44b4bc616e8bf1fdf5c768ff60d49";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "77c87603a353c741496ebf026901a408e3e7f5992654b1b4abc5ab9c3bf32a7b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/humble/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle-test-fixtures";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "1c29ab6ac3f6bf67656a5779aa550b6cc5b318ca148f11613834577c4a13d97b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "de25d91f6f4e065fc3b7ff43a74fd69a563f0d577f708e564c2a83e53ad2e7bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2lifecycle/default.nix
+++ b/distros/humble/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "31fca5415accd6b16320cf3c2cf5e419db5300e52cd1ea7f350a6942501b9d6e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "f073a4ae6a19c9420e16152f62307f934429d47bbb0029534aaea2ec51904b71";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2multicast/default.nix
+++ b/distros/humble/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2multicast";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "19c931579e981c14baa9ebc946367446bb61159687a6db1c2d9716e358fd8d78";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "4bcdac65a3ebbe3b4e17d2fed708bf313f8e66a0481735342879b6b9c3aab8f3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2node/default.nix
+++ b/distros/humble/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2node";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "78fcd39f666e56a187908c521f70f9d4d069819f2587ee7a641650eb29428ffb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "7cc6de1cfa0fca4a40ce4ac33552a7091e8f912ea26547c552c635a793234c3c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2param/default.nix
+++ b/distros/humble/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2param";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "fcb553fe873d1492ba2613d73bb635a6aa66afda98f8e505231da0838e11728f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "8027be6b9b6eede75dcc82c764423fb490c7e7d5adc65ea722da77d15a224e94";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2pkg";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "b3b30d1e9739409cdff2f2def123b78926dd272d7bd24e7c892f4454f2790c4a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "732d77015f9075d27039428f16aa5a62ec7274438c3d18cc2a7ac9a3ebf6d095";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2run";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "e669af4e87eb4e1e85ce1fb4083681850c5c792656300a57e383dde777128583";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "62bc73260b894d6230f64fdfd48082eee08dabe0569a7ff86146b0abaa0ff6fd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2service/default.nix
+++ b/distros/humble/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2service";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "1f16ff633b46dc3bc32128a5c851ff12ce81fd527eafb7f478e2d19c5f47587f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "b15dcfaa4c3c76f5af43dac5dc5392d2c31dc173934f9c0365a42e3d16b10bc5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2topic/default.nix
+++ b/distros/humble/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2topic";
-  version = "0.18.10-r1";
+  version = "0.18.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.10-1.tar.gz";
-    name = "0.18.10-1.tar.gz";
-    sha256 = "d0b1454788bb38b6c6d0bd7d380f08599cc25f6034171016b8d2e75bc9be4899";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.11-1.tar.gz";
+    name = "0.18.11-1.tar.gz";
+    sha256 = "75908db164fdc666cf9e66106e8d5ce25295ab009d2292da0008bafc7ffc1afd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosbag2-compression-zstd/default.nix
+++ b/distros/humble/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression-zstd";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "d8c41d4e81c341e059ee4adcc163ed5d88bdf2240d0030ba0bcef0b81a106d2e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "c7257e9a8a3a272b59f195b663d5ef3b2f13fdf82d7a0703134dd2700b2d7bb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-compression/default.nix
+++ b/distros/humble/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "d7d3852603652edfa3f2dfbee4066c6354ea27f83b04ea78e175941013b8f437";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "25ba0739c6096353a676f7cd85b84bd5aabc5f90a50e74278591e97a5c465ce9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-cpp/default.nix
+++ b/distros/humble/rosbag2-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-storage-mcap, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-cpp";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "c956d32a0dfe10321affc4b09814206de3b63ab7875e1abe8cf84cee0317175e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "ed2e0be48de3be357bb4ec0b9262eaf6700f5c34454cbe79859179de105aaf93";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-test-common test-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosbag2-storage-default-plugins rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp shared-queues-vendor ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-storage-default-plugins rosbag2-storage-mcap rosbag2-test-common test-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp shared-queues-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/rosbag2-interfaces/default.nix
+++ b/distros/humble/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-interfaces";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "7b1cbab74a410f8bedcae9457e383290cec7a3fc6135a41ce68ea8bba4dc08b9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "22b5c860a20ecb67e5d0ee284d7853d26779b44e782f12d36d9cb623b5483a13";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-performance-benchmarking/default.nix
+++ b/distros/humble/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rmw, rosbag2-compression, rosbag2-cpp, rosbag2-storage, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-performance-benchmarking";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "389085159b88299ced556d64b07779bbf6fc9a2cfcdb8b823cd62faf27e472f5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "be3bddca149a1ec09ead640edf7826c96d8fb8997d324aed450343d8128f994c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-py/default.nix
+++ b/distros/humble/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-py";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "1d10be4490ec81da453f69498c1197289cdd08e15dc3ee1d787e769c60e4b147";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "0386fa145a08d78694e1076cd8db905ddd59c89dd5a1b9f3f448d1dae61509e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-default-plugins/default.nix
+++ b/distros/humble/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-default-plugins";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "8438835399a1e928c7383c6005b424135cded4f776557f670ad859aa8e5703dc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "37210da06ecf3c489f7f7194fc70a9d317e8c5c6eb0358b18c067d20a19bc231";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap-testdata/default.nix
+++ b/distros/humble/rosbag2-storage-mcap-testdata/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap-testdata";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "e25d20786f79d01fe98f346399edcf71de2a369a0c6326c46f030003c89e6a60";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "ad008d19a0ccd4c86bd1307efdd90f567a69aecdac8d3358cff50e5f13899bd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-storage-mcap-testdata, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "9664666dddd183b2d9057a378a9f66cd3ce7e37356f00bd52025f1968aa6d599";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "ab581cc8727103abfcfd51e36e2c7f7b2f927dc2b3a074749fb29938264f210e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage/default.nix
+++ b/distros/humble/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "b56abdfdb34490628a2dabadf8696fca25ab1e752586b277b63e6d1325c4273c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "2aa2fcf26f95d68c8fcdfd7ea66bfd9ad7b36fda7fa6e831eb706069a5835005";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-test-common/default.nix
+++ b/distros/humble/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-test-common";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "567d4be8ff6d92a32513a2b1939ce4b13486ddb4eaaef01d6c83d92381d6d1fc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "3f81a8ab03276d95d5c6849300db4df22dd349eb6eb147d728c8cf855581c217";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-tests/default.nix
+++ b/distros/humble/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-tests";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "5183f57ca5f9bb1925f2efbecbbd9cbf8956951c24707fb075fb05dd02d5eb5e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "781e8bb55de91131ec757c6bf4785fcad2dffe479358cc8a57549a346a52a528";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-transport/default.nix
+++ b/distros/humble/rosbag2-transport/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-transport";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "8dc703059600b3166bed52261d1f2ff6b0f702b20435e159d2869f09d9dbd1de";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "6f4a8407b921d24a3b5eff2e8a080d8bfbe74eab760f25449a07a2c1fb57ea50";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gmock ament-index-cpp ament-lint-auto ament-lint-common rmw-implementation-cmake rosbag2-compression-zstd rosbag2-test-common test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-index-cpp ament-lint-auto ament-lint-common rmw-implementation-cmake rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common test-msgs ];
   propagatedBuildInputs = [ keyboard-handler rclcpp rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage shared-queues-vendor yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/humble/rosbag2/default.nix
+++ b/distros/humble/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "63850b41d877c893739b807301f66f63badcd02bba775734ff4d7f20acf273ab";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "43ced50be2c00e8ca9574e86be2e4ff43d7bb1371c3534b7fa743e0c3db46eca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosx-introspection/default.nix
+++ b/distros/humble/rosx-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fastcdr, geometry-msgs, rapidjson, rclcpp, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosx-introspection";
-  version = "1.0.1-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/humble/rosx_introspection/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ef0735f64667a76fbadcaab7489cd98d58b4f137cdb11e114473926319f521be";
+    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/humble/rosx_introspection/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "7219a64fdbab0624d00b67697ae66dc7a7c1d8008ad1930dd66e80c5aabe8182";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "07d3cbf4aec8c51c1ceac9c661389731d95a0466ea434f968715d12457281f07";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "9b83f04d7e6549124285b74996f264b766de2de83840b70e43199f3912cf463a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "4f2e33a3738ace7c6a9fe88e1a1415117e77048b62dc192fb8eaeab68ae877e3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "69416abe75da20370a55e02811e9c20621142ad27587ef6644a61f699837f3b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "7fd4f808ebf47419f3124885fea760f73d08a2f109219d4e0eb1c46a69425ebc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "dd8a91cfb605df379a415e1711419292aab957fdeb3eff7414867f909a6e9ab1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "2b5516a7e79df148cda7d848fd9db79f6a02b272626fab6262965ef2c8f222a6";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "41f490bf70db85a0cc5f3b40d22fdad08df7579d0c9be479960017182563feee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "87295176908ce2353e3b30fbf8e5b51c024af213cceb6ebd6e22a87145947706";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "51b1fecf7017bd0edee73cc0e42267da22a9df57a2977577034e20afa46ea172";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "73b4ea844314de5f0bc8aa5bd85d8c8a8d8203e7af2a4dd29ffd7f787f501e31";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "b8f169c7beb9c9e5107d10808a0aa6df7318732438146538eead2c8f99bf5dab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "fc2659a8933adcab429377eadd0fe3ebd6dcc3be0e0c5aecc884e6cda9f6598f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "4a55be8038f642b2f9c4adcadfd3614f9d0391ed99faaea2331cdf2bf1389271";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.12-r1";
+  version = "11.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.12-1.tar.gz";
-    name = "11.2.12-1.tar.gz";
-    sha256 = "ed23ea0a0cb614117436d3c7339252f174d5a4d9b60fa535f06ab404670b325d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.13-1.tar.gz";
+    name = "11.2.13-1.tar.gz";
+    sha256 = "5fd0ecea3e4f279d429936e805c2badf9ab801100eab74f3bb12247b004d2cd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/shared-queues-vendor/default.nix
+++ b/distros/humble/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-shared-queues-vendor";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "0fcf0a1b720d02f1c1b35bc872b1c37c6cdfa7b119a1365a47f2c310e45225c6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "213fe029acf0e5dbf52e70a4e9ca44b1467d22c07fc6cd39485e7ab6a9fb9d48";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sqlite3-vendor/default.nix
+++ b/distros/humble/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-humble-sqlite3-vendor";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "44844040cca8b0d99e8f7361528810ab90b21b91a97ceeab1e352b2af1e7e76b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "fca7cae92ea61fc86c2d346a0e7015f16761c2ae7cdb3b52213ff9e749d7acc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/test-ros-gz-bridge/default.nix
+++ b/distros/humble/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-humble-test-ros-gz-bridge";
-  version = "0.244.16-r1";
+  version = "0.244.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/test_ros_gz_bridge/0.244.16-1.tar.gz";
-    name = "0.244.16-1.tar.gz";
-    sha256 = "cd4d7ad197aa9b2b60fa48090a206515dcd85d9d97b1b84231c6ea3e22dc106e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/humble/test_ros_gz_bridge/0.244.15-1.tar.gz";
+    name = "0.244.15-1.tar.gz";
+    sha256 = "335e2948722dce23368012d9d24ae6600dbfc56f2b539b773c287fee0be4966a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/topic-monitor/default.nix
+++ b/distros/humble/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-topic-monitor";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_monitor/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "79b2fa3de786fb099eaa0deeafd4b0a541886a6c8a1696b8347e6a4ce602f903";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_monitor/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "5ceea49c9b70277c3c2932c3a99cfcdcb325419a9d4285a61b12927acdd0ae8d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/topic-statistics-demo/default.nix
+++ b/distros/humble/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-humble-topic-statistics-demo";
-  version = "0.20.4-r1";
+  version = "0.20.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_statistics_demo/0.20.4-1.tar.gz";
-    name = "0.20.4-1.tar.gz";
-    sha256 = "5f2d3984c25eb78da38f6557b7435a3a04de954c2b89d7cf0e52597333fd7b6d";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/humble/topic_statistics_demo/0.20.5-1.tar.gz";
+    name = "0.20.5-1.tar.gz";
+    sha256 = "2454e3022a91267326c7eeabd8ca124bdb1c311c9b66d7391eed55154091b31a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "50de4d4ff4e7a77c54332d8442d8b9a9926d489b8695e51f95be7e74188822d3";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "ea8c84cc9e922d70bcf2a6716b85fffcce2a12e4fe8a35d62f5ac2c1f192cccb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "b3428812ab7eebac7d53cb699af30fe98c735c9ce849c96bb4c983cd6e3c9369";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "cdfbd4b86b30c137fefd4d9fe053e0861661875b8a1cd030442fa1ccbfa7f593";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "f8b53d5a3a0626f732e41849a28edf1ca4b7393dba5fa8ffd630067ee17fd9fc";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "ded9d3147e07db5b476db01a718e532ce6bf9b393fad8f50e4d06155cd99f0c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "4d11f89f269bb810f80b432bfed2a635d6e2608b8e81364d92deaf39da3b5b84";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "6c670e55cc04346fa09b16743c112e7bb155479904167e72489ee306d2c9f409";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "802f175d86a8db2795c89970ffe041ac402ac851ab6644414664dd9e30955596";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "2366632fdfdfeb7988fc3d5a8f96a86e257cc1eb53192909d656da86a64f8c61";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "ad6a213eb5af9e717b82076fc1a50a1753f9290eb8deb9a44fc77e4e6fbceb7e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "c05aa60d803b9dd52a127d4e811e6b8873868e8a798f0e48fa1ca8ce030fa766";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "eaab4a5b13512cf2890083b0f985c324f6400d5dcaac109278d690981412ddc9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "1b8616306302a85ae2bf77a62da984bedf5818de9047b8678b0b7d9801ebe988";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zstd-vendor/default.nix
+++ b/distros/humble/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-vendor";
-  version = "0.15.11-r1";
+  version = "0.15.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.11-1.tar.gz";
-    name = "0.15.11-1.tar.gz";
-    sha256 = "6df4f83ba7585294e27eb97948c2235ab7a89fa1d67f24f9b161874b2fccba96";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.12-1.tar.gz";
+    name = "0.15.12-1.tar.gz";
+    sha256 = "ae0f346bc737684811d160337dce694878ef6b0f69ab57ca1951dae76e4e59fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-black/default.nix
+++ b/distros/iron/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-black";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/iron/ament_black/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "2b0145242a358298005b8261ccb642ad5a46a38651900928942c80e5f53e6295";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/iron/ament_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "cfdb5f55165595fb2f8eef80275584a7ac74fdfe04287251d7af94caf2ed8cea";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ament-cmake-black/default.nix
+++ b/distros/iron/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-black";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/iron/ament_cmake_black/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "c24ca0fa303beca74cd0fb551128534863bf99c9d1f1a79cd1ab355281c2e4ed";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/iron/ament_cmake_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "45cd02c5b752c83f9c4444cccc55e172afcbff7673368bb30efbfa0443834730";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-bridge/default.nix
+++ b/distros/iron/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-foxglove-bridge";
-  version = "0.7.9-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "b2f59105085daca2345eb7485c870421d467e215a1e850d2307c040159740a98";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "df0d62f7d515810c587de4aa84833047ff49ce8b27e82d4fc10d375599391a8b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs zlib ];
+  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -1090,6 +1090,8 @@ self: super: {
 
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
 
+ mola-msgs = self.callPackage ./mola-msgs {};
+
  mola-navstate-fg = self.callPackage ./mola-navstate-fg {};
 
  mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};

--- a/distros/iron/hpp-fcl/default.nix
+++ b/distros/iron/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-hpp-fcl";
-  version = "2.4.4-r1";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/iron/hpp-fcl/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "208814712a1fea77583b47521a2c991d8d9080294c63fe586a6f10e8b8fe55c1";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/iron/hpp-fcl/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "2a3bf2a349c93b34e8f79c12c223e499745833fc96fe700bab75428c5f327481";
   };
 
   buildType = "cmake";

--- a/distros/iron/kitti-metrics-eval/default.nix
+++ b/distros/iron/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-kitti-metrics-eval";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7a0d645e2c5f404cb635d8fb1b5c01f69cb1db2596de7aef92b6cc309106d5bf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e773fc69b0d5a1ac914787093263908a920aae21abaf5fe412c73771bd293ef2";
   };
 
   buildType = "cmake";

--- a/distros/iron/message-filters/default.nix
+++ b/distros/iron/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-message-filters";
-  version = "4.7.0-r3";
+  version = "4.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/iron/message_filters/4.7.0-3.tar.gz";
-    name = "4.7.0-3.tar.gz";
-    sha256 = "7738944a9e1330ad85c910454f2e87c83c18d6bf6ac51ab08d7a590108864a50";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/iron/message_filters/4.7.1-1.tar.gz";
+    name = "4.7.1-1.tar.gz";
+    sha256 = "b06a44fed7bbf3381371bf82d965751999a6762c5a501f901e3c9ee4e385b95d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-bridge-ros2/default.nix
+++ b/distros/iron/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mola-bridge-ros2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "864123717b79baa82459fae47343f43496115933de19086cb5087abb2a02811e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a3a5be88beca68f163d87470a63a50c26dee913bbfa2f9623996452251e3dc0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-demos/default.nix
+++ b/distros/iron/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-demos";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0003df414806dffc2a6bb02915113541484a053359243bd49bb704390afe80f9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "eb0ab9634fae8dce3b9fe669cc03af3a2651e6c82434ecd3dffc75a634df0097";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-imu-preintegration/default.nix
+++ b/distros/iron/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-imu-preintegration";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b81e05a4cf76d8780ae392a61a01cb10a0dd0498997009e63ad5ac5264ae1490";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3c97e4094707c5e050234078fec6046a0d111d9dde37bc32b1b8a0760c9d8f65";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-euroc-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0f0a27b0b17f260a07c11d6909f643d4eb11ba5df23a1e453bf2aa338ea11a6a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9898fa4c7705dd046c95e44ac4d687a6e9ea0fcddbef5283cee034759b798273";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "25e9d3b22b6a60b8a8982605d231d7c2b97625175d1ee60769501d57e56d4c78";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a5aa362a112d734042398044088cbc1432bb1ea4ac6838bf8019cb0053f507a8";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti360-dataset/default.nix
+++ b/distros/iron/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti360-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c1688f17bf2f98eb24c11f9d2f47426d5272e54a2f6053f1ba31e320d6fd816d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "860521acb3e18fbca17547f3381917c385c34f83a5aaf7cd76d1dce60e89ad33";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-mulran-dataset/default.nix
+++ b/distros/iron/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-mulran-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7b9fcf3f7f30130719b9bebfff97d567ba3dd8de941ace86fe0699a7251736fc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "66c5ca159f37e8e716c810dbdc30d0f0316578d45858b922a63f83d400efd6b9";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-paris-luco-dataset/default.nix
+++ b/distros/iron/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-paris-luco-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "9077b1a6c4d4220091a5b4da7321d2ca7ebb6992ffb34607490053e842e36be1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8be1c7a9faf9aab373502e9f240ad971c8e4eec2ad44c2c2e5d2e3bce1ca14bf";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rawlog/default.nix
+++ b/distros/iron/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rawlog";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "776d7c984d723b4ce60119b97de7dba1b99f8a1bc3f54035d65bcaca770aa09a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "337c2b71f3281f5f519ea138b05f1a734990670dcf119fd715f7de99e603914d";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rosbag2/default.nix
+++ b/distros/iron/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rosbag2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6de7ac7f11cf9e2bdf8e8d7926e7bc4924f21131b94605d53cb7c58b7a59a9c6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6ea7f009a5f4066c6c517dcc773eda39fa26b28a0b754a784708ebcc76526666";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-kernel";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7693eb7270cb1e8a8838951b395237bc5cba60e0ac76734968b1f6cecd234540";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d2824cbde1abdef06e4bd8d3cc3924bb9a8a8906ca07eb764968e3cab798264d";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-launcher/default.nix
+++ b/distros/iron/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-launcher";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "40df25c615ac07bc8a8e0389ec9623a112bf6f45f92fe8aa139a9686918142aa";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ee7ccabaa5c96477c81131b073b864f5b0b04c7b147cdd0d7490c11e1c38c47b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-metric-maps/default.nix
+++ b/distros/iron/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-metric-maps";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "37f0c43e69efcf4e510dc619c82180e5fbf55d7bc4c58b929004790874c6988b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "02a058a81db6d0cbd36017a776bb1463a103ed94d1dc6215412e7d877b2b6e81";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-msgs/default.nix
+++ b/distros/iron/mola-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-iron-mola-msgs";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9d6bbe8e3d24cb6ddc1f876e1e48128771df5fd949abb74824c546c59c4335bf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs mrpt-msgs nav-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS message, services, and actions used in other MOLA packages.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/iron/mola-navstate-fg/default.nix
+++ b/distros/iron/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fg";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fg/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "cb3b0587930eb8c5d480689d5471cacd5ebc25f6b90908c91cfa5fdd186bc2dc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fg/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a419834d31656c4f47e27117e820366be9a3c040d826b5e1a56d762e482885e4";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-navstate-fuse/default.nix
+++ b/distros/iron/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fuse";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "290b28c8667c5522ab84b3866b0265d67835d56f6ac09dab4b0e245cedfc28e1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b36918cc33da2355c36abea6e72e1a93a05d7ef6fc3f7e1f21331cb56392a71c";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-pose-list/default.nix
+++ b/distros/iron/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-pose-list";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "399dadd8267f1735ef3baa49b9f60a1b28958f7a37652b23ef6578f7c1aef862";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5633ce6008fa8f2e48ae8654d72ef36ac251e5717e72d31a5f70facd7183e02f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-relocalization/default.nix
+++ b/distros/iron/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-relocalization";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5e103d3c5233dc4d8586ea2470196bad7a734db2866d149caf8f91c33bde05fc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "1fd7e708dcd65c996a50c3c3079244558b50d430471d759316536be9c29bbf4b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-test-datasets/default.nix
+++ b/distros/iron/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-test-datasets";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/iron/mola_test_datasets/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "d00ee38c7b5400feeac16dc2c15d3d614c68b632d21601fcf6899a3082103499";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/iron/mola_test_datasets/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "6ce2dfc2d8577e35b52d3e4ca784efc6ff92c1dd5ca0899153711fa94c948230";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-traj-tools/default.nix
+++ b/distros/iron/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-traj-tools";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "71a8ab7407e75840ae17de6c18581eb9b55eeb21ab17615b6070f4f05e9eff39";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6cba2f09e1729f153ad57116794f1743e13881170962388d3f087d61c02ccca2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-viz/default.nix
+++ b/distros/iron/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-viz";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6fcddb10a0d65f704617524ff7e77f17f440fa351f84ec81af7fd93d1bf68d94";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "23fe69b4816e32612a11113767f6138fce5d9682d7a5b7f10c6c6e9b2c5698f4";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "556bfddb56d18212cd0cb42b7175d272df4fa358c6f1ad5666d07ea6a8b43075";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "aaabcfc77db45ac03b375c2beb8308cde7529fe69dc5ef9ddd2d4bf9fbb4d71b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola/default.nix
+++ b/distros/iron/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-iron-mola";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "441d76c10fa67c5a4227b849dee87e409207f71665fa74407298bed4a65e160e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c8cf7994a516865356862ff831ce3821d76018674b1dd834e049883a7c54ee94";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosx-introspection/default.nix
+++ b/distros/iron/rosx-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fastcdr, geometry-msgs, rapidjson, rclcpp, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosx-introspection";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/iron/rosx_introspection/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "1c35967ac6fa42ea9f218a0180fe76d76099c87a0ec38bea96e4860bfb93b664";
+    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/iron/rosx_introspection/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "937c1746fe37ceed3643df0db9153bbcd270c7cdaf044790b1a6563c951ec409";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ament-black/default.nix
+++ b/distros/jazzy/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-jazzy-ament-black";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_black/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "739fa91c31a79ad35ee45f03d7415d73878a132471ca2724b322bd7baada61dd";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "063ff98911ee5d1d70e44e13f439bdd79be6171b6ba36ab1e48584928debcf42";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ament-cmake-black/default.nix
+++ b/distros/jazzy/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-jazzy-ament-cmake-black";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_cmake_black/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "9820ff38850dd890a63a91626c9b5d5936fc335fdb14b6de550bf95081eb0c54";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_cmake_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "94eba3896db0aeafa4462a867c05b10ac502051170f2271311621394b9784e73";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compressed-depth-image-transport/default.nix
+++ b/distros/jazzy/compressed-depth-image-transport/default.nix
@@ -2,26 +2,26 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, image-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-depth-image-transport";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "9cb294fa0593b108512f86710f7127848cb803face0d7cfbf2a9d7f8bb4728d5";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "e11d2efcf92f40794cc992d94f13c4921fdb879f5838539e3621550af9e2f555";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cv-bridge image-transport ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Compressed_depth_image_transport provides a plugin to image_transport for transparently sending
     depth images (raw, floating-point) using PNG compression.";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsdOriginal mit ];
   };
 }

--- a/distros/jazzy/compressed-image-transport/default.nix
+++ b/distros/jazzy/compressed-image-transport/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-image-transport";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "e7c041db4bbc2d6f651b91c795e721653e9b55325db20da07fceaff49ab5f144";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "526df62f674964aadabf7d2e91e908b16ee5e40f5205a8a4899e60399a202329";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cv-bridge image-transport ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/dataspeed-can-msg-filters/default.nix
+++ b/distros/jazzy/dataspeed-can-msg-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-jazzy-dataspeed-can-msg-filters";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_msg_filters/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "f8d25c53e084ce226578b93337428b7a15b468e2107ba88fa5ea58044444b686";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Time synchronize multiple CAN messages to get a single callback";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/dataspeed-can-msgs/default.nix
+++ b/distros/jazzy/dataspeed-can-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-dataspeed-can-msgs";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "4250225624e3e1c4d1b251ff40bb39f79ba612db53e5d748433fe5a23b0c8c49";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller Area Network (CAN) messages";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/dataspeed-can-tools/default.nix
+++ b/distros/jazzy/dataspeed-can-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msgs, rclcpp, rosbag2-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-dataspeed-can-tools";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_tools/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "4da535349f42d24268c63f220ed7bf22a07ee160c1dad47908785cf0f9ba2f6c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-msgs rclcpp rosbag2-cpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CAN bus introspection";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/dataspeed-can-usb/default.nix
+++ b/distros/jazzy/dataspeed-can-usb/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, lusb, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-dataspeed-can-usb";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_usb/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "7c34d242260e7d661056724bbdba897da86faf8c8f4882eb79ae0e0d5d083305";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs lusb rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Driver to interface with the Dataspeed Inc. USB CAN Tool";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/dataspeed-can/default.nix
+++ b/distros/jazzy/dataspeed-can/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-can-msg-filters, dataspeed-can-msgs, dataspeed-can-tools, dataspeed-can-usb }:
+buildRosPackage {
+  pname = "ros-jazzy-dataspeed-can";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "c561f5f9a39b67e7281e23431d80aeff3dc4d96cc8998b1515a210ea0761b5c1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ dataspeed-can-msg-filters dataspeed-can-msgs dataspeed-can-tools dataspeed-can-usb ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CAN bus tools using Dataspeed hardware";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/diagnostic-aggregator/default.nix
+++ b/distros/jazzy/diagnostic-aggregator/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-aggregator";
-  version = "3.1.2-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_aggregator/3.1.2-3.tar.gz";
-    name = "3.1.2-3.tar.gz";
-    sha256 = "f927a71c3fd09ed6724ae933b3803fd21d94b87099a7687d2995cdc58ab562ab";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_aggregator/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "19fafb3899193842a688898c71f1a79c57bed1d7dfafa38fe24125759f19d346";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python diagnostic-msgs pluginlib rclcpp std-msgs ];
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing-ament-cmake launch-testing-ros ];
+  buildInputs = [ ament-cmake ament-cmake-python diagnostic-msgs pluginlib rcl-interfaces rclcpp std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch-pytest launch-testing-ament-cmake launch-testing-ros ];
   propagatedBuildInputs = [ rclpy ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/jazzy/diagnostic-common-diagnostics/default.nix
+++ b/distros/jazzy/diagnostic-common-diagnostics/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, python3Packages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-common-diagnostics";
-  version = "3.1.2-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_common_diagnostics/3.1.2-3.tar.gz";
-    name = "3.1.2-3.tar.gz";
-    sha256 = "800e3681a5cc896467651b1f414dc332cca52c85e5248bbf6283b8b9cfe1b6d9";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_common_diagnostics/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "2d09c158a1748fd19c7ccb74f87ef81085292f060d0de16eeb59b45d10530d88";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pytest ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ diagnostic-updater python3Packages.ntplib rclpy ];
+  checkInputs = [ ament-cmake-lint-cmake ament-cmake-pytest ament-cmake-xmllint ament-lint-auto launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ diagnostic-updater lm_sensors python3Packages.ntplib python3Packages.psutil ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/jazzy/diagnostic-updater/default.nix
+++ b/distros/jazzy/diagnostic-updater/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, pythonPackages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-updater";
-  version = "3.1.2-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_updater/3.1.2-3.tar.gz";
-    name = "3.1.2-3.tar.gz";
-    sha256 = "00c1d8fc65c57bce664a82bd531b9ffadea11471a3dd398f7ca5cc13f3bee72b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_updater/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "ac861210461b71d750d78f12c63ba3a9ee69fcbedcb29ec11c59760c61ac8af0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ros pythonPackages.pytest rclcpp-lifecycle ];
   propagatedBuildInputs = [ diagnostic-msgs rclcpp rclpy std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/jazzy/diagnostics/default.nix
+++ b/distros/jazzy/diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostics";
-  version = "3.1.2-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostics/3.1.2-3.tar.gz";
-    name = "3.1.2-3.tar.gz";
-    sha256 = "3daeab97bbdd8ace08bfa2af4e0357d90ade4c91f74377b1d1b934085081d87b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostics/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "94e9257dd4905dc7f2d1f6a5a33cb5a89ced4cdcddafc344843f1b666c21ffa5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-can/default.nix
+++ b/distros/jazzy/ds-dbw-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, ds-dbw-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ds-dbw-can";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2f8e55d1b13e73c7b5c36b19a5f84911d24194d5bf1c23d32e0a029e2ee573bc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake dataspeed-can-msg-filters ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb ds-dbw-msgs rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface to the Dataspeed Inc. Drive-By-Wire kit";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/ds-dbw-joystick-demo/default.nix
+++ b/distros/jazzy/ds-dbw-joystick-demo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ds-dbw-joystick-demo";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "37dc3b4c829cd88f0d935496437f4dc6e08a70fd78a0cc536af40e559a3fd7a5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ds-dbw-can ds-dbw-msgs joy rclcpp rclcpp-components sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Demonstration of drive-by-wire with joystick";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/ds-dbw-msgs/default.nix
+++ b/distros/jazzy/ds-dbw-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ds-dbw-msgs";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "3bc631d1d36efc720d25d667678fd209efb358610d357b809571ecb5592e3d1b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Drive-by-wire messages";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/ds-dbw/default.nix
+++ b/distros/jazzy/ds-dbw/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-joystick-demo, ds-dbw-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ds-dbw";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "7d6b75518160a7562cf6b51c2c05b450309ecefa2b2e71c1a46730bfb2f4fa1e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ds-dbw-can ds-dbw-joystick-demo ds-dbw-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interface to the Dataspeed Inc. Drive-By-Wire kits";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/foxglove-bridge/default.nix
+++ b/distros/jazzy/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-bridge";
-  version = "0.7.9-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "fd82fe43c308393dd31121acbea08e0f6d7de3a9c0fd9a9b0725a03b042e268c";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "02bb93f8766363311f2bc8cfcf0290041d38c91339fc7b0522dee91de2f7d022";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs zlib ];
+  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -354,6 +354,16 @@ self: super: {
 
  data-tamer-msgs = self.callPackage ./data-tamer-msgs {};
 
+ dataspeed-can = self.callPackage ./dataspeed-can {};
+
+ dataspeed-can-msg-filters = self.callPackage ./dataspeed-can-msg-filters {};
+
+ dataspeed-can-msgs = self.callPackage ./dataspeed-can-msgs {};
+
+ dataspeed-can-tools = self.callPackage ./dataspeed-can-tools {};
+
+ dataspeed-can-usb = self.callPackage ./dataspeed-can-usb {};
+
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
  delphi-mrr-msgs = self.callPackage ./delphi-mrr-msgs {};
@@ -399,6 +409,14 @@ self: super: {
  domain-coordinator = self.callPackage ./domain-coordinator {};
 
  draco-point-cloud-transport = self.callPackage ./draco-point-cloud-transport {};
+
+ ds-dbw = self.callPackage ./ds-dbw {};
+
+ ds-dbw-can = self.callPackage ./ds-dbw-can {};
+
+ ds-dbw-joystick-demo = self.callPackage ./ds-dbw-joystick-demo {};
+
+ ds-dbw-msgs = self.callPackage ./ds-dbw-msgs {};
 
  dual-arm-panda-moveit-config = self.callPackage ./dual-arm-panda-moveit-config {};
 
@@ -1143,6 +1161,8 @@ self: super: {
  mola-launcher = self.callPackage ./mola-launcher {};
 
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
+
+ mola-msgs = self.callPackage ./mola-msgs {};
 
  mola-navstate-fg = self.callPackage ./mola-navstate-fg {};
 
@@ -2109,6 +2129,8 @@ self: super: {
  rqt-topic = self.callPackage ./rqt-topic {};
 
  rsl = self.callPackage ./rsl {};
+
+ rslidar-msg = self.callPackage ./rslidar-msg {};
 
  rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
 

--- a/distros/jazzy/hpp-fcl/default.nix
+++ b/distros/jazzy/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-hpp-fcl";
-  version = "2.4.4-r3";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/jazzy/hpp-fcl/2.4.4-3.tar.gz";
-    name = "2.4.4-3.tar.gz";
-    sha256 = "c9045db14d1795af200abb4d341a38569a67bf76c06955a899911575bcfe877f";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/jazzy/hpp-fcl/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "2f7685458d63c52c4a8b6899e7e4ec86c1bc70288d55d868d1a5976824ccc027";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/image-transport-plugins/default.nix
+++ b/distros/jazzy/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport-plugins";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "951e0226ef192de023029a78ec0e81b210fe46225af9b9c619a7bdfb0d04258a";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "4268455daefc895dd288b548295fd340f30a2da7ddb5197b8eb5351e74b97e2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "617b65090dd26f049ea9f0d735f3f968ca4836983b0bcf417a7998b867121e1d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a525848fa44f30172fbd19e60272f24fc72602645eb58f8dfe1a275707f175ba";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/libcamera/default.nix
+++ b/distros/jazzy/libcamera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3, python3Packages, pythonPackages, udev }:
 buildRosPackage {
   pname = "ros-jazzy-libcamera";
-  version = "0.3.0-r3";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/jazzy/libcamera/0.3.0-3.tar.gz";
-    name = "0.3.0-3.tar.gz";
-    sha256 = "3da114d42cb483228994e808a50a71da1aa3c35affb119d423d9d34fb23d5935";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/jazzy/libcamera/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "725dbbdce06cce4ebdc2038f944a20cd73e2438c930055f98a9e96a6d8f5e837";
   };
 
   buildType = "meson";

--- a/distros/jazzy/message-filters/default.nix
+++ b/distros/jazzy/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-message-filters";
-  version = "4.11.1-r2";
+  version = "4.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.1-2.tar.gz";
-    name = "4.11.1-2.tar.gz";
-    sha256 = "c91337aea811a2bbc1423519cf736df41feffae1c9619b288d14c7df609a4c05";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/jazzy/message_filters/4.11.2-1.tar.gz";
+    name = "4.11.2-1.tar.gz";
+    sha256 = "03b2ef0830ab9cd9aa15938f507233db09ab578d936027441c10ffafcecac21b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "58b332d197e2896aeac2c760a4b23c11f8338735dc278c06d59fd1373e943e62";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "edffce007672ccfc240d5941bc1710ad3b269f07276dcf172de31b6a36324191";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0bc4c5be4cd1c464c02e28d09323d0e1efbe9824c138f7460c29b03c0753ec3a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "60d3a4b4edb13c55ca495bcfed249de432f64f6b612f0fff1a427d57c35336e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "70db160926515e0469b5465f279dd990024d5e1a4f2f93cc6284453525e99787";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f565db9ba954f501c7ba7e8c6da5ee3c3f4f82877cc478f8a61e723f6da0a5f6";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b0ebdcd4777467b22479a48e86445091cbb9f92039867ce915b6980227de2094";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ac45fa4dd369dfd3e91750c66304449dc5b1cf542b3a82d8d8bb79c218abb770";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2e12864170dba1f82f86db2de8e3272e0edbcd8670e2bc7aafb45ff3d930f511";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4cd1fb69e39f8e02f53f5d62771fdb50458d7088a2c394eb5663076a00e26c90";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "54a1cb120f106166bdcb672766900e1c1b15d9f3456cddb7ed1cc07dd83238cf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c4b035abe21f23222b18ddbb3767276f8d424e68b2dccf6c6b2c10ee4a7e583c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5531c2c29d27ef58034e7c23eebc1888e47b6e1b312873228b96e1a975117f18";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4a0945b7580f1afe45d4ed166b0f64e1f8e314cba193532d14685c58324c7031";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2b765bd0a88674c632a804b25ab17259ce25500f8bf3f689f12034706d3205f9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "28c5c995a12609b3393c219db26b3a6910153b09afa16ef894f0cede9de84f60";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3e21f0f992b181a56b2c5157f8bbf3998777ea138864896b8613325d509cf6d3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "dca020d95884ec892fc427954df5a153ccd62b109f6e0a7cb90cab815d98952a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e08d4700a1c9bad30f18aea3ab25cb8f5e010b3e7e001a71986e3b4eca3c23c7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "2883829d191c9f70870414ba7d69ee45dfe231e3362a593e8b1f443a0efe107d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "31c88a6835a886b9752800a2b59617629f260339040b6f57a3619b2dda6efba0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5fa0ae29953820837871f144acd2b6800d1e009911dbac168c5ca4cfb2297c37";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a9de69f9c0f6d0268210c096f32e2423bc9a57386b0ac416cb4147bb62f0bd99";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b735c14eb9bcbfc6e21280529eede4ccb16c14e85e8a53f67b5b56e951a2057f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "51dd0fa36d31b85c54ae86d4b58e023285a386c6363ac6a2510420f001598c6c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f78a4f67f255e7c8f0fc21bd8ba601e5f9dd8b1751c11acfcadcef25faf3ce80";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-msgs";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "33d71e2d8c2d6db87ca8c4d1c09de941ad5a14eb100d27a94f82eec6fc6f636f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs mrpt-msgs nav-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS message, services, and actions used in other MOLA packages.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/mola-navstate-fg/default.nix
+++ b/distros/jazzy/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-navstate-fg";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fg/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2c162383c776939ac9255223bd1b291bbec86f1b5d142a16f23243a2b5f3bb65";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fg/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "33076b510acf47d14da9975a4b5a29dd689936e119e00b99ebe02bf404f40526";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-navstate-fuse/default.nix
+++ b/distros/jazzy/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-navstate-fuse";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fuse/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5004c46078f526d51a022a4ddc53c4cba70af363e081def75d3001dde82b3cb7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fuse/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8ca849a9fd2f7ce1733338b39b44cf62ded16922e0e17cd6fa954a536f8e5d20";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0ac241aca483b78a498fb4ac37ff63e09eceb978921816164795eea1d0168356";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4b64ed687e81e404e2bcf130ce39aab78d71a233d98ad019a718081a5cc1bf5c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "41f07f80b5b1e84a085cd7661b08f0a7bf8f10caedbf24ef97a6b6ce103ab33d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9fb144e67af93ce30f0cb67c70fc31a73e206e6a0e078c269fb0645503488e12";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-test-datasets/default.nix
+++ b/distros/jazzy/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-test-datasets";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/jazzy/mola_test_datasets/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "a7bd0c22d5e86d5140de49751d79b9da6ec998171b8a50cd309fef928d45fd7a";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/jazzy/mola_test_datasets/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "f579f19b94919bebb27712cc0f3e47a95a1aec3cbfd3eeb3634d54ab10d228b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "11aca79e0e95f512ad1925c1eb88c70ecec7772926a5c4ae28e86ac1a8b1a131";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "86df4a35a910a62284824ab39509b92973c3a52a92d54d3cda8994611e9f3e4a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6c702007739cac07352a19b29eae8f6f676f0904766680513c83308e9279f793";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ed80bb15585da832c2cf5d47bd4b475d10893aa2eafcc0e5d74da9ceb6e5ac88";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "725fa55d864d5b66f29e453afa8e2f357bfabffc0cd2839c4051dd558fb39fb8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6f04eef0ff7e29049bc3404f81e6a7cce0f68bbe30717ca4cc60e4e917ca42d0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6141d8c0671844fce73a4e0bbbf4aca50d96c22936082013aa5f327a27548373";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "da7900f646bb49a6c8951e7ef8840952531690705fbc05b353953791d244b73e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosx-introspection/default.nix
+++ b/distros/jazzy/rosx-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fastcdr, geometry-msgs, rapidjson, rclcpp, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosx-introspection";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/jazzy/rosx_introspection/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f592fd3b5df463b4fe2bd6ad8f18f54ecb09c612791ae9245c1cbdf830a09e08";
+    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/jazzy/rosx_introspection/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "e75fd9f7062589565d6a461931ea12f3508ca590e037be720f9a08d2ec58f9b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rslidar-msg/default.nix
+++ b/distros/jazzy/rslidar-msg/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-rslidar-msg";
+  version = "0.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rslidar_msg-release/archive/release/jazzy/rslidar_msg/0.0.0-1.tar.gz";
+    name = "0.0.0-1.tar.gz";
+    sha256 = "132e8fe0f27e524fb8cef251d9158e2ef9c0607c36b19ddca5832c7e2385bee4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rclcpp rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ros msgs for the rslidar_sdk project";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/self-test/default.nix
+++ b/distros/jazzy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-self-test";
-  version = "3.1.2-r3";
+  version = "4.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/self_test/3.1.2-3.tar.gz";
-    name = "3.1.2-3.tar.gz";
-    sha256 = "73017fc9ad053502340445b5c2707b69c7d864c3e6be18ddf4e547040e4e1177";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/self_test/4.2.1-1.tar.gz";
+    name = "4.2.1-1.tar.gz";
+    sha256 = "6c16e94e4d97e46c57708871dd8f881bc117b57a28e7f9c8067f92a74b7deb39";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/theora-image-transport/default.nix
+++ b/distros/jazzy/theora-image-transport/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-theora-image-transport";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "9a320955888afbdffbb5bcf270a6d8543234505f66457479cb528a6df41ddda5";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "10ac13da104018ace175ecd301e199b4fa32676c2dd0b6c3e52bb3a243cbc7c1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
-  checkInputs = [ ament-lint-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cv-bridge image-transport libogg libtheora opencv opencv.cxxdev pluginlib rclcpp rcutils rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
 

--- a/distros/jazzy/zstd-image-transport/default.nix
+++ b/distros/jazzy/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-zstd-image-transport";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "bf305eef2ab3f1ed809110876e71eb2e99978ad360ef2e8df7094af493bddfdf";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "0610c3cf64ca08e8b4a38786bbc405229bbf86b6ee09866e00b966ee4d6fc7f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/cartesian-interface/default.nix
+++ b/distros/noetic/cartesian-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-interface";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "7852bec4675c7d0c401f8f4da568a4b337b4fea4010473127e407945b53f33da";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "ce2aaaea41e4809d26f624c9114d1bb1360d1610b477b8129e4c51b32cc253ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-trajectory-controller/default.nix
+++ b/distros/noetic/cartesian-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-trajectory-controller";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "7ec8ca594b1fe282d7f6709ce21e2aa7ef52788e689e38a824b0ba74f9554b7e";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "30c7992dc26cf63b05924ccadac3f559b8fd8283d73ca914164aa742d1d0d35f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/noetic/cartesian-trajectory-interpolation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-trajectory-interpolation";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "91f1d8f6bf5bcb1028c322ee3f0c43d190dba9434dcea7fb566780794b23e7a0";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "4dc6ef691cca2113e439e52d97d6e82ff8c12d7ae207d68b74211a522b2f28a8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hpp-fcl/default.nix
+++ b/distros/noetic/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-hpp-fcl";
-  version = "2.4.4-r1";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "4d80f780077468c017f19be97ad9a32b591d7ec4d672795abbf57f1947b4ca22";
+    url = "https://github.com/humanoid-path-planner/hpp-fcl-ros-release/archive/release/noetic/hpp-fcl/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "17940638cddae74b2b32c9606b88898e0cf73df1b1adce297440b413c7ae1410";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrt-cmake-modules/default.nix
+++ b/distros/noetic/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-mrt-cmake-modules";
-  version = "1.0.4-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/noetic/mrt_cmake_modules/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "a57151852aaea4af01ddd8037c45e191cdf38a2b3e4e402c14f87d0d8548385d";
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/noetic/mrt_cmake_modules/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "c70823a245fe20c82ad07bde2efdd7ddf57c63e6b4b78153ba09e4884b863e9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-controllers-cartesian/default.nix
+++ b/distros/noetic/ros-controllers-cartesian/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers-cartesian";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "c436da2b475cf766f6d09b3b48c155f9f35fa7d9cd1b0852a3b12c3b7de23a62";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "a62b89093dfc4cea5bc44b145e0d004b62e7731f4a326af88a08590a5210fecb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-scan-xd/default.nix
+++ b/distros/noetic/sick-scan-xd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslib, rospy, rviz, sensor-msgs, std-msgs, tf, tf2, tf2-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan-xd";
-  version = "3.2.6-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.2.6-1.tar.gz";
-    name = "3.2.6-1.tar.gz";
-    sha256 = "17f6417d6b4c3c97d162aca5450ab31f31e5cc19117e9cfb6832ae8327debcef";
+    url = "https://github.com/SICKAG/sick_scan_xd-release/archive/release/noetic/sick_scan_xd/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "468fc03e90058109200f46531020affcb985adc83137b0658ac05c0dca9f9e87";
   };
 
   buildType = "catkin";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = "ROS 1 and 2 driver for SICK scanner";
-    license = with lib.licenses; [ "Apache-License,-Version-2.0,-see-\"http-www.apache.org-licenses-LICENSE-2.0\"" ];
+    license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/twist-controller/default.nix
+++ b/distros/noetic/twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-twist-controller";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "26f6071a8f649e812e7361a065fde5eb9d3118d230518d6359f0df09c2dce33c";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "894fd079d790bdc7eec7024edda899a93e20e3842735c2de3a388bae4fdabfb0";
   };
 
   buildType = "catkin";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "5c6f7bf45897aa08de07e6e5f6e715a69025f4843bf6b8dd24ace1b9bed0836c";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "5f858a223547045fb0a3edaee4414f0cab3eec1c2069c3c898647466ccb48187";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-interfaces/default.nix
+++ b/distros/rolling/action-tutorials-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-interfaces";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "b9d75edc3c3ebbbc9844aa584d338e138ea7db897563bd6e8770eeb9afa7b080";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_interfaces/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "cd6788f37b3156cde531c25b1cb53f69726a84e6c5c737f7f2de7f647327c9f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "cd71e87a51622902886e5d9c2a3745304a0606afaffe07ece98de7c5a19ad2c4";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "02c105b0ac32cf59efac4792b2992554fdf1572149ebfcfe39451b5b05d1f21c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-black/default.nix
+++ b/distros/rolling/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-black";
-  version = "0.2.4-r2";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "467e2fe912a4e7cdd77282cc9b2b9322fa258d4bb9a91b86a52e1371f027f64d";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "4183874f252401a0d24aeece7cf6734284ce89a114cd37b811f735d8a604c19d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-black/default.nix
+++ b/distros/rolling/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-black";
-  version = "0.2.4-r2";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.4-2.tar.gz";
-    name = "0.2.4-2.tar.gz";
-    sha256 = "e7411823b3d51b21bf4871b195f1911865e3da52256548f4b8eaa2c015e6c242";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "4fe629c73f7db996c3106190db2e0dafdcf2e4e398a2bc8fea7df072dcaf5dbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "5640fa3e01df90144262b146972837461f093899ee042b866de9614fe7ec5c10";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "4dcaea779ef9c3d511e9e71cdb7c98e584901f5ae2d11009c8857559a43f7ab8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "cb428b9f9d3f2c93914ca2f84f92dce58b6841a8699caaeed8f4cee95e39bb5e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "d57b111968f5e59f9938ca3b3b1d97b6f7c66920d4f796fbc57203b41c144f37";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "cf555ae480e1724cd81f0909992da790eea4674ce6b3651ffad45d119e0974e9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "a505fed3815f1b64e9f84efc7191f36e526e812cf9f28ff8bd0c5e9689223e27";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/compressed-depth-image-transport/default.nix
+++ b/distros/rolling/compressed-depth-image-transport/default.nix
@@ -2,26 +2,26 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, image-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-compressed-depth-image-transport";
-  version = "4.0.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_depth_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "63fc6d4c667093c701e230826d111bbc2706d2801b863363425d4d666061b48f";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_depth_image_transport/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "9e4d2fbd555c06cd6fc1c6efd36da7d93865625a3da8107330c7a55d3b0f2039";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cv-bridge image-transport ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "Compressed_depth_image_transport provides a plugin to image_transport for transparently sending
     depth images (raw, floating-point) using PNG compression.";
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsdOriginal mit ];
   };
 }

--- a/distros/rolling/compressed-image-transport/default.nix
+++ b/distros/rolling/compressed-image-transport/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-compressed-image-transport";
-  version = "4.0.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "16589b06f945a7b52596633b515aabc74fe6ea3b07664d06a2e2e4ae43b2b8bc";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_image_transport/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "27b2968708d472a0bd8802095a37a26a8ce0e44b2c873c0f5b86a19b5e16da41";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cv-bridge image-transport ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "a2797587e864f688cbe1cb1d3fe19a1ec383d7cfc5d090edd2ad0d8b863949fe";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "ec5f80707d60cf6dfe60691fcb9fd5f3ea567fa327249e7429d4fd3914cbb969";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "bd1374efdf7ce3190f5c5bc45b0e3d63d28307b92e5f581ea3b5877997c630a7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "aa44fa71cc26d60a52d3c3256c647a1b3aa77a63a200867573f48ba58c689d2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "62de1de8620421f94a8a77bef6d864e4d52f027860d09055cc007e0ef9098db9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "8e3b00b5d51b2b077a81e40b681692a94fe002c60a911badcafb94b555968028";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/diagnostic-aggregator/default.nix
+++ b/distros/rolling/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-aggregator";
-  version = "4.3.0-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_aggregator/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "8415c17a6d2e32c6955dfddcf96fbdfea3b3853f89f1adff148a141a89dc1f41";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_aggregator/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "79042fa14a4c33c245c003b38be605804a7beae3f28e493e01a6622874c76f35";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostic-common-diagnostics/default.nix
+++ b/distros/rolling/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-common-diagnostics";
-  version = "4.3.0-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_common_diagnostics/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "e08cf7fb69a93d1fec3418a601d3da67463e2c05a8cde97bf1340406099d8c62";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_common_diagnostics/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "39f37717ae5f21c79b151a27e1dbc8ff51079fd193ffe51c1f449ba48edb693d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostic-updater/default.nix
+++ b/distros/rolling/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, pythonPackages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-updater";
-  version = "4.3.0-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_updater/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "3353508bf39b40c608d930223cc11a97c1f44e8afb79ebae130ef407c6ed13de";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostic_updater/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "09c030de75999cde17b3818d35c6d5b8b154b60646aab813bcea6fd68b908935";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostics/default.nix
+++ b/distros/rolling/diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-rolling-diagnostics";
-  version = "4.3.0-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostics/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "e85e5e09db15238e3637a3b6735dd1dc4f82975b2b9dc0b7d48922bc0a5054bb";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/diagnostics/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "18e673171073ca2da030482c3174f38a9a5dccc6f65f40dde63aade622c9d6ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "5e779f00a82f0017900615f21d2553e679888883393642fc57eb6861f5289704";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "a29d10175e24ed38646ac295dec2374b106bce25543caab2e58313ff0551053b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "9e53a188635a5149d398229909c22867fe494bb9d6ef2121be77fb4459ad47f7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "3f1a2bf3a2a9ad8b1ea6fb541829a9aafcf614f9ea650aa34b158ac95ff24495";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "6d534f3229e014e6a3013b0ec0c15a3d4d696b7191303dde3b3b2261b2ad03c9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "df5eaacf491d7141ed0ad6a3e6e0610a798d58d3a47f42bebbf05ab759a9f06b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-async-client/default.nix
+++ b/distros/rolling/examples-rclcpp-async-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-async-client";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_async_client/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "767e9ecb58b9e609208924340b4c37e65792b31dde4155bbc2c5dcebf02e9e2b";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_async_client/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "96d6ce8c22316eea4d66881518e3cf21e3b9524fde683b004b6b8c924819cb42";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-cbg-executor/default.nix
+++ b/distros/rolling/examples-rclcpp-cbg-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-cbg-executor";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_cbg_executor/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "5f1e23c98362a5482d5478743398d696c79641010668fa58b12591b60b1dbf9f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_cbg_executor/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "0010ff49039550324a001368fa9b287bb13a943feeb844ced153f623eb531c0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-action-client/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-action-client";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_client/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "ca4a6c610d5c144f2b9a9b59425cb66fac25eee5ea47ec25bd4544139322bfe4";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_client/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "beaf21f915f9ebcb26e0943946dd71a0ffc1874181edc42aa47d6e42e04fa227";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-action-server/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-action-server";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_server/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "86a01b209837613ccdd896e7ba1989ddca0df6b5d01055c84d27af5eba3afbe6";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_server/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "30ddf7b6c40e7e7d790b9375460bab6b37237d707533dd043811cd94f92e50ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-client/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-client";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_client/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "fca6d3c13fbed5918c1d093c9ae66f3d906c7d9e0847645ad0f86627c0787a7e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_client/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "c58a7f4da34c2cdff8a2635ebda0233709d6e5c167df9148b9d582a90fe742d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-composition/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-composition";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_composition/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "cc151422f35cf8114e03d24edbf7251a9bf9842ae968c8e4b8086da2f25ced26";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_composition/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "71d2890d5b11214fce0865d2d1b97f53004b232de2e0fe265b2616068583e5f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-publisher/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-publisher";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_publisher/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "35bea14ba953055baf7d75cfaa1ac32f1e1c08696c7cbb5d21e89f608edbc789";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_publisher/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "7a608e9ec2f920cc1ca8529c739f9b38a99c741d6f437b5e3eeb4c811a30e45f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-service/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-service";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_service/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "58f25660ad11cc21db5c9f61662d243d612243d3d0aeafd7abec1236d08328a4";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_service/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "039372ede82ae4b2aa730644ebe0ec4a288bceddbf4da03fe76ed2c460b9c62f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-subscriber/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-subscriber";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_subscriber/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "86e2278e34030dffbfd52769c84f13ee9305038c9044327ab803444dae2cdb4f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_subscriber/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "7f87d33b48c0708e455cc8a79949da734355ab0f6aefda4e61743fb247bcd65d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-timer/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-timer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-timer";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_timer/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "9d7a1a3e0d235cca285d9464e57eaa9bde7eaee17f4a531954c0e61b6eac68a6";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_timer/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "658fc4018b84e44352ff8b8d1c31128c3de46d42f4bf8e4f26f1f063522b906d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-multithreaded-executor/default.nix
+++ b/distros/rolling/examples-rclcpp-multithreaded-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-multithreaded-executor";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_multithreaded_executor/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "a27a70e513d3050798b1f79f36b952842b54244c61bc8a428e9473c06e430c19";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_multithreaded_executor/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "6e1b7c18a91c55abefdf397893a3bd06893dcfcce29c5dafbc943f751f2fa908";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-wait-set/default.nix
+++ b/distros/rolling/examples-rclcpp-wait-set/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-wait-set";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_wait_set/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "266ff2741279f0b52721237ca8e40513745564f042726fa82be57f4e9bacfe87";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_wait_set/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "2a24e0a56fa8b972fefda3139be0cc695c0d790b01a04114e57f57befd2c5c06";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclpy-executors/default.nix
+++ b/distros/rolling/examples-rclpy-executors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-executors";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_executors/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "4816838fa9128dc3c34547d68b4b3d5ee370cc649d9ea66e70a8e27c44ab657f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_executors/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "1582679df13a2989f394d7be226991ac5e732a204483aeb8fff1ab78582ba0ee";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-guard-conditions/default.nix
+++ b/distros/rolling/examples-rclpy-guard-conditions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-guard-conditions";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_guard_conditions/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "7d6c45cd18e32bf7bce95ebe84c0ad34ec606bbe2c63dadf0c249fd45da1edc3";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_guard_conditions/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "5fe5f8f15d9482d646910394a9b0eef419067485ae4e95fc24ee26c9c84e40a2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-action-client/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-action-client";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_client/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "9ed4834b431c4ef92028b4685af2f9ea84d4212eb8834763f258a946bd1102f6";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_client/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "b4c9d261994f902ebdcafb8cf4066ff4cec04acd4b7cd1188ca5ef8487ac3f64";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-action-server/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-action-server";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_server/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "53ea746fd63f4721181cca4b622b4a2f359ceffe040b7f9a729807309f790976";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_server/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "cdf3506108c1cd0e56129725a8ad3f954274a7030bb3e07fbedd65862c4e8496";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-client/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-client";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_client/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "9c3c0790daca105a6ed7a7e1dc9f7e5359c7b391cfcc69906f2d4c4c62c45234";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_client/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "2a851ab96001b93e957dc1808592de8f61f99ff16a6a728d7a41694879885256";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-publisher/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-publisher";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_publisher/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "32a976d84600a52091a69f220a93daf1f7a22c2a0d8602fe32f4e7a78159e80e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_publisher/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "e65493f6e23e1a20ba324f826933cab15e633939a408591d0d4d3140f3b1c9a1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-service/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-service";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_service/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "f25494c83998dbf0c7c300d2cc416fe9b549feeb315289aac1b110c26e4333ad";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_service/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "0ef134596cb5c61b3710a0cf79900d32dc4a98c585d8f73e9464de30b6e09b99";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-minimal-subscriber/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-subscriber";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_subscriber/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "a32ab1bf3c7547f5b0b6338b2d9ecf074943650cd4e6368901d30fb4609341ce";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_subscriber/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "e73a3bee43290ade1bc40a374563fee9758dcad60e6ecc9a4becc3fea4281e7e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/examples-rclpy-pointcloud-publisher/default.nix
+++ b/distros/rolling/examples-rclpy-pointcloud-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-pointcloud-publisher";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_pointcloud_publisher/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "bd338892a03f722e1cba2d6ab9b548bf2bf04b23517302bef228d3f538cd3bcc";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_pointcloud_publisher/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "76a618ae8b7cfc7dae79e2badc1be9fb72ca90a133e80bb73ac485fe17ad6af1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, std-msgs, std-srvs, websocketpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.7.9-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "eb5deee6fca1ce3057f32f6c1c7d085643283af9bf31469d3dd6b89fbc700701";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "d5437e8059cacf4d772d2e672e125016cedefb1a066c0a61273382bff8f939df";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake asio nlohmann_json ros-environment websocketpp ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto std-msgs std-srvs ];
-  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs zlib ];
+  propagatedBuildInputs = [ ament-index-cpp openssl rclcpp rclcpp-components resource-retriever rosgraph-msgs rosx-introspection zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -1074,6 +1074,8 @@ self: super: {
 
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
 
+ mola-msgs = self.callPackage ./mola-msgs {};
+
  mola-navstate-fg = self.callPackage ./mola-navstate-fg {};
 
  mola-navstate-fuse = self.callPackage ./mola-navstate-fuse {};

--- a/distros/rolling/hpp-fcl/default.nix
+++ b/distros/rolling/hpp-fcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-hpp-fcl";
-  version = "2.4.4-r2";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.4.4-2.tar.gz";
-    name = "2.4.4-2.tar.gz";
-    sha256 = "3ddb59db86a779012f0228bfad29780155c2d16da08dac78ad216ce3901dd216";
+    url = "https://github.com/ros2-gbp/hpp_fcl-release/archive/release/rolling/hpp-fcl/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "627193c739fb118667f53ec0e7cc5b1c9b5593990288532efebf8effcd9334a9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "9b4c2d9091f71b99e3263bb7f748adb400ae38f2a7968f788588ad716a1e48c5";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "1cd053b3159f5273f1ac783584317142c91f6f07a8377a936cec30184422b36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "540495df46d6f2abf4d4483604f82649ffce8c6096a40ab8591436c580fc97ce";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "b163467e629a7988cdbef3dd4b8b1e10a93e7402158add69a4f1957599a45d4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport-plugins/default.nix
+++ b/distros/rolling/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-transport-plugins";
-  version = "4.0.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/image_transport_plugins/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "fb6eb079d371ecea0cd5f7bdfe1a77299d4139da59036b1b70ef847833014cb6";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/image_transport_plugins/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "7b8f0ae03de42b959c08f4385f051f519f81e549624a7aaa02f0416748f5df75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "5.3.1-r1";
+  version = "5.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "73c539cb07832d6979fbf8e2454af3a047b4dc2891c2c0607d6758609ab83628";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/5.3.2-1.tar.gz";
+    name = "5.3.2-1.tar.gz";
+    sha256 = "63e31f56780c7a8b38ef918bc7f7be4fcbc89dec951239d0ec60fbc8ae77acfe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "753100fc0310ddcd68b0fba22d269e55bd676f78acdbfbba73a84a4bcd6fef82";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "8054242126884562c7969ee8d59e904c5ad00190480064e3f14206cf70586f24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "fe53715d81c753dd6e67637ea7ccf9c09b84b9395224fd3a7b2c6052feae73a8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3357b8c807373a35cc106aff748da60245f3ed54803ee85f81c02b5731356ca2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "cc38462ec365af3cd9c1f667bff4fd8319a8b2d18559ac0bd33e450615d79ac6";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "d6a51dcf11d4d9fdb65742bc3cd17db8c6184d3fd128176f7b95ce3748c9a5ca";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-ros/default.nix
+++ b/distros/rolling/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-launch-ros";
-  version = "0.27.1-r1";
+  version = "0.27.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.27.1-1.tar.gz";
-    name = "0.27.1-1.tar.gz";
-    sha256 = "71cca234ebcf3c344d68ce5b4c91068d0591bbfeb8810a3684c3c27f6b211be2";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.27.2-1.tar.gz";
+    name = "0.27.2-1.tar.gz";
+    sha256 = "03e57fc2ae59c3e7fa7e1ccb5018d7e568c20701b425a4a9b8859f7cf5451156";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "2d1fd1067917395c6684f00926174e560773ea85ebfdd03861ad40a5c859ed84";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "5dfcf636cf9245cc6966e32f25edccab15ab36aad883095015c968a0f7ba1296";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-testing-examples/default.nix
+++ b/distros/rolling/launch-testing-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-examples";
-  version = "0.20.1-r1";
+  version = "0.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/launch_testing_examples/0.20.1-1.tar.gz";
-    name = "0.20.1-1.tar.gz";
-    sha256 = "b8071c45354d5a1e144a1f4e1314cae0f81e19bb351919c1c48a655e0429f403";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/launch_testing_examples/0.20.2-1.tar.gz";
+    name = "0.20.2-1.tar.gz";
+    sha256 = "17795ad6e074221c909014f3240062fe97e9a7f91cfc5e2605e8dbf1c835052f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ros/default.nix
+++ b/distros/rolling/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ros";
-  version = "0.27.1-r1";
+  version = "0.27.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.27.1-1.tar.gz";
-    name = "0.27.1-1.tar.gz";
-    sha256 = "7b0fac7f8966f3e2cc66422802620f3e9f5c5da6ef484cc82ae8caf758e1d69b";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.27.2-1.tar.gz";
+    name = "0.27.2-1.tar.gz";
+    sha256 = "7b323f9f555e33bb60e52d758d2029612bd32068e0f3ca9d94e7e322bacc8e8a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "940b8e3f568cb50943e80fa044efe55468e3b87d70e6f7643d6d34528704931a";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "45c31b811897befddf8f6e8a1535c72aa9192d5ad3edb07e3c652df1b156251a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "560be017381fedbbfca3eae853e7e3cfd161a2a771a635752c59591adbbe8e32";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "d5b55f2660c3bceb70dd0b3c62d6f1ed6c30362bdee07a859734b69528c98d94";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "2b7ca8ef818fb426fcd227bcc6c77a02775d6f6e51e4e530abb8ac6645ff1f96";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "d7e4c5fb96a9a6da423a3fdcfa44081f3167f5533b87b66202017790a343df02";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "cb7a682ebcca5622a842ee64d467a515b8926be9768b17deb6c2143268094817";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "c837b8e52413460184de4b18bdb0277320327e73bc8ec84285ccc30ca6c6dfa8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/libcamera/default.nix
+++ b/distros/rolling/libcamera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3, python3Packages, pythonPackages, udev }:
 buildRosPackage {
   pname = "ros-rolling-libcamera";
-  version = "0.3.0-r3";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.3.0-3.tar.gz";
-    name = "0.3.0-3.tar.gz";
-    sha256 = "1cf0e570eb31582da007f1b792d4711045e7d5a29aacf2edeaa05097dabbe247";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "d63c056debe69db088e1dfd3539671617009b176afaef235e00298fb817d0f70";
   };
 
   buildType = "meson";

--- a/distros/rolling/libstatistics-collector/default.nix
+++ b/distros/rolling/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-libstatistics-collector";
-  version = "1.8.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "af8789b283a6d0e590388172f530452bbff281959e51819f477fa45221889a45";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6e9b84ec72ba715ecbf0ea2e2a36ab63e2ff0c43230b632ee642af53b1367273";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "828cd7c74b6fe76ecee4854ac93ecf2b699506bbfdd1c030ae469f9360e9377b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "717da045867164f785da448a87278823b2814e068a2f65f6eb49f6235b464c88";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "2b908fcfff16e3cfcaa3fa17143ad085dce189e66d774817c2916b9f20539fb7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "b918ecf90a4b2052e664cc9e86c722ad2ac0031f72dff5297d8112e715bee519";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "7046c35a3449518620c58b9e1472c4844af87cefb1defcdbf2a4ba017851dae3";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "9fe282f3c16f683006cf35af4b1c8fca2343d7fdcf468864674147c4a0a2105e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-cmake-uncrustify, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "6.0.1-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/6.0.1-1.tar.gz";
-    name = "6.0.1-1.tar.gz";
-    sha256 = "24e16c7cf59c05fe075c829800689d998c25ed90346b81e8200a5c91bce8fae0";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "23f6a245d1d68d37c76feca27e880408ab6b08d395aad0e456f0aecb9f5c956e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-cpplint ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pytest ament-cmake-uncrustify rclcpp-lifecycle sensor-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common rclcpp-lifecycle sensor-msgs ];
   propagatedBuildInputs = [ builtin-interfaces rclcpp rclpy rcutils std-msgs ];
   nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
 

--- a/distros/rolling/mimick-vendor/default.nix
+++ b/distros/rolling/mimick-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-mimick-vendor";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/rolling/mimick_vendor/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "685b1735c87b823fb312cdcc5cc5614de10e8bb261ab66ff22c85fe7364044e5";
+    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/rolling/mimick_vendor/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "59a3a55fd153527d2518f4056c90eaa01f4905d6bdf911817e35a06453bb745a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a3de10e13830e60f6afd086c181ec1ee5a770a6ff7004680786c6229737095e8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f77e74f9dedcdae9a43e646eb3b2c3665a0f5b0bf744f904f5fd298bac6831e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c66e02541f9e32a4b73130bf457753b82c941af11c3adcddc8e68a2fdf88cd4a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "262c15618653da373895c1ddc36a8cd628ea300cfcca240707d9f056ef5b7641";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a8684e9b6d0d587d708c3c108e59e0cd1bbe6bff4fba0a7f7b7fc69018444c42";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8750163ecd05a8ee1fe99b166d568db6697230b68dcf4308d2f24ce7f1f15ee3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e5558586ccb56b6109114c8f33a9852ddb1eb12acb8805cc91a956b842467802";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "fb240d08a2fec9347430c90d949c00c96ba759201810d3f67d5b3c3192fbb4ad";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "84a36418eccfaee12c4d7b78bba2001a66153388417c785794e0d87680911815";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ce25261158946f3938045d8f34d41399224a0142a6d199e434fc34fa25e19ea6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "cc68cba9a99d9839df77ed799a14f6894744517bbd34fbc74ee570f42f902b01";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "197ac83ea6941102cda664129e1af4eaee66133e246331e92020464f40cbad26";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "99be4e3f146ce01468bda92a78d2b3bae4095c683cb5e949ae9393d74bbb32bd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "51538d21df980820772071b7cf13cf4087fbd0b919931046419d2fa5fbdb7bef";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5356531017796569b0333b291e558badeb073866f7dceb462df0dfde07fc9696";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "cfa3ccf0f3b895b2693e398f90d26e334a9decf4af9cd461c6dff3daae88de9a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6f94985acc9a81dbfd9e796a2977c88b2a4d4b8342160ec6c4cc7d1bc2bd1a28";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "160930f5ab60a56e359635ec58489a2470101fad49b84182f740afa51a9c59a9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "47bd62056f296ced735de45902c112040d6c232456fdf9c41284e0a89167c8fd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6166857abcb85a215a51a4ccbac44ffffe01f57e55099c973762299da849aad5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7c4ac6adb595969caa0af5fd5e46a3296d0ce5af9699bfab63676a76f3c7a9ed";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9f581040e677f3331412ca0b37ff32a62e3caeb81d8251c8ba579aa2ffee1ba7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "cf12e704ffca2af2d449d4d6488f2dc0d4a05c7700b2e6873b7d4bdb41d7ad6f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b08a82761d84e41ccb32b06961dc97ae0bfe100989ffa6b305fc93b73cc3d25a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "f5a1fca1884e9b03d879f1df4c608639d2331023f15d2d41c43a0a6b2763032f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d96bef7d06b3b3666f77531943d83f3ac0e6c2d7f1f3a8d73c3938ecae7e009a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-mola-msgs";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a0d55e71cc168d211ddae88e511b7b77143e4914d5f3e748733efead19efca1e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs mrpt-msgs nav-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS message, services, and actions used in other MOLA packages.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-navstate-fg/default.nix
+++ b/distros/rolling/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fg";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fg/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a633c36baeb65be538cadaa2c21682423db63920fab704ff9e4479bfa799707e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fg/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e032ba6898e40bd9b0eb43fa4031806f3c407bdf6cac668189f899b6a0a9ece1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-navstate-fuse/default.nix
+++ b/distros/rolling/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fuse";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "72508308314e4cfc99afaa491fab98b6f2b28cc52a841a36f5baa98b74e180a2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "408a25d1f1eb28adea64a2df858fdee70bd60ef1555a1b9657534c16e31ab2b3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "041f276195d952fd548c7c322c84f3a9ff47781b363a119677009c8eb754b3b0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "87d78b085e7d095a349264128d471da441bb27756aa0570c03b7adebcdb07ae8";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "fed622e405509c67b193f80bab3237fa07fe2bdbc10deced729e93c8cdd82d44";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d2f2fd7178f256579af5ad210710f279e8533aa112c435a50e45af6b398b7761";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-test-datasets/default.nix
+++ b/distros/rolling/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-test-datasets";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/rolling/mola_test_datasets/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "89e46150b263db03d62c7a28a24be96d7d85d841765eded7eed2e4f79a6be13f";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/rolling/mola_test_datasets/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "2e2044b83233520878a5193dfe086f367764f2a09633ed308a02d5845236c043";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c86c56a639802b04148127eadb12750c27156517b68fd96223805232803a312a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9e2995466409d7f8652a877b3e7ef81ef6bf98e191878ed45c27f0b9d028b409";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e6e0b1bddb7cf8e3787c8ed25ac24cb6d826845a886b181eb714921f7c1cdf3a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "9d0bcb9d96a7ea2453bed80a39d0d4a038938b7354f80203af96d90e8953ff3e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "cdaaba42526da82183a2cce670cf9c08bba91991559618367f09dd4ab40f849a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "84a100748097b47830245b859129d7325c995910d5726459940c3ed9bed9e62b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "de25f3a78b2bd066638a00f5ae6ce12ca5cf1b61cd603216b2a38cd1e095d223";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b5ec7e91a72c58af33f3851a3e3faa387cfa601f0ce8a375c73d19d37c1c978c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "bb21c5b98b7dc2ca0051c9c6a0e6e28981d582e55cd1b240ba232f9e5b547078";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "a3bca05173f8aed298bc99cb3a7ddfdf706bf69dc2f0993bf0fc1ba28bc7eda7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "1ffbfc7b6f45b66dda0388a3baf5ec5686142564ff42d657703dcc2e65c84f84";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "4af8d51ac6076d820493ffda1fa215f8b5a4673717ee55044c977b9f44c07ff3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "6450bb906ef532d9ec33e182d540bce7dfe33a5c74814beb50a0de1b34ee1605";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "374c14d44a69ef1c617277deb659499681ccdd818451766977e932a1a8dcc1af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "fdf7148e2e8ecdef1a636fbffae6f851d35dabb52b84ef948f12f1b117010abb";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "1a7b3ca7e68ff721280f407bf79dd9d8328f30301e4e3baf0b36c26b52783160";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "9.4.0-r1";
+  version = "9.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/9.4.0-1.tar.gz";
-    name = "9.4.0-1.tar.gz";
-    sha256 = "24035ec9cd30f8ab69caa5a67514e86be59f3c11c96cfc0fd0771d25f144543d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/9.4.1-1.tar.gz";
+    name = "9.4.1-1.tar.gz";
+    sha256 = "2f9d7dbacd281795bc40fc72ba6649038b6e3cc5e5c6921f867bfbad8b546ad4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "9.4.0-r1";
+  version = "9.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/9.4.0-1.tar.gz";
-    name = "9.4.0-1.tar.gz";
-    sha256 = "737feb5440dcbc8ae02609ab3d32266bae95ee7a6f7610cc5ba9ba6634ad8ba8";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/9.4.1-1.tar.gz";
+    name = "9.4.1-1.tar.gz";
+    sha256 = "7e6d2073f8dbb4169dd8c36221cf3011792e2f4bfe31dde2534a2ec845730db3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-interface/default.nix
+++ b/distros/rolling/rcl-logging-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-interface";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_interface/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "fbbcb791d1f4b43f7f1d4430f0add02ca299b6301473f2458c7ead43768cf60c";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_interface/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "110ae5cae59ac524d13bed3256d605e159320122493201a5ea313174f43b4b28";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-noop/default.nix
+++ b/distros/rolling/rcl-logging-noop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, python3Packages, rcl-logging-interface, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-noop";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_noop/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "3b855e29add5721dad20889a14087ce33af3ff5712bac44dcdc7941acc62d404";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_noop/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "9d19c94c210592c7a68b05130f6347e152eb5a33a7bbc9ac4851cd07146d8d54";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-logging-spdlog/default.nix
+++ b/distros/rolling/rcl-logging-spdlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcl-logging-interface, rcpputils, rcutils, spdlog, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rcl-logging-spdlog";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_spdlog/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c97654c1e85311a8c8edb44863e591963dbd0b6f5ae0ce6f35081987aa7f8dfa";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/rolling/rcl_logging_spdlog/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "aaf6334f244ba4ff38eda28459512b1c544098b6e956a7090e09de465508b476";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "9.4.0-r1";
+  version = "9.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/9.4.0-1.tar.gz";
-    name = "9.4.0-1.tar.gz";
-    sha256 = "e1e7289282fde1cc15d3574c61d50e796c02e2c2ffd833ad16dc76fc12fdc0f7";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/9.4.1-1.tar.gz";
+    name = "9.4.1-1.tar.gz";
+    sha256 = "961bac4e2b47c65e567017f64fa00ce9eba023298524ad46ff83dd12cad5a37a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "9.4.0-r1";
+  version = "9.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/9.4.0-1.tar.gz";
-    name = "9.4.0-1.tar.gz";
-    sha256 = "8b6b2b07f198135a16775b8b2ee87a68f0e61134721213f02e477bb30dcedd05";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/9.4.1-1.tar.gz";
+    name = "9.4.1-1.tar.gz";
+    sha256 = "99cfbcef9106d2e0dfb4c0db71464bc9f6e0b6c6d6d6c8af093d7416e54c7975";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "28.3.2-r1";
+  version = "28.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/28.3.2-1.tar.gz";
-    name = "28.3.2-1.tar.gz";
-    sha256 = "713e1561a0830f918934b0e01070a1393f0d70c64ef4787ab4b0737a752aeb31";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/28.3.3-1.tar.gz";
+    name = "28.3.3-1.tar.gz";
+    sha256 = "65a575e8e4abfdf6cb283729e58d63bf544eceebb252bc961073d600701c5f46";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "28.3.2-r1";
+  version = "28.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/28.3.2-1.tar.gz";
-    name = "28.3.2-1.tar.gz";
-    sha256 = "f0b7eacae8d89ca6b516b4d05cbc28c198e14066f54d5f1bc41fec13a71dd6df";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/28.3.3-1.tar.gz";
+    name = "28.3.3-1.tar.gz";
+    sha256 = "af6b0fdf2fbc53b575970ab949501cb0eb3a4ad85059b38dd7851e73e806f769";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "28.3.2-r1";
+  version = "28.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/28.3.2-1.tar.gz";
-    name = "28.3.2-1.tar.gz";
-    sha256 = "4fb4e07791d69aa8f4d86f22e363809b77498c3b1d5401fcebee131ca7c3f4d1";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/28.3.3-1.tar.gz";
+    name = "28.3.3-1.tar.gz";
+    sha256 = "b42e39b925e7ed154022279f0d4c59a6e74f5cd628a1ae1ddbaf888b8ae42540";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "28.3.2-r1";
+  version = "28.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/28.3.2-1.tar.gz";
-    name = "28.3.2-1.tar.gz";
-    sha256 = "271299f106e2610283e4b8e0a8f211f4bf611f0667744588690431482d9ed3b8";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/28.3.3-1.tar.gz";
+    name = "28.3.3-1.tar.gz";
+    sha256 = "75b891211b38ee109059b4512d4f7e3d2c79762b1c4445f7e88c494e09ef3630";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, python3Packages, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "7.4.0-r1";
+  version = "7.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/7.4.0-1.tar.gz";
-    name = "7.4.0-1.tar.gz";
-    sha256 = "0bb9f6811f545dbae3c50f44bd36cebbf0d0518dc2603c8818820331b3e764b6";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/7.5.0-1.tar.gz";
+    name = "7.5.0-1.tar.gz";
+    sha256 = "2224103a8252b3e85ec0d69100e22e2e740d299e0b536f722635ee0fd1c71daf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.13.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "219c78858144ab9f2c77374e634400bea6db34fd7c78f2719d32668670b98d3b";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "675cd4fb28d2c83531edcac9d22256109268fd9ee3b54fab699ce70022dc0518";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.9.0-r1";
+  version = "6.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.9.0-1.tar.gz";
-    name = "6.9.0-1.tar.gz";
-    sha256 = "739f978cf16a3d69151cc1e6b9f3c835ba3713b3859c6320c2b60ccef5868aac";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.9.1-1.tar.gz";
+    name = "6.9.1-1.tar.gz";
+    sha256 = "6421a623f7c693f004bb853849da53176c2b08fb8d16ec309a2ca44c95e38bfe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.24.0-r1";
+  version = "0.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.24.0-1.tar.gz";
-    name = "0.24.0-1.tar.gz";
-    sha256 = "b3856adf25f476cebbe7128f4c443ce4444215fc29a2d94ae117eac5242e546c";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.24.1-1.tar.gz";
+    name = "0.24.1-1.tar.gz";
+    sha256 = "d96b38de6861456278a211fc03db91454a5e0adf1eefa59d4f38ef2a69b3179f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.24.0-r1";
+  version = "0.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.24.0-1.tar.gz";
-    name = "0.24.0-1.tar.gz";
-    sha256 = "442e69cddf8af5f8b4471bb160da9eb958efc40e765d63d5b7c5a41d225b1894";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.24.1-1.tar.gz";
+    name = "0.24.1-1.tar.gz";
+    sha256 = "26f64b4eefdc04b6dd9e32a56fc3df2c0443b6b0e1f2559f61cbaf8db7081844";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "e818bcbbdd642f78d2cb3c3f1a8065b3933887e8bb7ab6fb23d70fb11129f240";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ae1288b9088b86c0edf80de97d8091424c58820d644ce0d384d61907b07881ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.0.0-r1";
+  version = "9.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.0.0-1.tar.gz";
-    name = "9.0.0-1.tar.gz";
-    sha256 = "360077453e8497f427bdb04d1f722ee8a165dd77257deb79c3183418f58b7ead";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.0.1-1.tar.gz";
+    name = "9.0.1-1.tar.gz";
+    sha256 = "4b8978487fcc740c65d6c3236de36b36a32ec311a2579409aec75b6bdfef44bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.0.0-r1";
+  version = "9.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.0.0-1.tar.gz";
-    name = "9.0.0-1.tar.gz";
-    sha256 = "5a6160cd73c51f55391bf84f7faea2a7f37a79875d845f44ec58ee0e0fe01781";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.0.1-1.tar.gz";
+    name = "9.0.1-1.tar.gz";
+    sha256 = "704f145d4b841759345a4c88baed4a77af12784eda8cf7da16b5793d7eb4fd88";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp test-msgs ];
-  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ ament-cmake fastcdr fastrtps fastrtps-cmake-module rcpputils rcutils rmw rmw-dds-common rmw-fastrtps-shared-cpp rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros fastrtps-cmake-module ];
 
   meta = {

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.0.0-r1";
+  version = "9.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.0.0-1.tar.gz";
-    name = "9.0.0-1.tar.gz";
-    sha256 = "81610cbcc90a5c4dc1b6c5cffe17e325f568db2d6b97a1abac356ef0ea4f353a";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.0.1-1.tar.gz";
+    name = "9.0.1-1.tar.gz";
+    sha256 = "f6b44f8be3736d9abe7edeee90a6eeb432a969e62c96a6bf38db9a1d136b2eb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation-cmake/default.nix
+++ b/distros/rolling/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation-cmake";
-  version = "7.4.2-r1";
+  version = "7.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.4.2-1.tar.gz";
-    name = "7.4.2-1.tar.gz";
-    sha256 = "63a041da7685911dc56a0b60845bd08f3918a29dc36af8fed9e7c5c119cbb803";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.4.3-1.tar.gz";
+    name = "7.4.3-1.tar.gz";
+    sha256 = "f08762700f6004b7ba7e20e2857bab74f20a6fb7a17473067c35719d197881cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation/default.nix
+++ b/distros/rolling/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d9c1dc62b34c62a2ecc478b8d6a343328a4ba81e9432467d89b019e18c0438b3";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "3edc33cc5b55ae7f35c7ac08ed95a0ac521abdf5cdd2068b768d77f3449602ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw/default.nix
+++ b/distros/rolling/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rmw";
-  version = "7.4.2-r1";
+  version = "7.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.4.2-1.tar.gz";
-    name = "7.4.2-1.tar.gz";
-    sha256 = "881ce1fcf33170d4d6439c375bd54b9da90004a4ba8e4058395c09704c710f17";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.4.3-1.tar.gz";
+    name = "7.4.3-1.tar.gz";
+    sha256 = "08bbd60053bd0fd2365f553d164ec2b6ec1dba0acf6be130c63ef28ff3bbead1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "a011720ac70eaa216400836526574733dec6d609f4f4f37d30fe8cb257fc144b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "6967d134ebe29446b6f6d1327282af3bdfc545d00ef270c9919a151acc5efb86";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "dc10e8707ff057fd5539ad3a29393dc2426c488292e6085d0efdd7837214b637";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "943240decb0c1aae1e88fc6794076f170442ea91029d416b301386491f3f9ad6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "a2b03cc73e6845f9c1fdea03580a79a72306b593c12743e39e29714a04285252";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "01dc7d7041cb948f582e848c9ce325b94deac5186dd30de673c9dd9b77397029";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "7051a9f1de5b76073f1857b5048037343896e3263c776850670929a26badd1ec";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "46d9a17f13a32163ee754649414a18f58568ae082778480a30ae1d50385fb9b3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "da6221619adbfaf2cb33741c740b42a465c5687ff41f7a708141a1874272bab8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "c47b325fd86a6fabe65fc44d44c6d785bab737ab8e409e684f980be85dd7719b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "cb65b924202112e949242aa26a751224da13ae3a13c972e3ab34a99c7c01dc9e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "cbc7dbaa8d2f42e5f5210f512872cde35e257993991f047d961485b808e1692a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2launch/default.nix
+++ b/distros/rolling/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2launch";
-  version = "0.27.1-r1";
+  version = "0.27.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.27.1-1.tar.gz";
-    name = "0.27.1-1.tar.gz";
-    sha256 = "ec05848793e1c219f9490fdc09bba9e9c17c36aa813fe6019e0f75695135b13f";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.27.2-1.tar.gz";
+    name = "0.27.2-1.tar.gz";
+    sha256 = "73bffc902711babace578ec02ba7fec81978d29ec899dbb3033508a85ab18111";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "237809ea9e090dbfc84f05b45f9c74e6aecb6bd0327638fc7b56152a5391c80f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "1f85f0c96d9a068c7716967f60c12c3696ce372cd882072479c95b6fe2b88215";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "9c1841848608eba7565df06daae2d0b0f04bec5a357d2821514df86a6fec5378";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "db0e9a2b75f20bfb7ac9b5056e34e6169fa7c4662be093cd78043394d5bd2f5d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "c2881bb6571d62b7849344587e896b30fd2111d36897299179e1c6737dfcdbdb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "40d412ee1346e203fc910e3f1b21aaab70d90d463d4b2b9a00eb6c3cb2cfbc08";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "a8aba120adab2ac6d25c9787bd54319eb347af4c8eb94bebf4e9de150106029d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "cbed35000aab9ff2e4fce9a7ec46787fbacdb25422ac4cf1780e7d995576bcb8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "1b399d20ec659fb54d333021da20e52ea8abfe521f006c278acb915efd0b681f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "ccc0e179e99743df717a7a24c5ded3f803a2f31c50c4610005fb2e5e15a22d61";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "d209c84af9edfcc70bf3d72eff42165813a0afdbfc8a0af739d44784ab926334";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "50b2045f5b7ae3511f214ec4e3dc227341417d3a4a5041128aceda6412622fb6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "0b5db0ae01b026ccab82db16d9044be043e06d58e995255e17644b555060b4ac";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "a9766f280cb7408df604a3f902dee9927391e3e65f8248b6eecf27791d627cd7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "bb41379e85b6993713905f5a966095eda0d4d24360f36faaf5cc4480870c50a6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "956a36e12d153507b935e2f061f60e666b61eff460c34e100d7f518255f3d66c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.34.0-r1";
+  version = "0.34.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.34.0-1.tar.gz";
-    name = "0.34.0-1.tar.gz";
-    sha256 = "94e62ff7cf90602197c41f754bf57bb9c9db35f2509cad62db4204d69529a268";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.34.1-1.tar.gz";
+    name = "0.34.1-1.tar.gz";
+    sha256 = "f5aabc03c9211810cf70a8696c44ff793571c830fd0e0cecb5e90b2ef399cb62";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosx-introspection/default.nix
+++ b/distros/rolling/rosx-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fastcdr, geometry-msgs, rapidjson, rclcpp, rosbag2-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosx-introspection";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/rolling/rosx_introspection/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "4aca59106ea3bcafacb18a12feaa8454657419448e0ec84525640f876c918b03";
+    url = "https://github.com/ros2-gbp/rosx_introspection-release/archive/release/rolling/rosx_introspection/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "96e8c78e70d835097c862872c3a1f90718386d9b2807e69d903465ffb8504496";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.24.0-r1";
+  version = "0.24.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.24.0-1.tar.gz";
-    name = "0.24.0-1.tar.gz";
-    sha256 = "b291221394983d93d7f14d28a973981dbb896420050cf875ddb2c83884f77b17";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.24.1-1.tar.gz";
+    name = "0.24.1-1.tar.gz";
+    sha256 = "0232678fc1d4d186803800070446d663aaae0fcc97dd5f4a57bc84ab28f75c36";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rttest/default.nix
+++ b/distros/rolling/rttest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rttest";
-  version = "0.18.0-r1";
+  version = "0.18.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.18.0-1.tar.gz";
-    name = "0.18.0-1.tar.gz";
-    sha256 = "f885507615a36df8a16ee8bbb5cbd919ec2ecd53444aa0e1fc3ab50145836a7d";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.18.1-1.tar.gz";
+    name = "0.18.1-1.tar.gz";
+    sha256 = "705d03b192b3f1d7de736324c84b07a61af0c86b1658a5a33be8c87019a9ddb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "6e514c591cc4c75df31332ecbe44a9b7156fb6d9f24664b6357c46abd87a0503";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "e2d3e1ced17f72476e8ca03d91123ed163ddba3d45d647a5f3e5eb0131d3c2dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "04416e3e2c476a5d8a2c4eb17c1920557af35a558cfa5dfe0b02c2323924cf6e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "9d42e69fc6199970f6840973e1a02e48b14ab1741cb1545a64418849daa5dc22";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-gmock ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs message-filters pluginlib qt5.qtbase qt5.qtsvg rclcpp resource-retriever rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs tf2 tf2-ros tinyxml2-vendor urdf yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "cf178db0721557a2b9ea6ca9e45ec6650a19a27e2f31810c5383138d98fc420e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "2a49da5dc5c3e6c7935424ee52fbfc0d447a981249d2ff1f02345b776421882a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "4ea3d112cd7a268254bf07a222587bcca98fb546aa21daf9cf0439812b38f01b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "8f23a0e0da36f835f2202778c687523dc4166673254b6804d4bf5dd1f1c805e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "32d102e6f11ceda4eca0e14a5e9a43c6b5aed0947e5ef1a6d5905c9da025ec6e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "91fd055641125332ab545d859738a04d1d1f534ede644e00d48aa743bd6add55";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "22f05c5278444c9f16839142300fbd96d6954b93baba1c3085726b1c8227e0f8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "2d07204e69626452a805993588eb66f57761fa40d1b265a43946f249dea6056b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "ad1a853ac45dbab45e0fa5d759cbb13acdb3b38b0856cca815fa231de9b592b8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "441693f7942c7fef6824c6815b990c1c65d3d3ad680b070e447d52a7193eb309";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.2.4-r1";
+  version = "14.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.2.4-1.tar.gz";
-    name = "14.2.4-1.tar.gz";
-    sha256 = "a4c86ee4b133481ae9ce3277cf1f44675e2c4bae35080b02052bb76ef1f0f116";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.2.5-1.tar.gz";
+    name = "14.2.5-1.tar.gz";
+    sha256 = "5ebf7e5fddfa554b0bf727284b3f0527bf1378f9dcd10b90f8163373be7636fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/self-test/default.nix
+++ b/distros/rolling/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-self-test";
-  version = "4.3.0-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/self_test/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "0bc0ece37fa2544b6f63b01e5b9566145692844f4e51f6c3c95f1d056cbfb08a";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/rolling/self_test/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "f88966462df84b595fdf62347db18405c97e47aa518a130fcd46ef5624e097ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sros2-cmake/default.nix
+++ b/distros/rolling/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-rolling-sros2-cmake";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2_cmake/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "80487939cb87d16d59bf4fd2ac0199b4b1790f1790ac89aec7e6921046bc69fe";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2_cmake/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "cb2f1aeb6c90a93324fb9850d5e2519e3d1723c27fb32449be8f87ac6b363d46";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sros2/default.nix
+++ b/distros/rolling/sros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sros2";
-  version = "0.15.0-r1";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2/0.15.0-1.tar.gz";
-    name = "0.15.0-1.tar.gz";
-    sha256 = "6d9fbe2381cea09347b67acb2a87e200bcbf299011fc4c4281709077cd5360cb";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/rolling/sros2/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "048bf78d9dd5ff8149f831521029aa1d778d4f5cbea6d53479d2831abcf7510a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/theora-image-transport/default.nix
+++ b/distros/rolling/theora-image-transport/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-theora-image-transport";
-  version = "4.0.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "0c68d6fd03c435c00a4c6685ed7fda88c78824be3bb53d4e76d08aed800c6fb0";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "8c06b4e354e0a221db58a6450d18248f505f4b5cc0e0f64d1e31b112e9392622";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
-  checkInputs = [ ament-lint-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ cv-bridge image-transport libogg libtheora opencv opencv.cxxdev pluginlib rclcpp rcutils rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake pkg-config rosidl-default-generators ];
 

--- a/distros/rolling/tlsf-cpp/default.nix
+++ b/distros/rolling/tlsf-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rmw, rmw-implementation-cmake, std-msgs, tlsf }:
 buildRosPackage {
   pname = "ros-rolling-tlsf-cpp";
-  version = "0.18.0-r1";
+  version = "0.18.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.18.0-1.tar.gz";
-    name = "0.18.0-1.tar.gz";
-    sha256 = "ec47a198de0d97114870135b440ca33a76edd35e5c3d37b96f02eaaab018036d";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.18.1-1.tar.gz";
+    name = "0.18.1-1.tar.gz";
+    sha256 = "256d9067620942128cc32f2abf72dec9b131033a597f80161793bccdca589147";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "8da82c2c60be52c926dd1ad4071c015e856431237e9fb2575a44d8a54f5892c5";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "cc9470161f73dbe25cc45e0fe2eb020c01fe6ab965c509fb8d59460fac6e83d2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.34.1-r1";
+  version = "0.34.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.34.1-1.tar.gz";
-    name = "0.34.1-1.tar.gz";
-    sha256 = "f082dd61a20f5e39b6e7150b1a3bd813b316937a9b4f1141053a6fe2c23b046b";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.34.2-1.tar.gz";
+    name = "0.34.2-1.tar.gz";
+    sha256 = "367c132a37e9320bdc3ec56b274a4d0f81f43386c6d26bee72e655567afa96e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-image-transport/default.nix
+++ b/distros/rolling/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zstd-image-transport";
-  version = "4.0.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/zstd_image_transport/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "436db42d2bf0e68b527a0532f72f08e30e5835e1c085c800bfb044169b636f46";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/zstd_image_transport/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "7f86c4813d7b64d250814c90f9274e38c5e2c20bd1a837ae456c8cfd4bd606b9";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 400bfc88fb33b03c707d6dd2a3c6564fb10cf116.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *action-tutorials-cpp 0.20.4-r1 --> 0.20.5-r1*
* *action-tutorials-interfaces 0.20.4-r1 --> 0.20.5-r1*
* *action-tutorials-py 0.20.4-r1 --> 0.20.5-r1*
* *ament-black 0.2.4-r1 --> 0.2.5-r1*
* *ament-cmake 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-auto 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-black 0.2.4-r1 --> 0.2.5-r1*
* *ament-cmake-core 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-definitions 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-dependencies 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-include-directories 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-interfaces 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-libraries 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-link-flags 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-export-targets 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-gen-version-h 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-gmock 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-google-benchmark 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-gtest 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-include-directories 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-libraries 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-nose 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-pytest 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-python 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-target-dependencies 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-test 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-vendor-package 1.3.9-r1 --> 1.3.10-r1*
* *ament-cmake-version 1.3.9-r1 --> 1.3.10-r1*
* *clearpath-socketcan-interface 1.0.0-r1*
* *composition 0.20.4-r1 --> 0.20.5-r1*
* *demo-nodes-cpp 0.20.4-r1 --> 0.20.5-r1*
* *demo-nodes-cpp-native 0.20.4-r1 --> 0.20.5-r1*
* *demo-nodes-py 0.20.4-r1 --> 0.20.5-r1*
* *dummy-map-server 0.20.4-r1 --> 0.20.5-r1*
* *dummy-robot-bringup 0.20.4-r1 --> 0.20.5-r1*
* *dummy-sensors 0.20.4-r1 --> 0.20.5-r1*
* *examples-rclcpp-async-client 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-cbg-executor 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-action-client 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-action-server 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-client 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-composition 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-publisher 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-service 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-subscriber 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-minimal-timer 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-multithreaded-executor 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclcpp-wait-set 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-executors 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-guard-conditions 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-minimal-action-client 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-minimal-action-server 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-minimal-client 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-minimal-publisher 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-minimal-service 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-minimal-subscriber 0.15.1-r1 --> 0.15.2-r1*
* *examples-rclpy-pointcloud-publisher 0.15.1-r1 --> 0.15.2-r1*
* *foxglove-bridge 0.7.9-r1 --> 0.8.0-r1*
* *gmock-vendor 1.10.9004-r4 --> 1.10.9006-r1*
* *gtest-vendor 1.10.9004-r4 --> 1.10.9006-r1*
* *hpp-fcl 2.4.4-r1 --> 2.4.5-r1*
* *image-tools 0.20.4-r1 --> 0.20.5-r1*
* *intra-process-demo 0.20.4-r1 --> 0.20.5-r1*
* *kitti-metrics-eval 1.0.7-r1 --> 1.0.8-r1*
* *launch-testing-examples 0.15.1-r1 --> 0.15.2-r1*
* *libstatistics-collector 1.3.1-r1 --> 1.3.2-r1*
* *lifecycle 0.20.4-r1 --> 0.20.5-r1*
* *lifecycle-py 0.20.4-r1 --> 0.20.5-r1*
* *logging-demo 0.20.4-r1 --> 0.20.5-r1*
* *mcap-vendor 0.15.11-r1 --> 0.15.12-r1*
* *mola 1.0.7-r1 --> 1.0.8-r1*
* *mola-bridge-ros2 1.0.7-r1 --> 1.0.8-r1*
* *mola-demos 1.0.7-r1 --> 1.0.8-r1*
* *mola-imu-preintegration 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-euroc-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti360-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-mulran-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-paris-luco-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rawlog 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rosbag2 1.0.7-r1 --> 1.0.8-r1*
* *mola-kernel 1.0.7-r1 --> 1.0.8-r1*
* *mola-launcher 1.0.7-r1 --> 1.0.8-r1*
* *mola-metric-maps 1.0.7-r1 --> 1.0.8-r1*
* *mola-msgs 1.0.8-r1*
* *mola-navstate-fg 1.0.7-r1 --> 1.0.8-r1*
* *mola-navstate-fuse 1.0.7-r1 --> 1.0.8-r1*
* *mola-pose-list 1.0.7-r1 --> 1.0.8-r1*
* *mola-relocalization 1.0.7-r1 --> 1.0.8-r1*
* *mola-test-datasets 0.3.3-r1 --> 0.3.4-r1*
* *mola-traj-tools 1.0.7-r1 --> 1.0.8-r1*
* *mola-viz 1.0.7-r1 --> 1.0.8-r1*
* *mola-yaml 1.0.7-r1 --> 1.0.8-r1*
* *pendulum-control 0.20.4-r1 --> 0.20.5-r1*
* *pendulum-msgs 0.20.4-r1 --> 0.20.5-r1*
* *puma-motor-driver 1.0.0-r1*
* *puma-motor-msgs 1.0.0-r1*
* *quality-of-service-demo-cpp 0.20.4-r1 --> 0.20.5-r1*
* *quality-of-service-demo-py 0.20.4-r1 --> 0.20.5-r1*
* *rcl 5.3.8-r1 --> 5.3.9-r1*
* *rcl-action 5.3.8-r1 --> 5.3.9-r1*
* *rcl-lifecycle 5.3.8-r1 --> 5.3.9-r1*
* *rcl-yaml-param-parser 5.3.8-r1 --> 5.3.9-r1*
* *rclcpp 16.0.9-r1 --> 16.0.10-r1*
* *rclcpp-action 16.0.9-r1 --> 16.0.10-r1*
* *rclcpp-components 16.0.9-r1 --> 16.0.10-r1*
* *rclcpp-lifecycle 16.0.9-r1 --> 16.0.10-r1*
* *rclpy 3.3.13-r1 --> 3.3.14-r1*
* *rmw-fastrtps-cpp 6.2.6-r1 --> 6.2.7-r1*
* *rmw-fastrtps-dynamic-cpp 6.2.6-r1 --> 6.2.7-r1*
* *rmw-fastrtps-shared-cpp 6.2.6-r1 --> 6.2.7-r1*
* *rmw-implementation 2.8.3-r1 --> 2.8.4-r1*
* *ros-gz 0.244.16-r1 --> 0.244.15-r1*
* *ros-gz-interfaces 0.244.16-r1 --> 0.244.15-r1*
* *ros-ign 0.244.16-r1 --> 0.244.15-r1*
* *ros-ign-bridge 0.244.16-r1 --> 0.244.15-r1*
* *ros-ign-gazebo 0.244.16-r1 --> 0.244.15-r1*
* *ros-ign-gazebo-demos 0.244.16-r1 --> 0.244.15-r1*
* *ros-ign-image 0.244.16-r1 --> 0.244.15-r1*
* *ros-ign-interfaces 0.244.16-r1 --> 0.244.15-r1*
* *ros2action 0.18.10-r1 --> 0.18.11-r1*
* *ros2bag 0.15.11-r1 --> 0.15.12-r1*
* *ros2cli 0.18.10-r1 --> 0.18.11-r1*
* *ros2cli-test-interfaces 0.18.10-r1 --> 0.18.11-r1*
* *ros2component 0.18.10-r1 --> 0.18.11-r1*
* *ros2doctor 0.18.10-r1 --> 0.18.11-r1*
* *ros2interface 0.18.10-r1 --> 0.18.11-r1*
* *ros2lifecycle 0.18.10-r1 --> 0.18.11-r1*
* *ros2lifecycle-test-fixtures 0.18.10-r1 --> 0.18.11-r1*
* *ros2multicast 0.18.10-r1 --> 0.18.11-r1*
* *ros2node 0.18.10-r1 --> 0.18.11-r1*
* *ros2param 0.18.10-r1 --> 0.18.11-r1*
* *ros2pkg 0.18.10-r1 --> 0.18.11-r1*
* *ros2run 0.18.10-r1 --> 0.18.11-r1*
* *ros2service 0.18.10-r1 --> 0.18.11-r1*
* *ros2topic 0.18.10-r1 --> 0.18.11-r1*
* *rosbag2 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-compression 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-compression-zstd 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-cpp 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-interfaces 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-performance-benchmarking 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-py 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-storage 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-storage-default-plugins 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-storage-mcap 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-storage-mcap-testdata 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-test-common 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-tests 0.15.11-r1 --> 0.15.12-r1*
* *rosbag2-transport 0.15.11-r1 --> 0.15.12-r1*
* *rosx-introspection 1.0.1-r1 --> 1.0.2-r2*
* *rviz-assimp-vendor 11.2.12-r1 --> 11.2.13-r1*
* *rviz-common 11.2.12-r1 --> 11.2.13-r1*
* *rviz-default-plugins 11.2.12-r1 --> 11.2.13-r1*
* *rviz-ogre-vendor 11.2.12-r1 --> 11.2.13-r1*
* *rviz-rendering 11.2.12-r1 --> 11.2.13-r1*
* *rviz-rendering-tests 11.2.12-r1 --> 11.2.13-r1*
* *rviz-visual-testing-framework 11.2.12-r1 --> 11.2.13-r1*
* *rviz2 11.2.12-r1 --> 11.2.13-r1*
* *shared-queues-vendor 0.15.11-r1 --> 0.15.12-r1*
* *sqlite3-vendor 0.15.11-r1 --> 0.15.12-r1*
* *test-ros-gz-bridge 0.244.16-r1 --> 0.244.15-r1*
* *topic-monitor 0.20.4-r1 --> 0.20.5-r1*
* *topic-statistics-demo 0.20.4-r1 --> 0.20.5-r1*
* *ur 2.2.14-r1 --> 2.2.15-r1*
* *ur-bringup 2.2.14-r1 --> 2.2.15-r1*
* *ur-calibration 2.2.14-r1 --> 2.2.15-r1*
* *ur-controllers 2.2.14-r1 --> 2.2.15-r1*
* *ur-dashboard-msgs 2.2.14-r1 --> 2.2.15-r1*
* *ur-moveit-config 2.2.14-r1 --> 2.2.15-r1*
* *ur-robot-driver 2.2.14-r1 --> 2.2.15-r1*
* *zstd-vendor 0.15.11-r1 --> 0.15.12-r1*

Iron Changes:
-------------
* *ament-black 0.2.4-r1 --> 0.2.5-r1*
* *ament-cmake-black 0.2.4-r1 --> 0.2.5-r1*
* *foxglove-bridge 0.7.9-r1 --> 0.8.0-r1*
* *hpp-fcl 2.4.4-r1 --> 2.4.5-r1*
* *kitti-metrics-eval 1.0.7-r1 --> 1.0.8-r1*
* *message-filters 4.7.0-r3 --> 4.7.1-r1*
* *mola 1.0.7-r1 --> 1.0.8-r1*
* *mola-bridge-ros2 1.0.7-r1 --> 1.0.8-r1*
* *mola-demos 1.0.7-r1 --> 1.0.8-r1*
* *mola-imu-preintegration 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-euroc-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti360-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-mulran-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-paris-luco-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rawlog 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rosbag2 1.0.7-r1 --> 1.0.8-r1*
* *mola-kernel 1.0.7-r1 --> 1.0.8-r1*
* *mola-launcher 1.0.7-r1 --> 1.0.8-r1*
* *mola-metric-maps 1.0.7-r1 --> 1.0.8-r1*
* *mola-msgs 1.0.8-r1*
* *mola-navstate-fg 1.0.7-r1 --> 1.0.8-r1*
* *mola-navstate-fuse 1.0.7-r1 --> 1.0.8-r1*
* *mola-pose-list 1.0.7-r1 --> 1.0.8-r1*
* *mola-relocalization 1.0.7-r1 --> 1.0.8-r1*
* *mola-test-datasets 0.3.3-r1 --> 0.3.4-r1*
* *mola-traj-tools 1.0.7-r1 --> 1.0.8-r1*
* *mola-viz 1.0.7-r1 --> 1.0.8-r1*
* *mola-yaml 1.0.7-r1 --> 1.0.8-r1*
* *rosx-introspection 1.0.1-r1 --> 1.0.2-r1*

Jazzy Changes:
--------------
* *ament-black 0.2.4-r1 --> 0.2.5-r1*
* *ament-cmake-black 0.2.4-r1 --> 0.2.5-r1*
* *compressed-depth-image-transport 4.0.1-r1 --> 4.0.2-r1*
* *compressed-image-transport 4.0.1-r1 --> 4.0.2-r1*
* *dataspeed-can 2.0.4-r1*
* *dataspeed-can-msg-filters 2.0.4-r1*
* *dataspeed-can-msgs 2.0.4-r1*
* *dataspeed-can-tools 2.0.4-r1*
* *dataspeed-can-usb 2.0.4-r1*
* *diagnostic-aggregator 3.1.2-r3 --> 4.2.1-r1*
* *diagnostic-common-diagnostics 3.1.2-r3 --> 4.2.1-r1*
* *diagnostic-updater 3.1.2-r3 --> 4.2.1-r1*
* *diagnostics 3.1.2-r3 --> 4.2.1-r1*
* *ds-dbw 2.2.0-r1*
* *ds-dbw-can 2.2.0-r1*
* *ds-dbw-joystick-demo 2.2.0-r1*
* *ds-dbw-msgs 2.2.0-r1*
* *foxglove-bridge 0.7.9-r1 --> 0.8.0-r1*
* *hpp-fcl 2.4.4-r3 --> 2.4.5-r1*
* *image-transport-plugins 4.0.1-r1 --> 4.0.2-r1*
* *kitti-metrics-eval 1.0.7-r1 --> 1.0.8-r1*
* *libcamera 0.3.0-r3 --> 0.3.1-r1*
* *message-filters 4.11.1-r2 --> 4.11.2-r1*
* *mola 1.0.7-r1 --> 1.0.8-r1*
* *mola-bridge-ros2 1.0.7-r1 --> 1.0.8-r1*
* *mola-demos 1.0.7-r1 --> 1.0.8-r1*
* *mola-imu-preintegration 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-euroc-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti360-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-mulran-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-paris-luco-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rawlog 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rosbag2 1.0.7-r1 --> 1.0.8-r1*
* *mola-kernel 1.0.7-r1 --> 1.0.8-r1*
* *mola-launcher 1.0.7-r1 --> 1.0.8-r1*
* *mola-metric-maps 1.0.7-r1 --> 1.0.8-r1*
* *mola-msgs 1.0.8-r1*
* *mola-navstate-fg 1.0.7-r1 --> 1.0.8-r1*
* *mola-navstate-fuse 1.0.7-r1 --> 1.0.8-r1*
* *mola-pose-list 1.0.7-r1 --> 1.0.8-r1*
* *mola-relocalization 1.0.7-r1 --> 1.0.8-r1*
* *mola-test-datasets 0.3.3-r1 --> 0.3.4-r1*
* *mola-traj-tools 1.0.7-r1 --> 1.0.8-r1*
* *mola-viz 1.0.7-r1 --> 1.0.8-r1*
* *mola-yaml 1.0.7-r1 --> 1.0.8-r1*
* *rosx-introspection 1.0.1-r1 --> 1.0.2-r1*
* *rslidar-msg 0.0.0-r1*
* *self-test 3.1.2-r3 --> 4.2.1-r1*
* *theora-image-transport 4.0.1-r1 --> 4.0.2-r1*
* *zstd-image-transport 4.0.1-r1 --> 4.0.2-r1*

Noetic Changes:
---------------
* *cartesian-interface 0.1.6-r1 --> 0.1.7-r1*
* *cartesian-trajectory-controller 0.1.6-r1 --> 0.1.7-r1*
* *cartesian-trajectory-interpolation 0.1.6-r1 --> 0.1.7-r1*
* *hpp-fcl 2.4.4-r1 --> 2.4.5-r1*
* *mrt-cmake-modules 1.0.4-r1 --> 1.0.10-r1*
* *ros-controllers-cartesian 0.1.6-r1 --> 0.1.7-r1*
* *sick-scan-xd 3.2.6-r1 --> 3.5.0-r1*
* *twist-controller 0.1.6-r1 --> 0.1.7-r1*

Rolling Changes:
----------------
* *action-tutorials-cpp 0.34.1-r1 --> 0.34.2-r1*
* *action-tutorials-interfaces 0.34.1-r1 --> 0.34.2-r1*
* *action-tutorials-py 0.34.1-r1 --> 0.34.2-r1*
* *ament-black 0.2.4-r2 --> 0.2.5-r1*
* *ament-cmake-black 0.2.4-r2 --> 0.2.5-r1*
* *camera-calibration-parsers 5.3.1-r1 --> 5.3.2-r1*
* *camera-info-manager 5.3.1-r1 --> 5.3.2-r1*
* *composition 0.34.1-r1 --> 0.34.2-r1*
* *compressed-depth-image-transport 4.0.1-r1 --> 5.0.0-r1*
* *compressed-image-transport 4.0.1-r1 --> 5.0.0-r1*
* *demo-nodes-cpp 0.34.1-r1 --> 0.34.2-r1*
* *demo-nodes-cpp-native 0.34.1-r1 --> 0.34.2-r1*
* *demo-nodes-py 0.34.1-r1 --> 0.34.2-r1*
* *diagnostic-aggregator 4.3.0-r1 --> 4.3.1-r1*
* *diagnostic-common-diagnostics 4.3.0-r1 --> 4.3.1-r1*
* *diagnostic-updater 4.3.0-r1 --> 4.3.1-r1*
* *diagnostics 4.3.0-r1 --> 4.3.1-r1*
* *dummy-map-server 0.34.1-r1 --> 0.34.2-r1*
* *dummy-robot-bringup 0.34.1-r1 --> 0.34.2-r1*
* *dummy-sensors 0.34.1-r1 --> 0.34.2-r1*
* *examples-rclcpp-async-client 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-cbg-executor 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-action-client 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-action-server 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-client 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-composition 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-publisher 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-service 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-subscriber 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-minimal-timer 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-multithreaded-executor 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclcpp-wait-set 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-executors 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-guard-conditions 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-minimal-action-client 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-minimal-action-server 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-minimal-client 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-minimal-publisher 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-minimal-service 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-minimal-subscriber 0.20.1-r1 --> 0.20.2-r1*
* *examples-rclpy-pointcloud-publisher 0.20.1-r1 --> 0.20.2-r1*
* *foxglove-bridge 0.7.9-r1 --> 0.8.0-r1*
* *hpp-fcl 2.4.4-r2 --> 2.4.5-r1*
* *image-common 5.3.1-r1 --> 5.3.2-r1*
* *image-tools 0.34.1-r1 --> 0.34.2-r1*
* *image-transport 5.3.1-r1 --> 5.3.2-r1*
* *image-transport-plugins 4.0.1-r1 --> 5.0.0-r1*
* *intra-process-demo 0.34.1-r1 --> 0.34.2-r1*
* *kitti-metrics-eval 1.0.7-r1 --> 1.0.8-r1*
* *launch 3.6.0-r1 --> 3.6.1-r1*
* *launch-pytest 3.6.0-r1 --> 3.6.1-r1*
* *launch-ros 0.27.1-r1 --> 0.27.2-r1*
* *launch-testing 3.6.0-r1 --> 3.6.1-r1*
* *launch-testing-ament-cmake 3.6.0-r1 --> 3.6.1-r1*
* *launch-testing-examples 0.20.1-r1 --> 0.20.2-r1*
* *launch-testing-ros 0.27.1-r1 --> 0.27.2-r1*
* *launch-xml 3.6.0-r1 --> 3.6.1-r1*
* *launch-yaml 3.6.0-r1 --> 3.6.1-r1*
* *libcamera 0.3.0-r3 --> 0.3.1-r1*
* *libstatistics-collector 1.8.0-r1 --> 2.0.0-r1*
* *lifecycle 0.34.1-r1 --> 0.34.2-r1*
* *lifecycle-py 0.34.1-r1 --> 0.34.2-r1*
* *logging-demo 0.34.1-r1 --> 0.34.2-r1*
* *message-filters 6.0.1-r1 --> 6.0.3-r1*
* *mimick-vendor 0.8.0-r1 --> 0.8.1-r1*
* *mola 1.0.7-r1 --> 1.0.8-r1*
* *mola-bridge-ros2 1.0.7-r1 --> 1.0.8-r1*
* *mola-demos 1.0.7-r1 --> 1.0.8-r1*
* *mola-imu-preintegration 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-euroc-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-kitti360-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-mulran-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-paris-luco-dataset 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rawlog 1.0.7-r1 --> 1.0.8-r1*
* *mola-input-rosbag2 1.0.7-r1 --> 1.0.8-r1*
* *mola-kernel 1.0.7-r1 --> 1.0.8-r1*
* *mola-launcher 1.0.7-r1 --> 1.0.8-r1*
* *mola-metric-maps 1.0.7-r1 --> 1.0.8-r1*
* *mola-msgs 1.0.8-r1*
* *mola-navstate-fg 1.0.7-r1 --> 1.0.8-r1*
* *mola-navstate-fuse 1.0.7-r1 --> 1.0.8-r1*
* *mola-pose-list 1.0.7-r1 --> 1.0.8-r1*
* *mola-relocalization 1.0.7-r1 --> 1.0.8-r1*
* *mola-test-datasets 0.3.3-r1 --> 0.3.4-r1*
* *mola-traj-tools 1.0.7-r1 --> 1.0.8-r1*
* *mola-viz 1.0.7-r1 --> 1.0.8-r1*
* *mola-yaml 1.0.7-r1 --> 1.0.8-r1*
* *pendulum-control 0.34.1-r1 --> 0.34.2-r1*
* *pendulum-msgs 0.34.1-r1 --> 0.34.2-r1*
* *quality-of-service-demo-cpp 0.34.1-r1 --> 0.34.2-r1*
* *quality-of-service-demo-py 0.34.1-r1 --> 0.34.2-r1*
* *rcl 9.4.0-r1 --> 9.4.1-r1*
* *rcl-action 9.4.0-r1 --> 9.4.1-r1*
* *rcl-lifecycle 9.4.0-r1 --> 9.4.1-r1*
* *rcl-logging-interface 3.2.0-r1 --> 3.2.1-r1*
* *rcl-logging-noop 3.2.0-r1 --> 3.2.1-r1*
* *rcl-logging-spdlog 3.2.0-r1 --> 3.2.1-r1*
* *rcl-yaml-param-parser 9.4.0-r1 --> 9.4.1-r1*
* *rclcpp 28.3.2-r1 --> 28.3.3-r1*
* *rclcpp-action 28.3.2-r1 --> 28.3.3-r1*
* *rclcpp-components 28.3.2-r1 --> 28.3.3-r1*
* *rclcpp-lifecycle 28.3.2-r1 --> 28.3.3-r1*
* *rclpy 7.4.0-r1 --> 7.5.0-r1*
* *rcpputils 2.13.0-r1 --> 2.13.1-r1*
* *rcutils 6.9.0-r1 --> 6.9.1-r1*
* *rmw 7.4.2-r1 --> 7.4.3-r1*
* *rmw-connextdds 0.24.0-r1 --> 0.24.1-r1*
* *rmw-connextdds-common 0.24.0-r1 --> 0.24.1-r1*
* *rmw-cyclonedds-cpp 3.0.1-r1 --> 3.0.2-r1*
* *rmw-fastrtps-cpp 9.0.0-r1 --> 9.0.1-r1*
* *rmw-fastrtps-dynamic-cpp 9.0.0-r1 --> 9.0.1-r1*
* *rmw-fastrtps-shared-cpp 9.0.0-r1 --> 9.0.1-r1*
* *rmw-implementation 3.0.0-r1 --> 3.0.1-r1*
* *rmw-implementation-cmake 7.4.2-r1 --> 7.4.3-r1*
* *ros2action 0.34.0-r1 --> 0.34.1-r1*
* *ros2cli 0.34.0-r1 --> 0.34.1-r1*
* *ros2cli-test-interfaces 0.34.0-r1 --> 0.34.1-r1*
* *ros2component 0.34.0-r1 --> 0.34.1-r1*
* *ros2doctor 0.34.0-r1 --> 0.34.1-r1*
* *ros2interface 0.34.0-r1 --> 0.34.1-r1*
* *ros2launch 0.27.1-r1 --> 0.27.2-r1*
* *ros2lifecycle 0.34.0-r1 --> 0.34.1-r1*
* *ros2lifecycle-test-fixtures 0.34.0-r1 --> 0.34.1-r1*
* *ros2multicast 0.34.0-r1 --> 0.34.1-r1*
* *ros2node 0.34.0-r1 --> 0.34.1-r1*
* *ros2param 0.34.0-r1 --> 0.34.1-r1*
* *ros2pkg 0.34.0-r1 --> 0.34.1-r1*
* *ros2run 0.34.0-r1 --> 0.34.1-r1*
* *ros2service 0.34.0-r1 --> 0.34.1-r1*
* *ros2topic 0.34.0-r1 --> 0.34.1-r1*
* *rosx-introspection 1.0.1-r1 --> 1.0.2-r1*
* *rti-connext-dds-cmake-module 0.24.0-r1 --> 0.24.1-r1*
* *rttest 0.18.0-r1 --> 0.18.1-r1*
* *rviz-assimp-vendor 14.2.4-r1 --> 14.2.5-r1*
* *rviz-common 14.2.4-r1 --> 14.2.5-r1*
* *rviz-default-plugins 14.2.4-r1 --> 14.2.5-r1*
* *rviz-ogre-vendor 14.2.4-r1 --> 14.2.5-r1*
* *rviz-rendering 14.2.4-r1 --> 14.2.5-r1*
* *rviz-rendering-tests 14.2.4-r1 --> 14.2.5-r1*
* *rviz-visual-testing-framework 14.2.4-r1 --> 14.2.5-r1*
* *rviz2 14.2.4-r1 --> 14.2.5-r1*
* *self-test 4.3.0-r1 --> 4.3.1-r1*
* *sros2 0.15.0-r1 --> 0.15.1-r1*
* *sros2-cmake 0.15.0-r1 --> 0.15.1-r1*
* *theora-image-transport 4.0.1-r1 --> 5.0.0-r1*
* *tlsf-cpp 0.18.0-r1 --> 0.18.1-r1*
* *topic-monitor 0.34.1-r1 --> 0.34.2-r1*
* *topic-statistics-demo 0.34.1-r1 --> 0.34.2-r1*
* *zstd-image-transport 4.0.1-r1 --> 5.0.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libnanopb-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] protobuf-compiler-grpc
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-seaborn
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

