### PR TITLE
colcon-mixin: init at 0.2.3

### DIFF
--- a/pkgs/colcon/mixin.nix
+++ b/pkgs/colcon/mixin.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "colcon-mixin";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-4MNJz3sHCWEohm7BD6UI41QA2yCP7LvrhqVKsaHUnuk=";
+  };
+
+  propagatedBuildInputs = [
+    colcon-core
+    pyyaml
+  ];
+
+  # Requires unpackaged dependencies
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to read CLI mixins from files.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,6 +10,7 @@ self: super: with self.lib; {
     colcon-devtools
     colcon-library-path
     colcon-metadata
+    colcon-mixin
     colcon-notification
     colcon-output
     colcon-package-information
@@ -96,6 +97,8 @@ self: super: with self.lib; {
       colcon-library-path = pyFinal.callPackage ./colcon/library-path.nix { };
 
       colcon-metadata = pyFinal.callPackage ./colcon/metadata.nix { };
+
+      colcon-mixin = pyFinal.callPackage ./colcon/mixin.nix { };
 
       colcon-notification = pyFinal.callPackage ./colcon/notification.nix { };
 


### PR DESCRIPTION
This adds `colcon-mixin` to the set of available extensions.

I believe the extension is useful enough, while also being mentioned by the ROS 2 docs, to warrant a place in the default set of extensions, so I added it there. I'll remove it if you disagree.

Also, I provisionally put @lopsided98 as the maintainer because the commit to nixpkgs that adds me to the set of maintainers is currently stuck together with a PR that is slow to getting merged / reviewed.