### PR TITLE
rosdistro sync, Fri Aug 23 14:11:36 2024

### DIFF
--- a/distros/humble/aerostack2/default.nix
+++ b/distros/humble/aerostack2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, as2-alphanumeric-viewer, as2-behavior, as2-behavior-tree, as2-behaviors-motion, as2-behaviors-path-planning, as2-behaviors-perception, as2-behaviors-platform, as2-behaviors-trajectory-generation, as2-cli, as2-core, as2-external-object-to-tf, as2-gazebo-assets, as2-geozones, as2-keyboard-teleoperation, as2-map-server, as2-motion-controller, as2-motion-reference-handlers, as2-msgs, as2-platform-gazebo, as2-platform-multirotor-simulator, as2-python-api, as2-realsense-interface, as2-rviz-plugins, as2-state-estimator, as2-usb-camera-interface, as2-visualization }:
 buildRosPackage {
   pname = "ros-humble-aerostack2";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "d2b03c10ac6680c4519734c0db8d69af252465427200a8355d1d0d920465dab7";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/aerostack2/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "b01736d9ceeb14dc6e22ac0743ec0ba28523671f807f659c32d9ab5a71207dd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-alphanumeric-viewer/default.nix
+++ b/distros/humble/as2-alphanumeric-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, eigen, geometry-msgs, ncurses, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-alphanumeric-viewer";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9099726865d82f6d5b1a79eab7d566735d3f6b7119973e9b280e066c9e1da8f1";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_alphanumeric_viewer/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "4680eefa50a68b87cfe6543757ca648460f2c579ae1be7bea9f5ec64c1907e19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior-tree/default.nix
+++ b/distros/humble/as2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, behaviortree-cpp-v3, geometry-msgs, nav2-behavior-tree, nav2-msgs, rclcpp, rclcpp-action, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior-tree";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f5e4fd76466fffe51865388da3fd1ac0e73f293d1356a052377a959b2d4db575";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior_tree/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "db6bb5c9d8404aebbf9b3db3ba3ce08167690ae349d1a44c89bb4f1b1188b7a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behavior/default.nix
+++ b/distros/humble/as2-behavior/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behavior";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "920a4edb14fac52e007998391b98954cd61da44315a89ba71ca2c654fee440ba";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behavior/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "74cbe1e4cbeb9ec5976548923c55695d0c0d4264148233218cb5d7b8e3e312ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-motion/default.nix
+++ b/distros/humble/as2-behaviors-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-motion";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6e1acf35e4e6b5d1e8db477f84ed8d424331606433c0ff3d14346b7f9a41861e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_motion/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "5270acaecabe973fcdcc5fb6fbc86a8f01c5cbc0713b91ba3416d2bdc3b5320f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-path-planning/default.nix
+++ b/distros/humble/as2-behaviors-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-behavior, as2-core, as2-msgs, geometry-msgs, nav-msgs, rclcpp, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-path-planning";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_path_planning/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f1ed92124d87c858984dd078a4f326a7ca13dd0fbfa7766abc6b4201db0313b1";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_path_planning/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "e146d59e9fe4c61a3f91456672874369ca3450c313e67bbaf41e5a57bace88ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-perception/default.nix
+++ b/distros/humble/as2-behaviors-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-behavior, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-perception";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "54bd41a7ac436c1c4b0fcc3c9e6828f41b5ca085669f6daa0656418eaa6fa4fe";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_perception/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "cc1a183b06bef0c5a431faaa765984456e7c0f9ccde021e99c95a39b14daf411";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-platform/default.nix
+++ b/distros/humble/as2-behaviors-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-behavior, as2-core, as2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-platform";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9a701500c2f96c6b2b44a6c1548d4b167369eb5cb143fabd3a57188cebefcf06";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_platform/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "fab6e59c4330a9a00b9f7f46f22406cb9c7d786179947ddd6cdde591f6f99810";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-behaviors-trajectory-generation/default.nix
+++ b/distros/humble/as2-behaviors-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-behavior, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-components, std-msgs, std-srvs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-behaviors-trajectory-generation";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "31bda0dbf141ebb94980ca2c05a364dc04684d1d8b9d2741ced98af25e4c33c3";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_behaviors_trajectory_generation/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "771ec7f32ce69820137dfa26033e18a0c4678812764d301f28e346955752c734";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-cli/default.nix
+++ b/distros/humble/as2-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-as2-cli";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1a02d7b4519bdaf24108d69eff62651d4dced9ee1321c920b8a85fefd3efe7a2";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_cli/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "f7aef8d9e5b7fb86fc8f009462aed7eda92a1721e9de3de880f7744528312c43";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-core/default.nix
+++ b/distros/humble/as2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-msgs, cv-bridge, eigen, geographic-msgs, geographiclib, geometry-msgs, image-transport, nav-msgs, pythonPackages, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-core";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4f92705c6836bf52f80104755d1b521c7467b94870314bb5a390c761bd5f05ee";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_core/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "70ff8238e81884150557a79f6630e15c2191106b79539f72c7f341eae0459d29";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-external-object-to-tf/default.nix
+++ b/distros/humble/as2-external-object-to-tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, mocap4r2-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-external-object-to-tf";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_external_object_to_tf/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4e1ca582638e7d83e381e6c886e2f6e07b916a059f8e1e42170dfcee1da9f7e3";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_external_object_to_tf/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "4cda49871919a814392d86f1b1dbbbc9176de7100a55a8c431bd5408b13a7129";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-gazebo-assets/default.nix
+++ b/distros/humble/as2-gazebo-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, as2-core, backward-ros, geometry-msgs, python3Packages, pythonPackages, rclcpp, ros-gz-bridge, ros-gz-sim, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-gazebo-assets";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_assets/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1f7e6747a66cb1048082372f419a4009b9c1ae71de71c6800705dab1b9baa203";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_gazebo_assets/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "b1df210958fc45042dbcc6d267b391c0fe9ff16fbdd7e182cd4936eea4df2da2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-geozones/default.nix
+++ b/distros/humble/as2-geozones/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-geozones";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_geozones/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "fd375f2fbfe521a8fee75b138bbaf458a8cfd6d8c687a355f2c10e7c3860930b";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_geozones/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "712bde0d5acefc1897e5b6d7ad12bfd1119bb63ed730395400951dcd4b68a5ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-keyboard-teleoperation/default.nix
+++ b/distros/humble/as2-keyboard-teleoperation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-motion-reference-handlers, as2-python-api, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-as2-keyboard-teleoperation";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "46d5bde651afbd1f3c374e6f2e9a1a264b6aa5415ef7c18bebf6dee506954359";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_keyboard_teleoperation/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "50bcbad646fee20dc1006921b62af74067a33dfef2fe0ff4ac03587de7ce2e54";
   };
 
   buildType = "ament_python";

--- a/distros/humble/as2-map-server/default.nix
+++ b/distros/humble/as2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-map-server";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_map_server/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "38e3279d7cbcef13ae774f4cb5bc5e545fbf064422c7505f3b681b4ccf829e31";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_map_server/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "f8e6f913a1e92d6a92effb0dad39e5b29cc003da2b0f289af29b5d1d81b4440e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-motion-controller/default.nix
+++ b/distros/humble/as2-motion-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-motion-reference-handlers, as2-msgs, eigen, gbenchmark, geometry-msgs, pluginlib, rclcpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-controller";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4937f2c3b0036f429dc2284c65406188167f8144d480c688c15edc18fe0aa330";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_controller/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "9ece4c7766d2fae1fb9e6503eddb6f7f131e6fd89526d5871a43bb08d40cda01";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-motion-reference-handlers/default.nix
+++ b/distros/humble/as2-motion-reference-handlers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, eigen, geometry-msgs, rclcpp, rclcpp-action, rclpy, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-motion-reference-handlers";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "3edd92857e0f2caf47dfb214775b102a8481ebf5adc59f50843050a4ebf4dfe6";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_motion_reference_handlers/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "bf0e235e3703eb146626a0abcf321a53f070257346e091781821a96f0bc67dd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-msgs/default.nix
+++ b/distros/humble/as2-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "8be3dcad07e471ac41e3518820283e7cf235ae9febc1b0f702d4a03b094357ff";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_msgs/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "40d9a8fb07ef716ad67045ef5971bbf3ce59254942dc6256a2a3a8755c2a9b82";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces geographic-msgs geometry-msgs nav-msgs rclcpp rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geographic-msgs geometry-msgs nav-msgs rclcpp rosidl-default-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-platform-crazyflie/default.nix
+++ b/distros/humble/as2-platform-crazyflie/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-python, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, eigen, geometry-msgs, libusb1, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-crazyflie";
-  version = "1.0.9-r1";
+  version = "1.1.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_crazyflie/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "662b0d104723703a5caa603973155c658403360cb270118aec2e8db7c3754bab";
+    url = "https://github.com/ros2-gbp/as2_platform_crazyfile-release/archive/release/humble/as2_platform_crazyflie/1.1.0-3.tar.gz";
+    name = "1.1.0-3.tar.gz";
+    sha256 = "0ebe35daa2adab1b77f6d917ed38876763762d95fe0b9193e7f1d58fb6643715";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ as2-core as2-msgs eigen geometry-msgs libusb1 nav-msgs rclcpp rclpy sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 

--- a/distros/humble/as2-platform-dji-osdk/default.nix
+++ b/distros/humble/as2-platform-dji-osdk/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, libusb1, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, libusb1, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-dji-osdk";
-  version = "1.0.9-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_dji_osdk/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "009e4cc80ebfdb10012e8e80a0ead9dd43a9f28182b760e46fc2cac804668494";
+    url = "https://github.com/ros2-gbp/as2_platform_dji_osdk-release/archive/release/humble/as2_platform_dji_osdk/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "884f71791f5fc652d1e77aca57844402baedf7313e1c8fe92c45f7cc7af0fa49";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ as2-core as2-msgs geometry-msgs libusb1 nav-msgs rclcpp sensor-msgs std-msgs std-srvs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake ament-index-cpp as2-core as2-msgs geometry-msgs libusb1 nav-msgs rclcpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/as2-platform-dji-psdk/default.nix
+++ b/distros/humble/as2-platform-dji-psdk/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, psdk-interfaces, rclcpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-as2-platform-dji-psdk";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/as2_platform_dji_psdk-release/archive/release/humble/as2_platform_dji_psdk/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7604efdd5620f722867fdc2661df52ada3c2d5d5414cdd60f2848415ba69997f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake ament-index-cpp as2-core as2-msgs psdk-interfaces rclcpp std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "AS2 DJI PSDK aerial platform";
+    license = with lib.licenses; [ "BDS-3" ];
+  };
+}

--- a/distros/humble/as2-platform-gazebo/default.nix
+++ b/distros/humble/as2-platform-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-gazebo-assets, as2-msgs, geometry-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-gazebo";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "e8dc544c284505b8f2c2516b2fb61d73af184ae1fbf377134e1ae67f24a04cd7";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_gazebo/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "bab76253993a85aa88aa7c60ab88949c1578b961a64a8b353bc4ee78aa0dad15";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-mavlink/default.nix
+++ b/distros/humble/as2-platform-mavlink/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, eigen, geometry-msgs, mavros, mavros-extras, mavros-msgs, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-humble-as2-platform-mavlink";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/as2_platform_mavlink-release/archive/release/humble/as2_platform_mavlink/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f43c8b8ebc31d267de833ada2b6d2d80f04984360dd9afbed46a8e732c4f5d11";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake as2-core as2-msgs eigen geometry-msgs mavros mavros-extras mavros-msgs nav-msgs rclcpp sensor-msgs std-msgs std-srvs tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Package to communicate Mavlink based drones with Aerostack2 framework";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/as2-platform-multirotor-simulator/default.nix
+++ b/distros/humble/as2-platform-multirotor-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, rclcpp, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-multirotor-simulator";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_multirotor_simulator/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "a989c92e83fc5c4ab4dcbc9cfcc1da1c968c5dee359077efb18ee9b5d7867182";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_multirotor_simulator/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "14b0421a8797e59a132e294c50854a121c61ef304a174dba205fa5ccef12329d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-platform-tello/default.nix
+++ b/distros/humble/as2-platform-tello/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, eigen, geometry-msgs, nav-msgs, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-platform-tello";
-  version = "1.0.9-r1";
+  version = "1.1.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_platform_tello/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "81b7b95784a068e4828ec86f267cc71d34bd99a621378e46fd5c3348943cd914";
+    url = "https://github.com/ros2-gbp/as2_platform_tello-release/archive/release/humble/as2_platform_tello/1.1.0-4.tar.gz";
+    name = "1.1.0-4.tar.gz";
+    sha256 = "5573b1494b2bdbe72336f62ab82cad8993eaffdd2bebc66038ca9fd598bd85bf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ as2-core as2-msgs eigen geometry-msgs nav-msgs rclcpp rclpy sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/as2-realsense-interface/default.nix
+++ b/distros/humble/as2-realsense-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, geometry-msgs, librealsense2, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-realsense-interface";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "5d2771e9e49aaaed48500cc9021c5ae619ba32bcb8219eb4478820bd5194098e";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_realsense_interface/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "ac7fd77fc0993e8ceaaabe634395bd04fdebfa0f48b1a0a90ee2ac0a7bc6f57f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-rviz-plugins/default.nix
+++ b/distros/humble/as2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, as2-core, as2-motion-reference-handlers, as2-msgs, geometry-msgs, qt5, rclcpp, rviz-common, rviz-rendering, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-as2-rviz-plugins";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_rviz_plugins/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2aa9f229ad592ba36c1fc917fd2e49dee388b1c2ce2e4bf203ec480438e06fb6";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_rviz_plugins/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "a5a58331a4e2f27a7006cbb244b539e84f0d94882867e101fe2be88552d91dbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-state-estimator/default.nix
+++ b/distros/humble/as2-state-estimator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, geometry-msgs, mocap4r2-msgs, nav-msgs, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-as2-state-estimator";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2463e8d42475e2602e03ddf4e95515c5748ae378158dd5b103419791a39ef409";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_state_estimator/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "25de64881a116227b50f6a8e2a49e63f0f3417ef3dc21fdad2f5d2bcc1b66494";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-usb-camera-interface/default.nix
+++ b/distros/humble/as2-usb-camera-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, as2-core, as2-msgs, cv-bridge, rclcpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-as2-usb-camera-interface";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "478fed8ec19fb95537d461c2ca5bea76bb2e11261fdb48ded421a2ff454d68df";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_usb_camera_interface/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "c1ab0806e168ea92a9a897f3fbabe1c5ac7c04f8dd4954e21e6f72302622fc6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/as2-visualization/default.nix
+++ b/distros/humble/as2-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, as2-gazebo-assets, pythonPackages, robot-state-publisher, ros-gz, rviz2, sdformat-urdf }:
 buildRosPackage {
   pname = "ros-humble-as2-visualization";
-  version = "1.1.0-r1";
+  version = "1.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_visualization/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "49886453e78643f0b1d9c97cc69dd61349f24cad8f4473c5e417603f41763243";
+    url = "https://github.com/ros2-gbp/aerostack2-release/archive/release/humble/as2_visualization/1.1.2-2.tar.gz";
+    name = "1.1.2-2.tar.gz";
+    sha256 = "653b0ad1037db9fd0c9b295e77c99f753f6a540319052d05c4843d8a87422203";
   };
 
   buildType = "ament_python";

--- a/distros/humble/camera-calibration/default.nix
+++ b/distros/humble/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/camera_calibration/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "7030d1bbc0014a0e1fb98f679013869bed4869d7612b0c8ce8c67e337ac276f7";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/camera_calibration/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "3ff8c98d75b09256c5f0f5e28790cb750a0bbf1f2d00065c889feef1bffd7289";
   };
 
   buildType = "ament_python";

