### PR TITLE
Patch rosx-introspection to not download anything from the Internet

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -151,6 +151,16 @@ rosSelf: rosSuper: with rosSelf.lib; {
 
   rosidl-generator-rs = rosSelf.callPackage ../pkgs/rosidl-generator-rs { };
 
+  rosx-introspection = rosSuper.rosx-introspection.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    # Don't download CPM, which is never needed because all
+    # dependencies are provided by Nix.
+    postPatch = postPatch + ''
+      substituteInPlace CMakeLists.txt --replace-fail 'include(cmake/CPM.cmake)' ""
+    '';
+  });
+
   rqt-robot-monitor = rosSuper.rqt-robot-monitor.overrideAttrs ({
     postFixup ? "", ...
   }: {


### PR DESCRIPTION
This is needed at least for Humble and Iron. Jazzy version cannot be build due to build failures in its dependencies.

Without this change the build fails with:

    -- The CXX compiler identification is GNU 13.3.0
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /nix/store/mpm3i0sbqc9svfch6a17179fs64dz2kv-gcc-wrapper-13.3.0/bin/g++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    CMake Error at cmake/CPM.cmake:19 (file):
      file DOWNLOAD cannot compute hash on failed download

        status: [6;"Couldn't resolve host name"]
    Call Stack (most recent call first):
      CMakeLists.txt:8 (include)