### PR TITLE
Do not use import for the default module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       };
     }) // {
       overlays.default = import ./overlay.nix;
-      nixosModules.default = import ./modules;
+      nixosModules.default = ./modules;
 
       overlay = nixpkgs.lib.warn
         "'nix-ros-overlay.overlay' is deprecated, use 'nix-ros-overlay.overlays.default' instead"


### PR DESCRIPTION
Preserves module file location

See: https://fzakaria.com/2024/07/29/import-but-don-t-import-your-nixos-modules.html
See: https://github.com/nix-community/nixd/issues/556