--- a/distros/humble/depth-image-proc/default.nix
+++ b/distros/humble/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-depth-image-proc";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/depth_image_proc/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "1429ddb6b5a289c3e9e99957b7999fd6a57fd70e2c92d75d9933142f3b2adc2f";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/depth_image_proc/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "790403571393f77ae51f5dc1c56c4c0336f67a681f91008de4af533be575c1f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.26.1-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.26.1-1.tar.gz";
-    name = "2.26.1-1.tar.gz";
-    sha256 = "54f6003ee3f775ceafbc768478a572b673b94288fbec448e5d36c87693eab468";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "12c9742743567c26d8468b00ee45ea7bd909fc6ba90dce8004736c95463e4a62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fields2cover/default.nix
+++ b/distros/humble/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, protobuf, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, ortools-vendor, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fields2cover";
-  version = "2.0.0-r10";
+  version = "2.0.0-r11";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/2.0.0-10.tar.gz";
-    name = "2.0.0-10.tar.gz";
-    sha256 = "d8ab838f5f4ae552b6793076e7b74ad4ba745a09c36566ab3a8068b932dc58f2";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/humble/fields2cover/2.0.0-11.tar.gz";
+    name = "2.0.0-11.tar.gz";
+    sha256 = "abc2e28ad116a5f113a05d86cf26c9500205ad84afc407e9919b14afe7959d9e";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ boost eigen gdal geos git gtest protobuf python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
+  propagatedBuildInputs = [ boost eigen gdal geos git gtest ortools-vendor python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -250,9 +250,19 @@ self: super: {
 
  as2-msgs = self.callPackage ./as2-msgs {};
 
+ as2-platform-crazyflie = self.callPackage ./as2-platform-crazyflie {};
+
+ as2-platform-dji-osdk = self.callPackage ./as2-platform-dji-osdk {};
+
+ as2-platform-dji-psdk = self.callPackage ./as2-platform-dji-psdk {};
+
  as2-platform-gazebo = self.callPackage ./as2-platform-gazebo {};
 
+ as2-platform-mavlink = self.callPackage ./as2-platform-mavlink {};
+
  as2-platform-multirotor-simulator = self.callPackage ./as2-platform-multirotor-simulator {};
+
+ as2-platform-tello = self.callPackage ./as2-platform-tello {};
 
  as2-realsense-interface = self.callPackage ./as2-realsense-interface {};
 
@@ -1220,6 +1230,8 @@ self: super: {
 
  kinematics-interface-kdl = self.callPackage ./kinematics-interface-kdl {};
 
+ kinematics-interface-pinocchio = self.callPackage ./kinematics-interface-pinocchio {};
+
  kinova-gen3-6dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-6dof-robotiq-2f-85-moveit-config {};
 
  kinova-gen3-7dof-robotiq-2f-85-moveit-config = self.callPackage ./kinova-gen3-7dof-robotiq-2f-85-moveit-config {};
@@ -1827,6 +1839,8 @@ self: super: {
  navigation2 = self.callPackage ./navigation2 {};
 
  ndt-omp = self.callPackage ./ndt-omp {};
+
+ neo-nav2-bringup = self.callPackage ./neo-nav2-bringup {};
 
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
 

--- a/distros/humble/image-pipeline/default.nix
+++ b/distros/humble/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-humble-image-pipeline";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_pipeline/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "0eb6b898fbb0631645bd72167de53b06a1dd489fad6ac8a00a22fc5da8ed4d69";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_pipeline/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "5ef1151d93c41b8845f72dd2b92b7ba90120b6d0bb6aea23166618b2f6a3cb54";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-proc/default.nix
+++ b/distros/humble/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-humble-image-proc";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_proc/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "718066e2eea159a3ce0e75d6016e1a21ab251ac3168dd1fd6dc34fdef566ad77";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_proc/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "9cf2ecfa7bca00fec55a209c9dd835435e4b0bb5d8af02b3f6f6578f0f8c59a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-publisher/default.nix
+++ b/distros/humble/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-image-publisher";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_publisher/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "744f5a11b9e0bf32146e7b737c07695208e8f3b41b739335dd9ff9670965b64d";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_publisher/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "475a2ef901c6ce1de40b5526c0f3cee2de88e61c46608b4d78152667633094a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-rotate/default.nix
+++ b/distros/humble/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-image-rotate";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_rotate/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "a53d059e46a4f8aeb20cef34fffa2a6f4ebbaf84f3931125fb069fb248e1f10a";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_rotate/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "af54c0bdc07a9c77f7ded770623fcecf19e1a57ae04d83b008f4708c561a6965";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-view/default.nix
+++ b/distros/humble/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, boost, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-view";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_view/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "ce942a6f448972f7e22d37e9efb82e1568792d15d1be1b62cafc4003af9a258f";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/image_view/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "4f13ff674abc3f297c4e915b4b0fe1b8681e94798f697901c74c45728b4700ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kinematics-interface-pinocchio/default.nix
+++ b/distros/humble/kinematics-interface-pinocchio/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kinematics-interface, pinocchio, pluginlib, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-humble-kinematics-interface-pinocchio";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/justagist/kinematics_interface_pinocchio-release/archive/release/humble/kinematics_interface_pinocchio/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "2168a0bb8e266efbc66f1cf2ab0948caabdd283d70da2d9755de32e0ebe87155";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
+  propagatedBuildInputs = [ eigen eigen3-cmake-module kinematics-interface pinocchio pluginlib ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = "Pinocchio-based implementation of ros2_control kinematics interface";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d4eb59d99dca5e48353d090a1d2a7aaeda78785fb5d062f4f7defb2a1b669bfa";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "46181d3dff64b24cfdea8bf9a0e60f76d3719a6482f754cd44aff9b5a1803db6";
   };
 
   buildType = "cmake";

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.4-r1";
+  version = "4.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.4-1.tar.gz";
-    name = "4.3.4-1.tar.gz";
-    sha256 = "fc42f671f076306fc915b63cdee629c211d4845766f8b6c4e1520d68d866d2d9";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.5-1.tar.gz";
+    name = "4.3.5-1.tar.gz";
+    sha256 = "47ae144dd748d730505a462eabba1014172373cc16235b1d9512846ed80de1cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "831359bce286a7a3d0a3f00556a772e66893bf052f642ebfb745ffb19aee9e73";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a3a68b6a5d2f554eaa5948a22eabe0a14d1587bb383904b40ba35597627a8716";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ geometry-msgs mola-common mola-kernel mola-msgs mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-common/default.nix
+++ b/distros/humble/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-common";
-  version = "0.3.2-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/humble/mola_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "a7c78758187e53bcdd1861e46c9d92fbaac0260aba683fa86cff71f448d1f4bd";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/humble/mola_common/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3539fd9285d1791322fc6a87b0684b55ddc056db9ec95394191b5908ec808534";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "0b81a0ba6a99b1b7aaebc53958ae4705593e6e6a6b49444402773ff1591e02fb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8d0e727bb53e44924f5966ce8718958755bbf4c50e264b009f6ee13d4c637fb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f3f7fa0974ca0d3082023a6f29a817d68ce5d5cc27a7b1803751a8fffb2d8e25";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8bc7f081a4232ab7d4c00745e391563c83ec3b361382bc186b879cc07c5fd70e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "1bc2450b49f91b818f05c6c0b3ff62fe54977376a649ddc0fa5407f2b7cfe9fe";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ee75bb2aba00d8c16d1d4b8c1758c61f87ea6a8867fd0e02228a0357fc417bb9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "07ecdfac91596a7df8e93267b7c491cb0418025c3929e34feed792f0dd98f354";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "77eb8965016c0327fa301fcb9551be32c6f876c520ea5abe78ab929fbf22f090";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3bea460f6789da6d23da8ba119fb432b190017397cdccbff3e0cdc2cbc0ea4c3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "20f9de9259b5b8596bd439f5a72279855ad011ee123ece67a04cbbb6f144c74c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9616e80cc99c2a06caa188de342ee10d41a9bddd1767e9494e86946abb951a9e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "db687c59993c3eb3e1a4966acbb65d030886099c7db44785cd92791b406c05e5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b9c06392a4b46302d66f18e5fc5d723bd0719f2fa310de4df8be4a4dc6956751";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b641f6fce7189da75f73eb16e00af2fe31c2058647e4c1e7b98dcbaadf1709b9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "e70502a549078ce41710bc504d2788d2925a9d5ae1a60c1f3f40045020b25daa";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "839d33d6e6bb72f9e664db94730843e319ef4d60907aa0a0e0021c0ef3b91609";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "0c744f18fb4404c92d20d18d65ef5267b6c34ecb018046423102645a3e9dde3f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "52f866648cab7dd129e071877dc32b6c539a320afdc817ad2c2ffc4b9ea620be";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "61f3dff05f09df7321d34d21951099b6f066b5787445b6d91621d6ca5473211d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "079e8481f4828c47dc8f843f0dcd78712d2256df8665212bc9f72ca6d6712747";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3ce5209aa468a724985bbc845423f779758ef48108e04e643bd791eaec1e25dc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "78f51aa005d00bb1bff419d6e38df32bc9e614f3ab3529737f41d007c59b48d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "770586e6b5b363e75173c4e891c979db1d00b493db509117733144e11c078757";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c67fbc55314cab1022ad9a15437b2a5d0468a06ccdf3c672dcc125cf99ecc837";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-navstate-fuse mola-pose-list mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9e8404ceff185a9545a1c8b54035e7cf10cf9f11c8c89b21d18a1714ee7fb5bc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "da2a19b6e1768d7e6b7e95dbff82927aabc6177b5e392b2dd05f9135b177e895";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "5f93714cfcbecb3f4b5b4d8dce60f092aac79fd93de2eafd35d61b753fbf3d78";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "aa51dfc6ad1f7b5f9b562cb7f0d87fe49fb209cdd626eb0a4ce4051a48855bdf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-navstate-fg/default.nix
+++ b/distros/humble/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fg";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fg/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f23cc54114304dcbda72a269dfdb5285c6c57ad4e1be7cdf6aec3002c81b4768";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fg/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9ff130a44fe9ff7985a0e540183e298c70793707c888bc7c859ebc3051d79677";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-navstate-fuse/default.nix
+++ b/distros/humble/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fuse";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "11c1818cef50c8ee2985ae713eb6e601a752f560c3b7d7f04e057b0107003ef8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "31ceaad05808fcad41e1db7e1985350cb182c456490a184f5437acf42a3755b2";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a06728bfedac8a19f5d50c111d27eee68da7cb1db8f159a3c7333e85c468b590";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9ce3c7491c4852e4914d57c19e5a73b67891018559a6e408cfaa78cac78dd84d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b789fcae216936709e575f13b0ade6ae7f63f0f9e69a84f4ca65c036493e4dd7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e21400209c87747bad5e5f20a426144352a2fbf2cb0d7c38357551ab63313796";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "e2ec40b60db187d7829b0926b5bd5f91814dd0491dc2676ce81b4d2071a56dc9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "419e1e6b2f687d0737a60c7e8b716db9d66b279a474217f8e553779cd1fed30f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6aac2e0087bad278f0ea0e4afd3c9fdce8ffe199d7ee53a215b1a5669dd6e54f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1941765cbeabe357d38e68b57601a9505eb03afac74c23fce29cf080b7e61008";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b50fa1b7c81e7967936c75264493b11f974cd1af747c038c966db6bae866b8c3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "78948e85feb7200bc812efeaceda8faa5d8f6e6fdb14c4d81bc8174becaa9e3a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b91341c40e17396ce71f54a3a102e31f53b7b3b45f4e76b075cc0e8916049129";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7150c2782ccb5180901276c03bfb55b129fd569ff46b2b3d62d6d79d247022f6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.5.2-r1";
+  version = "1.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "040980796548e883876fcd2392772eabab9b639cf8c6ed66a9a82e7dc65d0401";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.5.3-1.tar.gz";
+    name = "1.5.3-1.tar.gz";
+    sha256 = "83821bab39fde89ac04ba1ac7326b4c18f9465caea14d7d0d14d1d0da9d8fc68";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "683719dec92d9333a5d5c6902bfda06876e8234c71c8dc417d897dec46235b3e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "5e16ba5bf2c46a06570a8b463ef5f23415ac7ca87ffa47aca60260960051cd3a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "12237804eb68b25106b55ee550c6b535802b9d079b9af19d7deedc7202115cb2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "c449a025a26ad2e19d7a872a22821764bf333747dba456a433a60ad191cd86d9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "9eb8e2e467ed3eab94975a6b4f14f2fcd27a972f60ee2c411c21f620c557e86b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "de331ca663fbb332602ec67d9a4285ca6891a3a15f00947c4de0d0c71ad8c397";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "922f4db8227ba19efb6c3050af4a89a84995d640b6374a0a788571c0af1952e0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "2c2199edec2237b303eec18440672a7cf007fa625a343cd569ebf31b46b23611";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "536607f810b1390d4e94e6ee09beda045dd94af99cbd189a5be23f625f066dc0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "1108a36b3a218ae2c7ad92c340531b9e5cdf4cb41fbc771f85398e898ad2e08d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "b6ea96e50b55d55cc269715eea027182811cbb1aa30a4662b819ad5cc43c16a8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "91bd82090e4f8c83c3e178f08d3382ab97e3034791489d21dd432ed70a037e7a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "3203462180845e223efc2c98bf75611e2256e73dd3682980d2480073ba2b1a02";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "e5912e75bcc89501b66b339915c7fdff5a985b919a40813ccc723d376ca2814d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "4382001b01c523c22a618a5c8ecfdc4acea434dcd03dcb189c563ba3a56c845b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "c824c6604b7b68bfeb4ecb82258c0f3f0bf54ecedfca6adbabbd2c28453a11be";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "1dec46f34798295f1693ac9f058f9157fbe469dd0d35edd385be649234eb912c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "c921c9bfb2d281407b6ecb0ece4156fcd5930a282be6f7a2ea3f2ca2f95e93b9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "62f5a23529cacf61da90ad2254cb1d437541332b4d6e256ba57904ccd4612362";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "8ff5d050bb3426e3834c15e68a34eef6e283fc0f009cb3d3cde9bdfc76205ef8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "2344656bd0024807770728493fa077ae83294c0201bc289a50fa2fff4507212c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "237d73c6f87ca6ed214dffbafa88d618920e910cb3e4e10a00581a1d00afa076";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libros2bridge/default.nix
+++ b/distros/humble/mrpt-libros2bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros2bridge";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros2bridge/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "ac2579ec2c19c5b40f9fd7f8796f4a500a000f22c1915a2d6ad982d4c9db9393";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros2bridge/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "847dfb6a70bf8f35a07c485131b3d21fb5693719e83a04f431aa9b9c51cdd43b";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "02824e24e298699d6e4f1c0ad9aa78b53671a23e459d637edea824a1336f75a2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "6e1ce7dfb4d1d87cacc36681344155c23506c5fe3ce31f98c3d18a11fc1a53eb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "65513f7ab35269355918537fc6c55c7e760fbcc891cb6eba8268438c1eaed12a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "c1ecdeb027cf51578a3a4d19707a58ed4f84b72c952ae451b0f06bbceb859052";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrt-cmake-modules/default.nix
+++ b/distros/humble/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mrt-cmake-modules";
-  version = "1.0.9-r3";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/humble/mrt_cmake_modules/1.0.9-3.tar.gz";
-    name = "1.0.9-3.tar.gz";
-    sha256 = "67fae5d9e5a4cb31235807dba74b4c061bde0e2deab633339c121f18638076fc";
+    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/humble/mrt_cmake_modules/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "6c66bd41771d0066429e2246ee9028e43437515b549d38081662a8129b785209";
   };
 
   buildType = "catkin";

--- a/distros/humble/neo-nav2-bringup/default.nix
+++ b/distros/humble/neo-nav2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-common, navigation2, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-humble-neo-nav2-bringup";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/neo_nav2_bringup-release/archive/release/humble/neo_nav2_bringup/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "0eebdb3795ccd94928cd536f83f6b015ed94fa90ababee4746d526f06342fcb9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-common navigation2 slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS-2 navigation bringup packages for neobotix robots";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/pcl-conversions/default.nix
+++ b/distros/humble/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pcl-conversions";
-  version = "2.4.0-r6";
+  version = "2.4.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.0-6.tar.gz";
-    name = "2.4.0-6.tar.gz";
-    sha256 = "dee51fc73a0875ced007e7bcab00eea6b5240327bc6bf5179a51b3aa70b1d87c";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_conversions/2.4.5-2.tar.gz";
+    name = "2.4.5-2.tar.gz";
+    sha256 = "289ad37ad62cc33e380db6d2f0a9585028ed0cd2932da4a4cf3f1220bfdaeeba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pcl-ros/default.nix
+++ b/distros/humble/pcl-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-pcl-ros";
-  version = "2.4.0-r6";
+  version = "2.4.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.0-6.tar.gz";
-    name = "2.4.0-6.tar.gz";
-    sha256 = "c05c0597712030197c8b1c5266e6587038c86694823565e8aaa89c275c2565dc";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/pcl_ros/2.4.5-2.tar.gz";
+    name = "2.4.5-2.tar.gz";
+    sha256 = "93d603953b187582e4a93885d897f4393cf0345bcbb7d261e804a50fae69ff0a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/perception-pcl/default.nix
+++ b/distros/humble/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-humble-perception-pcl";
-  version = "2.4.0-r6";
+  version = "2.4.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.0-6.tar.gz";
-    name = "2.4.0-6.tar.gz";
-    sha256 = "665287fc0bdf50f3f21d77ba6b5633a43fee2da6d0e0d334bd7f9f6dac380eb2";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/humble/perception_pcl/2.4.5-2.tar.gz";
+    name = "2.4.5-2.tar.gz";
+    sha256 = "887d5e933481d4b4043afdd392a3f7dbf805f265c940de60037a3b1db3d71ea9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robotraconteur/default.nix
+++ b/distros/humble/robotraconteur/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/humble/robotraconteur/1.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/humble/robotraconteur/1.1.1-1.tar.gz";
     name = "1.1.1-1.tar.gz";
-    sha256 = "93add797df392d650edff054674f3f2f02a2a539c6c90da18c3b19f8d2ec0990";
+    sha256 = "db1b74f0b2d8a431616e273cd8688730dc5bbb1c46d077041c3e9701ac9d5ec8";
   };
 
   buildType = "cmake";

--- a/distros/humble/sick-safetyscanners-base/default.nix
+++ b/distros/humble/sick-safetyscanners-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake }:
 buildRosPackage {
   pname = "ros-humble-sick-safetyscanners-base";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/humble/sick_safetyscanners_base/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "76d51b27367cd21ae26243c1708211816868ed939079158785594fae3fe35486";
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/humble/sick_safetyscanners_base/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "aa98db048bc7e85a023cea53dba5ca12345db2f01285bad68016a8c1a6eee9d2";
   };
 
   buildType = "cmake";

--- a/distros/humble/stereo-image-proc/default.nix
+++ b/distros/humble/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-humble-stereo-image-proc";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/stereo_image_proc/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "af3bcc9cf863240cc678b3cdf4a1294639b2bcbb0b3fd2e2f68b91927f7b760a";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/stereo_image_proc/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "19d0ee0d723db9949185849bef5db71a870f96f71d9e901c3685c141c1161f20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tracetools-image-pipeline/default.nix
+++ b/distros/humble/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-humble-tracetools-image-pipeline";
-  version = "3.0.5-r1";
+  version = "3.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/tracetools_image_pipeline/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "6c724c1d8a7b4a0ef82bcb1e88edd263beebca8187a30d81ad534cb8c319bff8";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/humble/tracetools_image_pipeline/3.0.6-1.tar.gz";
+    name = "3.0.6-1.tar.gz";
+    sha256 = "91f8c5a4b0f3cd4637eea7538a4a6fe56402e1323e7cfb05522c82391a76c25a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/urdf-parser-plugin/default.nix
+++ b/distros/humble/urdf-parser-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-humble-urdf-parser-plugin";
-  version = "2.6.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf-release/archive/release/humble/urdf_parser_plugin/2.6.0-2.tar.gz";
-    name = "2.6.0-2.tar.gz";
-    sha256 = "e02835634341dfbfc9221ec0bd9aadebca530b12d810f3de1e98eecf0989d0ab";
+    url = "https://github.com/ros2-gbp/urdf-release/archive/release/humble/urdf_parser_plugin/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e01d18af775f582794323bcf6f05abde3c5858759383b23a01817a95b6ccbf08";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/urdf/default.nix
+++ b/distros/humble/urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-ros, ament-lint-auto, ament-lint-common, pluginlib, tinyxml2-vendor, urdf-parser-plugin, urdfdom, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-humble-urdf";
-  version = "2.6.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdf-release/archive/release/humble/urdf/2.6.0-2.tar.gz";
-    name = "2.6.0-2.tar.gz";
-    sha256 = "c0e066600c68989333766241f68dda8038107107989ed642e4cb28e6f7fa50b6";
+    url = "https://github.com/ros2-gbp/urdf-release/archive/release/humble/urdf/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "652bfd0d89e3c10416c89c2b2fd5ce04a6e256a9b24261e63cde273de1519ca9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "1c80accf2f9f4f75b3d61b057431ef225dc3df1572564c26695bccd9525aec83";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "2e699ea02009ad8045b6636b4925bf1a949abed74141cd0a4cf0eee529870504";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "66bbe24ed436544edba7e5c866648e034ddc1819ddfb61f6c5cbbe0206a1e2f9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "44cfcbe9a6743ad0a3005974c679a03173448fee0ef18d54cfde427996e191b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "6913b792e5fd3b20507920173162a9c908bd8a664d9344433faf4308e48a6e49";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "9f2075cd2e7e700468356ed2c0feb4560b42f7307044eac0aaa99bc56cb630f7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "02b493e3c804d76edb81c7c703bbe7ef71138f0d1c6854135ceee06d01d00673";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "b45a4e0cc02270b6969a13096fc5772dafe56de39ca573592d9d6a50057d6e5e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "5e8cb759b5e2c32bb8e511bda111871a843e40c86084894420d023e3a3f09338";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "1fa86c8775aa352ad56fac4462e7f02cdeac16540a800723ecc35b61b3265ccb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "fd339582ae24021c2ccd468d0a225aa7e4e914a781881aa899b111df744e5183";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "5ed1cece1570793fdde225438ec814cf96a0214295e62519a3cbcd1acde0ed51";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "98163129d29d1ad7ad8fc0d9546fb1f7adc8627c68a57b22ba638213a927c756";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "a9042d63683a4297c419ce1b0aee4c1067787caf89e47f82be65c3b3a8b75f75";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "b31742a532868a1250853f3d22e19677e07f5f0bc138a502041876a74c82cde3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "735bf604c779bd447cd206831c8683db90ece4436bd6f82a2320f0117d2fef89";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "8cc879a979762eb860220c3dd35e64e6cd46cd6e2f5348e64b72f7325d182c70";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "eb2c0a737f31c350009e2ae0901567e779c5f30838333a84d49657f538999cd1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "7c9629a218e21fd9a7b2eeba6754916baedc3d3755b0b66ceb2d0795c5111188";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "458e47dd7ae72270ca21c5ecf9da0d569ca1445af596417f51b4131ddaa51c30";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "7da393a95153f7913d82858fa831a74e2d208c10cd2c44608da875877daf86ee";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "020577a80d4d363e8f99841495c370783c02fcc5e777fcba93289fa348c628c1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "1808685478aa5b5650ba97e4a4451bfb534535c02789f7e2651608f741b4ed32";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "9de841ee76af61d4f19fa4cca5153ad89a446c1d15ad76c59e2233423004fb62";
   };
 
   buildType = "ament_python";

