### PR TITLE
Allow changing the Python version in ROS distros

### DIFF
--- a/distros/default.nix
+++ b/distros/default.nix
@@ -5,40 +5,13 @@ self: super: {
     recurseForDerivations = true;
     lib = super.lib // import ../lib { inherit lib self; };
 
-    noetic = import ./distro-overlay.nix {
-      version = 1;
-      distro = "noetic";
-      python = self.python3;
-    } self super;
+    mkRosDistroOverlay = args: import ./distro-overlay.nix args;
 
-    foxy = import ./distro-overlay.nix {
-      version = 2;
-      distro = "foxy";
-      python = self.python3;
-    } self super;
-
-    humble = import ./distro-overlay.nix {
-      version = 2;
-      distro = "humble";
-      python = self.python3;
-    } self super;
-
-    iron = import ./distro-overlay.nix {
-      version = 2;
-      distro = "iron";
-      python = self.python3;
-    } self super;
-
-    jazzy = import ./distro-overlay.nix {
-      version = 2;
-      distro = "jazzy";
-      python = self.python3;
-    } self super;
-
-    rolling = import ./distro-overlay.nix {
-      version = 2;
-      distro = "rolling";
-      python = self.python3;
-    } self super;
+    noetic = mkRosDistroOverlay { version = 1; distro = "noetic"; } self super;
+    foxy = mkRosDistroOverlay { version = 2; distro = "foxy"; } self super;
+    humble = mkRosDistroOverlay { version = 2; distro = "humble"; } self super;
+    iron = mkRosDistroOverlay { version = 2; distro = "iron"; } self super;
+    jazzy = mkRosDistroOverlay { version = 2; distro = "jazzy"; } self super;
+    rolling = mkRosDistroOverlay { version = 2; distro = "rolling"; } self super;
   };
 }

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -1,4 +1,4 @@
-{ version, distro, python }:
+{ version, distro }:
 self: super:
 let
   pythonOverridesFor = with self.lib; prevPython: prevPython // {
@@ -25,11 +25,14 @@ let
       inherit (self) buildEnv;
     };
 
-    python = pythonOverridesFor python;
-    pythonPackages = rosSelf.python.pkgs;
-
-    python3 = pythonOverridesFor self.python3;
+    python3 = pythonOverridesFor rosSelf.rosPython or self.python3;
     python3Packages = rosSelf.python3.pkgs;
+
+    # While `python` in Nixpkgs is typically Python 2, this overlay has
+    # historically set it to Python 3 during the ROS transition. Keep it that
+    # way for compatibility.
+    python = rosSelf.python3;
+    pythonPackages = rosSelf.python.pkgs;
 
     boost = self.boost.override {
       python = rosSelf.python;


### PR DESCRIPTION
This PR reworks the Python overlay system to make changing the Python version used for a ROS distro easier.

When the top-level `rosPython` package is defined in a distro scope, it will be used instead of `python3`.

For example:

```nix
self: super:

{
  rosPackages = super.rosPackages // {
    jazzy = super.rosPackages.jazzy.overrideScope (rosSelf: rosSuper: {
      rosPython = self.python311;
    });
  };
}
```

Closes #413.
Closes #379.