### PR TITLE
Fix rosidl-generator-py patching.

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -62,19 +62,6 @@ in {
     hash = "sha256-Qaz26F11VWxkQH8HfgVJLTHbHwmeByQu8ENkuyk5rPE=";
   };
 
-  rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
-    postPatch ? "", ...
-  }: let
-    python = rosSelf.python;
-  in {
-    # Fix finding NumPy headers
-    postPatch = postPatch + ''
-      substituteInPlace cmake/rosidl_generator_py_generate_interfaces.cmake \
-       --replace-fail '"import numpy"' "" \
-       --replace-fail 'numpy.get_include()' "'${python.pkgs.numpy}/${python.sitePackages}/numpy/core/include'"
-    '';
-  });
-
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     url = "https://github.com/OGRECave/ogre.git";
     rev = "v1.12.10";


### PR DESCRIPTION
The patch is no longer needed on jazzy.

equivalent to https://github.com/lopsided98/nix-ros-overlay/commit/252ad9fcb29fcf2ff0f3f2151c786db13266dfb0