--- a/distros/iron/azure-iot-sdk-c/default.nix
+++ b/distros/iron/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-iron-azure-iot-sdk-c";
-  version = "1.13.0-r1";
+  version = "1.14.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "02a7e86d2efe916395fbcf0d914a64f663e138ad30b3998e2280b6af9f7ebb6a";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/iron/azure-iot-sdk-c/1.14.0-2.tar.gz";
+    name = "1.14.0-2.tar.gz";
+    sha256 = "780b8d7d7c09d508ce9b8a1a166b6d3573acb119a31865562861385b35a7c01b";
   };
 
   buildType = "cmake";

--- a/distros/iron/camera-calibration/default.nix
+++ b/distros/iron/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-camera-calibration";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/camera_calibration/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "1f001d3c65c9f8252b517742a92ff223c1f9a4a7033cea19a15f1dcddca4049e";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/camera_calibration/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "913f98313d163f143c4abe6dc35a876602c722372fe9fa23ad89f9981f126ed5";
   };
 
   buildType = "ament_python";

--- a/distros/iron/depth-image-proc/default.nix
+++ b/distros/iron/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-depth-image-proc";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/depth_image_proc/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "15eb3e0d1aab13e34540fa5ddb13b39365ea1bdc6b53692b7eebddd2f8e8fa79";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/depth_image_proc/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "fcea4b47d6721939edb8215269a1ab7d409600bd7715785db867ca946ef0fe88";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/fields2cover/default.nix
+++ b/distros/iron/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, protobuf, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, ortools-vendor, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-iron-fields2cover";
-  version = "2.0.0-r11";
+  version = "2.0.0-r12";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/2.0.0-11.tar.gz";
-    name = "2.0.0-11.tar.gz";
-    sha256 = "b59faf67dafd9a0e6bcaee1c28aac02449df8a509f232ca983710c866cbbeb81";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/iron/fields2cover/2.0.0-12.tar.gz";
+    name = "2.0.0-12.tar.gz";
+    sha256 = "032d3232cdc287fcfbf4973ecbd4666070fc69c25a06998c7e8c9a5799de6aa8";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ boost eigen gdal geos git gtest protobuf python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
+  propagatedBuildInputs = [ boost eigen gdal geos git gtest ortools-vendor python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/image-pipeline/default.nix
+++ b/distros/iron/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-iron-image-pipeline";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_pipeline/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "e40811f74eeb978756e9309deed6036ebff3068ab9aee262deb1bc580b79cd03";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_pipeline/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "c3b16b77dbc06bbec7a91541d093e9e100b5377dca2ef61e2e3f4895525daee4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-proc/default.nix
+++ b/distros/iron/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-iron-image-proc";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_proc/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "72d474f8c554cdd05f833aff73dc6ea5b42dada4ef4f0629610cf7321aaa7778";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_proc/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "32e9a1b13c52763c3b9f5cb21b6f743fbceab23968d6bc2d5932caef62c2c2d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-publisher/default.nix
+++ b/distros/iron/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-image-publisher";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_publisher/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "f354f5abd82dc5062d63fa59f2ae8cb39f2753991f466fdb54fdb03ccdc132cb";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_publisher/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "fa74cb195aabb2ddd4c456fb0cd02d4e59632e1145ba7b24d84ecde6c0376a89";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-rotate/default.nix
+++ b/distros/iron/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-image-rotate";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_rotate/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "6d64350d1afa9ede3dd196d49fad8f052f761d7fd34573c9b8cee9055b1fedbe";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_rotate/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "7b244986500c0b86fdac18e45e0fbb8b6039a3a5a1469f9a0198b660304715f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/image-view/default.nix
+++ b/distros/iron/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, boost, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-iron-image-view";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_view/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "97c5dfe2f6e60edf71d7b3ae4e6c46a2f3b9aee06c9d3b19b143a44fc63d590a";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/image_view/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "3f3ca9ffff54c35f7d42da56d96a6b2568fd46f845897e16cdfe7a665223068a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kitti-metrics-eval/default.nix
+++ b/distros/iron/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-kitti-metrics-eval";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "e773fc69b0d5a1ac914787093263908a920aae21abaf5fe412c73771bd293ef2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "372967aecdd79d9a3ae919b9ddac97225d8251e032897ed9ebcf6cb571f5297b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-bridge-ros2/default.nix
+++ b/distros/iron/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mola-bridge-ros2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a3a5be88beca68f163d87470a63a50c26dee913bbfa2f9623996452251e3dc0b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "363c3cf3f89f76522098c55553995cf1a209f07928e4722a002483ee94b79fcf";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ geometry-msgs mola-common mola-kernel mola-msgs mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/iron/mola-common/default.nix
+++ b/distros/iron/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-common";
-  version = "0.3.2-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/iron/mola_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c4b855480aafc5b581360cdc3f563d58c5dcbd406605b48557c0c164140404a9";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/iron/mola_common/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0d50b6e92b63d13b5f609abc8a5b968b8000c87864e41b3d15f81dcb548d2ca9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-demos/default.nix
+++ b/distros/iron/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-demos";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "eb0ab9634fae8dce3b9fe669cc03af3a2651e6c82434ecd3dffc75a634df0097";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8b5d00b82b3cd891d45841a5d812c6f341fb6541d06b17cde181999221fdeb2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-imu-preintegration/default.nix
+++ b/distros/iron/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-imu-preintegration";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3c97e4094707c5e050234078fec6046a0d111d9dde37bc32b1b8a0760c9d8f65";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9001e386050f9210047828892f5063f923e78e3551fda7129dc8c441f6f2dff3";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-euroc-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9898fa4c7705dd046c95e44ac4d687a6e9ea0fcddbef5283cee034759b798273";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4de444e6e92e2a2037a0fa2acbc5aeb0f07385eae450f47204f0496b2e483c1f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a5aa362a112d734042398044088cbc1432bb1ea4ac6838bf8019cb0053f507a8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5281f4cbbf6229cb0453e16caebfcb1567c810d6f1f83fb2d163244b74c33a8f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti360-dataset/default.nix
+++ b/distros/iron/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti360-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "860521acb3e18fbca17547f3381917c385c34f83a5aaf7cd76d1dce60e89ad33";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1478562f94f6e96485d8d51f7563ba17dcc72cd07228329f8ca956011272fc28";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-mulran-dataset/default.nix
+++ b/distros/iron/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-mulran-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "66c5ca159f37e8e716c810dbdc30d0f0316578d45858b922a63f83d400efd6b9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2acb9646ad5c46a40527468e01f0ae1154fe099bf73ecad6e47d5acb1be7efbf";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-paris-luco-dataset/default.nix
+++ b/distros/iron/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-paris-luco-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "8be1c7a9faf9aab373502e9f240ad971c8e4eec2ad44c2c2e5d2e3bce1ca14bf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a562ffad4f563ef620c08d5d104a763fc568a4722b2945c52e6284938a3ac61c";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rawlog/default.nix
+++ b/distros/iron/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rawlog";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "337c2b71f3281f5f519ea138b05f1a734990670dcf119fd715f7de99e603914d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "fd6805ba270ff8a0ac6c4b08f76975ee5104b9bbd8b209e5b55f7d2ccbb9c6b0";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rosbag2/default.nix
+++ b/distros/iron/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rosbag2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6ea7f009a5f4066c6c517dcc773eda39fa26b28a0b754a784708ebcc76526666";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d9aa6cb51416d9ad4346a97b58b840a9b677d4c1d5cea75d062422d6bf63a693";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-kernel";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d2824cbde1abdef06e4bd8d3cc3924bb9a8a8906ca07eb764968e3cab798264d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b5dd722f5d7852ce7bf4ad03ffabbb14e1f6cd9b47733254e0b503e8e7d67e4a";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-launcher/default.nix
+++ b/distros/iron/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-launcher";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "ee7ccabaa5c96477c81131b073b864f5b0b04c7b147cdd0d7490c11e1c38c47b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ccd6b92915dfd4e4f7d6ce26baa61f4b533f4a54827f2130afbdc10e7cc59e05";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-metric-maps/default.nix
+++ b/distros/iron/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-metric-maps";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "02a058a81db6d0cbd36017a776bb1463a103ed94d1dc6215412e7d877b2b6e81";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "fc41b7fddaf2c2cb3b75a73206f3dc8e878b6e7a303cb10d139761828e31293b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-msgs/default.nix
+++ b/distros/iron/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-mola-msgs";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_msgs/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9d6bbe8e3d24cb6ddc1f876e1e48128771df5fd949abb74824c546c59c4335bf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e6a36ba2b02cc02243384ab7ddee782e1be8612299cce31e63e40f9215d28160";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-navstate-fg/default.nix
+++ b/distros/iron/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fg";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fg/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a419834d31656c4f47e27117e820366be9a3c040d826b5e1a56d762e482885e4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fg/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "03280cf92482fe0d06ec1ac1df460beaf98a0821daf2d94084f7a906d80a2ae2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-navstate-fuse/default.nix
+++ b/distros/iron/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fuse";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b36918cc33da2355c36abea6e72e1a93a05d7ef6fc3f7e1f21331cb56392a71c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7ff0b73e48c6d7a2633525c4c02f322288fa4affc0e75369d08e81759d7f4d84";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-pose-list/default.nix
+++ b/distros/iron/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-pose-list";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "5633ce6008fa8f2e48ae8654d72ef36ac251e5717e72d31a5f70facd7183e02f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "46a2f23e61d671562e02eb8b57c5aeb2c0a7c993e4ead09f7a3024205e4349e2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-relocalization/default.nix
+++ b/distros/iron/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-relocalization";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "1fd7e708dcd65c996a50c3c3079244558b50d430471d759316536be9c29bbf4b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "26a9199d77dcfe15805d263a4f699e2a624648963739a14aa92a2cf90b4641d9";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-traj-tools/default.nix
+++ b/distros/iron/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-traj-tools";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6cba2f09e1729f153ad57116794f1743e13881170962388d3f087d61c02ccca2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "24aab63bcca36dc4ed8101b25d3ab81ab7d1d2dad0be08b21a173c9d4f35e53b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-viz/default.nix
+++ b/distros/iron/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-viz";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "23fe69b4816e32612a11113767f6138fce5d9682d7a5b7f10c6c6e9b2c5698f4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f6d0204c8655f7761fd65716211f862edb78fecb12f7e3c748950f1f5d7ebd8e";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "aaabcfc77db45ac03b375c2beb8308cde7529fe69dc5ef9ddd2d4bf9fbb4d71b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d924bbe49d401620545b758716c57cf25f809b5297ff447f1565710d930ad6f7";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola/default.nix
+++ b/distros/iron/mola/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-iron-mola";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c8cf7994a516865356862ff831ce3821d76018674b1dd834e049883a7c54ee94";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1369c00482ef8be499275b5d1c4b31264edd5301d1be46c956468a71c3b1a156";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "1.5.2-r1";
+  version = "1.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "0ad9f4e2433ae303bd87858fd82dba4321bd94f6fa3edcf11dfce694a6d74c45";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.5.3-1.tar.gz";
+    name = "1.5.3-1.tar.gz";
+    sha256 = "2e1943c5b302af3dcf210b96db9fd1f91b9f1348bd796b2ab36720e0a4a45f73";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-apps/default.nix
+++ b/distros/iron/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-apps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_apps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "9b871daf951504a74206783a4b78311a452686369b625fc2e1c5f8a8acc32dba";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_apps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "0988a336d7e5e93571971bf97e2366b6cd32902c2c97b161727511725cce345a";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libapps/default.nix
+++ b/distros/iron/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libapps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libapps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "837ff5beb4d02caf376be065bbc65db14f514324dfd69292d067d7915a355af6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libapps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "82f114eff05d8cf70f804ca068cb494749b1aaa0235a4ce1bea036b7d374c672";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libbase/default.nix
+++ b/distros/iron/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libbase";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libbase/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "cce416e7f35cf3d2bee35a760c5757e8b6922b3514d7bde65f886a9a3b9e927a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libbase/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "62654f78fae4fb5b64f7f87de50dff89e67fc7f2542c831434fe8dad8a29cbe7";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libgui/default.nix
+++ b/distros/iron/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libgui";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libgui/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "a6235702e39788beee347493e37464169183c50547105de5aa93de6e1d5bdeba";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libgui/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "530f35e0ec6a17783e19d17384aecfe4a01db95be30cba77bcc6f19e5441ea8c";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libhwdrivers/default.nix
+++ b/distros/iron/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libhwdrivers";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libhwdrivers/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "21246c92cfdc702a136455d62b2750762b714298ddb66f221a8cdf3675cc5d14";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libhwdrivers/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "6c3dc7475ad1a98281df478c93984b358174bb1e07df01f86f16f4d3466927d2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libmaps/default.nix
+++ b/distros/iron/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libmaps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmaps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "34a77c5eac9937d4661f169edc2439e285cfb0c4dec393e1c9665039ff48ed5b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmaps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "fbedce68dfede95fb16469c57f30912bbb698a317b0ead5b83b73c5bf6006d47";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libmath/default.nix
+++ b/distros/iron/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libmath";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmath/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "d03e73fc500782e83f8ce06d83ad96fae066b6b66926c42185ec92b0b4965906";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmath/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "bd39a2f60fd588ae14ef033e44b7fd1b4193e01f11bc31540bb91a6a8e7427a5";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libnav/default.nix
+++ b/distros/iron/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libnav";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libnav/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "2e5697e0412333b819a78ef008f8f45b81c1f57d7831028e8fd397a945979c7e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libnav/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "db2906e4fafdbcba3eaf7e4e2de4fffec2284219b7d14228b8d3e7a3cadf7ec8";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libobs/default.nix
+++ b/distros/iron/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libobs";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libobs/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "60ea8042c60f5cc0166c67137124971317ecb60cb1f45bbb9253d94602a4f145";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libobs/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "cd0ee5820b213dcba46659747eea4bb309eac06fd10d6a404ffdc09dbf914a51";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libopengl/default.nix
+++ b/distros/iron/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libopengl";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libopengl/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "2b50ee18c0f77d03e11a16a3660510f95e7691577c2a3e844381929d1a696c48";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libopengl/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "fde21c96c5cb9e06dce7ca9a908b17036544e84e1a78670d95575aba099a8ee5";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libposes/default.nix
+++ b/distros/iron/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libposes";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libposes/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "f82ec9bb7099b356e42dba7c90916cd55d8f153adc7e908ce09b18f7d23ab73a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libposes/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "384cbddcfde57232e6941a8ae4d19af85489edc04c4cd3b8e5a56eb5b6f80926";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libros2bridge/default.nix
+++ b/distros/iron/mrpt-libros2bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libros2bridge";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libros2bridge/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "b6517e7d081bf86eb4de4303947376733d67ebd831becb69f34a4abf6e99dc92";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libros2bridge/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "6c3f7413ff154facf22f289085cda8c0235d8413aac78280d8921f370d76c6a5";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libslam/default.nix
+++ b/distros/iron/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libslam";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libslam/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "08396505eb2a25e683f451b43ec377355978cf9067b8501fe9c600d7f3f0d0ef";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libslam/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "d7d03e45c428f435cf3955b8aeacde053c2454e092fa4281307c5b841f78f546";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libtclap/default.nix
+++ b/distros/iron/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libtclap";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libtclap/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "4ea1c8b38586caedf65268e863f919630c96532a2c937173e77c9f7fca1ab641";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libtclap/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "924d08cc540b13ba3c14b558dd11cbf54b1c8b2fbc660814a71d4a529761918a";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrt-cmake-modules/default.nix
+++ b/distros/iron/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mrt-cmake-modules";
-  version = "1.0.9-r4";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/iron/mrt_cmake_modules/1.0.9-4.tar.gz";
-    name = "1.0.9-4.tar.gz";
-    sha256 = "6c842930ef31705670429336ff21676d8f7a825d1fb56aefd852ac7ef0c0717a";
+    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/iron/mrt_cmake_modules/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "0e76f821f7c9e484c0682d37a00e11cdf4780e51ec8ecca7556ff34a7305ffbf";
   };
 
   buildType = "catkin";

