### PR TITLE
Adding support for colcon-cd

### DIFF
--- a/pkgs/colcon/cd.nix
+++ b/pkgs/colcon/cd.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-cd }:
+
+buildPythonPackage rec {
+  pname = "colcon-cd";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PnCjK30WuBanxyGCvbIN+YX/wBZ47Jxn1EZZgUphmH0=";
+  };
+
+  propagatedBuildInputs = [ colcon-core colcon-cd ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A shell function for colcon-core to change the current working directory";
+    homepage = "https://github.com/colcon/colcon-cd";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}


### PR DESCRIPTION
Currently colcon-cd seems to be missing (colcon-cd is a shell function for colcon-core to change current working directory).

Looking at `pkgs/colcon/argcomplete.nix` I made an effort to create a `pkgs/colcon/cd.nix`, but don't know how to proceed as [pypi](https://pypi.org/project/colcon-cd/) - (0.1.1) has an outdated version compared to their [github](https://github.com/colcon/colcon-cd/tags) - (0.2.1).

If I could get some guidance on how to proceed and if there's anything else I need to do apart from just adding this package.

(It's my first time contributing to this repository so forgive me if there's anything I've done incorrectly; I will squash all my commits into one before its ready to merge :D)

