### PR TITLE
rosdistro sync, Fri Aug  9 13:55:56 2024

### DIFF
--- a/distros/humble/etsi-its-cam-coding/default.nix
+++ b/distros/humble/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "47a68b197e696a7472dce3aef3e9cab04a82ced658cac3ff5b0cd1680ba36d07";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "411a875eccb7742dfac069b38b95d37ead88e7461253c1eba29a9a168aaf50cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b0b2b9a6ca11776ffb65cac3ca9bdd8fd9a3dd5ab0e6bf8cf3b0d26555e3c13b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5039a21a545cf51e73cf37dc8dd1cd4556bbdb58d01300e9015c17b64069149e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "127a08e3e3f415361adc53323292897695fd89d9048fcf3950c2aed01f28549f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "84aed2ce178ff937596d795928fbbd2f98e7ae6afb42a032109bb1c5562a6bd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-coding/default.nix
+++ b/distros/humble/etsi-its-cam-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-ts-coding";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b89e9cd86e655643135b7c135f7dcf963ac4d18796a40ac996fce9bfd5330cc3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS CAMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-ts-conversion";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2cc68a3ce7d59f1962bd9c678a83d33d69937d3ba314e5d8c99f3df5c4e30a7d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-ts-coding etsi-its-cam-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-cam-ts-msgs";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "acf6973b85924632c3b1c69006f71a6f25dd881c8b1e31cfa1d9ef44d196a2ac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS CAM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-coding/default.nix
+++ b/distros/humble/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6e3747a8f72307083222cc1158999966d8728e5d7b9f4504ff2edb8f82b1e38b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e300adc8e359e0488b52e1136557cfee8e1b033ba90d6f124206b530d78e7bfa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-conversion/default.nix
+++ b/distros/humble/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "c46d4808dd7920ff799a16761452eecd41739bb1828d300938bd45780fe38e1f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e77a594003c044ef093cc83251025e3ad704831198cf8b150ba4345cb618cf46";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "945eabb7748358af34bfe767cdbc5f25e5baaa8142395910c35ae569fd42cadd";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "28e3519acd31f2323ef8771ed6cd0be4d307c7b69a2d8bb4d98a083f9f75be0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "74c127d576bf039ba12a5d28ab15a50cf666e4cf10e71afec012c1ccbb23cd42";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f3990988f2bff7f17271f12c7e9a2ae250330573ec82af1bd345f5a59ae3264d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7a5034f044e1c7e01fe597f6b0a3ee868fd303b65c06120db34ccbce561f36d4";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "24383ba2abbe71ddf3578059cef174208275b351eb77a3c1593c47759f860e71";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-coding/default.nix
+++ b/distros/humble/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "bc3c08eb93c72d823d9c1dc2ec4ee795c88329bb582428f7703cbdcd69fb9bf8";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ca462017af498c1bb8e15ab6f13613352760b95154814b442d77b33cab5617d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "34142636e2cbd6adfabdbd5dfbe118102df7b347defb184b22cb5a042ef01076";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "284a4d1907da7d9c28bd894b58a09e46ef3b449b3afb741aeb72223ef1a84ffb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "87c0dd5c5e4968d0ed46695ab5c557a1fe7bf8d8b5f777fc47ac4bf1b07b1284";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "444dba4766666c0da882a1122f4376af0347e2ac0fc313682638b2a99a772b11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-messages/default.nix
+++ b/distros/humble/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-messages";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_messages/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "acccaf8cef62028661ff56d852a5bfff945757b84ffd2545e003843f2da1b5e0";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_messages/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "9a46665ea2b1f7064cb1fa30eb85f9d26c5e2255a6d9c5d38adbc97d709ee29b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs-utils/default.nix
+++ b/distros/humble/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs-utils";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e2c94ce2f65f9dc763e45e5cf12412b6a3aa05919850f8d81c71e9a11942ef2d";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0c5c544276b4f130201a1433396e09d252b5d6fc4815e21a2b0a9df9d9a4b5aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs/default.nix
+++ b/distros/humble/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "06d1d77d2b2a2e6f9651a14393500262522067f1928d2c775053be3998ecefd1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "af98ba1c1e48745e18cc140a11e73f2a7e21315d7bcdacdbe383bf5f302ee330";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-primitives-conversion/default.nix
+++ b/distros/humble/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-primitives-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "25b7ce1c5ddfd7f8ec2ff5d00cb9c015d69dc70acda1fc098ac3118e8946a379";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d5d028c44889f73af1d80f8b1029cce9178cf1738735efc64309811dedf02df4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-rviz-plugins/default.nix
+++ b/distros/humble/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-rviz-plugins";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "48790605d8db14a6a520f0bfea3bfc66302202cf580f000eaf2413436da05a2c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ce874cbbf526ce3198c8fd846a365aeffc1aaac1f80658e6b336004264931dbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -774,6 +774,12 @@ self: super: {
 
  etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
 
+ etsi-its-cam-ts-coding = self.callPackage ./etsi-its-cam-ts-coding {};
+
+ etsi-its-cam-ts-conversion = self.callPackage ./etsi-its-cam-ts-conversion {};
+
+ etsi-its-cam-ts-msgs = self.callPackage ./etsi-its-cam-ts-msgs {};
+
  etsi-its-coding = self.callPackage ./etsi-its-coding {};
 
  etsi-its-conversion = self.callPackage ./etsi-its-conversion {};
@@ -1870,9 +1876,9 @@ self: super: {
 
  omni-base-laser-sensors = self.callPackage ./omni-base-laser-sensors {};
 
- omni-base-maps = self.callPackage ./omni-base-maps {};
-
  omni-base-navigation = self.callPackage ./omni-base-navigation {};
+
+ omni-base-rgbd-sensors = self.callPackage ./omni-base-rgbd-sensors {};
 
  omni-base-robot = self.callPackage ./omni-base-robot {};
 

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.1.15-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.1.15-1.tar.gz";
-    name = "0.1.15-1.tar.gz";
-    sha256 = "8278ae482d8299e51cf9c38d38949606a7e98978a931c2f174542a7046154525";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "568de2348aac0bce1f105d4d29874008059768a90cc91e7b2872f9774cdf792f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mrpt2/default.nix
+++ b/distros/humble/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt2";
-  version = "2.13.4-r1";
+  version = "2.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.13.4-1.tar.gz";
-    name = "2.13.4-1.tar.gz";
-    sha256 = "74442fcb1be592034c52f694bca9d394cd87bc6a767d0479042813d989cd101a";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/humble/mrpt2/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "3bdb58060fdf705fc947206dca88676e02b709ba27e640e3d68316acf3c927ea";
   };
 
   buildType = "cmake";

--- a/distros/humble/omni-base-2dnav/default.nix
+++ b/distros/humble/omni-base-2dnav/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup, omni-base-laser-sensors, omni-base-maps, ros2launch, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup, omni-base-laser-sensors, pal-maps, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-omni-base-2dnav";
-  version = "2.0.7-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "5d00e39ab6cbdd58cb9cc4ffd1fbb2ece81333d799f4aa24a0081c55941aedaf";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "059eec874d482cde549e6a26a1e1934de3d7556eeda95f81d4a2bdc163498e49";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav2-bringup omni-base-laser-sensors omni-base-maps ros2launch rviz2 ];
+  propagatedBuildInputs = [ nav2-bringup omni-base-laser-sensors pal-maps ros2launch rviz2 ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-bringup/default.nix
+++ b/distros/humble/omni-base-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy-linux, joy-teleop, launch-pal, omni-base-controller-configuration, omni-base-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-omni-base-bringup";
-  version = "2.0.18-r1";
+  version = "2.0.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.0.18-1.tar.gz";
-    name = "2.0.18-1.tar.gz";
-    sha256 = "2db9d7ad51c1f069246b67771132e77c967f7a545b26ee1e274c2f71c0c0b654";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.0.19-1.tar.gz";
+    name = "2.0.19-1.tar.gz";
+    sha256 = "40649bffcd2aeecfdd8cc297334cb5840d0c214a454722eb1d9027f4dcf8e90d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-controller-configuration/default.nix
+++ b/distros/humble/omni-base-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, imu-sensor-broadcaster, joint-state-broadcaster, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-omni-base-controller-configuration";
-  version = "2.0.18-r1";
+  version = "2.0.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.0.18-1.tar.gz";
-    name = "2.0.18-1.tar.gz";
-    sha256 = "46760e3f4a28096b4ef5021ae3ddd0bfb3d5472e19bf48e13c683d39adde92bf";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.0.19-1.tar.gz";
+    name = "2.0.19-1.tar.gz";
+    sha256 = "9b35b4270ba4dbfb94d7c71940dd8146d05c70df01f598e94ff2a88ceff62b0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-description/default.nix
+++ b/distros/humble/omni-base-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-planar-move-plugin, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-omni-base-description";
-  version = "2.0.18-r1";
+  version = "2.0.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.0.18-1.tar.gz";
-    name = "2.0.18-1.tar.gz";
-    sha256 = "692b1585227455afcbc6e74f4402d748f7018e2562b474c42923fb72059b3100";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.0.19-1.tar.gz";
+    name = "2.0.19-1.tar.gz";
+    sha256 = "c4dfe247e166900d47c404fd7281eadaac1f76cf83f080ce33e3c27a4719f71a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-gazebo/default.nix
+++ b/distros/humble/omni-base-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, omni-base-2dnav, omni-base-bringup, omni-base-controller-configuration, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, omni-base-2dnav, omni-base-bringup, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-humble-omni-base-gazebo";
-  version = "2.0.3-r1";
+  version = "2.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "782b227b1fe2a0a35c1f084d8ca664943aa0af0e3b8a5ef94c612f93af2dd250";
+    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "01fe43f9c3c7fd67a67912369ac7805d293dc7e2cbb61349d9cfeef54fcb6fa2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch-pal omni-base-2dnav omni-base-bringup omni-base-controller-configuration omni-base-description pal-gazebo-plugins pal-gazebo-worlds ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch-pal omni-base-2dnav omni-base-bringup omni-base-description pal-gazebo-plugins pal-gazebo-worlds ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-laser-sensors/default.nix
+++ b/distros/humble/omni-base-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-omni-base-laser-sensors";
-  version = "2.0.7-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "ba3499de2ba2124a05946f29698be66180c7dafc27913ea64a3419ad90243974";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "bb38b4751cdea14041d147ae5f6c5fc8100280ee3e2e0a7bcf8ac1894e4ba6b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-navigation/default.nix
+++ b/distros/humble/omni-base-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-2dnav, omni-base-laser-sensors, omni-base-maps }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-2dnav, omni-base-laser-sensors, omni-base-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-omni-base-navigation";
-  version = "2.0.7-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "72b987f62285116906e8079a88e6e4f6b366ca1ff9050b40a357a8aefe9f1bd1";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "dddffb85347db46404eda212f1e2691e65075f2f07d4cfc9b162f319e935c436";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  propagatedBuildInputs = [ omni-base-2dnav omni-base-laser-sensors omni-base-maps ];
+  propagatedBuildInputs = [ omni-base-2dnav omni-base-laser-sensors omni-base-rgbd-sensors ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-rgbd-sensors/default.nix
+++ b/distros/humble/omni-base-rgbd-sensors/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-humble-omni-base-rgbd-sensors";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "f14ef731094b74f94449aa8c279adcb34699f0f9598fe2f68c62f6fb61f614c6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "omni_base-specific RGBD sensors module and params files.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/omni-base-robot/default.nix
+++ b/distros/humble/omni-base-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-bringup, omni-base-controller-configuration, omni-base-description }:
 buildRosPackage {
   pname = "ros-humble-omni-base-robot";
-  version = "2.0.18-r1";
+  version = "2.0.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.0.18-1.tar.gz";
-    name = "2.0.18-1.tar.gz";
-    sha256 = "425cc29924581949b9ae101c0855ca8cae737f33a55120ee35c40444069334a6";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.0.19-1.tar.gz";
+    name = "2.0.19-1.tar.gz";
+    sha256 = "1fa91d5917d2e69671ef964cc1117e3a5e230145244f980f703bb55dbb894f2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-simulation/default.nix
+++ b/distros/humble/omni-base-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-gazebo }:
 buildRosPackage {
   pname = "ros-humble-omni-base-simulation";
-  version = "2.0.3-r1";
+  version = "2.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f36d232770552a9d697d0e61ac9539c17bb6f7b2dc38f110094593dbcfa80b1b";
+    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.0.9-1.tar.gz";
+    name = "2.0.9-1.tar.gz";
+    sha256 = "269e2cce64189cfeed1685b72a7134724035d87120cc8f3b8350023f593aaef3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-robotiq-controller-configuration/default.nix
+++ b/distros/humble/pal-robotiq-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-robotiq-controller-configuration";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_controller_configuration/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "e2b9f6935821513c84bbe58dad9e185c38d88f0b6d4d57b3e139ae398392c29b";
+    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_controller_configuration/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "42de6a6dfc1fff125eaaacdbafb80e92032c737ce133b1f715dbc3314971c1b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-robotiq-description/default.nix
+++ b/distros/humble/pal-robotiq-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-robotiq-description";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "923b134a8ba9725fff0a20e5440018e92628473bf4af279605570666743da7fa";
+    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_description/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "da6300ef236be57001169547023fa3de8df57c1e54aa755bd6ea4277f548d2c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-robotiq-gripper/default.nix
+++ b/distros/humble/pal-robotiq-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-robotiq-controller-configuration, pal-robotiq-description, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-pal-robotiq-gripper";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_gripper/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "dd5cae2c1f4fb5fa63bee12767bb1c2b890828186648c86efe63e434a93082d9";
+    url = "https://github.com/pal-gbp/pal_robotiq_gripper-release/archive/release/humble/pal_robotiq_gripper/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "acd8831833bd96e4eb72bfa233b017e8ecf752f2138d327abdee4fded8d125a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup, pal-maps, pmb2-laser-sensors, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "4.0.21-r1";
+  version = "4.0.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.0.21-1.tar.gz";
-    name = "4.0.21-1.tar.gz";
-    sha256 = "f791158351ce1710550fd2cc7f8d6c6ad855d5297b5fb0a7a4866d26df10b36c";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.0.23-1.tar.gz";
+    name = "4.0.23-1.tar.gz";
+    sha256 = "1271fcabb7b1417a998877662e96a98d16329649e51235a33e476477b7475825";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "5.0.25-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.0.25-1.tar.gz";
-    name = "5.0.25-1.tar.gz";
-    sha256 = "0f9c951b849d954e02070cb152c1c08a900a011c620071fbe19ec698072e97e7";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "6d95bdab0044ef6c063762231c62f053113153ec18ae3aa12fecd6411811b3f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "5.0.25-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.0.25-1.tar.gz";
-    name = "5.0.25-1.tar.gz";
-    sha256 = "d92bbf392d9304040fcc13964adfb8df15fce14420f6777c7d3c63c195786640";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "25f36820dc293bcc552e30a3255d747ec59f5434d7d28944f92eca43f9e0e70a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "5.0.25-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.0.25-1.tar.gz";
-    name = "5.0.25-1.tar.gz";
-    sha256 = "ed30f8c232a0910543b2eae1afc6ca2e218205f5d4612bd354c93afc9e305102";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "94aa97ed5cffe91c35ed3183a282dc67f94974c08e7ceab62f256c1ec4790256";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-pmb2-laser-sensors";
-  version = "4.0.21-r1";
+  version = "4.0.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.0.21-1.tar.gz";
-    name = "4.0.21-1.tar.gz";
-    sha256 = "46ef401b35d30531a00ba44f41849f7ad00cda6da178bc3e5b23a8e58dde3da2";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.0.23-1.tar.gz";
+    name = "4.0.23-1.tar.gz";
+    sha256 = "47cd81520804ed99e8dd8c8a5f991b7ae0ed083900375279606138ffc17465fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "4.0.21-r1";
+  version = "4.0.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.0.21-1.tar.gz";
-    name = "4.0.21-1.tar.gz";
-    sha256 = "b5ae8fe4ec4fd8a5fbd734fd13b71735d9059a9362f7f6c21dcdaaf244bccb3a";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.0.23-1.tar.gz";
+    name = "4.0.23-1.tar.gz";
+    sha256 = "7b8474991d11fb62ee07788db5fc1a0bebaaf5622435d553abc6ad530ef8684b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "5.0.25-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.0.25-1.tar.gz";
-    name = "5.0.25-1.tar.gz";
-    sha256 = "87a18bd7d0b90a38f2611c3c3872e23f5b7a3172888cf2184fdc88a2718cd6cf";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "4efb01da2ff777945469bcb639a895463d012d04e3c2197d1c5b0a3ad16bc324";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/septentrio-gnss-driver/default.nix
+++ b/distros/humble/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-septentrio-gnss-driver";
-  version = "1.4.0-r2";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "dca396384bb208b75011bbb1f342a37981de3d8fb71bfc327be3a579ceea6ea9";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "7da5c3dacf4bc3a07172c249dabc3722331d05ce78d47ada9b343430229663e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf-transformations/default.nix
+++ b/distros/humble/tf-transformations/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-tf-transformations";
-  version = "1.0.1-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tf_transformations_release/archive/release/humble/tf_transformations/1.0.1-3.tar.gz";
-    name = "1.0.1-3.tar.gz";
-    sha256 = "6ad1074611765e9513c6afda5f08c704ba04b0202700d0aa689fde6375d85717";
+    url = "https://github.com/ros2-gbp/tf_transformations_release/archive/release/humble/tf_transformations/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a2126bb8aa5eae311071be1f83955306a30e949e471a5510f3b3f45e06e72cb8";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.numpy python3Packages.transforms3d ];
 
   meta = {
     description = "Reimplementation of the tf/transformations.py library for common Python spatial operations";

--- a/distros/humble/tiago-2dnav/default.nix
+++ b/distros/humble/tiago-2dnav/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, ros2launch, rviz2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, ros2launch, rviz2, tiago-description, tiago-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-2dnav";
-  version = "4.1.2-r1";
+  version = "4.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.1.2-1.tar.gz";
-    name = "4.1.2-1.tar.gz";
-    sha256 = "00cbd9db10ca993e553dfd90ea1f75ce37cfb3fbdd0ce6e839fb25b95c2737ca";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.1.7-1.tar.gz";
+    name = "4.1.7-1.tar.gz";
+    sha256 = "b2fb3180ab4cc2190419e705b103f87db4bd073e362dc95238974e941243d852";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ launch-pal nav2-bringup pal-maps ros2launch rviz2 ];
+  propagatedBuildInputs = [ launch-pal nav2-bringup pal-maps ros2launch rviz2 tiago-description tiago-laser-sensors ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/tiago-bringup/default.nix
+++ b/distros/humble/tiago-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, play-motion2, teleop-tools-msgs, tiago-controller-configuration, tiago-description, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-tiago-bringup";
-  version = "4.2.17-r1";
+  version = "4.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.2.17-1.tar.gz";
-    name = "4.2.17-1.tar.gz";
-    sha256 = "6f008f1cdb1e5c4f01982371c7c0eed776c8c534363006b82818431d8e5fddc6";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.2.21-1.tar.gz";
+    name = "4.2.21-1.tar.gz";
+    sha256 = "0ae5e86146a72077ea794595a9d5f7dd3d305b53eb14f0cbe1cc8198a7e3ba63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-controller-configuration/default.nix
+++ b/distros/humble/tiago-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, force-torque-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, omni-base-controller-configuration, pal-gripper-controller-configuration, pal-hey5-controller-configuration, pal-robotiq-controller-configuration, pmb2-controller-configuration, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-tiago-controller-configuration";
-  version = "4.2.17-r1";
+  version = "4.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.2.17-1.tar.gz";
-    name = "4.2.17-1.tar.gz";
-    sha256 = "f46a4dd8f56c74eedbf8ff863d4b7661df171d7144d283b6752f92c07f599d35";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.2.21-1.tar.gz";
+    name = "4.2.21-1.tar.gz";
+    sha256 = "e3d8d325f662e0cc1391ce777b44a1f5691bb08a33ae8ca0953a0a8510c77aa7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-description/default.nix
+++ b/distros/humble/tiago-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gripper-description, pal-hey5-description, pal-robotiq-description, pal-urdf-utils, pmb2-description, robot-state-publisher, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-description";
-  version = "4.2.17-r1";
+  version = "4.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.2.17-1.tar.gz";
-    name = "4.2.17-1.tar.gz";
-    sha256 = "3d6645ef19dcabdf9c08595cf8b92e5b6a517fb7ce4937b378c9cf605bc301cf";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.2.21-1.tar.gz";
+    name = "4.2.21-1.tar.gz";
+    sha256 = "6e9e8ebe00c52ca3cc8c6bc2543845cc24f4a39997246293bc70ee3f29831604";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-gazebo/default.nix
+++ b/distros/humble/tiago-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch, launch-pal, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds, play-motion2-msgs, rclcpp, sensor-msgs, tiago-2dnav, tiago-bringup, tiago-description, tiago-moveit-config }:
 buildRosPackage {
   pname = "ros-humble-tiago-gazebo";
-  version = "4.1.8-r1";
+  version = "4.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.1.8-1.tar.gz";
-    name = "4.1.8-1.tar.gz";
-    sha256 = "3d8d20e54a05ea3dbab9103e6f2519b416afa6b927b54489dc78a3d7ebc14301";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.1.9-1.tar.gz";
+    name = "4.1.9-1.tar.gz";
+    sha256 = "a3393d410c96dabf0ed5c6c83936264310c3da53d992b7a5bccf6068303b25bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-laser-sensors/default.nix
+++ b/distros/humble/tiago-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-tiago-laser-sensors";
-  version = "4.1.2-r1";
+  version = "4.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.1.2-1.tar.gz";
-    name = "4.1.2-1.tar.gz";
-    sha256 = "8b93bffeefc31e9bec40d5671555c7ecfa19ab8a265f2c8f9ba600c7938cf19f";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.1.7-1.tar.gz";
+    name = "4.1.7-1.tar.gz";
+    sha256 = "6cca8e7c0f76b967147d06ca1fb650fc19ead57ecad3eb9fdd8955cdb3996b44";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-moveit-config/default.nix
+++ b/distros/humble/tiago-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-moveit-config";
-  version = "3.0.16-r1";
+  version = "3.0.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.0.16-1.tar.gz";
-    name = "3.0.16-1.tar.gz";
-    sha256 = "4d5ad4434968e37a7dcbcef8b138b25c7ae00db54782e765f9f35e60004b7127";
+    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.0.18-1.tar.gz";
+    name = "3.0.18-1.tar.gz";
+    sha256 = "4fd9f2ff9ef4db257ac155bf49155337bd8c4c3ca25156c26fabd942e76d6fc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-navigation/default.nix
+++ b/distros/humble/tiago-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-2dnav, tiago-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-navigation";
-  version = "4.1.2-r1";
+  version = "4.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.1.2-1.tar.gz";
-    name = "4.1.2-1.tar.gz";
-    sha256 = "3112ef4edf5535b980a1a8f9611a4671cda6971c55bbfed4a699669b7f2b9010";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.1.7-1.tar.gz";
+    name = "4.1.7-1.tar.gz";
+    sha256 = "1be61c9351d4fb7b23f0a276295b176561e5aff587d572a2988c0810d860afbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-robot/default.nix
+++ b/distros/humble/tiago-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-bringup, tiago-controller-configuration, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-robot";
-  version = "4.2.17-r1";
+  version = "4.2.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.2.17-1.tar.gz";
-    name = "4.2.17-1.tar.gz";
-    sha256 = "049bffca74f9a62dbb948046cd0f7cc8e8d49886aeaef059d4d404bad4480040";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.2.21-1.tar.gz";
+    name = "4.2.21-1.tar.gz";
+    sha256 = "1cd60ffa225ba322ed3e3398c414597c3c99b17ed73b6471c32d4730a78ce913";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-simulation/default.nix
+++ b/distros/humble/tiago-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-gazebo }:
 buildRosPackage {
   pname = "ros-humble-tiago-simulation";
-  version = "4.1.8-r1";
+  version = "4.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.1.8-1.tar.gz";
-    name = "4.1.8-1.tar.gz";
-    sha256 = "4b8d37687cd8eeb3cf194aa82076dff29e0709b80913b64dcb46fbc4ae9fa784";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.1.9-1.tar.gz";
+    name = "4.1.9-1.tar.gz";
+    sha256 = "fe7826c79a2c189befa82a1887657e1637fee72d776321487c5156c39616aa57";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-coding/default.nix
+++ b/distros/iron/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cam-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7dcd0f8d56153af7fd3e8a9b5e82a020017cd1528fac1355a0b6d501e0b9e1c2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "da017c2a547b71eee47213eef23a1ad515c908b68db526bba4c6027645a59611";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-conversion/default.nix
+++ b/distros/iron/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cam-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "3ec8719e215a6630e33147fa3d6e4101c1300758d2758fb0a0d7662d678f400f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "45d429a5545f232c1bb64c35e3fe9ce83e26e26aafe046ae1687dc24e5a0b52a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-msgs/default.nix
+++ b/distros/iron/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cam-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "488b9776070d9136623e4c93627003dc3fa04a5ac9312876fad4fe7e17b3e184";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0c2174bb9541f63e249320944d46299dcd13bf7fc6274fdbb79c2b8613fd392e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cam-ts-coding/default.nix
+++ b/distros/iron/etsi-its-cam-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-ts-coding";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5f7941e0e32a6f09a292917c2b64886609167633e68f08f10ce024477ba08db7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS CAMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/iron/etsi-its-cam-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-ts-conversion";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "9a37aa71b02c582e213b9dedc561aed9c8455cc73d208db05ffebb44679e77b9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-ts-coding etsi-its-cam-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/iron/etsi-its-cam-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-etsi-its-cam-ts-msgs";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cam_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "412f070bafbf3aea35ece3262af34e7c4b32597b1c5e69e7ba8561619eef09d5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS CAM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/iron/etsi-its-coding/default.nix
+++ b/distros/iron/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f6046cfb20e0ac23d0b672a851331cebf80fb27144dbe886ddc3fb9ce96c0908";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6856b72a59a425f5afd6298c57ab3cc81722a8767aaaf5c4db6edbe678b80d5a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/etsi-its-conversion/default.nix
+++ b/distros/iron/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5aecf247b3630c794682b16cf5c6048b71c777fe11543fd1a3403364fe9c86ae";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "7ac4065a837eaa640f98cca6637f7adc681fc46641547db7fecb2a86c91a6911";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/iron/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cpm-ts-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cpm_ts_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d502322f49638181d354ce053b0cdb3c57371acdec8dbcd53c28ae9e1a473090";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cpm_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "de36c78a79e033500ab19a0b9164f0bb564864198f18cca1b588ae9a7996845d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/iron/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cpm-ts-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cpm_ts_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "91a2d9aa86b85a3e645cb1e0288e1970134d764d7d3caa4e9436a8898e04d58e";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cpm_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "bc98be12befb9caf0df5ec8fd7aa0b36b8799440600a9ea61d1dd82f418e3281";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/iron/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-cpm-ts-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cpm_ts_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b56f1628b118f1937d6066168a6118688875dab08647da0deae82abe30123f7e";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_cpm_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b1c769def24707d164f183108b84963167c41346ef026b4333bdf97887b456fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-denm-coding/default.nix
+++ b/distros/iron/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-denm-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_denm_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "7ada78cadb5b15bf1fc0c5be730e41dd57eebad0d8bd980035a65a46b75b0e9b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_denm_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b087826f5d67c0fb11534d2c608a7d362e00665c1925a0ebd43d5fcaaea40a9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-denm-conversion/default.nix
+++ b/distros/iron/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-denm-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_denm_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a208084bb45c79ff0a0df8220068bcbcd57c5ed01509fad6f4b0be2acde68b4e";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_denm_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b83c0c93b42c4b9ef913545404db762bb7ef39856c8581f38835df09bdee083d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-denm-msgs/default.nix
+++ b/distros/iron/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-denm-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_denm_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8f6868fdac378776602def7957d188341f9b7e9cd0faeaded7bb91c9c47f3986";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_denm_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "7b3ece8b85ee5ebe973862ca8510f4a6cfe03cc1b5b0ced41081e0659ce85032";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-messages/default.nix
+++ b/distros/iron/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-messages";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_messages/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "3dcb990c3161abd496f61a3134b1247639eef317e2b90905f994545453e8bfc0";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_messages/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ceb90bb665acc0359c7879d6e78209ce7af6df264ce84a037210dcca0ebc6db5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-msgs-utils/default.nix
+++ b/distros/iron/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-msgs-utils";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_msgs_utils/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "dc8a8b83c1a8c762ede232bb1e2d66e396f323c773020981c81f4a10b749381b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_msgs_utils/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ef73b9cdbea64da2021a37c01176040aa89b4581871b9faa2526502529865b4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-msgs/default.nix
+++ b/distros/iron/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "97287c0cdc8db72f2c9c37ee52c97b0d10d1047f5c2dc9a83952b1fac31a5d14";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f5aa388ed5514b8c98bd9a052fcd4a94b8e134d0aabd870c68781baa7e5cac45";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/etsi-its-primitives-conversion/default.nix
+++ b/distros/iron/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-primitives-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_primitives_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "13ec51f6e8e32f069c946584a98f83e61d76f720e4f0da786ff4e1c95fbfadf2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_primitives_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "4e5e3c14b97261b683d77c65600dde6480afec826dc810ab6c98bd504d814bc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/etsi-its-rviz-plugins/default.nix
+++ b/distros/iron/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-etsi-its-rviz-plugins";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_rviz_plugins/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f36cfa5664a092978f47967d85b56854a0f0ce0eb852a1229dd8f98ecbdaa1b2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/iron/etsi_its_rviz_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "8087b8ca012c43c2eea5b1107aeff7b5cb794174d7aa5147664409a80066a426";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -478,6 +478,12 @@ self: super: {
 
  etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
 
+ etsi-its-cam-ts-coding = self.callPackage ./etsi-its-cam-ts-coding {};
+
+ etsi-its-cam-ts-conversion = self.callPackage ./etsi-its-cam-ts-conversion {};
+
+ etsi-its-cam-ts-msgs = self.callPackage ./etsi-its-cam-ts-msgs {};
+
  etsi-its-coding = self.callPackage ./etsi-its-coding {};
 
  etsi-its-conversion = self.callPackage ./etsi-its-conversion {};

--- a/distros/iron/mrpt2/default.nix
+++ b/distros/iron/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt2";
-  version = "2.13.4-r1";
+  version = "2.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.13.4-1.tar.gz";
-    name = "2.13.4-1.tar.gz";
-    sha256 = "628576705483e7d2a35e0b38563ca3d969eac677fa98614f4f8653a145398c71";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/iron/mrpt2/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "a809888d7d2f0fb3972b93dad8449d42e1a8a870b59b2ee5016549874512191c";
   };
 
   buildType = "cmake";

--- a/distros/iron/septentrio-gnss-driver/default.nix
+++ b/distros/iron/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-septentrio-gnss-driver";
-  version = "1.4.0-r3";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/iron/septentrio_gnss_driver/1.4.0-3.tar.gz";
-    name = "1.4.0-3.tar.gz";
-    sha256 = "8b71256475ea5032aabf70304d445703aab0ee39d60287c3ac253072bc14d70f";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/iron/septentrio_gnss_driver/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "1706f899fe64d5031632b620e3477900c0d468b3afd84ad3ec6d400151ab7a03";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "1f1d3392b8426ae78e4134baa1da13a69e05ed84256c4fb34763d4792f3bed66";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "d12ed8f2a9105c3245e84230df2175a5afd59d9f1330c45840fbe914a7027110";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "3f5d38d5ca6512383fede2fb4cddaf8472d2b97996941767ad7902b9b419486c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "8361633b3b521f64760fba15be52795d647c748f1c92f7b8981ecc39bb41539a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "d6e54b9593752274b43be358bdf37c14214c2e7b84e4169867166dd16f16d9b2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "67feede1eb7fa43448a141311f6faab1b4fd2f0d0f4fd12c3a95e5d2d3c2c947";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
-  checkInputs = [ ament-cmake-gmock hardware-interface-testing ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-pytest hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 

--- a/distros/jazzy/etsi-its-cam-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4445f9798370094547fcce8ac67ff95f30c78fdf89a08360143ba3ac2d3fdb76";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "45fdbd7ab230871330e9336c2929b962e2e260170a6a818e37d45bcc650d04f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8567b861191bfb3b9078c46151d103de410b27b5625af174cad615218d2d2151";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e3b266842fa4e59cc0fb6711684fa83637b2317f1bfe7e6aaee3698026a5fbe3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "596efc932fd849664320b0cc914c532da4c14cc8de8cc4c61b403c7b39bab18d";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "dd8ec8a542688be61209886cc391f5c345a22101cd32d9f1cba3c08c0fba3f02";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-cam-ts-coding";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "877609c35b362c1dec387f2ec66f8a30930024d2b0328b04974a525e5509d640";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS CAMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-cam-ts-conversion";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "cac776207c56b84752eb689d09134f9d699c26c99138583f31db46421b01258a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-cam-ts-coding etsi-its-cam-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-cam-ts-msgs";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e0a46fdc23019a4bfac82c502e7360b96ac39e90dcc933d83b46d5990e1db580";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS CAM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-coding/default.nix
+++ b/distros/jazzy/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "cd4f5b0f56063aa71fff403bf534998c9f2fa47bd7cab30cd60fc423bff730de";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "3c741511ba16cde0b4e76e407789aa926db30a872352578957e3eb5677882eee";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-conversion/default.nix
+++ b/distros/jazzy/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5dc145e57dff0b5563265200b2a148b60dbaa9423c4046dac6a480408e7c5662";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ed9c17d0c98ae8b7f8018011e44289e514e6a180178c037352ebfdb38c4ab2b1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "9b88befe7e43df0bb21c6e9f07b919b94059a91810635373a200e7f6cf2f5be6";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f3a890b35d24f168aba74d2047becda0aba2fc45705857e96613ba899169dde6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6a58c756cbf5892aeaf5e304246af5f44d86c18a211659dbe872b7ecc9348279";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "c2b87627767429e1afa4d4a41307fb23782499e0805c46ba682e1b3a00a14d6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "597c05991d2b498a753d7593bd21d7e56af4e8316f110a7af932b24f2aa6d394";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "653ee28f63a5f434af6e119167e92ec638f8f6f55b155eb3791e6e1e0ddde05b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-coding/default.nix
+++ b/distros/jazzy/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-coding";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "79e6614b2ddc375005eb53af7dc3adee8c0ce2b8fa6a9862cbe88f8ecc39fa72";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "9acd5802c6f53b6eb4872a1eb04ba3c801093333c1707cbb68a2f722f3ee960f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-conversion/default.nix
+++ b/distros/jazzy/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5bbe6c6f02ba03c04ebd116bb9404ca1c8c08f37818e52ce0b8c20e0e5950689";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "9914ac7087a24aec9c681589631557c125d2c81d6cdf098e28805961a8acf8aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-msgs/default.nix
+++ b/distros/jazzy/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4644e0af8770679a38fe71d42c7a8b5f4cb0ec1c687977b41f38a5f16e3a52a3";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f90b9e1f51aa1884887f44d720673a65727b6a5e13e8b390ef44d1429dde5a59";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-messages/default.nix
+++ b/distros/jazzy/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-messages";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "256b51f9a069d00c3f429508131db01a05ac9445f1331e484a2f42659e0cfcd3";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ed889f02f2b1dad47ffa89de7fc8ac3dcceb81091dbfda74c0fbe0ec00d7b4d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs-utils/default.nix
+++ b/distros/jazzy/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs-utils";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b807987af1d2ef8f8c357f3d92e83bc66e84b31fbedd7a9716aa8f3b9d2b5261";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0ee6e7fa9a06e1de7b2e3948a22aa4128529cc21021035c8019f1117c17c4c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs/default.nix
+++ b/distros/jazzy/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "1966ad027525424808040e3a95f1060c0a1221c6b50faa7a35e1f9bc74c2f0b7";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "8155faf8dcf968116712c5718b3652e0e041601119045e6cdb4c82fd5722f027";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-primitives-conversion/default.nix
+++ b/distros/jazzy/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-primitives-conversion";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a61c56809371efca0d070a519fe86885b2bdd41ded8b0bd2efde48edec80b808";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "120d26a0883f772f67c081e0c511f0e1c5aa84c026ef29308f0fe427cf6f7e50";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-rviz-plugins/default.nix
+++ b/distros/jazzy/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-rviz-plugins";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "9c87d3974fa211109921ebf3640f9afd26d43c768956adf21806194d90f264b6";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "15847f945c80854f6520d5234772f185f27d55461cb2fadca4d3f8b208fd83ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -536,6 +536,12 @@ self: super: {
 
  etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
 
+ etsi-its-cam-ts-coding = self.callPackage ./etsi-its-cam-ts-coding {};
+
+ etsi-its-cam-ts-conversion = self.callPackage ./etsi-its-cam-ts-conversion {};
+
+ etsi-its-cam-ts-msgs = self.callPackage ./etsi-its-cam-ts-msgs {};
+
  etsi-its-coding = self.callPackage ./etsi-its-coding {};
 
  etsi-its-conversion = self.callPackage ./etsi-its-conversion {};

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "a82290d9737a8dc693e63624b83ffd70b3151822ab18d0c71cbf4a28447eaacc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "8ef25456d8a8719d18ad11068c8fc8edd8dd554de8d5be875d73aa99adfa42bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "b3fede5dc104255dcb0dee73fd1f2607c21751af7eaa7a3148f91b594a02757f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "aa7915720c5630a86bc262ba3f74d5a637625c4b93d317d7b352d3e2b5bbeb71";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "af35f788c786dea0ed49469da46ccc1518e6b77c080c335ef7ff1d579d51a852";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "de5c83e55cfbe6b3fc0af4d5c604b39b37d40d05e186febba4190ebfd556da10";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt2/default.nix
+++ b/distros/jazzy/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt2";
-  version = "2.13.4-r1";
+  version = "2.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/jazzy/mrpt2/2.13.4-1.tar.gz";
-    name = "2.13.4-1.tar.gz";
-    sha256 = "9e3f7386befa3e67b26c57c0a025ecc1a4f90d5e8220f21f5a77e36af44691a7";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/jazzy/mrpt2/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "c10525e9222306fb7e090d4ca8df81694d29e4ea59e92425e2f1c6957b52d9fa";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "3697005b9fc1720634fcdaf494d7e28eb044283cb0bf201313c6945af1b3b163";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "af778cea24d37db275e5c5806b442635a19a180061c3719c0d837d2daf05c78e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "b6d8f63f91732bfbe71b09431aa82a2aeb0adc2ee499b3ac9ec2d12b6e9c07d3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "4893eaa622169f246f48cbe480e582d73b4bbc8048908ffd88baf30585a9147f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "627f6aa87c9e918b0021f9e4b99f2679b3d41dd6ddf1595491633d650749881f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "384c572883ec78c796d235878cbefc277ca2ef8342adef5e4fc0952b2816da0d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "cb60d6d4f0a6435e4987579e4bb8bb1d8af4aaa1f30174cacd0fbef2f576b66b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "74b33ac0f09a00f8fdf93d5c3baa7fb28b1f1b7d5edcd217b460562a6cdd97ae";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/septentrio-gnss-driver/default.nix
+++ b/distros/jazzy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-septentrio-gnss-driver";
-  version = "1.4.0-r3";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.0-3.tar.gz";
-    name = "1.4.0-3.tar.gz";
-    sha256 = "ea913bca837990ebffff45c29404904672bd634d63aa807c4ab818d0eb2c5663";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "79d191f5e2fbb5ac76ce9f4e2bcb2d25c8c0a58979c9d6bebc52c4934e885bfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "72aaed824c0fba397d86aa28959574428333f22364616543d4dd9684ce78b5b8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "66b5a606f45d4096687ad0c8bbe5fb444b2573d672b88a44e6836da2bfedb365";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/etsi-its-cam-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-coding";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "f282865cb68607b9f0ccf8fb6348f7bc62259af9437a078cf5da153b4ded1958";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2ad477b2023f8818734efa3f2a3f7209777ac9b1d1283c9c1d1d0c7808c03f40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-conversion";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "1cd6e8956cec3b17f1a8ac8cfc32e6829eabc80a16c57da67ea620b2cc4cfb52";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f539925f567a4f6e9af3268e4d3b7e599a6846d7fdfe3b563fcb263dcd173f76";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-msgs";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "fc378315ff1c0b93e7e59f50a06ca9778fb88aeb8e1cef1a5041c347f55c6ae8";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "51537a334716da07afe5b31d05c98e047186b5efcfca1321efdfd030be8c3f50";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ros-environment }:
+buildRosPackage {
+  pname = "ros-noetic-etsi-its-cam-ts-coding";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "df5db45dd1316eb7e0a63be179850d009b05cea20d80eac88be668090fdd08f0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS CAMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-noetic-etsi-its-cam-ts-conversion";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "c1fc35c84bdc1c9cc1d23f9df1ed986801ba1a7b6f9be98d4e6dc4ea681e2a79";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ etsi-its-cam-ts-coding etsi-its-cam-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS CAMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-etsi-its-cam-ts-msgs";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5e168d1e375b6d6da238653d16b418e2e9fac5c1ce0ad9204246a19948bea2f9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ message-generation message-runtime ros-environment std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS CAM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/etsi-its-coding/default.nix
+++ b/distros/noetic/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-coding";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "ed0860960d2f5e541a43b452f902c7fba40f97b3a26e215200387fbb1fb8bbb6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2a73e451e8cfb0e2f280efc43b734d8a0de075188d9a15f0fb3a6ab07b75050f";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding ros-environment ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/etsi-its-conversion/default.nix
+++ b/distros/noetic/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, message-runtime, nodelet, ros-environment, roscpp, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, message-runtime, nodelet, ros-environment, roscpp, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-conversion";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "c0970e167dbf3fca0ee9d788226d841b7cef637caf7655562bf831f491ed33e1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "eb24adf2c365b686310b579614a2436e1bfb2cae37ca77dc49cffa2ac075c42e";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion message-runtime nodelet ros-environment roscpp std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion message-runtime nodelet ros-environment roscpp std-msgs udp-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-coding";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_coding/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "e016b530b31e7e36ea10f352481796f1936f8bc143a27bf13fcea9664eedc7ae";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6006b7c359311b632de66c27e107dafbbc8dd3c2e6627ecb97e3ede8c4850a21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-conversion";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_conversion/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "145719787ed6ec0c4ca52c538b385e79326b650f218bf8930a96fe5b21987ee0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6cb76a24f199ae18d7110028b1c40be4acbc301be4275ce9f6b6b1076afaaf20";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-msgs";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_msgs/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "0a86ae405665ba9f60f7994ec806f4076f3ee882c262570c291cc22a72fc454a";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1e4e1aa5c6ff1c93db07f518318f783e02ec143b1648ca1db807cd93ad187b92";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-coding/default.nix
+++ b/distros/noetic/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-coding";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "f09d4e5bd8ac9e271e415fbe25617e7d9c45d1a559511785fca1bd2bb7b8e8e1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "aa3b12a488f54772de52f45b7872517107094394e7ab91d0f3adb7bbe822568f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-conversion/default.nix
+++ b/distros/noetic/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-conversion";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "ab4e5b4f44907b88238874ed7e8f345502ebaf0986ff7b47ad5c17d3d04335a7";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "cb555b69f78d74270bcbcdf2398466a96dbd31a580a5264291cd1dd907ec2738";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-msgs/default.nix
+++ b/distros/noetic/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-msgs";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "08ea40b6ad7f6a92a0713696382b093b3232befcc46c31ff7595783fb1e08565";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e6f29d4c0c812b2cfcd34f3962102021ec3a0d30471404ba34243e3ffd0831a0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-messages/default.nix
+++ b/distros/noetic/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-messages";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "cef40bdd195928f817ee3df3c3e4a6d0ac13d70e79b427eddcdd7a4b9025e5e8";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "97ce7dbf3db0240dd6bb097bcf98968d9163cd6ef7267801ef959abbe580b792";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs-utils/default.nix
+++ b/distros/noetic/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs-utils";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "4d5b0797d2a7ccda96338d0dc81fc208c8ce372a514fd95355b25d8893f6b051";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "c00f1f3cf35ca68a7716a655bcdbce36454309b8cf239635ce9a016454016f5c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs/default.nix
+++ b/distros/noetic/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "bdc7bff8a9a32320e6efc78c1b4bf300082146be2301bdccd2b4f2be06b1d98f";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a85d2669aaf7589c8a0a035829e83fd69328aef4fc3495c0e32d7fabcb918f9a";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs ros-environment ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/etsi-its-primitives-conversion/default.nix
+++ b/distros/noetic/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-primitives-conversion";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "8685ae34cc36684180e46fd9be9d926d3efedcf7bf26532fcbcbb933a7ad9c08";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2d255978c29c4314d7e0b78365ee61a2fc067cd06b49b3ccb898342c2785cf8d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-rviz-plugins/default.nix
+++ b/distros/noetic/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-rviz-plugins";
-  version = "2.1.0-r3";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "be081a5113d5d3686812ae79986e11d5d626bb589a47db12935bef7d64be9bb5";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "735de69569c945b0b9ff7fd7a83730cf05dc75e6665bc7feb82c2cff05a5749a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -898,6 +898,12 @@ self: super: {
 
  etsi-its-cam-msgs = self.callPackage ./etsi-its-cam-msgs {};
 
+ etsi-its-cam-ts-coding = self.callPackage ./etsi-its-cam-ts-coding {};
+
+ etsi-its-cam-ts-conversion = self.callPackage ./etsi-its-cam-ts-conversion {};
+
+ etsi-its-cam-ts-msgs = self.callPackage ./etsi-its-cam-ts-msgs {};
+
  etsi-its-coding = self.callPackage ./etsi-its-coding {};
 
  etsi-its-conversion = self.callPackage ./etsi-its-conversion {};

--- a/distros/noetic/mrpt2/default.nix
+++ b/distros/noetic/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-geometry-msgs, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt2";
-  version = "2.13.4-r1";
+  version = "2.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.13.4-1.tar.gz";
-    name = "2.13.4-1.tar.gz";
-    sha256 = "a81a5fec32a4466700aab47413cce44f27b74e91e041636523e9c753875e251a";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt2-release/archive/release/noetic/mrpt2/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "2b6e0a7d8973875ec1d676c6d4fe2aeecc4362141b923c88041fe439097f0fac";
   };
 
   buildType = "cmake";

--- a/distros/noetic/point-cloud2-filters/default.nix
+++ b/distros/noetic/point-cloud2-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, filters, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-point-cloud2-filters";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ADVRHumanoids/point_cloud2_filters-release/archive/release/noetic/point_cloud2_filters/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "2d850891e224b1416a67e4087e55302cadfd6928eedfd99385ddccd59e5c8cd4";
+    url = "https://github.com/ADVRHumanoids/point_cloud2_filters-release/archive/release/noetic/point_cloud2_filters/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "c42d725fdd2cdea4a95a35a05d19410e10de889dcde3539a52e4c21d67e54653";
   };
 
   buildType = "catkin";

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, roscpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.4.0-r5";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.4.0-5.tar.gz";
-    name = "1.4.0-5.tar.gz";
-    sha256 = "5ba69e882175f617a6ff22ff64b33b5e6881e64aee1f00acac56649092f92deb";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "ceabe786a10ef4d6665701d152b09c6c0f0dac20dc70f27e23be160f1974d99e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "66819806629535766aa16545f0646b33a7e5186cdfef1f5fecfd9d566ce81827";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "ceb7f264ff9e4e3fbb7af784ce826cb79cdea490a9971c752f719bfd9f3f25a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/warehouse-ros-sqlite/default.nix
+++ b/distros/noetic/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, roscpp, rostest, rostime, sqlite, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, pluginlib, roscpp, rostest, rostime, sqlite, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-warehouse-ros-sqlite";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros_sqlite-release/archive/release/noetic/warehouse_ros_sqlite/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "55c1b940c50612b756897cd167512990caad3e2f26b79f7f20574fb0e49616fe";
+    url = "https://github.com/ros-gbp/warehouse_ros_sqlite-release/archive/release/noetic/warehouse_ros_sqlite/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "48a686292547869c9c3cad349ed491926355b93fd9aec263544f3645f714b06e";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ class-loader roscpp rostime sqlite warehouse-ros ];
+  propagatedBuildInputs = [ pluginlib roscpp rostime sqlite warehouse-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "db5f34244402940405788a283e12250d46996de25e52b62a04529496468259b0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "4877cc44c048352473a3d4334dcae5339ac11bddf752d74a97facb2f38516d82";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "2b2050be2e8cc0c06d7d881288e8486002c0aa060198baff08a07744153e06d3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "88241729538507069826a65b88b1c07b85be0d9126d09cbebfd3e8dd13c422a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "86b053fbae0c57c179fea77319254322a81d9dccca622a13fe2f1f6dffa95059";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "a90d9c7d3e74cb50156827f05c555805a7a378f1698d31418edc3d3483370cf5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
-  checkInputs = [ ament-cmake-gmock hardware-interface-testing ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-pytest hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "8279285705ae6639d6851172de87c12d4efe9f9dd979003a882b8f894e189a35";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "397f15fead9cdff0c6a12f3b563267090db205ab85233ece29687a931c54aaf3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "392e9550bc931145db2e0fc875f41406af000d182b4a70c2f5244ee0027cd7a2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "41976787320ad737a70cef20c80ead1b667e5240cdf330234999bcbaf447d11c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "36a4afa157bc7fcb895b28ecead2e900c2b56665dfbd7b8aef57e05df2a876fc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "18dd09e86fb7520f1879493c076ba06b2b2b58f0268706306a23d217f968698e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt2/default.nix
+++ b/distros/rolling/mrpt2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, jsoncpp, libGL, libGLU, libfyaml, libjpeg, libpcap, libusb1, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, suitesparse, tf2, tf2-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt2";
-  version = "2.13.4-r1";
+  version = "2.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.13.4-1.tar.gz";
-    name = "2.13.4-1.tar.gz";
-    sha256 = "c6685c31669e574a4ea2443ad53adf69322825510db7503fad0ae1e2f2b732e8";
+    url = "https://github.com/ros2-gbp/mrpt2-release/archive/release/rolling/mrpt2/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "d26c7238ce3004b9509f76f80903cdb81760add0f37d1258b0676d6d879ce525";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "5c1d9a3dfd28b7686563aba70dba2794038918b3b4d7499ba354a676f53b1dd8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "c757f7959057d1e9758c619b4d13eaf47c7ce245e1bfc2f2b4c72fd7369aad2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "9a2a849bd0a9bb385812bde1cc69ba567f9618eab87aa9249e916d2931f4c4f4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "7138c7eefb27de00771be3b381463483a6fddeda264d71c23d78566dd3c581d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "01f54e74820b492de9cb662135dc90714d73620cfbeaabedcd295eafc5fecf78";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "f0c88465c56f2e253a919c4d7aa06789a6715a0751e9f491a687aa516c41b875";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "f8fb9ca2e23f8bb551d4e414fd25ff524f77735f9d49232a8fe8edcc5df79fb2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "1233ddf1afb2fd752b02b066d768e11864bc2f4bdb81017355b0e5aace15b7e6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/septentrio-gnss-driver/default.nix
+++ b/distros/rolling/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-septentrio-gnss-driver";
-  version = "1.4.0-r5";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.0-5.tar.gz";
-    name = "1.4.0-5.tar.gz";
-    sha256 = "e12e6e9d976e903c4e2fabfa3bbd038f880be7f5faccb39793f53b858d89a5ef";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "0fb8d315803e89621a85d2fbc219faa083b2832608711b1d41a435fc9a207039";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "78b7a20abef4a71e89fc6b898dd862d51c675eeec775ad65515800b50f5459c0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "87f9790e31b4fefb1a8e57695199c5f556ea15004788ce77075a83f3164ed57c";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 69219f8f35e5ae08e4ccff256529355744bc06ba.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *etsi-its-cam-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-ts-coding 2.2.0-r1*
* *etsi-its-cam-ts-conversion 2.2.0-r1*
* *etsi-its-cam-ts-msgs 2.2.0-r1*
* *etsi-its-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-messages 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-msgs-utils 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-primitives-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-rviz-plugins 2.1.0-r1 --> 2.2.0-r1*
* *launch-pal 0.1.15-r1 --> 0.2.0-r1*
* *mrpt2 2.13.4-r1 --> 2.13.5-r1*
* *omni-base-2dnav 2.0.7-r1 --> 2.1.1-r1*
* *omni-base-bringup 2.0.18-r1 --> 2.0.19-r1*
* *omni-base-controller-configuration 2.0.18-r1 --> 2.0.19-r1*
* *omni-base-description 2.0.18-r1 --> 2.0.19-r1*
* *omni-base-gazebo 2.0.3-r1 --> 2.0.9-r1*
* *omni-base-laser-sensors 2.0.7-r1 --> 2.1.1-r1*
* *omni-base-navigation 2.0.7-r1 --> 2.1.1-r1*
* *omni-base-rgbd-sensors 2.1.1-r1*
* *omni-base-robot 2.0.18-r1 --> 2.0.19-r1*
* *omni-base-simulation 2.0.3-r1 --> 2.0.9-r1*
* *pal-robotiq-controller-configuration 2.0.3-r1 --> 2.1.0-r1*
* *pal-robotiq-description 2.0.3-r1 --> 2.1.0-r1*
* *pal-robotiq-gripper 2.0.3-r1 --> 2.1.0-r1*
* *pmb2-2dnav 4.0.21-r1 --> 4.0.23-r1*
* *pmb2-bringup 5.0.25-r1 --> 5.1.1-r1*
* *pmb2-controller-configuration 5.0.25-r1 --> 5.1.1-r1*
* *pmb2-description 5.0.25-r1 --> 5.1.1-r1*
* *pmb2-laser-sensors 4.0.21-r1 --> 4.0.23-r1*
* *pmb2-navigation 4.0.21-r1 --> 4.0.23-r1*
* *pmb2-robot 5.0.25-r1 --> 5.1.1-r1*
* *septentrio-gnss-driver 1.4.0-r2 --> 1.4.1-r1*
* *tf-transformations 1.0.1-r3 --> 1.1.0-r1*
* *tiago-2dnav 4.1.2-r1 --> 4.1.7-r1*
* *tiago-bringup 4.2.17-r1 --> 4.2.21-r1*
* *tiago-controller-configuration 4.2.17-r1 --> 4.2.21-r1*
* *tiago-description 4.2.17-r1 --> 4.2.21-r1*
* *tiago-gazebo 4.1.8-r1 --> 4.1.9-r1*
* *tiago-laser-sensors 4.1.2-r1 --> 4.1.7-r1*
* *tiago-moveit-config 3.0.16-r1 --> 3.0.18-r1*
* *tiago-navigation 4.1.2-r1 --> 4.1.7-r1*
* *tiago-robot 4.2.17-r1 --> 4.2.21-r1*
* *tiago-simulation 4.1.8-r1 --> 4.1.9-r1*

Iron Changes:
-------------
* *etsi-its-cam-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-ts-coding 2.2.0-r1*
* *etsi-its-cam-ts-conversion 2.2.0-r1*
* *etsi-its-cam-ts-msgs 2.2.0-r1*
* *etsi-its-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-messages 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-msgs-utils 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-primitives-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-rviz-plugins 2.1.0-r1 --> 2.2.0-r1*
* *mrpt2 2.13.4-r1 --> 2.13.5-r1*
* *septentrio-gnss-driver 1.4.0-r3 --> 1.4.1-r1*

Jazzy Changes:
--------------
* *controller-interface 4.14.0-r1 --> 4.15.0-r1*
* *controller-manager 4.14.0-r1 --> 4.15.0-r1*
* *controller-manager-msgs 4.14.0-r1 --> 4.15.0-r1*
* *etsi-its-cam-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cam-ts-coding 2.2.0-r1*
* *etsi-its-cam-ts-conversion 2.2.0-r1*
* *etsi-its-cam-ts-msgs 2.2.0-r1*
* *etsi-its-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-cpm-ts-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-coding 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-denm-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-messages 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-msgs 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-msgs-utils 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-primitives-conversion 2.1.0-r1 --> 2.2.0-r1*
* *etsi-its-rviz-plugins 2.1.0-r1 --> 2.2.0-r1*
* *hardware-interface 4.14.0-r1 --> 4.15.0-r1*
* *hardware-interface-testing 4.14.0-r1 --> 4.15.0-r1*
* *joint-limits 4.14.0-r1 --> 4.15.0-r1*
* *mrpt2 2.13.4-r1 --> 2.13.5-r1*
* *ros2-control 4.14.0-r1 --> 4.15.0-r1*
* *ros2-control-test-assets 4.14.0-r1 --> 4.15.0-r1*
* *ros2controlcli 4.14.0-r1 --> 4.15.0-r1*
* *rqt-controller-manager 4.14.0-r1 --> 4.15.0-r1*
* *septentrio-gnss-driver 1.4.0-r3 --> 1.4.1-r1*
* *transmission-interface 4.14.0-r1 --> 4.15.0-r1*

Noetic Changes:
---------------
* *etsi-its-cam-coding 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-cam-conversion 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-cam-msgs 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-cam-ts-coding 2.2.0-r1*
* *etsi-its-cam-ts-conversion 2.2.0-r1*
* *etsi-its-cam-ts-msgs 2.2.0-r1*
* *etsi-its-coding 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-conversion 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-cpm-ts-coding 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-cpm-ts-conversion 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-cpm-ts-msgs 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-denm-coding 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-denm-conversion 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-denm-msgs 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-messages 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-msgs 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-msgs-utils 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-primitives-conversion 2.1.0-r3 --> 2.2.0-r1*
* *etsi-its-rviz-plugins 2.1.0-r3 --> 2.2.0-r1*
* *mrpt2 2.13.4-r1 --> 2.13.5-r1*
* *point-cloud2-filters 1.0.2-r1 --> 1.0.3-r1*
* *septentrio-gnss-driver 1.4.0-r5 --> 1.4.1-r1*
* *urg-stamped 0.1.1-r1 --> 0.2.0-r1*
* *warehouse-ros-sqlite 0.9.0-r1 --> 0.9.1-r1*

Rolling Changes:
----------------
* *controller-interface 4.14.0-r1 --> 4.15.0-r1*
* *controller-manager 4.14.0-r1 --> 4.15.0-r1*
* *controller-manager-msgs 4.14.0-r1 --> 4.15.0-r1*
* *hardware-interface 4.14.0-r1 --> 4.15.0-r1*
* *hardware-interface-testing 4.14.0-r1 --> 4.15.0-r1*
* *joint-limits 4.14.0-r1 --> 4.15.0-r1*
* *mrpt2 2.13.4-r1 --> 2.13.5-r1*
* *ros2-control 4.14.0-r1 --> 4.15.0-r1*
* *ros2-control-test-assets 4.14.0-r1 --> 4.15.0-r1*
* *ros2controlcli 4.14.0-r1 --> 4.15.0-r1*
* *rqt-controller-manager 4.14.0-r1 --> 4.15.0-r1*
* *septentrio-gnss-driver 1.4.0-r5 --> 1.4.1-r1*
* *transmission-interface 4.14.0-r1 --> 4.15.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libnanopb-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] protobuf-compiler-grpc
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-seaborn
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