--- a/distros/iron/robotraconteur/default.nix
+++ b/distros/iron/robotraconteur/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotraconteur-packaging/robotraconteur-ros2-release/archive/release/iron/robotraconteur/1.1.1-1.tar.gz";
+    url = "https://github.com/ros2-gbp/robotraconteur-release/archive/release/iron/robotraconteur/1.1.1-1.tar.gz";
     name = "1.1.1-1.tar.gz";
-    sha256 = "d8c4b6665e9826694246c9e6c4106b835658ef20d2b90b49985ee0a95e2895bd";
+    sha256 = "1b7eec32c70e349856b846eee9e0ae53d7533a55f953640126b106aae533979a";
   };
 
   buildType = "cmake";

--- a/distros/iron/sick-safetyscanners-base/default.nix
+++ b/distros/iron/sick-safetyscanners-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake }:
 buildRosPackage {
   pname = "ros-iron-sick-safetyscanners-base";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/iron/sick_safetyscanners_base/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "d1483b618ec1cfacb14af9ac89d5c50b0d0aa9da72420359da7b8581b2b1cb13";
+    url = "https://github.com/SICKAG/sick_safetyscanners_base-release/archive/release/iron/sick_safetyscanners_base/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "5eff865176382d2fc626094504997c9d44439840df5402c9ed8098594e075859";
   };
 
   buildType = "cmake";

--- a/distros/iron/stereo-image-proc/default.nix
+++ b/distros/iron/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-iron-stereo-image-proc";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/stereo_image_proc/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "5da51c74a3575d80ec6f3dfed2ec109fe4b9d4209e8b68ffc9da1f3a45d6383d";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/stereo_image_proc/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "61f0c7a6754ad9f88c920b4e9baeb93bd7637222c7e7de783e9e2d6d5cc5c3d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tracetools-image-pipeline/default.nix
+++ b/distros/iron/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-iron-tracetools-image-pipeline";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/tracetools_image_pipeline/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "860e21c1d482e7763b4f4891f3ac0c42dd59880f4b39475f277b2374f5306a1c";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/iron/tracetools_image_pipeline/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "5efef89bd7c30f9351b29cd6591c94fb411e1e3adfeae721f582c228ae734554";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/azure-iot-sdk-c/default.nix
+++ b/distros/jazzy/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-jazzy-azure-iot-sdk-c";
-  version = "1.13.0-r2";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/azure_iot_sdk_c-release/archive/release/jazzy/azure_iot_sdk_c/1.13.0-2.tar.gz";
-    name = "1.13.0-2.tar.gz";
-    sha256 = "61bd420b5b0962a2abe09200876607d6489c321199ce41c05e1211437a48ebf3";
+    url = "https://github.com/ros2-gbp/azure_iot_sdk_c-release/archive/release/jazzy/azure_iot_sdk_c/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "10edb55ea60191e09279b20b389d45fc4e3922ee8856a6fae62cbedb3c6c16dd";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/camera-calibration/default.nix
+++ b/distros/jazzy/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-calibration";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/camera_calibration/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "a685b02e733cbf071cd02647b8e2108208843c134affb6cd112dd9e169b1abbc";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/camera_calibration/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "22143f69161e42b68f96be062f8f15634e1e91f12e6b2951c8a99dd2f78a976d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/depth-image-proc/default.nix
+++ b/distros/jazzy/depth-image-proc/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-proc, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-depth-image-proc";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/depth_image_proc/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "87a8006105f32eeaf2c19e8de229e773b9a5be26fb6fc3ff6ef9d139d3443c49";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/depth_image_proc/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "ce5f4f60266f1e90eefb912a4b53ea2108bcd8d2f13f0b5f8850e2e4f2afab7b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto class-loader ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge image-geometry image-transport message-filters opencv opencv.cxxdev rclcpp rclcpp-components sensor-msgs stereo-msgs tf2 tf2-eigen tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters opencv opencv.cxxdev rclcpp rclcpp-components sensor-msgs stereo-msgs tf2 tf2-eigen tf2-ros ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/jazzy/depthai/default.nix
+++ b/distros/jazzy/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-depthai";
-  version = "2.26.1-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/jazzy/depthai/2.26.1-1.tar.gz";
-    name = "2.26.1-1.tar.gz";
-    sha256 = "37b2c93808f785c66e709f7c3754c079977e71269e5f73629e8af4a0005db335";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/jazzy/depthai/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "4b59598aa06bc44891f0a19d69298a59f66c65af71ead774f6a2b2af8485f3d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fields2cover/default.nix
+++ b/distros/jazzy/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, protobuf, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, ortools-vendor, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-jazzy-fields2cover";
-  version = "2.0.0-r9";
+  version = "2.0.0-r10";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/jazzy/fields2cover/2.0.0-9.tar.gz";
-    name = "2.0.0-9.tar.gz";
-    sha256 = "0c3e08b92e2d4c0556d3c3427de38eb50c6258efabc8b4a3ada0e594c5ccb2a0";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/jazzy/fields2cover/2.0.0-10.tar.gz";
+    name = "2.0.0-10.tar.gz";
+    sha256 = "a27070b25c613fef28162cf8cdd9824aae51edec650ae3076e53ef833f3fb1b8";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ boost eigen gdal geos git gtest protobuf python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
+  propagatedBuildInputs = [ boost eigen gdal geos git gtest ortools-vendor python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1662,6 +1662,8 @@ self: super: {
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
 
+ qml-ros2-plugin = self.callPackage ./qml-ros2-plugin {};
+
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};

--- a/distros/jazzy/image-pipeline/default.nix
+++ b/distros/jazzy/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-jazzy-image-pipeline";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_pipeline/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "12f6c81976dbc5759c1a461937211a5d92230c40b053607f0d79bd5147064f9b";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_pipeline/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "35b17a845a5ad522c8906d7cc83027f4331ecf3bbaa05ac42fa066d1279264eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-proc/default.nix
+++ b/distros/jazzy/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, geometry-msgs, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-jazzy-image-proc";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_proc/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "8be9c260f6d15368f8ecaca1a9dda95afbba446a7e4cb463084e08a3e1675259";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_proc/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "14e1a04019b5fba075df03a6cfb87dba5849b29d3d7703b6618bb84aaf3cd601";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-publisher/default.nix
+++ b/distros/jazzy/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-image-publisher";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_publisher/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "45d1ff9e22d2d724ab8d069f29710356cacc018fe087f7cef5e828ec4f696182";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_publisher/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "58af2f5a3fc109ff6849ad905092909e96f5bbf91137e4415292f4791bf9d9fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-rotate/default.nix
+++ b/distros/jazzy/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-image-rotate";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_rotate/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "ea27a00cdf85c543d44496d01ee0e356d655f0740c4125003e50ea9b25f09244";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_rotate/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "642d457b0a98cb5d57dd96ef9814f536edf2a04bbc096bed09964e2e7d177e90";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-view/default.nix
+++ b/distros/jazzy/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-view";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_view/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "963c8af2c755a960fecdab674fe95907d05126404698c059dcfc55bc9ede80fc";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/image_view/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "fff8137c096dcfd3ec79477df2c7ce7f4c891466afc4f03071d70d4e7feb4d97";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a525848fa44f30172fbd19e60272f24fc72602645eb58f8dfe1a275707f175ba";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "32494e3e8071c78faaff7456a8f9e3f7fc51d253d479ed8ff4eea70c51a4c247";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "edffce007672ccfc240d5941bc1710ad3b269f07276dcf172de31b6a36324191";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "25b889410fe4b1296f023ecad1b54c1444fcaec3aad18241df576af1aadf3b70";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ geometry-msgs mola-common mola-kernel mola-msgs mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-common/default.nix
+++ b/distros/jazzy/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-common";
-  version = "0.3.2-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/jazzy/mola_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "9d2cabf3c40e872fe701cb5e86036975b5115cc67373cba7865e12d9c6404789";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/jazzy/mola_common/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "09e2e5932930bbb02ba4bb85cb3d92031f7f134aafa2abb0360f7c5ba0b6b62e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "60d3a4b4edb13c55ca495bcfed249de432f64f6b612f0fff1a427d57c35336e3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c5bad345c70512e0e0f16a3239a722c58cd7ed1acf54f524a26cb34b1bcb4ec6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f565db9ba954f501c7ba7e8c6da5ee3c3f4f82877cc478f8a61e723f6da0a5f6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "04a7e7eb4fe995fcefdb2f885a6788492d93948be45e847a3cc4f46c4d15e038";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "ac45fa4dd369dfd3e91750c66304449dc5b1cf542b3a82d8d8bb79c218abb770";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a185ce82d41a3edf73cdc418aa6e0e1d5eb15ac16b8806f936d2111c13a4ab76";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "4cd1fb69e39f8e02f53f5d62771fdb50458d7088a2c394eb5663076a00e26c90";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6562b15d47ff78ad5c31d8c9716bc5ab04eaaa662dc99163c462139c413f917e";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "c4b035abe21f23222b18ddbb3767276f8d424e68b2dccf6c6b2c10ee4a7e583c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b63f9d582364cf192c65372f8488a1a31bdbd6d0910fc82e38eb4164090b8ec8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "4a0945b7580f1afe45d4ed166b0f64e1f8e314cba193532d14685c58324c7031";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "bb524142b885286928b25ad0bd014b6ac3116eb9bd277fa22ff2ea8e95360e10";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "28c5c995a12609b3393c219db26b3a6910153b09afa16ef894f0cede9de84f60";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5aa2f6b1bb54324968edcdc58c97d7f2f6336ed3d9a863d308016e7b4055d962";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "dca020d95884ec892fc427954df5a153ccd62b109f6e0a7cb90cab815d98952a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "07090db7c91fb9ef93cacdc24ef03c867fab445aa1a08016e205cd63a14858ff";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "2883829d191c9f70870414ba7d69ee45dfe231e3362a593e8b1f443a0efe107d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f4027aeaef33bc1dcfab190b5b924c0854b94c5fe8bbc0e305ca75ac6ab9325f";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "5fa0ae29953820837871f144acd2b6800d1e009911dbac168c5ca4cfb2297c37";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5c8ddde1423f0b6dfcf5576ae1cbaf96088d10539a0d1f2184155129ffd83d18";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b735c14eb9bcbfc6e21280529eede4ccb16c14e85e8a53f67b5b56e951a2057f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0fcc76c6ee00c4a5e3ef62c37de42d112cdaafd99333ca94204329241a685251";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "3589bd3f590f20256c040d74de2bcfe050e924246987e49a4f4fc34f66a6d6ab";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "daa8b0d340effc841d75c2e241b7fa635ce9477efd6253a19dc3457e49e92a18";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-navstate-fuse mola-pose-list mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f78a4f67f255e7c8f0fc21bd8ba601e5f9dd8b1751c11acfcadcef25faf3ce80";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ca590b96083ea092b44c855ba444dba6dcc1d1b766ad80bdd28c39d26910eaaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "33d71e2d8c2d6db87ca8c4d1c09de941ad5a14eb100d27a94f82eec6fc6f636f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e41d2c7c8b518014638d2b731ff810fb7cd7e6b05e8512a0f9e4c2191b1580b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-navstate-fg/default.nix
+++ b/distros/jazzy/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-navstate-fg";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fg/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "33076b510acf47d14da9975a4b5a29dd689936e119e00b99ebe02bf404f40526";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fg/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3ef15103d617d345823cbc09fc524ea85808c2461ca8c9961c32dc6aa1a5a9a3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-navstate-fuse/default.nix
+++ b/distros/jazzy/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-navstate-fuse";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fuse/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "8ca849a9fd2f7ce1733338b39b44cf62ded16922e0e17cd6fa954a536f8e5d20";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fuse/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8a9eea6996b28eb87eb8208fd2b6874905eec465a84726b5802371e97553f64a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "4b64ed687e81e404e2bcf130ce39aab78d71a233d98ad019a718081a5cc1bf5c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d424048b94df70ed040ddf31b01277d5a909e7827e6dfa3b36850cfa3c264a11";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9fb144e67af93ce30f0cb67c70fc31a73e206e6a0e078c269fb0645503488e12";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2cb293441d4deeb7754c60ed6c44343abfe97e0fc2132428276df5226b1492cd";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "86df4a35a910a62284824ab39509b92973c3a52a92d54d3cda8994611e9f3e4a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7bf5c39e82f1e92066432ca5494fa84ed729e4ec50fbae6c65fd96eef527640a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "ed80bb15585da832c2cf5d47bd4b475d10893aa2eafcc0e5d74da9ceb6e5ac88";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "086b3060bbcc1cd2c7ec9d9397253a79875a6f6f46166fbac8404884a02b800f";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6f04eef0ff7e29049bc3404f81e6a7cce0f68bbe30717ca4cc60e4e917ca42d0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1967dbf14a731da88467a37265975df96742008aad832bfa116b04e834c41bcd";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "da7900f646bb49a6c8951e7ef8840952531690705fbc05b353953791d244b73e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5f70695f991bd3e377dc889bbf1beda6dca9d0bbfd1e950cace83f8f86706ed0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "1.5.2-r1";
+  version = "1.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "68258c830dcf05d375e5abda88ca7c77cd4f406eefb2d104d261b0752bdd6b68";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.5.3-1.tar.gz";
+    name = "1.5.3-1.tar.gz";
+    sha256 = "1dcfcef14c81cd19c81d75d655513cd4520890705b744552d99a7177c227e704";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-apps/default.nix
+++ b/distros/jazzy/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-apps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "f3d5ae1eb0697e73101fc6087c421d73a344a15a4e8293c8027f94464b526d21";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "af7157f6b451fe48bc93ace2b7e2f779b2b064bc877134a44df960f10093dde0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libapps/default.nix
+++ b/distros/jazzy/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libapps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "14522e103bbe486974ea6e531b2a80009c384ca4e009234e17b4e16bc58223ce";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "933d1286a025781a9b799e452e3e4e577f711ea5d55c7d61221e607759d33ef0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libbase/default.nix
+++ b/distros/jazzy/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libbase";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "fec673eea8772badd0048704af1ff3ee61b94f7923a616f83ec0cd81e225983b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "776ac5dd4c1e5adfa13a91baa0baa2d636f902d1398102dea8a43a0865ab7ed2";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libgui/default.nix
+++ b/distros/jazzy/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libgui";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "0a83d7c09f516173e08284f753b9b3728489706754267ea1a811897fda85ec55";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "14e92a3dba8c586d8530def79a364c1f0e274802f603f7f6ddee8a3ce46651cc";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libhwdrivers/default.nix
+++ b/distros/jazzy/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libhwdrivers";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "2cd0ed81b6dcf3cc1a90421e38e28bf7957b99bd79de1b9c1905f1372eecfdff";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "c44dc5329b6cfb459b41e2ca4f50b87f7c8a1f662d340e7fb395987f6eb6dc98";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmaps/default.nix
+++ b/distros/jazzy/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmaps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "f527fc187950c35d143fab50e76d7e455ba9e8ffdbe81cce5956e0d62e3f33c3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "cb42e7dc9ed8b881e7f12166e705803fbbfc774696f8bf979ad8340f14b05417";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmath/default.nix
+++ b/distros/jazzy/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmath";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "162c36ee9c11c31463373ee8bfb672ef758ca26893c4bffaf50e81adffa4e267";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "ba8ac0f45967fc88db319c8c6d00adb9e615d31e04f4c6355fcf95561e0713e4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libnav/default.nix
+++ b/distros/jazzy/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libnav";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "2910708b17a6ab29a76361f4e0b1693ba377dea03bb166583994c86854e21bb9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "4bd95fa378fe0eeaed8ed65ebf1859bc7f34da8a988fef1a35ede299d9755579";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libobs/default.nix
+++ b/distros/jazzy/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libobs";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "9d54a15e2ee09350875affbbac8ec248e45d450aea482b4bebe9203497109e0b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "b6836f25d04a6e26bb9c76e9f34b5bd6d7ecddfd15e20fee27df50e2ae57a79a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libopengl/default.nix
+++ b/distros/jazzy/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libopengl";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "52b438bbf0558a9b48ccdebe9c94a4f73d6da6a65d2cc5129db3758a8724827b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "b91eefcda6db2f38f16172ae60ab79175a65a5485a4b6261759e5f95a4ea3f4a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libposes/default.nix
+++ b/distros/jazzy/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libposes";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "670fe78fde2e318435d5315eb4559552af1189c75d056277d1b6b10fd9ecfdd7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "229c3936d86d38f3e9d71677058ab3ba916ca18f5318d36abb3ddf337caed156";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libros2bridge/default.nix
+++ b/distros/jazzy/mrpt-libros2bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libros2bridge";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros2bridge/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "139f31aa7829a263aa683aaf348a794f1d06e7f0bc371e3111fa7ef25fad055b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros2bridge/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "c08dfdf7f4b1875c1d6bfade6c7961b3aaf85d82e3e6fbe9358791f9ff38dc94";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libslam/default.nix
+++ b/distros/jazzy/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libslam";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "8302b78ca56e4db8701237060a2673bb07e31c23fc5cfcde3d4c07f0a2c94d8f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "33de2478a8536be84bc4c6115797be8fa96e894cecedd09df6ffd7e9400d27c9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libtclap/default.nix
+++ b/distros/jazzy/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libtclap";
-  version = "2.13.6-r1";
+  version = "2.13.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "546ee36808b072588971ac1566e9a1e6afbd1a62bca27c23a49cb586d42840c1";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "964173d14a32872191fc3f6509acf36d62543570af1e13744c21cb73760fa3ad";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrt-cmake-modules/default.nix
+++ b/distros/jazzy/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mrt-cmake-modules";
-  version = "1.0.9-r5";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/jazzy/mrt_cmake_modules/1.0.9-5.tar.gz";
-    name = "1.0.9-5.tar.gz";
-    sha256 = "2ce1d5d813d3ba8494c29b7566d8f7d4b3a51e6a334247ea397d5e17d5e1f0aa";
+    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/jazzy/mrt_cmake_modules/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "25f8606c21ef907805760dc913b74896689e40d9b8c5dbdc590de2d20e66d1ff";
   };
 
   buildType = "catkin";

--- a/distros/jazzy/qml-ros2-plugin/default.nix
+++ b/distros/jazzy/qml-ros2-plugin/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, image-transport, qt5, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-srvs, tf2-ros, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-jazzy-qml-ros2-plugin";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/qml_ros2_plugin-release/archive/release/jazzy/qml_ros2_plugin/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "1c691e1eb5decad3483eae738999b52a9c9002ceb63821a77ee16c86fc0d113a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto example-interfaces qt5.qtquickcontrols2 ros-babel-fish-test-msgs std-srvs ];
+  propagatedBuildInputs = [ ament-index-cpp image-transport qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia rclcpp ros-babel-fish tf2-ros yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A QML plugin for ROS.
+    Enables full communication with ROS from QML.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/rviz-assimp-vendor/default.nix
+++ b/distros/jazzy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-assimp-vendor";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "844c3a92d8551a47ac83870099560f8ab840472f957907fdc414b3d532198931";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "dd8eab63f3c4254ab3598c96d1479d559ae8f0da1f4d4bf3222fbe134217c501";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-common/default.nix
+++ b/distros/jazzy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-common";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "5a887a9ce76d3541e280e04248702665514794c6e190eec2c8b618bbbacde100";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "b99f5daa2e1c68f8481fd8a590f66ab73e349e0808f41a5fdb23ca33a8adbaf2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-default-plugins/default.nix
+++ b/distros/jazzy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-default-plugins";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "fbe99fcab8b3252bc7c20efe802304dfda0ea67ca1ed629b618d324e7b00e4bb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "f53cfec1f4c26b2c0886c77e9f0b4d1d370e5d72fedc84a597eedfa93caa36ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/default.nix
+++ b/distros/jazzy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-ogre-vendor";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "9e79fba9afc0868e756bcab1ced3aa5fbf156469fcc0caa802919fd60d4f16dc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "95acf6270bf57383d3f7986b943e705a624c19142700c0ef88d5bba43b04e78d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering-tests/default.nix
+++ b/distros/jazzy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering-tests";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "bf1336a0b594008c068f1a4df83a97dca49f0936e372b7442b81de406afa2722";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "d6388a2fcb8c4c5468efbadb8acb69461071e9663521d859dbd9bd70de7a4e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering/default.nix
+++ b/distros/jazzy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "c2a081d47025ef59865dcf3c65774e89e8d137e362b70d8f53991bb725c999d1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "c4185253af8a54d44d8e2ee61ca60177bfb220227ca8e327ae25ddbeb776ebcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-testing-framework/default.nix
+++ b/distros/jazzy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-testing-framework";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "9ead125304b07e3426e588ae322144f8ee389ee84030c8a4a9a606d56aeff0c3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "f0c7e719127e359bf6aeda462b89f0f0a139fdec0ba3c57e9872e6fc262f08e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz2/default.nix
+++ b/distros/jazzy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz2";
-  version = "14.1.3-r1";
+  version = "14.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.3-1.tar.gz";
-    name = "14.1.3-1.tar.gz";
-    sha256 = "4fe7eb277c878c58e6751cf79a9eefcdbf3ba7c8b7353ddbc20adcfa360fccce";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.4-1.tar.gz";
+    name = "14.1.4-1.tar.gz";
+    sha256 = "63d884f33ac91e887cf2a554a9a19968a46b89e14de39b94203611476765991d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/stereo-image-proc/default.nix
+++ b/distros/jazzy/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-stereo-image-proc";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/stereo_image_proc/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "499f820fc5fdeb2b21a1314bb6eeb424c6cf3a9da0a33563c03b45a266bd0228";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/stereo_image_proc/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "3709f2c426c22c05ca1c65a9e08998b8807be6465fad4dafc05ca98b539698c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tracetools-image-pipeline/default.nix
+++ b/distros/jazzy/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-image-pipeline";
-  version = "5.0.3-r1";
+  version = "5.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/tracetools_image_pipeline/5.0.3-1.tar.gz";
-    name = "5.0.3-1.tar.gz";
-    sha256 = "951253cf1e662ae122787ed52d9a492a3400ef0de676525ed5b3723474a9f9b5";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/jazzy/tracetools_image_pipeline/5.0.4-1.tar.gz";
+    name = "5.0.4-1.tar.gz";
+    sha256 = "1eebabd0b81ae4dff6b6248a0e55380e3914f269d63c86787d989ccdeaa35946";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-control/default.nix
+++ b/distros/jazzy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-control";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_control/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "5e354d776ad44a1ca33f99d08e164fe0e4b7789890290bc1bb195ebf9abcf35e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_control/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "8c0b409198f0dea7343366a3d5f83c465c50db4012f419fc54b25a8a6b71d4ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-driver/default.nix
+++ b/distros/jazzy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-driver";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_driver/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "cbe3c4f1853c488cfe85e55287383a636c682a3b70cb407ccb3ea84808927139";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_driver/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "caa552be3ee3632007ad4dfd618ffd103cff0c77c23705345d596de341f413de";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-epuck/default.nix
+++ b/distros/jazzy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-epuck";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_epuck/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "030dc88f69e2a19e15d6a693ff542aa111236b51f61e1da68931d7408ce0afe0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_epuck/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "9fbed94264a2d0d3097d9e128a7800743cd130972a7f0943bcaebdf4b6f709e6";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-importer/default.nix
+++ b/distros/jazzy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-importer";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_importer/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "b6e8e6483646f624288a08c507ed4f6416e1d3aa146c3e3578b43e1774e855f9";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_importer/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "281f7c67d686666ef1618117e84f76f3a1f83b83d4a3ac70a76c8ee612d5685d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-mavic/default.nix
+++ b/distros/jazzy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-mavic";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_mavic/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "06480cca25a7580ddabc1240c20e7bd5ab8586d464ec84af77e6bad908438dfc";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_mavic/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "678521c76060f410adbb36d98ec1697b8167c1e78f9f812aad89643ef72f441d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-msgs/default.nix
+++ b/distros/jazzy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-msgs";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_msgs/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "0d87062174cc4688f118084ae0a651eaed51623f0e4e628fc0031d5a0df6e768";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_msgs/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "b2d69b0547187be071c6c85c9d83d085357641d95e89e5929cb78503c0a3aa85";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-tesla/default.nix
+++ b/distros/jazzy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tesla";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tesla/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "ffa5738dd78d7cb8d3bc1e6e0d95c6914e6a1b8da5f6ae0e75c52b552ef6f50a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tesla/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "e77fa29d2e63ae1abce82e24f713f971c1902bb7301795f1e4cc55ac62212652";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-tests/default.nix
+++ b/distros/jazzy/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tests";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tests/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "63afc486cec9943f3a0152d511b9bcea36e29f6f203baf0382fa354547ebacc3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tests/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "d9f002f838ca43e25144d94c21da50dd3d286041aa885a28a87330eb6401e309";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-tiago/default.nix
+++ b/distros/jazzy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tiago";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tiago/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "8e050ec5f16e9c6bdb00cab895c3dfcb3d6f8216e3ac6a147aa099195a16f1c3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tiago/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "490a79154c59e4ebdd581a0190c86cc381d921f9979f656238adaaf2338c5cb2";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-turtlebot/default.nix
+++ b/distros/jazzy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-turtlebot";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_turtlebot/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "2016d63a8cfa57e1f74cdb55533be820e828408c7cafe32686476f8f29871160";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "02690b6c535a32c41fbaebb4219cb15e8d12afb6479ecdec4befc630ad9f2514";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-universal-robot/default.nix
+++ b/distros/jazzy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-universal-robot";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_universal_robot/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "2faa12a6619a3ca565bd1c2ed66bafa3c002d472a90edf69a77b631e0d321e16";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "6c2a39e82afdfa890dddb0dad395803146fdb8ba0332690b683bc5921fc07c04";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2/default.nix
+++ b/distros/jazzy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2";
-  version = "2023.1.2-r4";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2/2023.1.2-4.tar.gz";
-    name = "2023.1.2-4.tar.gz";
-    sha256 = "b178cef832605cff89fa4105b18d8e9485e6a893e604186e7113b2e2f87b172c";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "6ae6ca8b3698e453c8485de2cec26853d2a0158e6edc939575b902c7b2558af4";
   };
 
   buildType = "ament_python";

--- a/distros/noetic/adi-tmc-coe/default.nix
+++ b/distros/noetic/adi-tmc-coe/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-grant, geometry-msgs, message-generation, message-runtime, roscpp, roscpp-serialization, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-adi-tmc-coe";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_tmcl_coe-release/archive/release/noetic/adi_tmc_coe/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e15522a8d1124851fb6575d376499a353387ef5b99fd5d4d00383d9b16ca42eb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ ethercat-grant geometry-msgs message-runtime roscpp roscpp-serialization std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "The adi_tmc_coe package";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "7d6176afd5dde7a5279b72b46eb9b6379e021a1e129a23270313298b711def21";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "d8067d84ec31fffe20e5ac25a5ad7f46833b44d56d497f8063cec17cd23e0958";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "cb3c5311b8146ef572345376dfbe03a4e46189f51aba47523d1251623dea21fe";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "e7bef1878d2b6dbf26ed258146035e1d77e787463a50a0cab1790119d39f33d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "ade8b86b9d1c1c5d47367df4905a53890d87a91dbfea15d4563fee70d4bdf7bf";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "21c90df91571760b9d9152924fe3c4a0e87e588a0ae7797b311432cf60393103";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "068bfe0dcef0d3b4016e42d835866097a15b6d0e62da5a05c820d4422773f53c";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "8e5b95553bab2541e5e321ae5fa97f14da62511572c0948131a40038f0666925";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.26.1-r1";
+  version = "2.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.26.1-1.tar.gz";
-    name = "2.26.1-1.tar.gz";
-    sha256 = "8ed8be4623d3ace6f9b20406a5517d2c520199ad0201a419534efe7093388fef";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.28.0-1.tar.gz";
+    name = "2.28.0-1.tar.gz";
+    sha256 = "911d195e183438e68b23486e55ca8ef313cdd0fc98dd61e836cf1cc8a1acb8bf";
   };
 
   buildType = "cmake";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  actionlib-tutorials = self.callPackage ./actionlib-tutorials {};
 
+ adi-tmc-coe = self.callPackage ./adi-tmc-coe {};
+
  adi-tmcl = self.callPackage ./adi-tmcl {};
 
  agni-tf-tools = self.callPackage ./agni-tf-tools {};
@@ -2010,6 +2012,8 @@ self: super: {
 
  mocap-optitrack = self.callPackage ./mocap-optitrack {};
 
+ mola-common = self.callPackage ./mola-common {};
+
  mongodb-log = self.callPackage ./mongodb-log {};
 
  mongodb-store-msgs = self.callPackage ./mongodb-store-msgs {};
@@ -2140,6 +2144,8 @@ self: super: {
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
+ mrpt-apps = self.callPackage ./mrpt-apps {};
+
  mrpt-ekf-slam-2d = self.callPackage ./mrpt-ekf-slam-2d {};
 
  mrpt-ekf-slam-3d = self.callPackage ./mrpt-ekf-slam-3d {};
@@ -2149,6 +2155,32 @@ self: super: {
  mrpt-graphslam-2d = self.callPackage ./mrpt-graphslam-2d {};
 
  mrpt-icp-slam-2d = self.callPackage ./mrpt-icp-slam-2d {};
+
+ mrpt-libapps = self.callPackage ./mrpt-libapps {};
+
+ mrpt-libbase = self.callPackage ./mrpt-libbase {};
+
+ mrpt-libgui = self.callPackage ./mrpt-libgui {};
+
+ mrpt-libhwdrivers = self.callPackage ./mrpt-libhwdrivers {};
+
+ mrpt-libmaps = self.callPackage ./mrpt-libmaps {};
+
+ mrpt-libmath = self.callPackage ./mrpt-libmath {};
+
+ mrpt-libnav = self.callPackage ./mrpt-libnav {};
+
+ mrpt-libobs = self.callPackage ./mrpt-libobs {};
+
+ mrpt-libopengl = self.callPackage ./mrpt-libopengl {};
+
+ mrpt-libposes = self.callPackage ./mrpt-libposes {};
+
+ mrpt-libros2bridge = self.callPackage ./mrpt-libros2bridge {};
+
+ mrpt-libslam = self.callPackage ./mrpt-libslam {};
+
+ mrpt-libtclap = self.callPackage ./mrpt-libtclap {};
 
  mrpt-local-obstacles = self.callPackage ./mrpt-local-obstacles {};
 

--- a/distros/noetic/mola-common/default.nix
+++ b/distros/noetic/mola-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-noetic-mola-common";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mola_common-release/archive/release/noetic/mola_common/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6505e58ca6c6d41575f9f1d56a4c8fe8744e213a96b4b9c7d5c5a1bc8af0f824";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin cmake ros-environment ];
+  nativeBuildInputs = [ catkin cmake ];
+
+  meta = {
+    description = "Common CMake scripts to all MOLA modules";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mp2p-icp/default.nix
+++ b/distros/noetic/mp2p-icp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mrpt2 }:
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-noetic-mp2p-icp";
-  version = "0.1.0-r1";
+  version = "1.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f090e068a36d0fcc5a69fca60d30b847bfc156daf89fcce02bd5cc96dfadf45b";
+    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.5.4-1.tar.gz";
+    name = "1.5.4-1.tar.gz";
+    sha256 = "e218e7caf746f330a301f186ee936ff468604ad579063fa52608d3487e2fccb8";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
-  propagatedBuildInputs = [ mrpt2 ];
+  propagatedBuildInputs = [ mola-common mrpt2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/mrpt-apps/default.nix
+++ b/distros/noetic/mrpt-apps/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-apps";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "97d7a0887cf121da470acfa703afcf606d15c04f68ba34bf8dfb21e1af24dffb";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libapps mrpt-libnav ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) applications";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libapps/default.nix
+++ b/distros/noetic/mrpt-libapps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libapps";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "a78e55ec8392ce819143c75fd6cc92e3847b40a12e3a4d5e9e46065ed2fd5804";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libgui mrpt-libhwdrivers mrpt-libmaps mrpt-libslam mrpt-libtclap ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (apps C++ libraries).
+  This package contains: mrpt-apps lib, mrpt-graphslam";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libbase/default.nix
+++ b/distros/noetic/mrpt-libbase/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libbase";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "b94cffcc999d2382528959064145d0aaf3ede2d222e144dcbd7bc1e764ad0d6e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp suitesparse tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (core C++ libraries).
+  This package contains: mrpt-io, mrpt-serialization, mrpt-random, mrpt-system, mrpt-rtti, mrpt-containers, mrpt-typemeta, mrpt-core, mrpt-random, mrpt-config, mrpt-expr";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libgui/default.nix
+++ b/distros/noetic/mrpt-libgui/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libgui";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "584453261321d25d524bead5a3bbac70b5f2849ab166be2263e33e470acb0cf1";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ glfw3 mrpt-libopengl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (GUI C++ libraries).
+  This package contains: mrpt-gui, nanogui";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libhwdrivers/default.nix
+++ b/distros/noetic/mrpt-libhwdrivers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libhwdrivers";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "cb6c27f6553ac3460f0f3739423e34ae6eef5ec61381a956458c56df454a9de2";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libgui mrpt-libmaps mrpt-libslam ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (hwdrivers C++ libraries).
+  This package contains: mrpt-hwdrivers, mrpt-comms";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libmaps/default.nix
+++ b/distros/noetic/mrpt-libmaps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libmaps";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "660d7b96cf6e399354b4e9751ca77889d93ae97a963b46e3c9d0ef7fef82577e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (maps C++ libraries).
+  This package contains: mrpt-maps, mrpt-graphs";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libmath/default.nix
+++ b/distros/noetic/mrpt-libmath/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libmath";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "9f7a480846d2177ecfbc093e04c7358e6f6cd79bcda180214da4adeb8894e8f3";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ eigen mrpt-libbase suitesparse ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (math C++ libraries).
+  This package contains: mrpt-math";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libnav/default.nix
+++ b/distros/noetic/mrpt-libnav/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libnav";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "e1f1f74e191cb1cf8470232809ebc8396cea607c2e3fa1e405695d02db030e96";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libmaps ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (nav C++ libraries).
+  This package contains: mrpt-nav, mrpt-kinematics";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libobs/default.nix
+++ b/distros/noetic/mrpt-libobs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libobs";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "57f0b50cbee110d101735cee2803bfce745442b1ea5542d0bb7353de400d7daa";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libopengl mrpt-libposes ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (obs C++ libraries).
+  This package contains: mrpt-obs, mrpt-topography";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libopengl/default.nix
+++ b/distros/noetic/mrpt-libopengl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libopengl";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "b552542a5d768c3610dc229967485b859835c3c5080ed3c6fb62fccd9df219d6";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libbase mrpt-libposes ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (opengl/img C++ libraries).
+  This package contains: mrpt-opengl, mrpt-img";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libposes/default.nix
+++ b/distros/noetic/mrpt-libposes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libposes";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "e5cd9d41e952d7fcf40a54cfe56d317ec1297bf5b932c46f8b0840d26dcd254e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libbase mrpt-libmath ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (poses C++ libraries).
+  This package contains: mrpt-poses, mrpt-tfest, mrpt-bayes";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libros2bridge/default.nix
+++ b/distros/noetic/mrpt-libros2bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libros2bridge";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros2bridge/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "a327e326208c59666256fb84c100689c63c99ccbf8e17d8db34698ce6ffcafbe";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libmaps ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (ros2bridge C++ library).
+  This package contains: mrpt-ros2bridge";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libslam/default.nix
+++ b/distros/noetic/mrpt-libslam/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libslam";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "f9802f894336d9797e02c9929857ed215f38d6fdf5ed1e55e00a7f3d93715e2a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libmaps ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (slam/vision C++ libraries).
+  This package contains: mrpt-slam, mrpt-vision";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrpt-libtclap/default.nix
+++ b/distros/noetic/mrpt-libtclap/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-noetic-mrpt-libtclap";
+  version = "2.13.6-r3";
+
+  src = fetchurl {
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.13.6-3.tar.gz";
+    name = "2.13.6-3.tar.gz";
+    sha256 = "865fe80ad2b5bcfb65b79c9e97908dbf399578a4569895f2f106f7057bb4dd8d";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp suitesparse tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Mobile Robot Programming Toolkit (MRPT) libraries (tclap C++ library).
+  This package contains: mrpt-tclap";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/azure-iot-sdk-c/default.nix
+++ b/distros/rolling/azure-iot-sdk-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-azure-iot-sdk-c";
-  version = "1.13.0-r3";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/azure_iot_sdk_c-release/archive/release/rolling/azure_iot_sdk_c/1.13.0-3.tar.gz";
-    name = "1.13.0-3.tar.gz";
-    sha256 = "04b780137ee18e8286c6664d5482b2987ca4c4159e2e5a3fd0a923442e099fc2";
+    url = "https://github.com/ros2-gbp/azure_iot_sdk_c-release/archive/release/rolling/azure_iot_sdk_c/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "8087467f162b6e304854d36f2455a76369057f00dd101badd5815250769be66a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/camera-calibration/default.nix
+++ b/distros/rolling/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "a5d1a508b5c456d159739756bc1d0e6a122d633c2580517ca4425e7b9122957d";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "28f568138f7ec60508b219e095d055b657b702da4ed688986828c8794ca5c83e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/depth-image-proc/default.nix
+++ b/distros/rolling/depth-image-proc/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-proc, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-depth-image-proc";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "6d902451f1a9fdb4cc9cd33293e4a9bd313ad4c1b342cbf4cc62b6c25df101d6";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "674e9a42a148238c34ca76c3b287ae0b6c7f7240285f76f3d2e96a831922fb08";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto class-loader ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge image-geometry image-transport message-filters opencv opencv.cxxdev rclcpp rclcpp-components sensor-msgs stereo-msgs tf2 tf2-eigen tf2-ros ];
+  propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters opencv opencv.cxxdev rclcpp rclcpp-components sensor-msgs stereo-msgs tf2 tf2-eigen tf2-ros ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/rolling/fields2cover/default.nix
+++ b/distros/rolling/fields2cover/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, protobuf, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, gdal, geos, git, gtest, lcov, ortools-vendor, python3, python3Packages, swig, tbb_2021_11, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fields2cover";
-  version = "2.0.0-r14";
+  version = "2.0.0-r15";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/2.0.0-14.tar.gz";
-    name = "2.0.0-14.tar.gz";
-    sha256 = "a47129a73dba10b6abcd1a9a7730b379332e3d7b4a06b526c2579983fe33df50";
+    url = "https://github.com/ros2-gbp/fields2cover-release/archive/release/rolling/fields2cover/2.0.0-15.tar.gz";
+    name = "2.0.0-15.tar.gz";
+    sha256 = "df1ee5d830e1240d1819d1705ed113f7bad7a40b83650ad68f28c042661bac08";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ gtest lcov ];
-  propagatedBuildInputs = [ boost eigen gdal geos git gtest protobuf python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
+  propagatedBuildInputs = [ boost eigen gdal geos git gtest ortools-vendor python3 python3Packages.matplotlib python3Packages.tkinter swig tbb_2021_11 tinyxml-2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/image-pipeline/default.nix
+++ b/distros/rolling/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-rolling-image-pipeline";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "5e92dd001c7c1234fa9b071ff3bf6656a3091de2c26a8b9bcea91a0a0e9c3438";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "41b4c24e4603322d9bd8daabb61dad4e942381e7d0c1d095c76243b9ef89e0ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-proc/default.nix
+++ b/distros/rolling/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, geometry-msgs, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-rolling-image-proc";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "91f30e7fb7a7f2b66fae620d87890b6496f895dbba2a69b93867425c6a2f5e56";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "ca8476552bb1cb47f9debc0bd09f20cce1bedde72cf35faece6dea2f6de14e1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-publisher/default.nix
+++ b/distros/rolling/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-image-publisher";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "0442a7dc298fee16e5aabf203911b8d06e997a6f7e2970205cce2022256446bb";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "c244de94858a5a662ab9678b42bf10aae056c97447013a802fbca3d42b701ff6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-rotate/default.nix
+++ b/distros/rolling/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-image-rotate";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "eb8ad83b0184ac6922286ba6323e33cdb57cd4e4f654cc131c74fcd2263a8b9a";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "1526ff720a05499f64acb67cb967ef04e986fc7f46427fcb5fce8a41d4012552";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-view/default.nix
+++ b/distros/rolling/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-view";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "81285f7dd550ed5983c9f018cda7f4d31ace3644c9d581bfb00deea9d71189de";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "d040ef738c31fb3e8b7ddcae80f8f8a3aa95993ad099249c8a00d0b812f8c634";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "3357b8c807373a35cc106aff748da60245f3ed54803ee85f81c02b5731356ca2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3b388e4e49f03988c5438adc1eaa4e353ec5f5baa6f224f6fbcfc8c053b28836";
   };
 
   buildType = "cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "6.0.3-r1";
+  version = "6.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/6.0.3-1.tar.gz";
-    name = "6.0.3-1.tar.gz";
-    sha256 = "23f6a245d1d68d37c76feca27e880408ab6b08d395aad0e456f0aecb9f5c956e";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/6.0.4-1.tar.gz";
+    name = "6.0.4-1.tar.gz";
+    sha256 = "fd048ca2c208d2049ff2bbf5394b15a79781d5bddb927551119fa43a8f7556a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, geometry-msgs, mola-common, mola-kernel, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt2, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "f77e74f9dedcdae9a43e646eb3b2c3665a0f5b0bf744f904f5fd298bac6831e3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "590c3aab96035f462f91d37fbafe6dd381bd82773cb667c06778d8ac1454304c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mola-common mola-kernel mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ geometry-msgs mola-common mola-kernel mola-msgs mrpt2 nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-common/default.nix
+++ b/distros/rolling/mola-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-common";
-  version = "0.3.2-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "7ae80f325c90f3078c58714c13363942696d9971df9903e341be6cf69885f0c4";
+    url = "https://github.com/ros2-gbp/mola_common-release/archive/release/rolling/mola_common/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "445a1d9823a4736b26a521f46196383ab1f6f1efb6122a8aab32f85e2518c0d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "262c15618653da373895c1ddc36a8cd628ea300cfcca240707d9f056ef5b7641";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "fc2bca15c7d9ca3840bf523d368cd737555237f0a2c8fd451bfc74e4893a6b13";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "8750163ecd05a8ee1fe99b166d568db6697230b68dcf4308d2f24ce7f1f15ee3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b424658d39a74e90b9cd13af578fff8795f3a827fbc717a84a514ed1569cd962";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "fb240d08a2fec9347430c90d949c00c96ba759201810d3f67d5b3c3192fbb4ad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "342c69dd70cfb8072d85bd20cd4635f4b5f28a1a110c597aaed6287e0dd0ed45";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "ce25261158946f3938045d8f34d41399224a0142a6d199e434fc34fa25e19ea6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9764e0a0b1eb9480f386132e3c83186192bf24596423840b89f28565e90f937b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "197ac83ea6941102cda664129e1af4eaee66133e246331e92020464f40cbad26";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "408d8cb34b430f8b6c8cf4f96a751aaf222f80590be36117268aacd6661d82ab";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "51538d21df980820772071b7cf13cf4087fbd0b919931046419d2fa5fbdb7bef";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ce6e4337cceced8cc2f81c5931165332d2ec437467e1d862260481248fb38f92";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "cfa3ccf0f3b895b2693e398f90d26e334a9decf4af9cd461c6dff3daae88de9a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "159cfbe6c99a3d3c7e6b4b1f0694d4daa8800ba15ae8dbfb3c6c37f1f9aab150";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "160930f5ab60a56e359635ec58489a2470101fad49b84182f740afa51a9c59a9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "dd577edcfeeb1f144a09aa91129f51ea8013173544a41c5e399083ea99b1ea2b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt2, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "6166857abcb85a215a51a4ccbac44ffffe01f57e55099c973762299da849aad5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "bee8def0e339d31b1fdd2c8def8e17a5f7b82edc5c54cbf8d53f7eb4f05d7658";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9f581040e677f3331412ca0b37ff32a62e3caeb81d8251c8ba579aa2ffee1ba7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b92e8b11e3ba82a9a40c05d76a3b52dd0e4185a95d10abe885445b0a6bc549e9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b08a82761d84e41ccb32b06961dc97ae0bfe100989ffa6b305fc93b73cc3d25a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2647d0dcc2c7ee2c58d6dc5858afebaf865867567027a38f4677173bcd57cb26";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "eb9ca265846ed3dd04fe9ad29bb7133e95ae758704a086d2d30a6d51f999696d";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "5bcff9f1462664ea2319db7901afc1487aa1b5aaa411441f73690c42bd53b68b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-navstate-fuse mola-pose-list mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt2, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d96bef7d06b3b3666f77531943d83f3ac0e6c2d7f1f3a8d73c3938ecae7e009a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d2b5ce3781635fbe27e235356ced0ce291dde2db6d76c56514e1670bbf9904bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "a0d55e71cc168d211ddae88e511b7b77143e4914d5f3e748733efead19efca1e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f2f57ded6a95f3e4de6a4402c8445103549855aadfb1e9171909fefeb3141832";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-navstate-fg/default.nix
+++ b/distros/rolling/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fg";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fg/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "e032ba6898e40bd9b0eb43fa4031806f3c407bdf6cac668189f899b6a0a9ece1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fg/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4c2f2b4eb6c44fd5889b77f30202c1241cd3045ecb3ae0a5a9216cbf8b14222b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-navstate-fuse/default.nix
+++ b/distros/rolling/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fuse";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "408a25d1f1eb28adea64a2df858fdee70bd60ef1555a1b9657534c16e31ab2b3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9405ac994ad674e75666af7fc5c1d488c341582a636b56db326330e3ca9a29de";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "87d78b085e7d095a349264128d471da441bb27756aa0570c03b7adebcdb07ae8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7cfac38fe33bf01887cdf44f697f641aee97dc9d2effe3a1268a9a312efe0186";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "d2f2fd7178f256579af5ad210710f279e8533aa112c435a50e45af6b398b7761";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7dff105e5a29cb95f67e9423afa45dda8a3249f73d89f7d4eaab8212bd0ac575";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9e2995466409d7f8652a877b3e7ef81ef6bf98e191878ed45c27f0b9d028b409";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7311ee1fc2624c9d728f470747cc82373f626e007c4bfcbd32e590e7a1b57045";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "9d0bcb9d96a7ea2453bed80a39d0d4a038938b7354f80203af96d90e8953ff3e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b0c6d81bb775f0aa95e5787aed4c3260de4d6125265aec65836c53237dd03d84";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "84a100748097b47830245b859129d7325c995910d5726459940c3ed9bed9e62b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2b03aa3cb0bde6abc87a1959634621cc48261990d942c49fc5ea2e2093f1be36";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "1.0.8-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "b5ec7e91a72c58af33f3851a3e3faa387cfa601f0ce8a375c73d19d37c1c978c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "26e07b2994c8bad70aaf9085b226ccae34773f03cb9370f5175d0007e62e9c4e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ kitti-metrics-eval mola-bridge-ros2 mola-demos mola-imu-preintegration mola-input-euroc-dataset mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-metric-maps mola-navstate-fg mola-navstate-fuse mola-pose-list mola-relocalization mola-traj-tools mola-viz mola-yaml ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt2 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.5.2-r1";
+  version = "1.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "ef0fa1004f0b33292df851b90c75088ae70560eec071f7f919a443a8cbf39044";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.5.3-1.tar.gz";
+    name = "1.5.3-1.tar.gz";
+    sha256 = "ce3a200e8e55b3a1c88557c062d7c29de76d31e30a6931a91d54d30278e31cbb";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "b408951d80b22ba067febc8c3189a3c8fffa4f276e173619f4144a02f0959545";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "8b746dce9c50b7c02efd507bb17f27c9c25c3eb7c7af65c56075cc147894b085";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "f40da1cb42e7be231df902c5bc2e5ea44c9d2bb67054ff1226ad73c223ea8154";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "e6c9c3a073b8ae0c09dec17be11f3644ce04da814dec308b1523470dc0133557";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "dc52b2f0b758687fde2a776d8616ae51a89aa8e97783172441198e403ba7e90a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "26526103e3b77dedd84b8836027ab8e46d1352b0a1e755e8bfce7343e1dfc9f0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "dcfe39daee6ebca49a10d54fc518e493f92ffdd2569d04e813fdf4e7b47d6744";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "6111933e571b89b284118b00c4a406375618fb4a2b7e2f79322aefcfcd8345a3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "da5e14a2ae91c4efeb0f1ddfcbda881be3babffbc6a8c78a96005a12ccbcfe2d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "4bcfefa6552a9f8202de579cd330a013dd36187f5ba3c809cb7e9b4d6aa1703a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "4f2930a4c581e0b2863da3f27f7d36fbe40eea81b9b54e563409c109f04c0b59";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "274fafc87bb558e806a90b21d6d846e3d82057f22548bd397d4fee190cb2120f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "fbaaa752aa359347163de0bed825ebd3b041338a183974407ab3457c38af36e7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "fd53ed2789bb6de6570ab6be8966cf359edc89014402e0708cf8a48b7c84f561";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "0e35b91069564b20c1f67cce1c321da5522cab056f5c559084d5f8bdf7bc157f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "c0fb7cb48fb326f1133a113e6366efdd8bfc7b70f7605135564679dc6f7b486b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "75f29fda9e360b683dbdf1bda88fbb5e4c3a79cfb2ad1edfe11228acbea6b968";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "b79ce94d5995e5f9dd76e03841a04e9b5631410898f398651c0b491cb6dad88e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "e6da0eeb0b6a235befa961191d03684687957b5d32da4a61ed809e1cfb7955d7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "fa9b117a7ed2b491fa368d12cf1e68a968d4cfa8c830db5f9af316152123dad1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "145f1095f87ba6c2d359f0d542907b4de7fddac1ae2ca8ff448f58478f9523a2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "4bb7154d811524a2fcdfbd9ab5d47838d0ce2dde73b401b46864ec878f86c0fa";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libros2bridge/default.nix
+++ b/distros/rolling/mrpt-libros2bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros2bridge";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros2bridge/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "646c01bbaf9f006590dae8efec096395139c6a7a0ce21f9b0a2a778d3b2532e4";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros2bridge/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "9ea5ce359b37d6260d5675239fc43d7683215540b72561a825d2d5241a87a734";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "4217eca4123b6c6b65986c6269b1e15510dd379ad30b970fd91477c0eb909615";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "b6e2fc7abbc9d2ee15ede00a0a8ea0b632ee25399145ac1e7c5b4f398c9e977f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.13.6-r1";
+  version = "2.13.6-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.13.6-1.tar.gz";
-    name = "2.13.6-1.tar.gz";
-    sha256 = "b6a723a95fc4d6e883fa3f49e6c7572793ba6a280fa59380ce5747a0cd2d1ab4";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.13.6-4.tar.gz";
+    name = "2.13.6-4.tar.gz";
+    sha256 = "009aad5c88ffeaa651e735842a17cd53d4a418671547164228c5310178dbcebf";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrt-cmake-modules/default.nix
+++ b/distros/rolling/mrt-cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mrt-cmake-modules";
-  version = "1.0.9-r4";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/rolling/mrt_cmake_modules/1.0.9-4.tar.gz";
-    name = "1.0.9-4.tar.gz";
-    sha256 = "c5cdf7dfc11e043d4b6de840b31d37fc30a8cb4e918e3faf5d75972bf1232dc9";
+    url = "https://github.com/ros2-gbp/mrt_cmake_modules-release/archive/release/rolling/mrt_cmake_modules/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1d54b4069266b4c337b1a8350f349cbe44021d57c72054dda740f8b8057d6a80";
   };
 
   buildType = "catkin";

--- a/distros/rolling/stereo-image-proc/default.nix
+++ b/distros/rolling/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-image-proc";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "7ddb96783dd28f74b39140a915ce27908defaab9e365ace687eca2e1ff3279e7";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "d94e4dab49a54f40dce532a39bb59520a3fc5700ba232619f39868c9042391ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-image-pipeline/default.nix
+++ b/distros/rolling/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-image-pipeline";
-  version = "6.0.2-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "b9fa6e440117d1d0584e00a8c698f38c016775f24b7d7e868919bff1db5f28eb";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "12d243ad985cdf677bc7bba23638bcac88d10386fb0cbcc3c2d233a3eacd56f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "3dccd1c2e991a7da8a16636b4dabfe7ec3f2c0da3770f4cffacd5da1f4c5e51a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "bf409bef7ab0bc06f18b89f5db7164ff4383cc025d63c4f79c5dea174a0ca0db";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "e71f9fcb468ef3538ed4984b84c8621dfff6662a948615df6bb22c80a85c6571";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "03e07b6b1496ca26d0bdb508cc54d570a7f9dc13c66005bd1b8c2875b4839d09";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, pythonPackages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "d8720fb401fb8073acbdb7cc7596391a8a16ea59dc85f29934f42540d18d0472";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "5b35066fe8015309e635635e28a15c1b4d2e06e6b3778d04e6808d633548bfec";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "4166ec5320069a7ceceaaff1318a0276103e8fcb4c398682d0aea46398fc527e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "f0eadb664b9f4d23e638c5578c17bcab3ed983bb3348338704bd70f8d6144f8d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "0cdf88e2747568a1927d85d57885700e2802dc8bce986f13505f9a9191dd3c9e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "cca601ccde4e61f932050b51b86769324c565c917a072d93bf888ed22e3e1096";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "80a2f48af7c144a57a95f1ce73f90d101623c4bee53e401544f37ba8bc34d2aa";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "2abda887078365784efede179bd82a7319ef444524b62047917b5282c0f91417";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, pythonPackages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "c16c0344775d0b1ac91013e563515f70bd052618431eac9e2e76f27283e1f2c3";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "0c2b24aca5e8123552832c9ed8801062ba61fef29cf14d3d54d2396b51cb8114";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "062d86d80742df334c1a6e15b8da46480b8e1e5d56d7a23173b9cfb6a55fb33a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "25fed7b6430c61de521b26fced53847c2c80c3657d4410a6d9f124b8b83b6c43";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "d1091c2310bc280585766fe8671d6da9241b9e38423f3ec2720306a0ae564a97";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "88cf81bf057ff234eae42977cd6ae19d276e561eb97ff7e165f2cc012f6d824a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "d53910ae47930f24eec3dbf7c6b578e74422109a94a0b02bca909e5376962211";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "43a43b0b5a15a0694d72c70c382c79a2324ba41126f278e34ea0e5317cb254df";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, pythonPackages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "7225468b946a023616125e25da57646ccc9368da328a575a3dae7b5229af6fdc";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "7c2ddf4cc2325193b6060850a918457f2ef21c328f42e7be0d555f48ef6be411";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.1.2-r1";
+  version = "2023.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.2-1.tar.gz";
-    name = "2023.1.2-1.tar.gz";
-    sha256 = "6f061b8b89060b79d464e0feca835cc69fb0bd68018adef7931bced2bbb6de41";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.3-1.tar.gz";
+    name = "2023.1.3-1.tar.gz";
+    sha256 = "88d045b361d88db007d35c71710f67a9940a6b4c7df076eeba781a962365ea97";
   };
 
   buildType = "ament_python";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 1992646cf65ac8f036a21a2005e10c4454c9e3fc.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *aerostack2 1.1.0-r1 --> 1.1.2-r2*
* *as2-alphanumeric-viewer 1.1.0-r1 --> 1.1.2-r2*
* *as2-behavior 1.1.0-r1 --> 1.1.2-r2*
* *as2-behavior-tree 1.1.0-r1 --> 1.1.2-r2*
* *as2-behaviors-motion 1.1.0-r1 --> 1.1.2-r2*
* *as2-behaviors-path-planning 1.1.0-r1 --> 1.1.2-r2*
* *as2-behaviors-perception 1.1.0-r1 --> 1.1.2-r2*
* *as2-behaviors-platform 1.1.0-r1 --> 1.1.2-r2*
* *as2-behaviors-trajectory-generation 1.1.0-r1 --> 1.1.2-r2*
* *as2-cli 1.1.0-r1 --> 1.1.2-r2*
* *as2-core 1.1.0-r1 --> 1.1.2-r2*
* *as2-external-object-to-tf 1.1.0-r1 --> 1.1.2-r2*
* *as2-gazebo-assets 1.1.0-r1 --> 1.1.2-r2*
* *as2-geozones 1.1.0-r1 --> 1.1.2-r2*
* *as2-keyboard-teleoperation 1.1.0-r1 --> 1.1.2-r2*
* *as2-map-server 1.1.0-r1 --> 1.1.2-r2*
* *as2-motion-controller 1.1.0-r1 --> 1.1.2-r2*
* *as2-motion-reference-handlers 1.1.0-r1 --> 1.1.2-r2*
* *as2-msgs 1.1.0-r1 --> 1.1.2-r2*
* *as2-platform-crazyflie 1.0.9-r1 --> 1.1.0-r3*
* *as2-platform-dji-osdk 1.0.9-r1 --> 1.1.0-r1*
* *as2-platform-dji-psdk 1.1.0-r1*
* *as2-platform-gazebo 1.1.0-r1 --> 1.1.2-r2*
* *as2-platform-mavlink 1.1.0-r1*
* *as2-platform-multirotor-simulator 1.1.0-r1 --> 1.1.2-r2*
* *as2-platform-tello 1.0.9-r1 --> 1.1.0-r4*
* *as2-realsense-interface 1.1.0-r1 --> 1.1.2-r2*
* *as2-rviz-plugins 1.1.0-r1 --> 1.1.2-r2*
* *as2-state-estimator 1.1.0-r1 --> 1.1.2-r2*
* *as2-usb-camera-interface 1.1.0-r1 --> 1.1.2-r2*
* *as2-visualization 1.1.0-r1 --> 1.1.2-r2*
* *camera-calibration 3.0.5-r1 --> 3.0.6-r1*
* *depth-image-proc 3.0.5-r1 --> 3.0.6-r1*
* *depthai 2.26.1-r1 --> 2.28.0-r1*
* *fields2cover 2.0.0-r10 --> 2.0.0-r11*
* *image-pipeline 3.0.5-r1 --> 3.0.6-r1*
* *image-proc 3.0.5-r1 --> 3.0.6-r1*
* *image-publisher 3.0.5-r1 --> 3.0.6-r1*
* *image-rotate 3.0.5-r1 --> 3.0.6-r1*
* *image-view 3.0.5-r1 --> 3.0.6-r1*
* *kinematics-interface-pinocchio 0.0.1-r1*
* *kitti-metrics-eval 1.0.8-r1 --> 1.1.0-r1*
* *message-filters 4.3.4-r1 --> 4.3.5-r1*
* *mola 1.0.8-r1 --> 1.1.0-r1*
* *mola-bridge-ros2 1.0.8-r1 --> 1.1.0-r1*
* *mola-common 0.3.2-r1 --> 0.4.0-r1*
* *mola-demos 1.0.8-r1 --> 1.1.0-r1*
* *mola-imu-preintegration 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-euroc-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti360-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-mulran-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-paris-luco-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rawlog 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rosbag2 1.0.8-r1 --> 1.1.0-r1*
* *mola-kernel 1.0.8-r1 --> 1.1.0-r1*
* *mola-launcher 1.0.8-r1 --> 1.1.0-r1*
* *mola-lidar-odometry 0.3.0-r1 --> 0.3.1-r1*
* *mola-metric-maps 1.0.8-r1 --> 1.1.0-r1*
* *mola-msgs 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fg 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fuse 1.0.8-r1 --> 1.1.0-r1*
* *mola-pose-list 1.0.8-r1 --> 1.1.0-r1*
* *mola-relocalization 1.0.8-r1 --> 1.1.0-r1*
* *mola-traj-tools 1.0.8-r1 --> 1.1.0-r1*
* *mola-viz 1.0.8-r1 --> 1.1.0-r1*
* *mola-yaml 1.0.8-r1 --> 1.1.0-r1*
* *mp2p-icp 1.5.2-r1 --> 1.5.3-r1*
* *mrpt-apps 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libapps 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libbase 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libgui 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libhwdrivers 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libmaps 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libmath 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libnav 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libobs 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libopengl 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libposes 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libros2bridge 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libslam 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libtclap 2.13.6-r1 --> 2.13.6-r4*
* *mrt-cmake-modules 1.0.9-r3 --> 1.0.10-r1*
* *neo-nav2-bringup 1.0.1-r1*
* *pcl-conversions 2.4.0-r6 --> 2.4.5-r2*
* *pcl-ros 2.4.0-r6 --> 2.4.5-r2*
* *perception-pcl 2.4.0-r6 --> 2.4.5-r2*
* *sick-safetyscanners-base 1.0.2-r1 --> 1.0.3-r1*
* *stereo-image-proc 3.0.5-r1 --> 3.0.6-r1*
* *tracetools-image-pipeline 3.0.5-r1 --> 3.0.6-r1*
* *urdf 2.6.0-r2 --> 2.6.1-r1*
* *urdf-parser-plugin 2.6.0-r2 --> 2.6.1-r1*
* *webots-ros2 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-control 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-driver 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-epuck 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-importer 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-mavic 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-msgs 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-tesla 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-tests 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-tiago 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-turtlebot 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-universal-robot 2023.1.2-r1 --> 2023.1.3-r1*

Iron Changes:
-------------
* *azure-iot-sdk-c 1.13.0-r1 --> 1.14.0-r2*
* *camera-calibration 4.0.1-r1 --> 4.0.2-r1*
* *depth-image-proc 4.0.1-r1 --> 4.0.2-r1*
* *fields2cover 2.0.0-r11 --> 2.0.0-r12*
* *image-pipeline 4.0.1-r1 --> 4.0.2-r1*
* *image-proc 4.0.1-r1 --> 4.0.2-r1*
* *image-publisher 4.0.1-r1 --> 4.0.2-r1*
* *image-rotate 4.0.1-r1 --> 4.0.2-r1*
* *image-view 4.0.1-r1 --> 4.0.2-r1*
* *kitti-metrics-eval 1.0.8-r1 --> 1.1.0-r1*
* *mola 1.0.8-r1 --> 1.1.0-r1*
* *mola-bridge-ros2 1.0.8-r1 --> 1.1.0-r1*
* *mola-common 0.3.2-r1 --> 0.4.0-r1*
* *mola-demos 1.0.8-r1 --> 1.1.0-r1*
* *mola-imu-preintegration 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-euroc-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti360-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-mulran-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-paris-luco-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rawlog 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rosbag2 1.0.8-r1 --> 1.1.0-r1*
* *mola-kernel 1.0.8-r1 --> 1.1.0-r1*
* *mola-launcher 1.0.8-r1 --> 1.1.0-r1*
* *mola-metric-maps 1.0.8-r1 --> 1.1.0-r1*
* *mola-msgs 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fg 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fuse 1.0.8-r1 --> 1.1.0-r1*
* *mola-pose-list 1.0.8-r1 --> 1.1.0-r1*
* *mola-relocalization 1.0.8-r1 --> 1.1.0-r1*
* *mola-traj-tools 1.0.8-r1 --> 1.1.0-r1*
* *mola-viz 1.0.8-r1 --> 1.1.0-r1*
* *mola-yaml 1.0.8-r1 --> 1.1.0-r1*
* *mp2p-icp 1.5.2-r1 --> 1.5.3-r1*
* *mrpt-apps 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libapps 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libbase 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libgui 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libhwdrivers 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libmaps 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libmath 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libnav 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libobs 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libopengl 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libposes 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libros2bridge 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libslam 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libtclap 2.13.6-r1 --> 2.13.6-r3*
* *mrt-cmake-modules 1.0.9-r4 --> 1.0.10-r1*
* *sick-safetyscanners-base 1.0.2-r1 --> 1.0.3-r1*
* *stereo-image-proc 4.0.1-r1 --> 4.0.2-r1*
* *tracetools-image-pipeline 4.0.1-r1 --> 4.0.2-r1*

Jazzy Changes:
--------------
* *azure-iot-sdk-c 1.13.0-r2 --> 1.14.0-r1*
* *camera-calibration 5.0.3-r1 --> 5.0.4-r1*
* *depth-image-proc 5.0.3-r1 --> 5.0.4-r1*
* *depthai 2.26.1-r1 --> 2.28.0-r1*
* *fields2cover 2.0.0-r9 --> 2.0.0-r10*
* *image-pipeline 5.0.3-r1 --> 5.0.4-r1*
* *image-proc 5.0.3-r1 --> 5.0.4-r1*
* *image-publisher 5.0.3-r1 --> 5.0.4-r1*
* *image-rotate 5.0.3-r1 --> 5.0.4-r1*
* *image-view 5.0.3-r1 --> 5.0.4-r1*
* *kitti-metrics-eval 1.0.8-r1 --> 1.1.0-r1*
* *mola 1.0.8-r1 --> 1.1.0-r1*
* *mola-bridge-ros2 1.0.8-r1 --> 1.1.0-r1*
* *mola-common 0.3.2-r1 --> 0.4.0-r1*
* *mola-demos 1.0.8-r1 --> 1.1.0-r1*
* *mola-imu-preintegration 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-euroc-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti360-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-mulran-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-paris-luco-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rawlog 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rosbag2 1.0.8-r1 --> 1.1.0-r1*
* *mola-kernel 1.0.8-r1 --> 1.1.0-r1*
* *mola-launcher 1.0.8-r1 --> 1.1.0-r1*
* *mola-lidar-odometry 0.3.0-r1 --> 0.3.1-r1*
* *mola-metric-maps 1.0.8-r1 --> 1.1.0-r1*
* *mola-msgs 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fg 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fuse 1.0.8-r1 --> 1.1.0-r1*
* *mola-pose-list 1.0.8-r1 --> 1.1.0-r1*
* *mola-relocalization 1.0.8-r1 --> 1.1.0-r1*
* *mola-traj-tools 1.0.8-r1 --> 1.1.0-r1*
* *mola-viz 1.0.8-r1 --> 1.1.0-r1*
* *mola-yaml 1.0.8-r1 --> 1.1.0-r1*
* *mp2p-icp 1.5.2-r1 --> 1.5.3-r1*
* *mrpt-apps 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libapps 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libbase 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libgui 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libhwdrivers 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libmaps 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libmath 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libnav 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libobs 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libopengl 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libposes 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libros2bridge 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libslam 2.13.6-r1 --> 2.13.6-r3*
* *mrpt-libtclap 2.13.6-r1 --> 2.13.6-r3*
* *mrt-cmake-modules 1.0.9-r5 --> 1.0.10-r1*
* *qml-ros2-plugin 1.0.1-r1*
* *rviz-assimp-vendor 14.1.3-r1 --> 14.1.4-r1*
* *rviz-common 14.1.3-r1 --> 14.1.4-r1*
* *rviz-default-plugins 14.1.3-r1 --> 14.1.4-r1*
* *rviz-ogre-vendor 14.1.3-r1 --> 14.1.4-r1*
* *rviz-rendering 14.1.3-r1 --> 14.1.4-r1*
* *rviz-rendering-tests 14.1.3-r1 --> 14.1.4-r1*
* *rviz-visual-testing-framework 14.1.3-r1 --> 14.1.4-r1*
* *rviz2 14.1.3-r1 --> 14.1.4-r1*
* *stereo-image-proc 5.0.3-r1 --> 5.0.4-r1*
* *tracetools-image-pipeline 5.0.3-r1 --> 5.0.4-r1*
* *webots-ros2 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-control 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-driver 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-epuck 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-importer 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-mavic 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-msgs 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-tesla 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-tests 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-tiago 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-turtlebot 2023.1.2-r4 --> 2023.1.3-r1*
* *webots-ros2-universal-robot 2023.1.2-r4 --> 2023.1.3-r1*

Noetic Changes:
---------------
* *adi-tmc-coe 1.0.0-r1*
* *audio-capture 0.3.17-r1 --> 0.3.18-r1*
* *audio-common 0.3.17-r1 --> 0.3.18-r1*
* *audio-common-msgs 0.3.17-r1 --> 0.3.18-r1*
* *audio-play 0.3.17-r1 --> 0.3.18-r1*
* *depthai 2.26.1-r1 --> 2.28.0-r1*
* *mola-common 0.4.0-r1*
* *mp2p-icp 0.1.0-r1 --> 1.5.4-r1*
* *mrpt-apps 2.13.6-r3*
* *mrpt-libapps 2.13.6-r3*
* *mrpt-libbase 2.13.6-r3*
* *mrpt-libgui 2.13.6-r3*
* *mrpt-libhwdrivers 2.13.6-r3*
* *mrpt-libmaps 2.13.6-r3*
* *mrpt-libmath 2.13.6-r3*
* *mrpt-libnav 2.13.6-r3*
* *mrpt-libobs 2.13.6-r3*
* *mrpt-libopengl 2.13.6-r3*
* *mrpt-libposes 2.13.6-r3*
* *mrpt-libros2bridge 2.13.6-r3*
* *mrpt-libslam 2.13.6-r3*
* *mrpt-libtclap 2.13.6-r3*

Rolling Changes:
----------------
* *azure-iot-sdk-c 1.13.0-r3 --> 1.14.0-r1*
* *camera-calibration 6.0.2-r1 --> 6.0.3-r1*
* *depth-image-proc 6.0.2-r1 --> 6.0.3-r1*
* *fields2cover 2.0.0-r14 --> 2.0.0-r15*
* *image-pipeline 6.0.2-r1 --> 6.0.3-r1*
* *image-proc 6.0.2-r1 --> 6.0.3-r1*
* *image-publisher 6.0.2-r1 --> 6.0.3-r1*
* *image-rotate 6.0.2-r1 --> 6.0.3-r1*
* *image-view 6.0.2-r1 --> 6.0.3-r1*
* *kitti-metrics-eval 1.0.8-r1 --> 1.1.0-r1*
* *message-filters 6.0.3-r1 --> 6.0.4-r1*
* *mola 1.0.8-r1 --> 1.1.0-r1*
* *mola-bridge-ros2 1.0.8-r1 --> 1.1.0-r1*
* *mola-common 0.3.2-r1 --> 0.4.0-r1*
* *mola-demos 1.0.8-r1 --> 1.1.0-r1*
* *mola-imu-preintegration 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-euroc-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-kitti360-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-mulran-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-paris-luco-dataset 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rawlog 1.0.8-r1 --> 1.1.0-r1*
* *mola-input-rosbag2 1.0.8-r1 --> 1.1.0-r1*
* *mola-kernel 1.0.8-r1 --> 1.1.0-r1*
* *mola-launcher 1.0.8-r1 --> 1.1.0-r1*
* *mola-lidar-odometry 0.3.0-r1 --> 0.3.1-r1*
* *mola-metric-maps 1.0.8-r1 --> 1.1.0-r1*
* *mola-msgs 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fg 1.0.8-r1 --> 1.1.0-r1*
* *mola-navstate-fuse 1.0.8-r1 --> 1.1.0-r1*
* *mola-pose-list 1.0.8-r1 --> 1.1.0-r1*
* *mola-relocalization 1.0.8-r1 --> 1.1.0-r1*
* *mola-traj-tools 1.0.8-r1 --> 1.1.0-r1*
* *mola-viz 1.0.8-r1 --> 1.1.0-r1*
* *mola-yaml 1.0.8-r1 --> 1.1.0-r1*
* *mp2p-icp 1.5.2-r1 --> 1.5.3-r1*
* *mrpt-apps 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libapps 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libbase 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libgui 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libhwdrivers 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libmaps 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libmath 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libnav 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libobs 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libopengl 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libposes 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libros2bridge 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libslam 2.13.6-r1 --> 2.13.6-r4*
* *mrpt-libtclap 2.13.6-r1 --> 2.13.6-r4*
* *mrt-cmake-modules 1.0.9-r4 --> 1.0.10-r1*
* *stereo-image-proc 6.0.2-r1 --> 6.0.3-r1*
* *tracetools-image-pipeline 6.0.2-r1 --> 6.0.3-r1*
* *webots-ros2 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-control 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-driver 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-epuck 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-importer 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-mavic 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-msgs 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-tesla 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-tests 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-tiago 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-turtlebot 2023.1.2-r1 --> 2023.1.3-r1*
* *webots-ros2-universal-robot 2023.1.2-r1 --> 2023.1.3-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libnanopb-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] protobuf-compiler-grpc
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-seaborn
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

