### PR TITLE
rosdistro sync, Fri Sep  6 14:00:09 2024

### DIFF
--- a/distros/humble/ament-black/default.nix
+++ b/distros/humble/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-black";
-  version = "0.2.5-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_black/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "630b19024c714b71ebed940babfdb2a19d75e6551936fa720ffe232c2ec87d2c";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_black/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "4c8c4b0261a13dcedfbf2ee540b01392d8fb27300061658b24a878fd663a1168";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cmake-black/default.nix
+++ b/distros/humble/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-black";
-  version = "0.2.5-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_cmake_black/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "2cc92498e7bd66d1ebb137c49b55390e8149b813669bf5546c7fb6c6c4631f2a";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/humble/ament_cmake_black/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "b55fc5d76436856fec0390e0f1a5ccb48b2d7b162ec401b878de246f42d01b2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension-python/default.nix
+++ b/distros/humble/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension-python";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "6f599c2e6f8cb033837b11b2f6ec116c470aca0ba3286fabe255e6227397a346";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c9a4e2b1be48bc5b1b38ea5dca8bca761972167c3bc838e19d655181314229f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension/default.nix
+++ b/distros/humble/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "c2795bef4e26cfaad64e836cfdb2f9a4608a42c7f75af42d1d14a72c27b45480";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d5bbdf8444f8b20199521cf9609e5b4c9a01a7964175480161409e7b0842e9a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "f39ba917d33f9011789d6c15baed1282ae551cf5f0383c84ec5290c3b1b678af";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "544acbb107041b44f9804c6eb45c2a4473330981578ddb7076b2763ee1919896";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ffmpeg-encoder-decoder/default.nix
+++ b/distros/humble/ffmpeg-encoder-decoder/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ffmpeg-encoder-decoder";
+  version = "1.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/humble/ffmpeg_encoder_decoder/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "8cb7b4eba4d5e39e1ac0b38daa50ea107e18e716c2ec1ceb777f56d11fd3c8e0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg opencv opencv.cxxdev rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+
+  meta = {
+    description = "ROS2 convenience wrapper around ffmpeg for encoding/decoding";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -892,6 +892,8 @@ self: super: {
 
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
+ ffmpeg-encoder-decoder = self.callPackage ./ffmpeg-encoder-decoder {};
+
  ffmpeg-image-transport = self.callPackage ./ffmpeg-image-transport {};
 
  ffmpeg-image-transport-msgs = self.callPackage ./ffmpeg-image-transport-msgs {};
@@ -1301,6 +1303,8 @@ self: super: {
  kuka-robot-descriptions = self.callPackage ./kuka-robot-descriptions {};
 
  kuka-rsi-simulator = self.callPackage ./kuka-rsi-simulator {};
+
+ kuka-sunrise-fri-driver = self.callPackage ./kuka-sunrise-fri-driver {};
 
  lanelet2 = self.callPackage ./lanelet2 {};
 
@@ -2192,6 +2196,8 @@ self: super: {
 
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
+ python-mrpt = self.callPackage ./python-mrpt {};
+
  python-orocos-kdl-vendor = self.callPackage ./python-orocos-kdl-vendor {};
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
@@ -2219,6 +2225,8 @@ self: super: {
  qb-softhand-industry-ros2-control = self.callPackage ./qb-softhand-industry-ros2-control {};
 
  qb-softhand-industry-srvs = self.callPackage ./qb-softhand-industry-srvs {};
+
+ qml-ros2-plugin = self.callPackage ./qml-ros2-plugin {};
 
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 
@@ -2559,6 +2567,10 @@ self: super: {
  ros2trace = self.callPackage ./ros2trace {};
 
  ros2trace-analysis = self.callPackage ./ros2trace-analysis {};
+
+ ros-babel-fish = self.callPackage ./ros-babel-fish {};
+
+ ros-babel-fish-test-msgs = self.callPackage ./ros-babel-fish-test-msgs {};
 
  ros-base = self.callPackage ./ros-base {};
 
@@ -3115,6 +3127,8 @@ self: super: {
  tricycle-steering-controller = self.callPackage ./tricycle-steering-controller {};
 
  turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
+
+ turtle-nest = self.callPackage ./turtle-nest {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "8a786760e5cdc78634098ad8839f9a6380de70a03ff2b288299b85480b0a4aa2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "1b734fac14aa8c124e715cb0ea73105922593ef1a610e25a77fbfc776f4b007f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hebi-cpp-api/default.nix
+++ b/distros/humble/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
 buildRosPackage {
   pname = "ros-humble-hebi-cpp-api";
-  version = "3.9.0-r1";
+  version = "3.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/humble/hebi_cpp_api/3.9.0-1.tar.gz";
-    name = "3.9.0-1.tar.gz";
-    sha256 = "18192037cae0895302b07746ae4a9a62971b20fe5f54b7be2d0f82e29f274d52";
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/humble/hebi_cpp_api/3.10.0-1.tar.gz";
+    name = "3.10.0-1.tar.gz";
+    sha256 = "a46abd28af27f85d466f74b7a1e173d04b9a8e7a713fdac241629a59f05f3734";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joy-teleop/default.nix
+++ b/distros/humble/joy-teleop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joy-teleop";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/joy_teleop/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "26b8b70e5c0fbe70d0c720fedfe1899deeb95c003afd8ee0da7598556e99b7e3";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/joy_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "2d573562cfa5adc29d5d770283b0f0332287a053eb485f4a724b70b07ecaebf7";
   };
 
   buildType = "ament_python";
-  checkInputs = [ action-tutorials-interfaces ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
   propagatedBuildInputs = [ control-msgs rclpy rosidl-runtime-py sensor-msgs teleop-tools-msgs trajectory-msgs ];
 
   meta = {

--- a/distros/humble/key-teleop/default.nix
+++ b/distros/humble/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-key-teleop";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/key_teleop/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "ddb72d5b8d968de1987c72e0f40918eedb207ae16972d07977d5fb13eee53a00";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/key_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "540e293898079b7a22171529b0ea5df61d41ea225aadaabea89e23dcb7d45227";
   };
 
   buildType = "ament_python";

--- a/distros/humble/kuka-sunrise-fri-driver/default.nix
+++ b/distros/humble/kuka-sunrise-fri-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, fri-configuration-controller, fri-state-broadcaster, hardware-interface, joint-group-impedance-controller, joint-state-broadcaster, joint-trajectory-controller, kuka-control-mode-handler, kuka-driver-interfaces, kuka-drivers-core, kuka-event-broadcaster, kuka-lbr-iiwa-support, launch-testing-ament-cmake, nanopb, ros2-control, ros2lifecycle, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-kuka-sunrise-fri-driver";
+  version = "0.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/kuka_drivers-release/archive/release/humble/kuka_sunrise_fri_driver/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "37ce1ed012e5bdd95423f67bcfc4f7595d80a1af453955a250c8539b224e2625";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ launch-testing-ament-cmake ros2lifecycle ];
+  propagatedBuildInputs = [ controller-manager-msgs fri-configuration-controller fri-state-broadcaster hardware-interface joint-group-impedance-controller joint-state-broadcaster joint-trajectory-controller kuka-control-mode-handler kuka-driver-interfaces kuka-drivers-core kuka-event-broadcaster kuka-lbr-iiwa-support nanopb ros2-control std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS2 KUKA sunrise interface";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/libcamera/default.nix
+++ b/distros/humble/libcamera/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3Packages, udev }:
+{ lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3, python3Packages, udev }:
 buildRosPackage {
   pname = "ros-humble-libcamera";
-  version = "0.1.0-r1";
+  version = "0.1.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/humble/libcamera/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "bc1fd57c844650ea25b854739a93b02797c7305aea633d6e2ef696178bf0996b";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/humble/libcamera/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "d7f25b0607c2bcd5dc08ba689cf6d5f3d71c9bb9868f4b717e2c0027b104c885";
   };
 
   buildType = "meson";
   buildInputs = [ meson pkg-config python3Packages.jinja2 python3Packages.ply python3Packages.pyyaml ];
-  propagatedBuildInputs = [ libyaml openssl udev ];
+  propagatedBuildInputs = [ libyaml openssl python3 udev ];
   nativeBuildInputs = [ meson ];
 
   meta = {

--- a/distros/humble/marti-can-msgs/default.nix
+++ b/distros/humble/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-can-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_can_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "ca860f5f97b9c07a8669db074c5f3f44c08ef1e3b278327ad924da3ec8d80bf7";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_can_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "f34fc04875ca096c55a8afa7735eb5f90301bd899db98ef6506fbb14d6eccb9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-common-msgs/default.nix
+++ b/distros/humble/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-common-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_common_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "e4c418e6fb9d32da4b013f86cd40124c5a93ae7b42a50a14808f7eedae0bd9c5";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_common_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "83e06b11fd5a082b2e26b1aca0c12d6e035a02c21b2a81d98552b4ac8117554f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-dbw-msgs/default.nix
+++ b/distros/humble/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-dbw-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_dbw_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "6eec9d2e8afa14f9af150a3881f05976b7ede5cb98395056ba8d1cc82d94f1a1";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_dbw_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "8e571a962a1c784577e1ab3036554be4b13d7d4b8f914c6c0cd10cbc28ccb115";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-introspection-msgs/default.nix
+++ b/distros/humble/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-introspection-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_introspection_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "0460aae5c773c1accee1be650aa7caa23a99a231c3c2d6854d4c319007668ce8";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_introspection_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "3de897f61171f7241fd1097da503646fe130c1a2f10771911fc4d4c6d0f8d816";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-nav-msgs/default.nix
+++ b/distros/humble/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-nav-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_nav_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "c2b3b937a87bac79e30aff98482edc78d1cac367a8ad63fb438ca2b7c5e355fe";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_nav_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "71b73eb7a898ec7c850b653631335038d85527e3eea094ccd9a9a29dc6209d54";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-perception-msgs/default.nix
+++ b/distros/humble/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-perception-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_perception_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "5c73c63bf7672fa7f5d1a47150d0e7aab3491e79c92afae5decbff02309d9d3e";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_perception_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "f770e0bde96092471067961ae67819abdde008313451055095bdccd7039d0917";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-sensor-msgs/default.nix
+++ b/distros/humble/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-marti-sensor-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_sensor_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "7467230552192b6400a1fe33463444a3f652281465bee5d4cb5b665d6d6f0372";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_sensor_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "847db3173aaf3eaaeb084f072dd539e2d23b0ce5c59c70a64d14803c57a01088";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-status-msgs/default.nix
+++ b/distros/humble/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-status-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_status_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "71852d18efb34f3ccbe3252246261d8a70588ba709c8e35665e83d4b55683049";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_status_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "79f6f4dc6d5f66fa5fb6a7121bd24c336ba6186352b745128d50583c121a19d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/marti-visualization-msgs/default.nix
+++ b/distros/humble/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-marti-visualization-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_visualization_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "43798d59bbe29d8113710620c8ec03d98e1e7d168ff96e575f13a48f59a79db3";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/humble/marti_visualization_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "4b5ef267b9d7a3ce3a45854189311c3be6e71fa7c1fcfa9c07ce294d3389c0c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "407cc16b9f6f50b194d1f67b180331de0b0810f86bf9199ee0822ead21218e15";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c8751aa5963271346febc2781f02b496dde38e5f13b55914b41c4dbb39c061a5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mouse-teleop/default.nix
+++ b/distros/humble/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-mouse-teleop";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/mouse_teleop/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "fc78bf91d0c94a6e135237605067b110803447e18bf44f8f9b6786b86da8a7c7";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/mouse_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "db8ba07e1133d3d8424de264fc4ad19d0ebbed95ad2587c268b96dab882ec8e1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "d6745c0e32df378cc0248286d15b0fe6206ac5acf1ba8dbfd71f18415cb8ddf0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "05d7b2dea534dfe5c6b8eff323ad027131e2e4f5376b4e43d4a5d969d33abcfd";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-generic-sensor/default.nix
+++ b/distros/humble/mrpt-generic-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-generic-sensor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_generic_sensor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "6fdcc6f13d76ff376ee96eeccaa291201201c73c51886b601c63e9fbda7d567c";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_generic_sensor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "e80ec924d263cc8eac30178e958deec8cca7353b53204be1895b18073a73a834";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "b19465ce089a6640afd9b39bc7401dbbcaa3d9922a0c57d25df00b5ffbcdd432";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "d3d35ebd9108277553968bfe76950f4a69b004a19acc3337dc20c8a6727dcbb9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "046868744deb4467bcadde9b2d0f19026f19eca4e62a4b8b1b5e1a7c3a8a6d6b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "ccfac21d85cb25060dacaad711a298d2f4da8815fe346870a9d9ebe0e0903e37";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "87ac1723b131210c3012bb753a4c4fefa6d83743e135a873a9273a440dbba672";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "0b8673931d4362311acc9c7bace42543c9310ac4b2808e9c6d4aa4ee5bfa7110";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "7dd8e4c676368fa86cae6a1dce823f585955a74eb8c7909f72ebe715b15394a7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "f2f5dfffd177db4057e166843a4641e4a6d37ac966078eaa4908a88bcbbcc9bb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "7f0390ca3f21d23160c94ded809dab4e37fb048360c23d1d748f6d4a7b0fec93";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "481231bc9791d5e7e247ea9a07b00262ad4838aa23a5f833d7bda8fd22ca62d9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "783a41eeef0a4c2be54a2590219feb1936a576aac4ec44ea6dd9a1b984982618";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "e6a689f1ebce9cb220adf42fc647f2ce316a4d5346850911e3d68c79337c2497";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "6b89645480f2e5384cf6c1d03e3260e26fe487693c04f126641a0d7505e61278";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "55316d72616e11ee1b274402dd33d07a136db807f9211c4d8e3ca80217d63434";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "22e2d18bbc45d4eb36095f1796df8b4d75a05665fac5e17a5a132d87053ad111";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "855430fee7e4bcde9a9ffa0ee4e4ed75a7ff3f1cf87e9994af594aa9eca74025";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "3f44e543137ceed3cc604189096aa8ab8ef275324aee81aa81bf1003ff95160b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "deb159d3463641cd4b31501ab30930fe1486aa59152bc28f29a06c017a4128e0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "2fa875bb86ae6c4e2e518acd0eebab50a386bb2ddbd9da2632b966aea52e66d5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "a2452604b7a46b667c9d1741db4b276d1a34e7a9a1493dc33e0c24d66eff1699";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libros-bridge/default.nix
+++ b/distros/humble/mrpt-libros-bridge/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros-bridge";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "17ffaaa9636ff5b1558073118f4fc3e00d79298d198da3957599416d2d00f30d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "9cc0d938641edbd353f3552229fc86f361f05486ba9689a8b882ffb5eeb81850";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect geometry-msgs glfw3 libGL libGLU libjpeg libpcap libusb1 nav-msgs octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage sensor-msgs std-msgs stereo-msgs tf2 tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
-  propagatedBuildInputs = [ mrpt-libmaps ];
+  buildInputs = [ ament-cmake assimp cmake ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs mrpt-libmaps nav-msgs rclcpp sensor-msgs std-msgs stereo-msgs tf2 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "4b0da584a71dfa2bde2686b4ae495a11b60f9a47c2479e5234b10304707c4a1a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "e90e3bb7f9d090179cca58ce57e9903aacc915edc42caaca424d9700786542d2";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.13.7-r2";
+  version = "2.13.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.13.7-2.tar.gz";
-    name = "2.13.7-2.tar.gz";
-    sha256 = "5d26829e7e35b6ac6153791ed78de5d19c672c91653250847b8a9bdd0f8128fc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.13.7-3.tar.gz";
+    name = "2.13.7-3.tar.gz";
+    sha256 = "81e034e8538591fe7b9a16a7bb3c0ed3d52b58bb5659fab83b9355e5604c0a10";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-map-server/default.nix
+++ b/distros/humble/mrpt-map-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-mrpt-map-server";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_map_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "78b6ab8e475f4b6d8d23f9c3c06b5d817adeaf3f2664291fef092cf7c13bbd6f";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_map_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "55a04221bb6ebd45ac06599868715afcfd7a0f7613b3c8cb6bca49fb75647c47";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libmaps mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces rclcpp-components ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-msgs-bridge/default.nix
+++ b/distros/humble/mrpt-msgs-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt2, ros-environment, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-humble-mrpt-msgs-bridge";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_msgs_bridge/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "70fc8b69474ddede7e59d3e89af76cc03b47c70f2f754137ff4648052ec2b3aa";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_msgs_bridge/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "410ab7c39430509f14806060815013c135e3687d24f45a959fba902b776177df";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt2 tf2 ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libobs mrpt-libros-bridge mrpt-msgs rclcpp tf2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-nav-interfaces/default.nix
+++ b/distros/humble/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mrpt-nav-interfaces";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_nav_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8772fd5d4b98d09b4d21320a0bda5c94aa7cc162780ff531873fb8fba548a410";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_nav_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d79773bfdc2a071a6b4059837bfe5cc640b5a4de5b93bcac9f56ff8df938584d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-navigation/default.nix
+++ b/distros/humble/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-map-server, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-humble-mrpt-navigation";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_navigation/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "993d28a30aaded5279812a1db53c60cccdcfaa4dcb51102f468479d0ca1dd25f";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_navigation/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3f03299b9b5d86ecfa627458815d27f575ca0623e202a313c6817ac4a6ba2a92";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-pf-localization/default.nix
+++ b/distros/humble/mrpt-pf-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, mrpt2, nav-msgs, pose-cov-ops, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-pf-localization";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pf_localization/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "bd1a5f81200da43125aaf3022a2082702277e6bdbffbd396ea60d9b754b9c6dd";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pf_localization/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0ba35495536f3385a163201e6caa00ff07af3c0039785e2b0daa83fab7c0f726";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
   checkInputs = [ mrpt-tutorials ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs mrpt-msgs-bridge nav-msgs pose-cov-ops rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/humble/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/humble/mrpt-pointcloud-pipeline/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-pointcloud-pipeline";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pointcloud_pipeline/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6a3563957a3f2547c3c4033f2f183435ee269a79f36763299d04743bf0d0fe35";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_pointcloud_pipeline/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d947919026911d16aafe791fa418e867909a76957e701914987583dbcdf6c5af";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libros-bridge nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-rawlog/default.nix
+++ b/distros/humble/mrpt-rawlog/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-libros-bridge, mrpt-libtclap, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-rawlog";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_rawlog/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6323ba30118e27fc8ee34edc08272b47dc963f4e9f016c5fce08ece5e004478b";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_rawlog/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "9ab2ecad7569b1de31381e2572564868bce69173ddc682332cbe3cf5d8722aa7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-msgs mrpt2 nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-libros-bridge mrpt-libtclap mrpt-msgs nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/humble/mrpt-reactivenav2d/default.nix
+++ b/distros/humble/mrpt-reactivenav2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-reactivenav2d";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_reactivenav2d/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6361d10c5ef53d071e6764fc37c6ac8bfde947746f2796a24004481c6d584d43";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_reactivenav2d/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "1d7bd2b7b257325e091a65a77d2e5002fd2832f754f8e641a77de7a62e16ee69";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libnav mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/humble/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_bumblebee_stereo/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "212707ac7a8f425147150a2e0569b8a8dfe6af8ebaac1231b1573803f13e6478";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_bumblebee_stereo/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "5951ee17239893005655db7156b35a6c8a0376546df7326dfde049a09af0e844";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/humble/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, nmea-msgs, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-gnss-nmea";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_nmea/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "176cd42490f152aa4c0ea2765eb9c5f9ca24e75e86eb02eb46b33e52241eaa8d";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_nmea/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "d35a0de923ef6f643d7c3ff9d52f1bad64ab24bf0bb43af4a341ea2d8f434e83";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 nmea-msgs rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/humble/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-gnss-novatel";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_novatel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "ed894f7693148eb69a7e576735929764351fff6f0b39ff0ada4551c7c8485d59";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_gnss_novatel/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "5d015af55047a5ec6c7e3de7b2e02769644c6d9b92a22504d65f0d429c6aac9d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/humble/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensor-imu-taobotics";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_imu_taobotics/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "02e4944a0e21b4aea087257eba8db348bfc74b6e4f6c8ec6717b306f4165f1ce";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensor_imu_taobotics/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "6c20d8885a66e4e4abd47250cefa68d0332636a54aa2ee5e30a9348744f79472";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensorlib/default.nix
+++ b/distros/humble/mrpt-sensorlib/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensorlib";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensorlib/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "c9c0ec20d2b621381a82a81705f4916deed508f8b795721c3ac6779e835d54c8";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensorlib/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "46e9e05fcc2c971d9d39a16a3d956a6e7361db2808b4d7420c438f51c5e0c4a6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt2 rclcpp rclcpp-components tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-sensors/default.nix
+++ b/distros/humble/mrpt-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-sensors";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensors/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "dfda8af40cc3cf2fae4664307dc128a53968a5cf7bdc1c7c86802c1233ac88bb";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/humble/mrpt_sensors/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "046aad4e205007df158cdc76d3317ce9061933410795068a94518ed2a11b42e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-tps-astar-planner/default.nix
+++ b/distros/humble/mrpt-tps-astar-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-tps-astar-planner";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tps_astar_planner/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "63ebafecd5bb0b327092bf08245e9b762c3bdac6a06711b36b97dc7846d381e3";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tps_astar_planner/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "f1ce2aa214f7af8172875f3db4eb0c700c2cc0aba71d80f76a0f2e560d6ea7c8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt-path-planning mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-libgui mrpt-libmaps mrpt-libnav mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces mrpt-path-planning nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/mrpt-tutorials/default.nix
+++ b/distros/humble/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-mrpt-tutorials";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tutorials/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "07254190cade6d6a13b8c8e27d76d1ff905cede2f094792d76687d878f2a4814";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/humble/mrpt_tutorials/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "1de3c60b2460d6f6ebae3c8ff57567507d892785a32ec41a06b9ddc110109426";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/python-mrpt/default.nix
+++ b/distros/humble/python-mrpt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-humble-python-mrpt";
+  version = "2.13.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/humble/python_mrpt/2.13.7-1.tar.gz";
+    name = "2.13.7-1.tar.gz";
+    sha256 = "f82b897d6164f1b8f343b1d46a1eaf19cf290c5d3c8f98e1c26484262a621fd4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libapps mrpt-libgui mrpt-libnav mrpt-libslam ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Python wrapper for Mobile Robot Programming Toolkit (MRPT) libraries";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/qml-ros2-plugin/default.nix
+++ b/distros/humble/qml-ros2-plugin/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, image-transport, qt5, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-srvs, tf2-ros, yaml-cpp }:
+buildRosPackage {
+  pname = "ros-humble-qml-ros2-plugin";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/qml_ros2_plugin-release/archive/release/humble/qml_ros2_plugin/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6876de963f97807133507394f9fc61a79ef54d481ce1fa7ce6be3bcb84e0bf32";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto example-interfaces qt5.qtquickcontrols2 ros-babel-fish-test-msgs std-srvs ];
+  propagatedBuildInputs = [ ament-index-cpp image-transport qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia rclcpp ros-babel-fish tf2-ros yaml-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A QML plugin for ROS.
+    Enables full communication with ROS from QML.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/ros-babel-fish-test-msgs/default.nix
+++ b/distros/humble/ros-babel-fish-test-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros-babel-fish-test-msgs";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/humble/ros_babel_fish_test_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "20f7506ff961795f541f9c93686a2c2e4919663082f5af352d06a2fb0dfaad79";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Test messages for the ros_babel_fish project tests.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/ros-babel-fish/default.nix
+++ b/distros/humble/ros-babel-fish/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, geometry-msgs, rclcpp, rclcpp-action, rcpputils, ros-babel-fish-test-msgs, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-ros-babel-fish";
+  version = "0.9.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/humble/ros_babel_fish/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "898c6849cd09f23682a25db29b2934cba9348ba747de6bc673e8ba015635d40f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ action-tutorials-interfaces ament-cmake geometry-msgs ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-gtest ament-lint-auto example-interfaces ros-babel-fish-test-msgs std-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp rclcpp rclcpp-action rcpputils rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A runtime message handler for ROS.
+    Allows subscription, publishing, calling of services and actions with messages known only at runtime as long
+    as they are available in the local environment.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/teleop-tools-msgs/default.nix
+++ b/distros/humble/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-teleop-tools-msgs";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "7684b1b0c05f404227cfe05b9a9ef5f014f9a7f83a44cd3ee5c65520b86e1542";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "afeaa1729f2c7047a976d74e2c7583e6e5b5f057cc1daafeb5cbc6c997ec10a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/teleop-tools/default.nix
+++ b/distros/humble/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-humble-teleop-tools";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "9f718f5c55ef540aa10dc2e1c483e499784ba4b214198732e0808d881765329d";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/humble/teleop_tools/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "1e59d06c1100f244e588b856a49af9d3c8d33e8252389baf757007b4a4fe24e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "da5c74fccec858d24b75ee998c38c298bf070f64db26ed425649f41949afd0d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "d3400eb10f948bc0207b7a2ef49a4a4cc89de1954497e50bfd45146890f0f396";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "9bfab92237a38ab18fbaeb6dbfd60dad883ba62b8c816a5351ad409f75c69498";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "ffb732cd5881aaa3480ac7936d40ab6ba0561cd02a4d23ce39e8a3e21d19e17d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "2395563b6212ea167eb7680f3eabbe8b853925c60e70df36f611f42fb63be3f7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "52d201357aae661fd262858e0fdfe246b778ee2c929b43d8f414cbed039126b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "82a00781b32eea7f9669965ea38dee187f4cac4c53f49bd3ae7d080a7d630b91";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "20c80215ad4cd9644af9baa367772787653291e3dfc3c563ddddc8da743f6d24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "6abe6b50a41fd2ee6af67200615b0bb32978d94df990b91abcb197054c885c72";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "c31510035dfcfc2acc549e9dfdbf36322708fd79a7d15f3eb6549b9e83f43eef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "336ffd3d144d80858159263e6fdfb125a8d6a0d6cf200a7b5ead137982db5f68";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "cfc6ee7c9f094ee67cb0ac5d6680f476d84923fea0c602f690c6072392b0045a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "018908110246ed202dd85db75e3acd7d4f43f6acc3b1cbd2414ce85d92177184";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "93d55036d2fd4d478959f6c05065d6a50ed8ff474d659e7353ce143deb050987";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "9ff4d188195b02a3a482a2dfd7609ffa501840f53cd8886310c99d255ebd01c6";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "3a9704e041893827a9f1375fbe5ff975dc1cbf4808d4a105c311cf09ecc4f3fa";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "8a2e3bebda1808b711868d15f769806e072f177b7d826461d72517db50cfd4cc";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "d2c61936220d48a9242dd9371b53222b71808a937b0f24741914f1f862d9fc35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "3a2a04c4a3991e2803223800496413f7dd995d559eee85c4a71d1dd1a4ccfee7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "1e435ecc0ef5d5a9c1ba9dd0a22c4c15431e6305535f274f382b7304cc870593";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "f162902a5986bf37c56e7c8a6c11c3ff40a12fcf425a11c45cea7acd8ea23c9b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "e0a8186e1167bdcd8480c2f0f3fa1c15be701d158e8708c10ea8c078d58f13a4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "98daf78a1404e595d078e7ebe391785a641a9fec93002a3511eb4fd7ac3287c1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "dcdd5372d9437abb1d25f64641c879cbcbdfc2de4f7077369aa876f8cbf76744";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtle-nest/default.nix
+++ b/distros/humble/turtle-nest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, qt5 }:
+buildRosPackage {
+  pname = "ros-humble-turtle-nest";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtle_nest-release/archive/release/humble/turtle_nest/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "3725f09cbe1a521c44646d6079efb88dc1c94764286ef4b09eb0317633466b5d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 Package Creator";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/warehouse-ros-sqlite/default.nix
+++ b/distros/humble/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
 buildRosPackage {
   pname = "ros-humble-warehouse-ros-sqlite";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/humble/warehouse_ros_sqlite/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "41c7e248b302bd30e3f67035e3e4f298414cd04e9bf1dfe778a4cc579a52dfb0";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/humble/warehouse_ros_sqlite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7bed57e1126dbc539984fe5b369a97c78f9f037d0457fb16eb951d07b01ab7bc";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake boost sqlite3-vendor ];
+  buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/examples-tf2-py/default.nix
+++ b/distros/iron/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-iron-examples-tf2-py";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/examples_tf2_py/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "4a008de0fa28ea2c2030e8b0361c7d29b87eb8c993e1b8a00e02eea97c7713c7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/examples_tf2_py/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "96bf03527c8707d19b243114c7544157dfa99c24afbba7c43d271d1c320076a8";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ffmpeg-encoder-decoder/default.nix
+++ b/distros/iron/ffmpeg-encoder-decoder/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-ffmpeg-encoder-decoder";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/iron/ffmpeg_encoder_decoder/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "82c3744b84b2355d4758ad1de3c27e26bccfa496108a842af4a4829dcdd2c463";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg opencv opencv.cxxdev rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+
+  meta = {
+    description = "ROS2 convenience wrapper around ffmpeg for encoding/decoding";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -578,6 +578,8 @@ self: super: {
 
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
+ ffmpeg-encoder-decoder = self.callPackage ./ffmpeg-encoder-decoder {};
+
  ffmpeg-image-transport = self.callPackage ./ffmpeg-image-transport {};
 
  ffmpeg-image-transport-msgs = self.callPackage ./ffmpeg-image-transport-msgs {};
@@ -2467,6 +2469,8 @@ self: super: {
  tricycle-steering-controller = self.callPackage ./tricycle-steering-controller {};
 
  turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
+
+ turtle-nest = self.callPackage ./turtle-nest {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/iron/geometry2/default.nix
+++ b/distros/iron/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-iron-geometry2";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/geometry2/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "d85b71d63673400684ce4fd6599cfd4d677396cfeb6a90e844e1cc6624adb865";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/geometry2/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "e64890ff3290e1c8a9a8fbce65fbc9a116df73f76e6579fae88f6d723d498651";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joy-teleop/default.nix
+++ b/distros/iron/joy-teleop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joy-teleop";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/joy_teleop/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "165a99da695f1a8e81484fb2ef8f5f106f5b7ff07b8ae1d2b029f67fad9adfaa";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/joy_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "315c011901037a69b6314b6448119ccca50827699deca1703170e80062772cf2";
   };
 
   buildType = "ament_python";
-  checkInputs = [ action-tutorials-interfaces ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
   propagatedBuildInputs = [ control-msgs rclpy rosidl-runtime-py sensor-msgs teleop-tools-msgs trajectory-msgs ];
 
   meta = {

--- a/distros/iron/key-teleop/default.nix
+++ b/distros/iron/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-key-teleop";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/key_teleop/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "88be6e7fbabbf11c576d66aea0c77c52149788a84640eda144618e3fa2e074f6";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/key_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "daea01da9a4eaffeb4028ed21967d6de5746854cd36906c17b9719d3afe70d10";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mola-lidar-odometry/default.nix
+++ b/distros/iron/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-iron-mola-lidar-odometry";
-  version = "0.3.1-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/iron/mola_lidar_odometry/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "474da5c03e44a4e0fed9b229e86696a8d7d26777d3d22923c22f6adcdc3cc989";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/iron/mola_lidar_odometry/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "4167db4a9e50ef641685d9dca965ca810f112802e42813e5ddf960a3c1e9c4fb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/iron/mouse-teleop/default.nix
+++ b/distros/iron/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-mouse-teleop";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/mouse_teleop/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "9f1587d424780e41b61b5954a4cd207ead60ce2e5384b16b86d313a88592ca18";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/mouse_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "9c31e5a8353c6a1a1b633a8c6e331c667f70c2f6dc80777aa092e7b43ca89fbd";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mrpt-generic-sensor/default.nix
+++ b/distros/iron/mrpt-generic-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-generic-sensor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_generic_sensor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "bb94a3d4836bb100d94f4042949d466241308f224e2ae85836f8cab986e708c3";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_generic_sensor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "69141b0c87d8dabe2b941fd59aa8f96da0e11c6a3553253cab06f4766b838eb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt-map-server/default.nix
+++ b/distros/iron/mrpt-map-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components }:
 buildRosPackage {
   pname = "ros-iron-mrpt-map-server";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_map_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "bec2672c70562571129c83c11e775b5d0a53975ac721963dfcf63028382a7f50";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_map_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3cbe54da54a9ecf904da0287c073426084d24a80370902ee30eea65804371bd2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libmaps mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces rclcpp-components ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-msgs-bridge/default.nix
+++ b/distros/iron/mrpt-msgs-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt2, ros-environment, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-iron-mrpt-msgs-bridge";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_msgs_bridge/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "75936032485f2c0852918a0fe41bbf9de2c3a9377f8a760eec608ed6063e215e";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_msgs_bridge/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3db7c2ca7eed5dff2d17090987ce54ebe27d394efe0976a6ea29192f73d30445";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt2 tf2 ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libobs mrpt-libros-bridge mrpt-msgs rclcpp tf2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-nav-interfaces/default.nix
+++ b/distros/iron/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-mrpt-nav-interfaces";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_nav_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "86f2c90e63bba2a19805fe2e571a485a5cf460d9e6179dc0af7305b2e381ba49";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_nav_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0eb2a6186b1c16bb4148588152b3c44f24d9aa7ed9bd8150c5a0cc83e665649e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt-navigation/default.nix
+++ b/distros/iron/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-map-server, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-iron-mrpt-navigation";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_navigation/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "274ed2a0eaae3707588bf2582095265ca749f79fbe9784031f5df8fb1a0d4cff";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_navigation/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5fbb567d4e172c2425752fe43edb61135d313df09391079f79ffd188f96fd8c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt-pf-localization/default.nix
+++ b/distros/iron/mrpt-pf-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, mrpt2, nav-msgs, pose-cov-ops, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mrpt-pf-localization";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_pf_localization/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e754e52023038dbbabe8176713b35c072308c17afc98facc42bd58dd928c3cc4";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_pf_localization/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ccd390ffbb46eeb83f9e1d11355bb9918f657812a39783d4575d5d9f9969a4c3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
   checkInputs = [ mrpt-tutorials ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs mrpt-msgs-bridge nav-msgs pose-cov-ops rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/iron/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/iron/mrpt-pointcloud-pipeline/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mrpt-pointcloud-pipeline";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_pointcloud_pipeline/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0a19c6fe395c76f98ec343d3b512d4518ddfc0ffb8fab15d62bcb067997f126c";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_pointcloud_pipeline/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a08ab63c042dfad3d29783af3509707acc616c9d605d94c57c07a259712c3873";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libros-bridge nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-rawlog/default.nix
+++ b/distros/iron/mrpt-rawlog/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-libros-bridge, mrpt-libtclap, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-rawlog";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_rawlog/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8dfc3889170232d32e754fc6a54aea5f321eb0ed0f1fd611ac5e221e948d444a";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_rawlog/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e10efe3a58f4968a6dee3d8c6127896fc0629259df6e9dccad041a80ba940248";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-msgs mrpt2 nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-libros-bridge mrpt-libtclap mrpt-msgs nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/iron/mrpt-reactivenav2d/default.nix
+++ b/distros/iron/mrpt-reactivenav2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-mrpt-reactivenav2d";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_reactivenav2d/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "386b9cf5e23c04ee1751c79f66de5774e87b1588c4ce59c50725da8c7b6375df";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_reactivenav2d/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3cae21f79cf41b2e397397a8115b3e5ec1e9c39c85301e57a51f29941b3d8b2b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libnav mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/iron/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_bumblebee_stereo/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "e4e8181f06e12885ab72362a2cceb7df1055496fcf5a60616ad47b1493c03464";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_bumblebee_stereo/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "4218cba961cadec5aadf1750babcb40f8f2209fb1cb2d0b1964e93c0b048ad6a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/iron/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, nmea-msgs, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-sensor-gnss-nmea";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_gnss_nmea/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d18469187185b9657f6632a8dd7eb1d951ecb21a6dd143b7dfe8307282f3c360";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_gnss_nmea/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "1920eb81e1e61275f88f28e0b04be90f4a787560a99880fa391bfba95e1dcce2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 nmea-msgs rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/iron/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-sensor-gnss-novatel";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_gnss_novatel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d6b901acefdc90d69219f3404325e2420f3cd245f043b68c78f346349e261a31";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_gnss_novatel/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "7b66aa0d4a4653144bb589edb57df5643e096aebde562c1caff8ef9bb573975b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/iron/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-sensor-imu-taobotics";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_imu_taobotics/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "89439de16e5c66ae4b74d9299622c0b038c082599a33253a5c8eed1533aae95f";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensor_imu_taobotics/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "6728039d29ccf45d1b0c374bcaa1b7677e747adccc28ec47613d322704fcde1c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-sensorlib/default.nix
+++ b/distros/iron/mrpt-sensorlib/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mrpt-sensorlib";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensorlib/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "2a4e1ef330f50f97e360fc5e3f1bbcfb66412c358425cafbbb5c62b7557eb747";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensorlib/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "626c75cb39708ef860d64a05ba24f234e8de680ea9f6e6544d7d2ac4d2d9194e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt2 rclcpp rclcpp-components tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-sensors/default.nix
+++ b/distros/iron/mrpt-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-sensors";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensors/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "eb2847266eec207b2af91073276ba8b487a113c275367ee9e9c00a8e3013b384";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/iron/mrpt_sensors/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "91524a41ddacc52b28ad90432658bd6288ffe310922df2825615de48807bfac4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt-tps-astar-planner/default.nix
+++ b/distros/iron/mrpt-tps-astar-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-mrpt-tps-astar-planner";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_tps_astar_planner/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b9ec7c0e8da07bb5521f90ed4e8e9c744f69ad959b9268d8f5f9b3280394313d";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_tps_astar_planner/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "f8623069b9b84580f1061ca1547e2e931dc3d1b2d1a53cbaff3120193f92b751";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt-path-planning mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-libgui mrpt-libmaps mrpt-libnav mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces mrpt-path-planning nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/mrpt-tutorials/default.nix
+++ b/distros/iron/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-iron-mrpt-tutorials";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_tutorials/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "be1e1093be5e4187fe1f4ee52231946f72da9f4e5b5489c4d258a65db3d415a7";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/iron/mrpt_tutorials/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "3ff326b20f75dedb277dd25b19503b2258f6198f097a7ac2864570a6e817a38b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/teleop-tools-msgs/default.nix
+++ b/distros/iron/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-teleop-tools-msgs";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "827c11392f46cc40694f90d6238782c8b4d5c20403e5a1d93af899f8ab235701";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "e2ceaadd1020de6f877a7c3565838b152bb9f863e53ec7b9deeb3bc6fdc80253";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/teleop-tools/default.nix
+++ b/distros/iron/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-iron-teleop-tools";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "51a5a7e053aa12f5c167450dd9d9dcffff25cd54f0f6664b5d1ee10b9b5468c4";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/iron/teleop_tools/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "407d5e759e0d6769187a8f688ede1ecbec6421590ea524b87f3369dbd3c75463";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-bullet/default.nix
+++ b/distros/iron/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-tf2-bullet";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_bullet/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "05490f96530d5b2c1e41f957bc95ec733b9295f9e41cf1f28b6d162dca050ba9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_bullet/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "4edc9084303c5fde55bab2baed07910d71fed71c8196370d6b8f04cc3e22f21e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-eigen-kdl/default.nix
+++ b/distros/iron/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-iron-tf2-eigen-kdl";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_eigen_kdl/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "438a72666bc1b03298b60b39b402b276e4ef2271139f766a7c0d74c29daf2fe8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_eigen_kdl/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "8e40cf357970c2cf0bb1a30715182fbf0c3970fc80ac7f70ea00381edcbeeff5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-eigen/default.nix
+++ b/distros/iron/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-tf2-eigen";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_eigen/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "88623dedacc7a566af3920d485f2902327f106d42d81a59a069005c16015ff90";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_eigen/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "681dbd6ed8c640020440ed9d59d39c3f7208949dc6c617fd8e030f1afec0d3d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-geometry-msgs/default.nix
+++ b/distros/iron/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-iron-tf2-geometry-msgs";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_geometry_msgs/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "b07e2374f6b887ab49390dbff32db8770c853e4360a1a2a9f58768e9a74df4ef";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_geometry_msgs/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "9d919682d65e76607ba6a9d3443288a42ce7155562d37956cadd135d311b0dd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-kdl/default.nix
+++ b/distros/iron/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-iron-tf2-kdl";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_kdl/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "be57b14d462bd6b8d7214f02d85cb3342d8871a52e22070e7a05595847cd1eb2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_kdl/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "f9c75e47676ff16aa28e729461cfcdba7cfecd1534d68fc2e44cd1ac322d1b53";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-msgs/default.nix
+++ b/distros/iron/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-tf2-msgs";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_msgs/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "199d88d593bb1cbed0e19b6adffafd771fb340af85b22eb66208335012b3ce58";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_msgs/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "4ca2428da22c3d1e5b19cee5ad933e5c4f4dc96da6966054299c1b2a269eb96c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-py/default.nix
+++ b/distros/iron/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-iron-tf2-py";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_py/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "ea91af3a2f4ac562273fe6b8a8e828a084725e0790cfeefc963745a02648ad78";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_py/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "e82c5b581df7f87fe7338efea293fd64990794f2408f9d9b46b07d9878aa5b96";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-ros-py/default.nix
+++ b/distros/iron/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-iron-tf2-ros-py";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_ros_py/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "e721397e936bad1157973d7ec8311e7c3f70f2b813b1ecd853f3bde6a39d7682";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_ros_py/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "09ab0a6e65f0d8c5d7e18e7024bb105adb739e8c0824102df91848c2daba956a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/tf2-ros/default.nix
+++ b/distros/iron/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tf2-ros";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_ros/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "7efcdd3af56be27606ba37a975fd596a44f63966323ed9b9bbb323df26acf107";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_ros/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "7a7c2834c4fa4d5be2aecd964bb56312066354a6024407ff1bd43db6a9bb8ee8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-sensor-msgs/default.nix
+++ b/distros/iron/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-iron-tf2-sensor-msgs";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_sensor_msgs/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "5b7cfb36c8435ab3cfc0e6654b18ab0f2a3bd4d81f38b2301f320182976bdc00";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_sensor_msgs/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "52d876c889d3066b6ca6cc04fef3c05d4ca65dab9c8b239ba5bdfa23dd3309fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tf2-tools/default.nix
+++ b/distros/iron/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-iron-tf2-tools";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_tools/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "6fbe27c0cc48eec3f4610913ae3fd30dc23477fbf158de024099567b0c8a16a7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2_tools/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "ea2055f46ec38f042f31bb832b2cb00a073ac2832deec8a8c9a6c9b94069152d";
   };
 
   buildType = "ament_python";

--- a/distros/iron/tf2/default.nix
+++ b/distros/iron/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-iron-tf2";
-  version = "0.31.7-r1";
+  version = "0.31.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2/0.31.7-1.tar.gz";
-    name = "0.31.7-1.tar.gz";
-    sha256 = "97ef7b14c4ce8653c87e98cc8872fe4df8176149d2514ee21e1c22ac0e641fea";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/iron/tf2/0.31.8-1.tar.gz";
+    name = "0.31.8-1.tar.gz";
+    sha256 = "0bbff0d79058d3e2b66358c0b72b067bef652c83140470366c077b8b6e3094f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/turtle-nest/default.nix
+++ b/distros/iron/turtle-nest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, qt5 }:
+buildRosPackage {
+  pname = "ros-iron-turtle-nest";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtle_nest-release/archive/release/iron/turtle_nest/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4090d2180d4646790bde4c503da6c1f9675604daf091f9dc1fa20b7ab4efb984";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 Package Creator";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/iron/warehouse-ros-sqlite/default.nix
+++ b/distros/iron/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
 buildRosPackage {
   pname = "ros-iron-warehouse-ros-sqlite";
-  version = "1.0.3-r3";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/iron/warehouse_ros_sqlite/1.0.3-3.tar.gz";
-    name = "1.0.3-3.tar.gz";
-    sha256 = "c8eb45f7d61dd93cf09c5666a2015863bda83cb8f7b79b6de701facd3b2137e1";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/iron/warehouse_ros_sqlite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3bb559924ace41db6ea5f036659ca41942303b4a2f81dec9ca7a416639c075a3";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake boost sqlite3-vendor ];
+  buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/ament-black/default.nix
+++ b/distros/jazzy/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-jazzy-ament-black";
-  version = "0.2.5-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_black/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "063ff98911ee5d1d70e44e13f439bdd79be6171b6ba36ab1e48584928debcf42";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_black/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "a13c64a9e5e2d1f6580423c252e6b996e3ed57913a5551d603ab4b6c1d631ead";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ament-cmake-black/default.nix
+++ b/distros/jazzy/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-jazzy-ament-cmake-black";
-  version = "0.2.5-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_cmake_black/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "94eba3896db0aeafa4462a867c05b10ac502051170f2271311621394b9784e73";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/jazzy/ament_cmake_black/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "7d8a2ccc8ba3f32cd069a56d74d2c85badfebf806296d80a84920cdb619232e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lanelet2-extension-python/default.nix
+++ b/distros/jazzy/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lanelet2-extension-python";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension_python/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "3d0741e911bdcd30ee587836537590a402a7a6e00ffa403052f312b4de861a02";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension_python/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2d139a423d4a1dbdcd8880055960790d8d8bb7640e3a44dfbf365184ae9eeb82";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lanelet2-extension/default.nix
+++ b/distros/jazzy/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lanelet2-extension";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "a00afd9104eb93dbe39e69046dd880e6238cafb9b7fe91c16f08024f732292f0";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e231ddd305846ef9bbd1bc7c837d29619f593357208677607bf5e1aea552fa70";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/draco-point-cloud-transport/default.nix
+++ b/distros/jazzy/draco-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, draco, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, rcpputils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-draco-point-cloud-transport";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/draco_point_cloud_transport/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "09d189c7b32122b692e1537581b30ff7d48b57ff7a11fefc744c0793941b726d";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/draco_point_cloud_transport/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "031d526ff6f745d26e3dd66eddfe9d270c55b0e91e2292786a8625999604ad46";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffmpeg-encoder-decoder/default.nix
+++ b/distros/jazzy/ffmpeg-encoder-decoder/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-ffmpeg-encoder-decoder";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/jazzy/ffmpeg_encoder_decoder/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6cd96058c1d501a69c80ae369c2f7993a1bc5a1422aae6d7444194d67030f9d9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg opencv opencv.cxxdev rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+
+  meta = {
+    description = "ROS2 convenience wrapper around ffmpeg for encoding/decoding";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -648,6 +648,8 @@ self: super: {
 
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
+ ffmpeg-encoder-decoder = self.callPackage ./ffmpeg-encoder-decoder {};
+
  ffmpeg-image-transport = self.callPackage ./ffmpeg-image-transport {};
 
  ffmpeg-image-transport-msgs = self.callPackage ./ffmpeg-image-transport-msgs {};
@@ -1692,6 +1694,8 @@ self: super: {
 
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
+ python-mrpt = self.callPackage ./python-mrpt {};
+
  python-orocos-kdl-vendor = self.callPackage ./python-orocos-kdl-vendor {};
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
@@ -1927,6 +1931,8 @@ self: super: {
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
+
+ robot-upstart = self.callPackage ./robot-upstart {};
 
  robotiq-controllers = self.callPackage ./robotiq-controllers {};
 
@@ -2312,6 +2318,8 @@ self: super: {
 
  simple-launch = self.callPackage ./simple-launch {};
 
+ simple-term-menu-vendor = self.callPackage ./simple-term-menu-vendor {};
+
  simulation = self.callPackage ./simulation {};
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
@@ -2526,6 +2534,8 @@ self: super: {
 
  turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
 
+ turtle-nest = self.callPackage ./turtle-nest {};
+
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 
  turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
@@ -2535,6 +2545,26 @@ self: super: {
  turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
 
  turtlebot3-simulations = self.callPackage ./turtlebot3-simulations {};
+
+ turtlebot4-description = self.callPackage ./turtlebot4-description {};
+
+ turtlebot4-desktop = self.callPackage ./turtlebot4-desktop {};
+
+ turtlebot4-gz-bringup = self.callPackage ./turtlebot4-gz-bringup {};
+
+ turtlebot4-gz-gui-plugins = self.callPackage ./turtlebot4-gz-gui-plugins {};
+
+ turtlebot4-gz-toolbox = self.callPackage ./turtlebot4-gz-toolbox {};
+
+ turtlebot4-msgs = self.callPackage ./turtlebot4-msgs {};
+
+ turtlebot4-navigation = self.callPackage ./turtlebot4-navigation {};
+
+ turtlebot4-node = self.callPackage ./turtlebot4-node {};
+
+ turtlebot4-simulator = self.callPackage ./turtlebot4-simulator {};
+
+ turtlebot4-viz = self.callPackage ./turtlebot4-viz {};
 
  turtlesim = self.callPackage ./turtlesim {};
 

--- a/distros/jazzy/joy-teleop/default.nix
+++ b/distros/jazzy/joy-teleop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-joy-teleop";
-  version = "1.5.0-r3";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/joy_teleop/1.5.0-3.tar.gz";
-    name = "1.5.0-3.tar.gz";
-    sha256 = "bab71036e6c237d4ccb99e1177138b8969b4f3ad986214da77a0b2479d02c7e6";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/joy_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "27f2c5cd82a73d9b779d7589ccc5a283b19ab86e379f2c6dcfc3a5348f982b71";
   };
 
   buildType = "ament_python";
-  checkInputs = [ action-tutorials-interfaces ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
   propagatedBuildInputs = [ control-msgs rclpy rosidl-runtime-py sensor-msgs teleop-tools-msgs trajectory-msgs ];
 
   meta = {

--- a/distros/jazzy/key-teleop/default.nix
+++ b/distros/jazzy/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-key-teleop";
-  version = "1.5.0-r3";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/key_teleop/1.5.0-3.tar.gz";
-    name = "1.5.0-3.tar.gz";
-    sha256 = "25c4652b6e83f2cf0954b7cc42af57414e2c4a3f924d77d39df04f3d977dd267";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/key_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "1d3ce6e5508d53882a416711924b8574bb2caa6db3be45ce3ae8862fc1167f34";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/libcamera/default.nix
+++ b/distros/jazzy/libcamera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3, python3Packages, pythonPackages, udev }:
 buildRosPackage {
   pname = "ros-jazzy-libcamera";
-  version = "0.3.1-r1";
+  version = "0.3.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/jazzy/libcamera/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "725dbbdce06cce4ebdc2038f944a20cd73e2438c930055f98a9e96a6d8f5e837";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/jazzy/libcamera/0.3.1-4.tar.gz";
+    name = "0.3.1-4.tar.gz";
+    sha256 = "eb5546c1316a0fb7bcbf1c709e4a0d7be780132faac5e90eae1984364e179d15";
   };
 
   buildType = "meson";

--- a/distros/jazzy/marti-can-msgs/default.nix
+++ b/distros/jazzy/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-can-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_can_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "164859a94dbaff474ab8d301782c3b6f913a368cc3d7e5392907d975c204c0cd";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_can_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "a2d807a4b0ffb67c581a9b8f626ff10d33c23c3018e68ff338ee168653666695";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-common-msgs/default.nix
+++ b/distros/jazzy/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-common-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_common_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "9fa8d675937e272dc1fe1bf8779a5460138c60da706c3e3f38439cfe2052cfee";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_common_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "2e247cc5a1ab318743123a2ae2ff755a934b1777f14446a932fc479c9a77888b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-dbw-msgs/default.nix
+++ b/distros/jazzy/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-dbw-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_dbw_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "da93be62dbf8f1b33a90b05c710e9c4b466a42d12e892a97964771641ecf363e";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_dbw_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "13ca82daf8820da4889b4d0a60c8a63e9fece2bbde6f0a070e292abf6feb9ebd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-introspection-msgs/default.nix
+++ b/distros/jazzy/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-introspection-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_introspection_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "25e745af7bf5b04edd765c487522025ffea8570f8f492b8b1e6686a2a271c35e";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_introspection_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "0f68782acf645c2ba40319c5ff8facef10ed30c25c3c59f2b09bd6362d53c4e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-nav-msgs/default.nix
+++ b/distros/jazzy/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-nav-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_nav_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "db362238681c3d74be5d4d6b0e768840e185ac5468e54cc254e6a12e0f978f95";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_nav_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "6a1bb26e98389968c11a9504e41f9933d86c902435f1f4cecb4ac31d731ac219";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-perception-msgs/default.nix
+++ b/distros/jazzy/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-perception-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_perception_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a334534b2535a57147f2b08b395e028ba9f278b5733b326998a87342416a9144";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_perception_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "87b98954babc661b0d2034bb7126778e755b16155209d760866b41a471120ff9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-sensor-msgs/default.nix
+++ b/distros/jazzy/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-marti-sensor-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_sensor_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "2db4954d41411fe642b50c168c488b14c1e74e601cb775cdcddb7ad25e289930";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_sensor_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "f8c9d42b04843c869788cb60e120b7d9d1908c24e484b25cff496ff9b767befd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-status-msgs/default.nix
+++ b/distros/jazzy/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-status-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_status_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1c8192a2dfc82e67f710ca643df1a01f15c7165ba33198f592dff150a1c9165f";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_status_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "f3c579dea991b53ac219df40e00a8c85c91d49f2e00e4c6b54ffdb733dbc8cfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/marti-visualization-msgs/default.nix
+++ b/distros/jazzy/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-marti-visualization-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_visualization_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "3d09d5e03f2422aef79608a1e3b079df7eb6cd4f4ef0642dcf03c04c4ad74666";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/jazzy/marti_visualization_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "e03fde51e361901abde8520adf0748ddda24cbfb000e96ac0f7e30458876778d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.3.1-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "daa8b0d340effc841d75c2e241b7fa635ce9477efd6253a19dc3457e49e92a18";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "50bd0e63c8756419f60c65feb4203426a5ec8225a1b9df5af06ef2756a60a2e3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mouse-teleop/default.nix
+++ b/distros/jazzy/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-mouse-teleop";
-  version = "1.5.0-r3";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/mouse_teleop/1.5.0-3.tar.gz";
-    name = "1.5.0-3.tar.gz";
-    sha256 = "f3028053e87279f0e1c494e6e704b5df805b02a48101bec366ef3c393f365dc0";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/mouse_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "f34766819b0f44c2ab03671e81934bf091f1d9aff1b1b2d2a3cee9ac48c4a411";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/mrpt-generic-sensor/default.nix
+++ b/distros/jazzy/mrpt-generic-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-generic-sensor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_generic_sensor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "233157af964785c4041bad45538eadc70e767cbf7ac12a8c2d3090c2b3b7122e";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_generic_sensor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "b52a0e6f2d2790bb6ed851948d346dda6a66b00332c73a5b7cfd5bad0da5d827";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-map-server/default.nix
+++ b/distros/jazzy/mrpt-map-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-map-server";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_map_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ff6a92888855061296d6a79df2f9e1a137d265931fb64486b179c06a1545bc9b";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_map_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "71bf61906478c9728c044bb1fe24fffcec599d924c79dfd368456956e8429336";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libmaps mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces rclcpp-components ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-msgs-bridge/default.nix
+++ b/distros/jazzy/mrpt-msgs-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt2, ros-environment, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-msgs-bridge";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_msgs_bridge/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "9dda3a58cc01d5087a7030458fabd2576a48f6cf298a29b370f18cbff6476a96";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_msgs_bridge/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a467fcb5ed9ab14eb645aec1035c25116299dbd89a90330a77e3ecf235dc01f9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt2 tf2 ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libobs mrpt-libros-bridge mrpt-msgs rclcpp tf2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-nav-interfaces/default.nix
+++ b/distros/jazzy/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-nav-interfaces";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_nav_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "2c029a8cbda42f03a9db427a4623f37ab517b79ef0b0072922282cd738dbcbfa";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_nav_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "b224421a385bd2773f7ba1e9fd748d7c05b5f0525dd0449416d84e885a31e418";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-navigation/default.nix
+++ b/distros/jazzy/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-map-server, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-navigation";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_navigation/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "02f457e2c4314c67d80e9dcf9b8329ba062bef89a94d8d52fe267a4b30db54c5";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_navigation/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5e3d5a204dee8771c84d700319fe7d3338b8a08432b1fe14f8d43dbcd1c2e20e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-pf-localization/default.nix
+++ b/distros/jazzy/mrpt-pf-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, mrpt2, nav-msgs, pose-cov-ops, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-pf-localization";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pf_localization/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "72df3c764b7aa78ab9ffa83b46a7cd6287546db79425e7cbf0188dfd28603cae";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pf_localization/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "b3c0c19d546639ca8f1d5990c50a716c023a3a1180b82a7259e621fcc7b1570d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
   checkInputs = [ mrpt-tutorials ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs mrpt-msgs-bridge nav-msgs pose-cov-ops rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/jazzy/mrpt-pointcloud-pipeline/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-pointcloud-pipeline";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pointcloud_pipeline/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6bb44a5069e079dcd7bedfe4154e854294bf58586a9e3c0f6f8b62db54600583";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_pointcloud_pipeline/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5573f74b03fa7bad71f7d23d29741f8a10376f93384e4dfc30c2053ae794a77b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libros-bridge nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-rawlog/default.nix
+++ b/distros/jazzy/mrpt-rawlog/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-libros-bridge, mrpt-libtclap, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-rawlog";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_rawlog/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "51b7e9f1d470d4cfa635f9de3e887df9beedafcf2710e4309327a8f6bfc85803";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_rawlog/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "93354b81e9e754aeb19d6f2504572da9be2b66e83421e60aea69ae83100c63f4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-msgs mrpt2 nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-libros-bridge mrpt-libtclap mrpt-msgs nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-reactivenav2d/default.nix
+++ b/distros/jazzy/mrpt-reactivenav2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-reactivenav2d";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_reactivenav2d/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0173ace7996a0cd39bcfa3b646dbf4d438050322c7c5dde9148afe45f143fc73";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_reactivenav2d/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "07c14d6be4f918d3e0b0b627e42beca041dae1334ff7f8f5583f5c3aaa89a82e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libnav mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/jazzy/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_bumblebee_stereo/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "eee51ab21b07e02e412cdcba2e37d26ba57a853516392ee7ab247f66803fcf5a";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_bumblebee_stereo/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "4add7a33e3929b4b7bebe35306e2cc76a01230b0922c81150ab1a94533c6c59a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/jazzy/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, nmea-msgs, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-gnss-nmea";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_nmea/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "eb80a6f0b909ade1968baca8a279210fb8f75166ccae12793c4615f2f7d408cd";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_nmea/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "6004a6f335d46c7c8022607cfca6275c3f21fcd3d86d0ccf145a0a9f37401697";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 nmea-msgs rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/jazzy/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-gnss-novatel";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_novatel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d80d9aac3a4f63cfac8a37d701a47af03cef7a11479f683079b6e9de1fb89a70";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_gnss_novatel/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "b8e9caf170f75c2fa84fa6fdf57876836fe07b67f6d1895452dd4208bf4bacfc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/jazzy/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensor-imu-taobotics";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_imu_taobotics/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "90db874ffedf8ef6d9f2d6d63299da2dc92560845864e066ec897cf7ab91985a";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensor_imu_taobotics/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "2364e38b5c00225ef6f3ab950f06c139afaf5426604604982e43a8356befa110";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensorlib/default.nix
+++ b/distros/jazzy/mrpt-sensorlib/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensorlib";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensorlib/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "2f3ebb899856a06587199c2e3deeb55befb06f5db80e8be36eb77ae8292ffcda";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensorlib/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "77c645c1a2cbff50281fd4dfe5ab6f318e06d848877ecb91d9c0b49e8cec4b58";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt2 rclcpp rclcpp-components tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-sensors/default.nix
+++ b/distros/jazzy/mrpt-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-sensors";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensors/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "8eb090dd78cfd137a15510069e4b8afef0b617545500283750720af5b4973a54";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/jazzy/mrpt_sensors/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "3916b77728b0e1d696aade98ffc65893f859873f826afaeeb3a2d41b63041c86";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-tps-astar-planner/default.nix
+++ b/distros/jazzy/mrpt-tps-astar-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-tps-astar-planner";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tps_astar_planner/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e33bec7e5aa195e5ebff2c709dd1b9531fc79607f5c648db29473c41f136303a";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tps_astar_planner/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "cacf08f6b2e76f75e24e471d7c6d6f1fef8e8741a49afe5ef8175fbddc925d0a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt-path-planning mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-libgui mrpt-libmaps mrpt-libnav mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces mrpt-path-planning nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-tutorials/default.nix
+++ b/distros/jazzy/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-tutorials";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tutorials/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d53b5de888ddd1c0ba5ea5a5403b64d7c46603ce389786dbfcc4c7d1ab730adf";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/jazzy/mrpt_tutorials/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "66d13d7088b700d1c123f99ed5381f34abec873cbb5ddb0160e4d2486f43cfc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/openvdb-vendor/default.nix
+++ b/distros/jazzy/openvdb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, c-blosc, git, openvdb, tbb_2021_11, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-openvdb-vendor";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release/archive/release/jazzy/openvdb_vendor/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "386beb08033aed6d988e22f7ac8bed8fc237e3526742c8d6e6b27e94138d25b3";
+    url = "https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release/archive/release/jazzy/openvdb_vendor/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "b09b6d725c1aa223b16fae24c6e5b2073006bd2710c1e83abc6edaa561cc9fbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/point-cloud-interfaces/default.nix
+++ b/distros/jazzy/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-point-cloud-interfaces";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/point_cloud_interfaces/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "f471ff777e722d3e67da7d92c53a10a333a4de63a628900b6e3e1450caca6504";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/point_cloud_interfaces/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "71b38cee44fccfa68a72c74d67a548b2927f83d28a052f7df065f3313936022f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/point-cloud-transport-plugins/default.nix
+++ b/distros/jazzy/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-jazzy-point-cloud-transport-plugins";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/point_cloud_transport_plugins/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "6bd3c46a98c6ea106a882867642b03172465961c82821c19d66abae14e2253e0";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/point_cloud_transport_plugins/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "81b38fb34f9828bc93ed2c65dae86d56b11cb8fb9cc9b6d13ead5dee07561586";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/python-mrpt/default.nix
+++ b/distros/jazzy/python-mrpt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-jazzy-python-mrpt";
+  version = "2.13.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/jazzy/python_mrpt/2.13.7-1.tar.gz";
+    name = "2.13.7-1.tar.gz";
+    sha256 = "243df2746525f6534095d1dd33ebf09b7e9ce86ca7fa753b74edd4f45acb823a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libapps mrpt-libgui mrpt-libnav mrpt-libslam ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Python wrapper for Mobile Robot Programming Toolkit (MRPT) libraries";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/robot-upstart/default.nix
+++ b/distros/jazzy/robot-upstart/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-jazzy-robot-upstart";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/jazzy/robot_upstart/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f3ab183c06d2eb3e42c1293eb39d662f78ae19611f9d5dfbe3ec3d6b9b610e48";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python ];
+
+  meta = {
+    description = "The robot_upstart package provides scripts which may be used to install
+    and uninstall Ubuntu Linux upstart jobs which launch groups of roslaunch files.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/ros-gz-bridge/default.nix
+++ b/distros/jazzy/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-bridge";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_bridge/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "65d787081a34f899024c38efae99361055fce59a7991ff2825f28ad79bdb7cf5";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_bridge/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "8bab40a2313e82e77a872ee0161b17e102d158cdceea598258536e4b77890c47";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-image/default.nix
+++ b/distros/jazzy/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-image";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_image/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "2f5ec4501d76eb17a6892efd25332e7f8bb0dfc37e1db72df7d37735e0e3e2ab";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_image/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "febff86fcc21ea8d5523036c30beb8e122dc84e6e3e2f65272201f69ed80b9f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-interfaces/default.nix
+++ b/distros/jazzy/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-interfaces";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_interfaces/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "4dd563fc4328366655dc4c0ef49ed055c1e685cef25f363031ef4f265a800d4a";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_interfaces/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "20944fcf25db2fd8df7126c364e153d833ebddd63d9f603f4d4e2a1ad8cfd776";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-sim-demos/default.nix
+++ b/distros/jazzy/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-sim-demos";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim_demos/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "1e7a91e83be14cd28deadcce9d43d27970ef3d063feeb0561cddfc2e5aff3d4e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim_demos/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "9b38385f4770b192432fd37a025c16f355837497a5d2d8f6eb57a1224dd39c6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-sim/default.nix
+++ b/distros/jazzy/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-sim";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "1e8e200f05dccaa443c307fe3f2a50be3edb94ea12115dd452f395806082915f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d0097e1f951ed874bb44082a30c8d18568f518c2a59595a394dc794ce9a7c415";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz/default.nix
+++ b/distros/jazzy/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "5a4e01efb00969ca068b71c58640f3ea95d2b557f83e219fa045d2ded460c624";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "4ff0d344e4327ee826ec0a18cc2c234502433747b30732851fae3ffbbd599921";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/simple-term-menu-vendor/default.nix
+++ b/distros/jazzy/simple-term-menu-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-jazzy-simple-term-menu-vendor";
+  version = "1.5.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/simple_term_menu_vendor-release/archive/release/jazzy/simple_term_menu_vendor/1.5.7-1.tar.gz";
+    name = "1.5.7-1.tar.gz";
+    sha256 = "4a9a521e7e3bccff7483d1b8ef49853376a9129bc32bfbd2f415210aecac1728";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "A Python package which creates simple interactive menus on the command line.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/spatio-temporal-voxel-layer/default.nix
+++ b/distros/jazzy/spatio-temporal-voxel-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, builtin-interfaces, geometry-msgs, laser-geometry, message-filters, nav2-costmap-2d, openexr, openvdb-vendor, pcl, pcl-conversions, pluginlib, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-spatio-temporal-voxel-layer";
-  version = "2.5.1-r1";
+  version = "2.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release/archive/release/jazzy/spatio_temporal_voxel_layer/2.5.1-1.tar.gz";
-    name = "2.5.1-1.tar.gz";
-    sha256 = "58f757eccab9c279c65bc1440f9233c3f66cc5514b78cf4d0e632ff8faf12e74";
+    url = "https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release/archive/release/jazzy/spatio_temporal_voxel_layer/2.5.2-1.tar.gz";
+    name = "2.5.2-1.tar.gz";
+    sha256 = "d99ba3048bac41ae6086640a92d2e5402ff3804ece69e42350799fa90a1a5f09";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/teleop-tools-msgs/default.nix
+++ b/distros/jazzy/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-teleop-tools-msgs";
-  version = "1.5.0-r3";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/teleop_tools_msgs/1.5.0-3.tar.gz";
-    name = "1.5.0-3.tar.gz";
-    sha256 = "9190592362c4b22dd34e2488af1165d584d10adc5d592eca7b10cfabfc30d0c4";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/teleop_tools_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "e9fdfef61a027196ea1afa9ff39efe2fa1041061a8ff76d2cf063d1d0535452c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/teleop-tools/default.nix
+++ b/distros/jazzy/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-teleop-tools";
-  version = "1.5.0-r3";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/teleop_tools/1.5.0-3.tar.gz";
-    name = "1.5.0-3.tar.gz";
-    sha256 = "38dd4405348da4842c43dace4f0f986d70e9f622436e5f492fa16b05b114501f";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/jazzy/teleop_tools/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "06f72893a2717757b7f137c54c16bd16d013b3652ffae9c14c55fc00ddc11d8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/test-ros-gz-bridge/default.nix
+++ b/distros/jazzy/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-jazzy-test-ros-gz-bridge";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/test_ros_gz_bridge/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "db4d8f637798a8e5af85861984e3a607d5bc7247071c11494889e4aea2a8c6a3";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/test_ros_gz_bridge/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "a779fa7905ba5e3ca1805f94df46c0744a52d23aa0b0211e64529fb4db33ec5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-tools-interfaces/default.nix
+++ b/distros/jazzy/topic-tools-interfaces/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools-interfaces";
-  version = "1.3.0-r3";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.0-3.tar.gz";
-    name = "1.3.0-3.tar.gz";
-    sha256 = "08beac724cd30e306074e59ba447831d1e44f2585a0abeb706fb22dddf8e7a7f";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "ea2aaeb3858cee9663e2a24a3829826afbf715273e5e794ea56a7964aaa7e8f9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "topic_tools_interfaces contains messages and services for topic_tools";

--- a/distros/jazzy/topic-tools/default.nix
+++ b/distros/jazzy/topic-tools/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools";
-  version = "1.3.0-r3";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.0-3.tar.gz";
-    name = "1.3.0-3.tar.gz";
-    sha256 = "a976242000b6285eb1254facd131cd1dbed0e0459f2a7b1339c28cf4e0d97f19";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "606390bc4609220e21a0ff356ea7046f1e725d5c3a4d3db01947679615305703";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
+  buildInputs = [ ament-cmake ament-cmake-python rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
-  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python rosidl-default-generators ];
 
   meta = {
     description = "Tools for directing, throttling, selecting, and otherwise messing with

--- a/distros/jazzy/turtle-nest/default.nix
+++ b/distros/jazzy/turtle-nest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, qt5 }:
+buildRosPackage {
+  pname = "ros-jazzy-turtle-nest";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtle_nest-release/archive/release/jazzy/turtle_nest/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "441020e2abfaaa7ba7b07e624fe212d4b41cbe007f043fbcb0898fcc22f0ae63";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 Package Creator";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-description/default.nix
+++ b/distros/jazzy/turtlebot4-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-description, joint-state-publisher, robot-state-publisher, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "99930aef0c63ab7c1e27d69dcb4c708fd226c150be4a06f7f1862970c85c15ee";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ irobot-create-description joint-state-publisher robot-state-publisher urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Turtlebot4 Description package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-desktop/default.nix
+++ b/distros/jazzy/turtlebot4-desktop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-viz }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-desktop";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_desktop-release/archive/release/jazzy/turtlebot4_desktop/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "5ad56dcddfdb1ed92395c4870f36e71f58d317b5df6acaa0eba33d0f2a578de2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ turtlebot4-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Turtlebot4 Desktop Metapackage";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-gz-bringup/default.nix
+++ b/distros/jazzy/turtlebot4-gz-bringup/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, irobot-create-common-bringup, irobot-create-description, irobot-create-gz-bringup, irobot-create-gz-toolbox, irobot-create-msgs, irobot-create-nodes, irobot-create-toolbox, ros-gz-interfaces, ros-gz-sim, std-msgs, turtlebot4-description, turtlebot4-gz-gui-plugins, turtlebot4-gz-toolbox, turtlebot4-msgs, turtlebot4-navigation, turtlebot4-node, turtlebot4-viz }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-gz-bringup";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/jazzy/turtlebot4_gz_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "59d8f72335172ef1f5f6f84bdb20c768b8ec286d458c3fbb78f502427d7f554d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs irobot-create-common-bringup irobot-create-description irobot-create-gz-bringup irobot-create-gz-toolbox irobot-create-msgs irobot-create-nodes irobot-create-toolbox ros-gz-interfaces ros-gz-sim std-msgs turtlebot4-description turtlebot4-gz-gui-plugins turtlebot4-gz-toolbox turtlebot4-msgs turtlebot4-navigation turtlebot4-node turtlebot4-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "TurtleBot 4 Gazebo Simulator bringup";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-gz-gui-plugins/default.nix
+++ b/distros/jazzy/turtlebot4-gz-gui-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-gui-vendor, qt5 }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-gz-gui-plugins";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/jazzy/turtlebot4_gz_gui_plugins/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "41e95f4417edac7b3f6887b6dbcc6e32eb2c2fc0783d513976975810cf8f6869";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gz-gui-vendor qt5.qtquickcontrols ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Turtlebot4 Gazebo Simulator GUI Plugins";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-gz-toolbox/default.nix
+++ b/distros/jazzy/turtlebot4-gz-toolbox/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, rcutils, ros-gz-interfaces, sensor-msgs, std-msgs, turtlebot4-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-gz-toolbox";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/jazzy/turtlebot4_gz_toolbox/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8ef1f94596d1f1c9311268e7ed84cf6bb7ec1e53d8fd38323503970e952f5c1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-action rcutils ros-gz-interfaces sensor-msgs std-msgs turtlebot4-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Turtlebot4 Gazebo Toolbox";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-msgs/default.nix
+++ b/distros/jazzy/turtlebot4-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "f804b802a4297a44c25659d5b2a3edb462342b815d084ad3fc266e3f2df8b13e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Turtlebot4 Messages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-navigation/default.nix
+++ b/distros/jazzy/turtlebot4-navigation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, nav2-bringup, nav2-simple-commander, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-navigation";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_navigation/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "7320ac0fa68cc9182f8e875c2ea2a0427fa9970628d248860e1384e03f98868f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ nav2-bringup nav2-simple-commander slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Turtlebot4 Navigation";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-node/default.nix
+++ b/distros/jazzy/turtlebot4-node/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, irobot-create-msgs, rclcpp, rclcpp-action, rcutils, sensor-msgs, std-msgs, std-srvs, turtlebot4-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-node";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4-release/archive/release/jazzy/turtlebot4_node/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "460ea5fec1128ba3e6da87885b3f0c99ac8555f01f8f1db5461eb82f973f5619";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ irobot-create-msgs rclcpp rclcpp-action rcutils sensor-msgs std-msgs std-srvs turtlebot4-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Turtlebot4 Node";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-simulator/default.nix
+++ b/distros/jazzy/turtlebot4-simulator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot4-gz-bringup, turtlebot4-gz-gui-plugins, turtlebot4-gz-toolbox }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-simulator";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_simulator-release/archive/release/jazzy/turtlebot4_simulator/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a14c9b19854b0e87e5626530c1bf8a4154c13dc5c12daaeac61503829956797b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ turtlebot4-gz-bringup turtlebot4-gz-gui-plugins turtlebot4-gz-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Metapackage for Turtlebot4 simulations";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot4-viz/default.nix
+++ b/distros/jazzy/turtlebot4-viz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rqt-robot-monitor, rviz2, turtlebot4-description }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot4-viz";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot4_desktop-release/archive/release/jazzy/turtlebot4_viz/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6ddf94789d0a6fa49ce98d16e7f0631656e6788d2580323349855ffa4242d706";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rqt-robot-monitor rviz2 turtlebot4-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Visualization launchers and helpers for Turtlebot4";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/warehouse-ros-sqlite/default.nix
+++ b/distros/jazzy/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
 buildRosPackage {
   pname = "ros-jazzy-warehouse-ros-sqlite";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/jazzy/warehouse_ros_sqlite/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d3113c354eaf60ed5fb6fea2c2ba3a8988687838c47ab3e494de3d6258bad798";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/jazzy/warehouse_ros_sqlite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "d7fe29e8f986d1dd7d9d27aa850eb98a2046797e725e8af3bd21a1ea3a9a1e69";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake boost sqlite3-vendor ];
+  buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/zlib-point-cloud-transport/default.nix
+++ b/distros/jazzy/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-zlib-point-cloud-transport";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/zlib_point_cloud_transport/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "12c6834a15cb9c5e9d3c7fbee191ae6c49e69299d167d44f6aa2c4fde366b940";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/zlib_point_cloud_transport/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "e4100043c20d3af196b4726f2ae19209d1a65e882403e3691325241349c22aa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/zstd-point-cloud-transport/default.nix
+++ b/distros/jazzy/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-jazzy-zstd-point-cloud-transport";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/zstd_point_cloud_transport/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "6f0bbabc4cabbbcf310cc15ee1497847c513ecbc615161ae7308964c1b95fcd4";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/jazzy/zstd_point_cloud_transport/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "0b91ed7ed147e866e06b37efe6fd4b63579e7f2b033f22b50a50fa86def18e50";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/dataspeed-pds-lcm/default.nix
+++ b/distros/noetic/dataspeed-pds-lcm/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, lcm, message-filters, nodelet, roscpp, roslaunch, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-pds-lcm";
+  version = "1.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_lcm/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "60295fe3ef2f370ac7fcaf4bd9d1e2d51a2ea92bdc92f2091236815f4157a870";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin lcm.dev ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dataspeed-pds-msgs lcm message-filters nodelet roscpp roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "Interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS) via LCM";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -602,6 +602,8 @@ self: super: {
 
  dataspeed-pds-can = self.callPackage ./dataspeed-pds-can {};
 
+ dataspeed-pds-lcm = self.callPackage ./dataspeed-pds-lcm {};
+
  dataspeed-pds-msgs = self.callPackage ./dataspeed-pds-msgs {};
 
  dataspeed-pds-rqt = self.callPackage ./dataspeed-pds-rqt {};
@@ -3737,6 +3739,8 @@ self: super: {
  thunder-line-follower-pmr3100 = self.callPackage ./thunder-line-follower-pmr3100 {};
 
  tile-map = self.callPackage ./tile-map {};
+
+ timed-roslaunch = self.callPackage ./timed-roslaunch {};
 
  timestamp-tools = self.callPackage ./timestamp-tools {};
 

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.3.9-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.3.9-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.4.2-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "7e7420f68f7d728ea801fcd393b015ad5a32fed3a9f3c2e998fb2b0c193d5b0c";
+    sha256 = "1ea4175b9b6160598831af9434bf9fa78bd206eb96942946a2c07716ef75e3d5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-apps/default.nix
+++ b/distros/noetic/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-apps";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "0501716128c5208105686ac6b99e9eaaf6f4e9a117a52b275023c4e7c90d0a8e";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "7f17876ea043b58f5462a5b41ad8da9796fd130eaacd02ceda56d4bb80e46638";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs-bridge, mrpt-rawlog, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-2d";
-  version = "0.1.17-r1";
+  version = "0.1.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.17-1.tar.gz";
-    name = "0.1.17-1.tar.gz";
-    sha256 = "f9ed9f88710739af315640b4a3c284705695a79740fde9766ab98ff083bc97c1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.18-1.tar.gz";
+    name = "0.1.18-1.tar.gz";
+    sha256 = "0fae5bd95d08f8676157fb0b844205fdc3cfe028ebdf34b15d9dc1cab7dbe494";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs-bridge mrpt-rawlog nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs-bridge, mrpt-rawlog, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-3d";
-  version = "0.1.17-r1";
+  version = "0.1.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.17-1.tar.gz";
-    name = "0.1.17-1.tar.gz";
-    sha256 = "4dd75c02320bdfd3ea3561330924a49858d63469a8609fd4eb7d85e94f024ca9";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.18-1.tar.gz";
+    name = "0.1.18-1.tar.gz";
+    sha256 = "2514aa8a7961ab1c7e53e94e2e3c8f16075aea1c6860e50fff96913983dd1324";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs-bridge mrpt-rawlog nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-libapps, mrpt-libgui, mrpt-libros-bridge, mrpt-msgs, mrpt-msgs-bridge, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-graphslam-2d";
-  version = "0.1.17-r1";
+  version = "0.1.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.17-1.tar.gz";
-    name = "0.1.17-1.tar.gz";
-    sha256 = "bc41dd8439e320a34105596077f3ed73094c27865b1da353f7280aed0e1262c5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.18-1.tar.gz";
+    name = "0.1.18-1.tar.gz";
+    sha256 = "5b02ce04f7806786716ac7186984addb6e13e74b82e24a1215a3c9660106130a";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ fkie-multimaster-msgs geometry-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs roscpp rospy sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ fkie-multimaster-msgs geometry-msgs mrpt-libapps mrpt-libgui mrpt-libros-bridge mrpt-msgs mrpt-msgs-bridge nav-msgs roscpp rospy sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-rawlog, mrpt2, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-rawlog, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-icp-slam-2d";
-  version = "0.1.17-r1";
+  version = "0.1.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.17-1.tar.gz";
-    name = "0.1.17-1.tar.gz";
-    sha256 = "d4c0ff2af024ef51f5ae79ec4e99aedcddfeaf82c04771ce376e050892c7f81f";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.18-1.tar.gz";
+    name = "0.1.18-1.tar.gz";
+    sha256 = "25b7b323e6126c56f24be8270a30d072a86b6921653e1fa011b8d87772ee23d4";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-rawlog mrpt2 nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-rawlog nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-libapps/default.nix
+++ b/distros/noetic/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libapps";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "3b0ffdd6ae2bceee1a68e010efdd89a2eaf8275d61ae5249c21b69474b8751a9";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "00d11d08e6aacd8cc2058bfd49dc89b910543d91a3b6212b4614f021cceb41a7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libbase/default.nix
+++ b/distros/noetic/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libbase";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "6fa27794383178d94131ff865f3081259572c59a7374b18d8172105e3eaadf80";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "964bd91b11b4814df288ad39074402ef984959e5feb852a3571ea8a586f87694";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libgui/default.nix
+++ b/distros/noetic/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libgui";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "177ffa2965f43b14115db2d0705da35b486182a4f91e35becfa88addad49bb07";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "55216262f8dadda31cea5e55ffcf1ac40e4a04cdfb05ddf26f4b56a070a01f86";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libhwdrivers/default.nix
+++ b/distros/noetic/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libhwdrivers";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "84e5fc825132f6528c1c4531eb85218883cb68b6b933a84c3185d2cd32f34d17";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "86f7e3a607642f348025fac7f8ff568cb7ac2c7543d9191ca6608f2d776a3c38";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libmaps/default.nix
+++ b/distros/noetic/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libmaps";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "f9bf06233ed8ed4a05f9daf72bf85662363b85fb47e315041169c67ee46a7ed2";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "8a8e22dea645308176623786e48a327c73cacab1daeb9ad937d8323bb28467c0";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libmath/default.nix
+++ b/distros/noetic/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libmath";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "6248395511088addadf1bf12d86e35c387353376a2b85e5a834a10e29e1d5b0a";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "44b32a055cebf75cb0b1073e8b4896de809610ba424fd31fd3eeabbecfae3cfc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libnav/default.nix
+++ b/distros/noetic/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libnav";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "7b9dc66649f44f2911fe3b71e15cc63707e166c651583aeb9426b11098cf2f0d";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "88a9a2a3e2f8346207c700ade86c9d6d0a96f91adec27247961eae2cfdc6a244";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libobs/default.nix
+++ b/distros/noetic/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libobs";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "d07b90e1e66d5e5484f5b5a11bac3be876a426676657e3a8a3356f2f6be23f4a";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "299ab3203725d68d25c6dcaa0b94382d37018b90bc22767c7c46f3766c1eaf40";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libopengl/default.nix
+++ b/distros/noetic/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libopengl";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "e9c679383daeb4128d849117391423a892cfa5d09d0fe396dec218f262ad21b5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "1e264bd778aa40d37ef6d715b6c9871771f97b0558ccb77148498842d5d9e0ed";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libposes/default.nix
+++ b/distros/noetic/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libposes";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "df3b74f44a57d4f9e7e8ae37440c925a6f81b0baccba7c0128c5d842e7c24048";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "b75841cb64e562ba6bca50a188adbb923823123a3504fb79faea017d1efcef33";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libros-bridge/default.nix
+++ b/distros/noetic/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libros-bridge";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros_bridge/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "a7026b4ce63cceb810380f4cdcfdbdfc51018fdecbc5d3a8d30e34ea03a70976";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros_bridge/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "d7cb337bef83cb8bde06455e6ee997e7100d1c20253bd4ca655995103bfd3026";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libslam/default.nix
+++ b/distros/noetic/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libslam";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "0043bd1a3f51129e5f3863f63b7b47acc8d83597f39b475000fc48b712dd2912";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "32c1f8d4b0f68b331186c0a3e7a4b52428e44306e216539f86c6ff4b3acde356";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libtclap/default.nix
+++ b/distros/noetic/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libtclap";
-  version = "2.13.7-r4";
+  version = "2.13.7-r5";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.13.7-4.tar.gz";
-    name = "2.13.7-4.tar.gz";
-    sha256 = "94614a08000a55eac9abfa629a28116340f716b10af83f9ce761f77b4736d053";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.13.7-5.tar.gz";
+    name = "2.13.7-5.tar.gz";
+    sha256 = "6dbe2df2be4a8c55fc9cbb4526ed251f0f875c60d5a4d5b31ddab6daa785e3bb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-local-obstacles/default.nix
+++ b/distros/noetic/mrpt-local-obstacles/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt2, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libmaps, mrpt-libros-bridge, mrpt-libtclap, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-local-obstacles";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9a8495aa6fc40a95e1ae4930e7a7e6568dd336f68db7f80403a2ea698ab22d67";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "055f599d64ad8502c352b5f29fa73861eba39e9e33d2006bdf22f464043e57f6";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt2 roscpp sensor-msgs tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-libgui mrpt-libmaps mrpt-libros-bridge mrpt-libtclap roscpp sensor-msgs tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-localization/default.nix
+++ b/distros/noetic/mrpt-localization/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-localization";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "487dcc6e8c2058f47663c3d142e02fd19f32444478ffa061658f996de03d1a88";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "52949811e06f4a275f0bf5df8d4e0051ae3bc9f4ba2269cc854b7923e1c4db6e";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs mrpt-msgs-bridge nav-msgs pose-cov-ops roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-map/default.nix
+++ b/distros/noetic/mrpt-map/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mrpt2, nav-msgs, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-map";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "288b74bf615f58f3d4120de178bbdab0430ab6a0a46ecea02f2552311194d820";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "0f27e86b10d2f1c09886dcdd77f690ebaf80ae667badc0e6624c6a8b0fe36493";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ mrpt2 nav-msgs roscpp ];
+  propagatedBuildInputs = [ mrpt-libmaps mrpt-libros-bridge nav-msgs roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-msgs-bridge/default.nix
+++ b/distros/noetic/mrpt-msgs-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, marker-msgs, mrpt-msgs, mrpt2, ros-environment, roscpp, tf2 }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, marker-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, ros-environment, roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs-bridge";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "728cdfad5b650ef8cd263cb55ff0e93f354f0e30f7a9d1483de58d570ac8d297";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "8535ee14b6ae934eb6fa36b0a74cf98ef074e507917c6f7e4331f33dd22be6b0";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ros-environment ];
-  propagatedBuildInputs = [ geometry-msgs marker-msgs mrpt-msgs mrpt2 roscpp tf2 ];
+  propagatedBuildInputs = [ geometry-msgs marker-msgs mrpt-libobs mrpt-libros-bridge mrpt-msgs roscpp tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-navigation/default.nix
+++ b/distros/noetic/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-navigation";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "61b33bce5ebbac1f0a14f39902a9187294724a38fcc7e81eb6958695bf865cc1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "168519b2c792fe1b6667df40a75d70254b98fb1818f85062e66672c47814b6ad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-rawlog/default.nix
+++ b/distros/noetic/mrpt-rawlog/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-msgs, mrpt-msgs-bridge, mrpt2, nav-msgs, rosbag, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-libgui, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, mrpt-msgs-bridge, nav-msgs, rosbag, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rawlog";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "7cc37cd2aa8528fa61b75460299e2c5a1829b51e0082926dde1ba482c04b936b";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "6b034b0ae1c204c3062de2547cc79edd6b7e1a60f2c7e4d66fc7fd9e9b4d7c00";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs rosbag roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ dynamic-reconfigure marker-msgs mrpt-libgui mrpt-libobs mrpt-libros-bridge mrpt-msgs mrpt-msgs-bridge nav-msgs rosbag roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-msgs-bridge, mrpt-rawlog, mrpt2, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs-bridge, mrpt-rawlog, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rbpf-slam";
-  version = "0.1.17-r1";
+  version = "0.1.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.17-1.tar.gz";
-    name = "0.1.17-1.tar.gz";
-    sha256 = "6897ff3436603d02a6ba5d42d31d58d5541228ed05b7a87654ea77ba5ddf5bf7";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.18-1.tar.gz";
+    name = "0.1.18-1.tar.gz";
+    sha256 = "3f64f473e544daa59727ee74b82171d659bf7354c1d8594e1b3f62087c5c0de1";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-msgs-bridge mrpt-rawlog mrpt2 mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs-bridge mrpt-rawlog mvsim nav-msgs roscpp roslaunch roslib rviz sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-reactivenav2d/default.nix
+++ b/distros/noetic/mrpt-reactivenav2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-msgs, mrpt2, nav-msgs, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, nav-msgs, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-reactivenav2d";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "4b7943fdea1de6606573158dce800d622b91905973573250d462223071878729";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "23445b377f0258c7a31710f6bb7d4f123ff361f93085bdeb0f22908d66996f97";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-msgs mrpt2 nav-msgs roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mrpt-libnav mrpt-libros-bridge mrpt-msgs nav-msgs roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-slam";
-  version = "0.1.17-r1";
+  version = "0.1.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.17-1.tar.gz";
-    name = "0.1.17-1.tar.gz";
-    sha256 = "9c4981f13e6dd1a4d08c77553718dc1a2a81fb00ad51950fdd5678faffee0a13";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.18-1.tar.gz";
+    name = "0.1.18-1.tar.gz";
+    sha256 = "ee7d6ba589a47c49b016e2357feff6de7f3d22716d7629c91bd60e90b0b073d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-tutorials/default.nix
+++ b/distros/noetic/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-tutorials";
-  version = "1.0.5-r1";
+  version = "1.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "b3e3dcd831acd3dcacc7c36d53afb0bfd0479bdfec3bef517234839602edabfd";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "35e2813cda4ed07d65e0b376e1ef99be915b2a230a9365d316cba9607b74179c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mvsim/default.nix
+++ b/distros/noetic/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, cppzmq, cv-bridge, dynamic-reconfigure, geometry-msgs, gtest, mrpt-libgui, mrpt-libmaps, mrpt-libposes, mrpt-libros-bridge, mrpt-libtclap, nav-msgs, protobuf, python3, python3Packages, pythonPackages, ros-environment, roscpp, rviz-plugin-tutorials, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-noetic-mvsim";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "7d3111bd3ef153142934f8117b16a43cf96b736879ea7b2043eea601ffaa06a3";
+    url = "https://github.com/ual-arm-ros-pkg-release/mvsim-release/archive/release/noetic/mvsim/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "a7cc58fc1e9f20748366bd7510f236532d517b57d09bba3fb54c13ffcfb0d325";
   };
 
   buildType = "catkin";

--- a/distros/noetic/timed-roslaunch/default.nix
+++ b/distros/noetic/timed-roslaunch/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-timed-roslaunch";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Tiryoh/timed_roslaunch-release/archive/release/noetic/timed_roslaunch/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "dd6c9f8915719ae4208645d57551085c86902c9abac372694f91881ff715a992";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "Script to delay the launch of a roslaunch file";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ament-black/default.nix
+++ b/distros/rolling/ament-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-black";
-  version = "0.2.5-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "4183874f252401a0d24aeece7cf6734284ce89a114cd37b811f735d8a604c19d";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_black/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "8609d05b23e3cd3d8b1a77c30ca1bc38e11c8d5e0bd4ab7ab5cb05a5fdb71a2c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-black/default.nix
+++ b/distros/rolling/ament-cmake-black/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-black, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-black";
-  version = "0.2.5-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "4fe629c73f7db996c3106190db2e0dafdcf2e4e398a2bc8fea7df072dcaf5dbb";
+    url = "https://github.com/ros2-gbp/ament_black-release/archive/release/rolling/ament_cmake_black/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "1b8193fdd77b869a98613c6b0b8fc9d068b181ec587491f32abd14c4a4141e68";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-lanelet2-extension-python/default.nix
+++ b/distros/rolling/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lanelet2-extension-python";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension_python/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "6e0936a81696e426ce7231489f40f5ce117ddc0c5236bc2d08bd6e9890d6c938";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension_python/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9a10677623e6271fbc8b52ac36260f9d179bd5061cf4b9231ad4cc35d276ac4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-lanelet2-extension/default.nix
+++ b/distros/rolling/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lanelet2-extension";
-  version = "0.5.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "f52edb8d1367abf2a4e93be54594237040354eaec58bb6fcbd4e05ecdcfc736a";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "738fb18deb6a8bd3196b267cb2da29bd1236254de01c860c457835d13f254235";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/draco-point-cloud-transport/default.nix
+++ b/distros/rolling/draco-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, draco, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, rcpputils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-draco-point-cloud-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/draco_point_cloud_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "0b4b82939249fa8bc6c1a47ed071093b80d2688c595ddcbf943fe58db17f1f36";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/draco_point_cloud_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "e5708a6332091ee869a785297ba40b02cf1363bfd3a36f5bf646886c102d9585";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ffmpeg-encoder-decoder/default.nix
+++ b/distros/rolling/ffmpeg-encoder-decoder/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-ffmpeg-encoder-decoder";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/rolling/ffmpeg_encoder_decoder/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d6adae78af221fb7fda9354ec8dfe27fa8d594bfa26a34662745f33022aab404";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg opencv opencv.cxxdev rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+
+  meta = {
+    description = "ROS2 convenience wrapper around ffmpeg for encoding/decoding";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -564,6 +564,8 @@ self: super: {
 
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
+ ffmpeg-encoder-decoder = self.callPackage ./ffmpeg-encoder-decoder {};
+
  ffmpeg-image-transport = self.callPackage ./ffmpeg-image-transport {};
 
  ffmpeg-image-transport-msgs = self.callPackage ./ffmpeg-image-transport-msgs {};
@@ -1486,6 +1488,8 @@ self: super: {
 
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
+ python-mrpt = self.callPackage ./python-mrpt {};
+
  python-orocos-kdl-vendor = self.callPackage ./python-orocos-kdl-vendor {};
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
@@ -2293,6 +2297,8 @@ self: super: {
  tricycle-steering-controller = self.callPackage ./tricycle-steering-controller {};
 
  turbojpeg-compressed-image-transport = self.callPackage ./turbojpeg-compressed-image-transport {};
+
+ turtle-nest = self.callPackage ./turtle-nest {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/rolling/joy-teleop/default.nix
+++ b/distros/rolling/joy-teleop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, launch-ros, launch-testing, rclpy, rosidl-runtime-py, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-joy-teleop";
-  version = "1.5.0-r2";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/joy_teleop/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "b588029bf44d82df516c6bf7955e54f7f623a53addd7d4bbbdd7618a7a076a80";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/joy_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "cf0e409543be1dfae8ee3c97a1d43ee00f375fc16ab4a83476ac438db7e139b4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ action-tutorials-interfaces ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint example-interfaces geometry-msgs launch-ros launch-testing std-msgs std-srvs test-msgs ];
   propagatedBuildInputs = [ control-msgs rclpy rosidl-runtime-py sensor-msgs teleop-tools-msgs trajectory-msgs ];
 
   meta = {

--- a/distros/rolling/key-teleop/default.nix
+++ b/distros/rolling/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-key-teleop";
-  version = "1.5.0-r2";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/key_teleop/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "97a45fc76188b90a4897fea75f0a50126c9804552a591483401c432c17e7c816";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/key_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "d6b48db0332c8912bcd8a7efbc4ebd66a7376677ae44a6ee0138d4c49af795cd";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/libcamera/default.nix
+++ b/distros/rolling/libcamera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3, python3Packages, pythonPackages, udev }:
 buildRosPackage {
   pname = "ros-rolling-libcamera";
-  version = "0.3.1-r1";
+  version = "0.3.1-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "d63c056debe69db088e1dfd3539671617009b176afaef235e00298fb817d0f70";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.3.1-5.tar.gz";
+    name = "0.3.1-5.tar.gz";
+    sha256 = "ed2cd28f1cb75592f480c75d6b7f606b53e674f4e1ca8659eb4262c4e5b7436d";
   };
 
   buildType = "meson";

--- a/distros/rolling/liblz4-vendor/default.nix
+++ b/distros/rolling/liblz4-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, lz4 }:
 buildRosPackage {
   pname = "ros-rolling-liblz4-vendor";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/liblz4_vendor/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "d9c33cbaa75af7ad090fc6b6e9de6afcb10ef79ad7eab0457fa39733800f0c7a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/liblz4_vendor/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "5aa558742c76743be4fcd37aed37627a26637f7a658ea7c1ef923ba3e0fdb996";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-can-msgs/default.nix
+++ b/distros/rolling/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-can-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_can_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a08171d648a6c18192d6a57132c174c35b20780c6fbb8ceb2af587da7e896896";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_can_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "e029dbe99ff92fee740fcc6d14c6d5383be63b38e733875b417c1b642f5e0050";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-common-msgs/default.nix
+++ b/distros/rolling/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-common-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_common_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "4222c355d90391d46d232aa347f7eeede148c0503a16b6a3423a0f63654d3efb";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_common_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "c0df98545c64d927ffb73e6fce1bfdca4b976d9f36e7a2a9192d9c89bafab137";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-dbw-msgs/default.nix
+++ b/distros/rolling/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-dbw-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_dbw_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "eca143f1534a76c20b0ef57a13b64d5fc5b70434b8e8290354398f56f1dad1ad";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_dbw_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "960f1b1100805d043b0ad90d58ca0c358ca0724c67ddc04e19c7e75be199ec97";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-introspection-msgs/default.nix
+++ b/distros/rolling/marti-introspection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-introspection-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_introspection_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "f738216b7b2075c8b18d91bcaf64853ae82e9e6f299a879b8732d0008308bf05";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_introspection_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "82d72b814d6db9f3f4b7074fdd91dae793413df95fc163b4927b30b66b6db36b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-nav-msgs/default.nix
+++ b/distros/rolling/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-nav-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_nav_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "ebdd147c97d5997cbc2abf5e55ab35b0aee21ba0263d57a601f2676d9693286f";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_nav_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "742b587f01b0c2c910f192f2253064a1c5425c4765fd216d728327dc749be066";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-perception-msgs/default.nix
+++ b/distros/rolling/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-perception-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_perception_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "9154e9fd292359a8b5ef7733943fe3d2eadd76e3b0d313a941d68e57c0e20e1a";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_perception_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "a9a1b4d1040d7a1d8ea3887f669e5ca61bd29832c2da7de86c6d7b8266ec97af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-sensor-msgs/default.nix
+++ b/distros/rolling/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-marti-sensor-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_sensor_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "0549eb8b324238806d0b6d94df37edf12b9dfdeef9ac3559e641301ac8251928";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_sensor_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "5a0070914869a25520cab997a2b73fafeaebdbb88e610f583218706e35f23df9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-status-msgs/default.nix
+++ b/distros/rolling/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-status-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_status_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "6e5e60ed6372a84dd4b1527e0954cd01914c8971053a715a9133dfc23ca4a28a";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_status_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "14ad8a92dfdf99e8d5c072e43990ba47be24932e7091deb8386f1b582056b5c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/marti-visualization-msgs/default.nix
+++ b/distros/rolling/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-marti-visualization-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_visualization_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "84c936181073fda9656ad4dcdd1c20d4c9542d510abb40ae5e5b17be2c8b8042";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/rolling/marti_visualization_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "63367e265a24977b2a814e60f749857b09a0f75d7f05491de48e1c820d502d7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, liblz4-vendor, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "86017fe1f66feeb89ea157f3a2741ab337a454d8054980ac2f2b604b14c5d777";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "e96146185d6e0b95d13ba64b5da82fca35176769563e2ec1505368cef900ff1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt2, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.3.1-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "5bcff9f1462664ea2319db7901afc1487aa1b5aaa411441f73690c42bd53b68b";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "e78e5636ef6437eafb3d94a2435145b446fc49ecb2e236f2093f79e884a765e9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt2 ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mouse-teleop/default.nix
+++ b/distros/rolling/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-mouse-teleop";
-  version = "1.5.0-r2";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/mouse_teleop/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "eb4fd5c97ab70c1de97dfb2b71a0a937f1d25b2797d05f552f9e1a5385c4227e";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/mouse_teleop/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "b7502338fb5a0ff192aacbd2e205939f69b94b7e4a8d46f918032ed04e0f39bc";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/mrpt-generic-sensor/default.nix
+++ b/distros/rolling/mrpt-generic-sensor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, rclcpp, rclcpp-components, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-generic-sensor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_generic_sensor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "ed97ba90426592961981802d6d654228da2ff7bfca8ebb0ba43c8b60eaea562f";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_generic_sensor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "81b59af1e63d8c1b26da85b3899fda2458e4a4d5e49f2ca7fa29970d1c9ef41a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-map-server/default.nix
+++ b/distros/rolling/mrpt-map-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libmaps, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-map-server";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_map_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "97b8f1e94893c3ce80725873922109dc64781818ada6b74c48ca478055821919";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_map_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "68c15db4ebca48eda870d9dada35f53c5df3cad422477393661ad77f876836e8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libmaps mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces rclcpp-components ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-msgs-bridge/default.nix
+++ b/distros/rolling/mrpt-msgs-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt2, ros-environment, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, rclcpp, ros-environment, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-msgs-bridge";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_msgs_bridge/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "37f6d8f8ed5a690c971926d1c2d4d67271b17c93fa7c15b28a19d954edfc5229";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_msgs_bridge/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5968fc29f1d95a717ce2c9c61f7a847de0827022b0d245f74c78da7d1f8345e2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt2 tf2 ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libobs mrpt-libros-bridge mrpt-msgs rclcpp tf2 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-nav-interfaces/default.nix
+++ b/distros/rolling/mrpt-nav-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-nav-interfaces";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_nav_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d5035d56b18676d7ec49f934f0863f95e6ca6d2528a8a1283adcf9558ca16fc4";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_nav_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a61e056113d3f7368a40439093e74a0a43686376eee803c2fd69ee70bbbe2812";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-navigation/default.nix
+++ b/distros/rolling/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-map-server, mrpt-nav-interfaces, mrpt-pf-localization, mrpt-pointcloud-pipeline, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-navigation";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_navigation/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "9f1d36868b7f5b1d044a688cf6dd5b18ac6b171ef582921a4f0c466fc3d465a1";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_navigation/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "9bc1fa3298f94f278c7be07064f5d56ce4328482dc3739b67e1eda085e6ee060";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-pf-localization/default.nix
+++ b/distros/rolling/mrpt-pf-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, mrpt2, nav-msgs, pose-cov-ops, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mola-relocalization, mp2p-icp, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, mrpt-tutorials, nav-msgs, pose-cov-ops, rclcpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-pf-localization";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pf_localization/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "fe921b1a8a45d41705b55033021c49a3fa0cc11f3dd705385d5cdc40a615a66e";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pf_localization/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "158c8808609d2254bdbf55490901e2ba9955d29eea53dfda8175413662c87697";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
   checkInputs = [ mrpt-tutorials ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-msgs mrpt-msgs-bridge mrpt2 nav-msgs pose-cov-ops sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mola-relocalization mp2p-icp mrpt-libgui mrpt-libros-bridge mrpt-libslam mrpt-msgs mrpt-msgs-bridge nav-msgs pose-cov-ops rclcpp sensor-msgs std-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-pointcloud-pipeline/default.nix
+++ b/distros/rolling/mrpt-pointcloud-pipeline/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libros-bridge, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-pointcloud-pipeline";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pointcloud_pipeline/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "30a0f6f7faa61488d545c86301e516fe5faaefa2a2bf02b8f1d2dabebfd8f96a";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_pointcloud_pipeline/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "bcf086c7cddb622a8f128420633004dd0dd81233cec29ef5be93bc4497a67015";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libros-bridge nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-rawlog/default.nix
+++ b/distros/rolling/mrpt-rawlog/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-msgs, mrpt2, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, cv-bridge, mrpt-libros-bridge, mrpt-libtclap, mrpt-msgs, nav-msgs, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-rawlog";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_rawlog/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8ed52c111ead1568e2119b33fc9a25117c523b22aff48612b8203681c9053640";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_rawlog/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "10a39843c9946088c569fa811efccf708229930a1354acbb282f7146115c6f3c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-msgs mrpt2 nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge mrpt-libros-bridge mrpt-libtclap mrpt-msgs nav-msgs rosbag2-cpp sensor-msgs tf2-geometry-msgs tf2-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-reactivenav2d/default.nix
+++ b/distros/rolling/mrpt-reactivenav2d/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-reactivenav2d";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_reactivenav2d/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "992e5a2663351b227a0251b0925282803e3eb9e11f750914658e0549d5d7172d";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_reactivenav2d/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0e79b8961c8b798c40da04eafcd0f75a57dae6e03b27c0a21a2186ef9afed82e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-libnav mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-bumblebee-stereo/default.nix
+++ b/distros/rolling/mrpt-sensor-bumblebee-stereo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-bumblebee-stereo";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_bumblebee_stereo/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "1b1c3e06d129698de5c1c92ca3aed31c67623c31b2ab4ec8d99f4a43b669b4b9";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_bumblebee_stereo/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "204cfd1e81adf73401a58d756efdef97ad5144ce493f617d9dddea69b92fb9ec";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-gnss-nmea/default.nix
+++ b/distros/rolling/mrpt-sensor-gnss-nmea/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, nmea-msgs, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-gnss-nmea";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_nmea/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "54a0cab6242ca5db515279d73ce4c588379d129613ff45c6228425276afc6b09";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_nmea/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "74baae9b60365c23279ca66a4b0390ae4249d36c7afde84470e845a5382a9dd4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 nmea-msgs rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs nmea-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-gnss-novatel/default.nix
+++ b/distros/rolling/mrpt-sensor-gnss-novatel/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-gnss-novatel";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_novatel/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "a20ee7c97eeebc2b67e3bf0825a078a6f5a2675c201b544208ea9509bddc011e";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_gnss_novatel/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "96f7ea67d3a6f02d693a798e536fcb94ce318db0cca04e8afeb3ec10de95b223";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensor-imu-taobotics/default.nix
+++ b/distros/rolling/mrpt-sensor-imu-taobotics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt-sensorlib, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, mrpt-sensorlib, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensor-imu-taobotics";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_imu_taobotics/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "4ebadbfc640f8d9cc341118c2553f1c0a1acda67b5abf40c9a566884064ade86";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensor_imu_taobotics/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "caadc5e6595244a37ba5c65068be3040bbe11dcadab3590c7499fac86a433386";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt-sensorlib mrpt2 rclcpp rclcpp-components tf2 tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs mrpt-sensorlib nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensorlib/default.nix
+++ b/distros/rolling/mrpt-sensorlib/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-msgs, mrpt2, rclcpp, rclcpp-components, ros-environment, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, mrpt-libhwdrivers, mrpt-libros-bridge, mrpt-msgs, nav-msgs, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensorlib";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensorlib/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "b3d7fa41873b274dcd759e0a4a493a541a85ad211b6651f68490511ff082a58d";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensorlib/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "49c1fe3609f88a480a4d10988acdba9cc43b940d49e33e616eb16c2f148a5a74";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ros-environment ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-msgs mrpt2 rclcpp rclcpp-components tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common cv-bridge geometry-msgs mrpt-libhwdrivers mrpt-libros-bridge mrpt-msgs nav-msgs rclcpp rclcpp-components sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-sensors/default.nix
+++ b/distros/rolling/mrpt-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-generic-sensor, mrpt-sensor-bumblebee-stereo, mrpt-sensor-gnss-nmea, mrpt-sensor-gnss-novatel, mrpt-sensor-imu-taobotics, mrpt-sensorlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-sensors";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensors/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "4c04f46b9d7880b0e5844977d3ebc3d302c64180e54d746604aac57590431bfb";
+    url = "https://github.com/ros2-gbp/mrpt_sensors-release/archive/release/rolling/mrpt_sensors/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "7c2b052264dc5842793ea03cd8bdaeb0150d394d34f1cfbf1ce96840cfb456fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-tps-astar-planner/default.nix
+++ b/distros/rolling/mrpt-tps-astar-planner/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, mrpt2, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, mrpt-nav-interfaces, mrpt-path-planning, nav-msgs, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-tps-astar-planner";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tps_astar_planner/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6f13c2181c1617b3451891be4deeb678d8fe19144e44a9f864004c5742b25131";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tps_astar_planner/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "bd3c3a4b1e3a66361ed681daf763281d69cecb3667fa0b46b752050adaf38c5b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-lint-auto ament-lint-common geometry-msgs mrpt-msgs mrpt-nav-interfaces mrpt-path-planning mrpt2 nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ ament-lint-auto ament-lint-common mrpt-libgui mrpt-libmaps mrpt-libnav mrpt-libros-bridge mrpt-msgs mrpt-nav-interfaces mrpt-path-planning nav-msgs rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-tutorials/default.nix
+++ b/distros/rolling/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cmake, mvsim, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-tutorials";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tutorials/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "68199d58f22e0bb9a94a2dc60072424d644715e7cdc019d464239a009a868662";
+    url = "https://github.com/ros2-gbp/mrpt_navigation-release/archive/release/rolling/mrpt_tutorials/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "190fe63994ac9974af0ed6af526669526f08a2f9e02afc17f8dc253463299b65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-interfaces/default.nix
+++ b/distros/rolling/point-cloud-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-interfaces";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "04c8b7211ad168072233827ef210961030d23730d66519cd697199642b283a58";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_interfaces/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "706c1024ab78b8f9bff1628d02780a58659f10fc96fd66b304bc8174256afa57";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-plugins/default.nix
+++ b/distros/rolling/point-cloud-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, draco-point-cloud-transport, point-cloud-interfaces, zlib-point-cloud-transport, zstd-point-cloud-transport }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-plugins";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "8e03a300a150c626d9599c032138541f4e79d32403b3e224a2a6bf9704950b33";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/point_cloud_transport_plugins/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "9a70c6ad3a2ec0da92883352699280738c252e6ced9743a6126231b4569dfa40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-mrpt/default.nix
+++ b/distros/rolling/python-mrpt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+buildRosPackage {
+  pname = "ros-rolling-python-mrpt";
+  version = "2.13.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/rolling/python_mrpt/2.13.7-1.tar.gz";
+    name = "2.13.7-1.tar.gz";
+    sha256 = "76b5fb90168b3e088c24094fcceb35a91aed09656c82cab3ea9708efabb15659";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  propagatedBuildInputs = [ mrpt-libapps mrpt-libgui mrpt-libnav mrpt-libslam ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Python wrapper for Mobile Robot Programming Toolkit (MRPT) libraries";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "afe6625faf54fc292371283fec41c75d7fe148359950a6ca4c93feb5138f4d65";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a5667d844694538756c4a3a2735ffce05a4ce8f71dece0de97d7a9e37ed6c0aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "0ee0e494a4e56f5b88500943d9043ca19ba120aa7291bbaedfe21d27dcc0345f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2416282358bdef55f92038803dee354cc8e1a0a0482853899fe144a43b19dec8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b701d09134bc6f9614d0d0ef0ccc94bdbb27299a0fa0a9e10c1f734abfd0b92b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "9e0125fde5d5f296203189b13a031d2cc19b4e7c50b8525a97f61de7e7c5f334";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "79021cae7cd811f951c8e5c53fc2cb82aef004e56b65b99fc4a030283cdc9ead";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "962a03f908d8257984eb1155a588549783e83fa8447d77d099814358353b8c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "c7f273335ecfa8f544b1fae7120f7e0dbd629757e89dd7f542db87bb013ac397";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f0f72e6e0de9b42cfc9cdce5398727a459370847da75917a727575dad6006442";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "a006fc14e6c25832acc48adfb1be65c5c2d3c769fb46bce5be44520bdd79954f";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "0797c33bac32e257f9c2021c7b15f9efc30ff0dd3ffdba6377fbb9da866e2b61";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "a25815a10bbb7d2af291467c98b34e53e3131b876bedc8e7fb54c419b9b172e2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "a11fd1f4f874a7cbf7b2acd9eb58df2d0e3b5850f2bc02d0a2025f659488114e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "2b50a75b50bf2a6050c8c10e4e7d2696fcd08c895fd4eb9ff161c7c28e28fdd7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "c6ea5edd0c298ef3f773cfb4177b016c909148df6a8b8cff3057bfe2a56cc78f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "adcb8ab45f28d60df9b34a7953ee602a1f818d2a3923d7900b8289f1417371ab";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "8d702ad79a5a396e847344d65c3cfb10f4d41cf852e142f831abe15eb3d6e006";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "fb6c81a3e49af192e94e54d29bae8d2fa05e05110a3f2f1e56c3b21efed86596";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "2d8c12ce4f1ce0fb8441983d9fba3f6fc45562b28a244ceec15c0c90578dc052";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs std-msgs test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp shared-queues-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "d5b482f15a4a662c5170bd31b6a1f7324103181a0856a128aae3be3ebbc9a2eb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "4ad9fac8df5bd4953c7af34aa82204934c0a584c84598f226f13bd939b48889f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ example-interfaces rclcpp rosbag2-cpp ];
+  propagatedBuildInputs = [ example-interfaces rclcpp rosbag2-cpp rosbag2-transport ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "31beae3ede5293deeb7893d301aed8334206038079697878479e0a652e169be6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "7331116b1bf97efb9ed1ed0499553bcf833f9906ed670c81cca2f10ec792ded3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "dd6753a4d353acb0c7813891dca274b79194daab434176b66c2abb1e8d6e4382";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "f5c0dc94c1bde8dae21df0ec4d4bd2c3f4c557f8e8a29ee1f439e9a2727a7f24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "de2c9105334eaa11cca5b71e7fd9e30e27fdf1f08bf249d8944b5a5d84b42b3a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "e3c2075dd7b3941504184d08f6466c2e336f63ecb52eca5e54f72d259e4d2eb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "df49ad5c8ed84f60467d7ee2a16b1691efa0d6562f7e0090799b068f2d7ee98b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "99a8e9e33a2e6878689114506e80a37c63dc3c272ff8c06a2fd5894b3da29bb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "38e95c857aee8f04fbad5027281cae12338d5abfd95fb88315fe2fdef2860164";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "41d9c8c3c61027ec3adbd5aae38d7c41faa581a399fd3b6a1bdbc83088d881a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "c72fd932038584042a127d028ea2630886555d67befed2d422554c5e4f53650a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "2d5a8fb4fb0192195515544117ba21b0dd88634f4ae96a1b79aeb08d5b4ab214";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "e863a22c6c1fe6da498a9eb881a1014495a3cb252df8a2a1f9dca5446879c68b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "8d0e6864ea268c14fc28948d9d73472c4f7eae531f4418acf161f0341ae5fa24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "b4b4cc5712658f6e944d6d738dce70c2a1e06f1845a0e8f10ce9db02018207b0";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "2ee0cad7471db19b76bcf2fcc2902701b0a358dfcc64fdaa57c8dbb3bb917bf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rmw, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "b5141bdb884453bc544773877f702af21d1db716eb9bfa6d6a21a091a8632f44";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "e50020d9f38583cadd2b35263c22186a4d08745d043e7de7d576a75351be582d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "198aafcdb5d679a29eabe24066058debcca58ce15cc46be0cd394d4a1a49782c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "79068f0f6ee6fcf39e22cab7c13421d01651841acd3022964d85875de7e8c352";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "3a5f63a6b9eb377f8663b0f68e4d2a27003a23d5afbbaad2e1399add521b564a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "5129ae00eb3f6ade51c3b1b34b3f8fbe4564b302fffb54b1a8a71f6880dd9538";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "faee1e33481de9e766765b045596d751955f799e377cf9f16564f82ce178fb7c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "5b7a84aac4b494a46875eb769b8b7b9f6f6f97894c7c98c03c6e547ceb68f66b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-components, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "1208219b0d53cd09cacad98999d6788e48a41f7f9ad7f48309dc684655794847";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "68b2a297752a4d845bf45f1f76899ab15e2c755a443a6fb36e38920e45956576";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "4a3e66282d10aadf8d820e7a42da0cd43e0322169cab13e1b1b2747f60266502";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "ed157bafc9ffac036c091cee751936bd5b13f378d5802209933686ef5eef05b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-bag-plugins/default.nix
+++ b/distros/rolling/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, pythonPackages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag-plugins";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4009fcf46e7c4eb21bfee40f908e1126a866e4e7cb689dafd525cdf95be30be9";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "cab30d3234c2f61767cc1ba6e915b490f9bc168943598802e3097a18bc973132";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-bag/default.nix
+++ b/distros/rolling/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python-qt-binding, pythonPackages, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "3359e8a6059649c7c65b99ee9b26da8c882ccbc4b9506ca5ae118f3d195a15c4";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "902669d15ff990e964a22864048f69773938d3514cf91f1d12de2b4d70ec3020";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/shared-queues-vendor/default.nix
+++ b/distros/rolling/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-shared-queues-vendor";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "ea0167b78c8c709aae182cb7db7c3580a5b043fdee1123b5dee39d5ad16fe906";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/shared_queues_vendor/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "a7ac16c67588c3452dc6a7305acf416ad2021a6a8fe6b305e1bf92ff6ee5cb40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sqlite3-vendor/default.nix
+++ b/distros/rolling/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-sqlite3-vendor";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "b6c193aa057f5b4493b1d66994958000fe2edbb5c673ab64f07bfa559d9c42ff";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "c0dce7569172d30f7d523c123bdd3c7ee4e1fca524ea3fcd1f31bd95ade3598c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/teleop-tools-msgs/default.nix
+++ b/distros/rolling/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-teleop-tools-msgs";
-  version = "1.5.0-r2";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools_msgs/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "4de66399c08963b0122827208b04457f857fa92570e2d91d782f4986639a57fc";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "bcea0348088216af06f5a151e15bd2052b9610b93c26b97e1efbeed299cb74a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/teleop-tools/default.nix
+++ b/distros/rolling/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-rolling-teleop-tools";
-  version = "1.5.0-r2";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "7efdc8acfd937a294cbd5ea017ebd1afa7166f74cd7de6e0e938d07c3c6367cd";
+    url = "https://github.com/ros2-gbp/teleop_tools-release/archive/release/rolling/teleop_tools/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "754f1d27401ecc705b9951624fcec5f7d431904f970cd021c805ca781dc4b3ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/test-ros-gz-bridge/default.nix
+++ b/distros/rolling/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-rolling-test-ros-gz-bridge";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "f4b7e82c1ed66beef600e5ee8781e814099d3e700d6ddffd4a56e9a17c1bb18c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2bb7daa0669553d98b4e072dbeff66224456096c6f903caef9f873c5f581fcc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools-interfaces/default.nix
+++ b/distros/rolling/topic-tools-interfaces/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools-interfaces";
-  version = "1.3.0-r2";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "ffdd71eeaa2bb3bf2696254b73b7dc452af97f198dc524d2d9a478b7243572fb";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2c809e5cfbf7b0908086531a7859a0402f4b009763946c71efe0ca04ef742c33";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = "topic_tools_interfaces contains messages and services for topic_tools";

--- a/distros/rolling/topic-tools/default.nix
+++ b/distros/rolling/topic-tools/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools";
-  version = "1.3.0-r2";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.3.0-2.tar.gz";
-    name = "1.3.0-2.tar.gz";
-    sha256 = "4ecf4259b15ebd76a4a92e71b5a67df1b256169cd4b73be23475f4b7a3b95449";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "d7da181c766df343bc5dccbac991aece29d87ab75a77ae57ba4dbb91f92cb323";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
+  buildInputs = [ ament-cmake ament-cmake-python rosidl-default-generators ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ rclcpp rclcpp-components rclpy ros2cli rosidl-runtime-py topic-tools-interfaces ];
-  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python rosidl-default-generators ];
 
   meta = {
     description = "Tools for directing, throttling, selecting, and otherwise messing with

--- a/distros/rolling/turtle-nest/default.nix
+++ b/distros/rolling/turtle-nest/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, qt5 }:
+buildRosPackage {
+  pname = "ros-rolling-turtle-nest";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtle_nest-release/archive/release/rolling/turtle_nest/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "303b3a731c23fbc06e17c7f08d26a10fe8fb1fbb13bbf97b9554cfd2c92c3841";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 Package Creator";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/warehouse-ros-sqlite/default.nix
+++ b/distros/rolling/warehouse-ros-sqlite/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite3-vendor, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-warehouse-ros-sqlite";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "f19b3f67939e2d03673a39b4bf86a2ea0104a2be5389d3f57d70e5c16c8b221d";
+    url = "https://github.com/ros2-gbp/warehouse_ros_sqlite-release/archive/release/rolling/warehouse_ros_sqlite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "d63961bb4aefb4ce229426771780d4a9c6268a9333dcdf6aae168e5c4051cfaf";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake boost sqlite3-vendor ];
+  buildInputs = [ ament-cmake boost ];
   checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
-  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite3-vendor warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/zlib-point-cloud-transport/default.nix
+++ b/distros/rolling/zlib-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zlib-point-cloud-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "bbf69557dd35a2bd3418d971b9e5a2ff45f57b492e40f06c4c583ba066d566d3";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zlib_point_cloud_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "2dc6e73dce813cae5dec326ee61163488c4e1eb7390994b58e4dc50010abf31a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-point-cloud-transport/default.nix
+++ b/distros/rolling/zstd-point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, point-cloud-interfaces, point-cloud-transport, rclcpp, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-point-cloud-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "be37d282dc8b6f75123aa5dd384897a505daf5477644eb72d3175de6aa511670";
+    url = "https://github.com/ros2-gbp/point_cloud_transport_plugins-release/archive/release/rolling/zstd_point_cloud_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "f0dbbaaf69eb33cc0712bdc75b107b95403ee52876b9fd8f33102ce216003900";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-vendor/default.nix
+++ b/distros/rolling/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-vendor";
-  version = "0.28.0-r1";
+  version = "0.29.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.28.0-1.tar.gz";
-    name = "0.28.0-1.tar.gz";
-    sha256 = "c95323f7f5f746e651572642aa9cf4bb57a01362bb7537774ca1684b3af770b9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.29.0-1.tar.gz";
+    name = "0.29.0-1.tar.gz";
+    sha256 = "b3f842b55d15b7f623fd673eb94337a1ede85b1aea6a4f104d0e2bce93d70dd6";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 9133804172751b22a40bccc478050cf7c0d4ae15.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ament-black 0.2.5-r1 --> 0.2.6-r1*
* *ament-cmake-black 0.2.5-r1 --> 0.2.6-r1*
* *autoware-lanelet2-extension 0.5.0-r1 --> 0.6.0-r1*
* *autoware-lanelet2-extension-python 0.5.0-r1 --> 0.6.0-r1*
* *examples-tf2-py 0.25.7-r1 --> 0.25.8-r1*
* *ffmpeg-encoder-decoder 1.0.1-r2*
* *geometry2 0.25.7-r1 --> 0.25.8-r1*
* *hebi-cpp-api 3.9.0-r1 --> 3.10.0-r1*
* *joy-teleop 1.5.0-r1 --> 1.5.1-r1*
* *key-teleop 1.5.0-r1 --> 1.5.1-r1*
* *kuka-sunrise-fri-driver 0.9.2-r1*
* *libcamera 0.1.0-r1 --> 0.1.0-r3*
* *marti-can-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-common-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-dbw-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-introspection-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-nav-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-perception-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-sensor-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-status-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-visualization-msgs 1.6.0-r1 --> 1.6.1-r1*
* *mola-lidar-odometry 0.3.2-r1 --> 0.3.3-r1*
* *mouse-teleop 1.5.0-r1 --> 1.5.1-r1*
* *mrpt-apps 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-generic-sensor 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-libapps 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libbase 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libgui 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libhwdrivers 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libmaps 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libmath 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libnav 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libobs 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libopengl 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libposes 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libros-bridge 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libslam 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-libtclap 2.13.7-r2 --> 2.13.7-r3*
* *mrpt-map-server 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-msgs-bridge 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-nav-interfaces 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-navigation 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pf-localization 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pointcloud-pipeline 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-rawlog 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-reactivenav2d 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-nmea 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-novatel 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-imu-taobotics 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensorlib 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensors 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-tps-astar-planner 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-tutorials 2.1.0-r1 --> 2.1.1-r1*
* *python-mrpt 2.13.7-r1*
* *qml-ros2-plugin 1.0.1-r1*
* *ros-babel-fish 0.9.4-r1*
* *ros-babel-fish-test-msgs 0.9.4-r1*
* *teleop-tools 1.5.0-r1 --> 1.5.1-r1*
* *teleop-tools-msgs 1.5.0-r1 --> 1.5.1-r1*
* *tf2 0.25.7-r1 --> 0.25.8-r1*
* *tf2-bullet 0.25.7-r1 --> 0.25.8-r1*
* *tf2-eigen 0.25.7-r1 --> 0.25.8-r1*
* *tf2-eigen-kdl 0.25.7-r1 --> 0.25.8-r1*
* *tf2-geometry-msgs 0.25.7-r1 --> 0.25.8-r1*
* *tf2-kdl 0.25.7-r1 --> 0.25.8-r1*
* *tf2-msgs 0.25.7-r1 --> 0.25.8-r1*
* *tf2-py 0.25.7-r1 --> 0.25.8-r1*
* *tf2-ros 0.25.7-r1 --> 0.25.8-r1*
* *tf2-ros-py 0.25.7-r1 --> 0.25.8-r1*
* *tf2-sensor-msgs 0.25.7-r1 --> 0.25.8-r1*
* *tf2-tools 0.25.7-r1 --> 0.25.8-r1*
* *turtle-nest 1.0.2-r1*
* *warehouse-ros-sqlite 1.0.4-r1 --> 1.0.5-r1*

Iron Changes:
-------------
* *examples-tf2-py 0.31.7-r1 --> 0.31.8-r1*
* *ffmpeg-encoder-decoder 1.0.1-r1*
* *geometry2 0.31.7-r1 --> 0.31.8-r1*
* *joy-teleop 1.5.0-r1 --> 1.5.1-r1*
* *key-teleop 1.5.0-r1 --> 1.5.1-r1*
* *mola-lidar-odometry 0.3.1-r1 --> 0.3.3-r1*
* *mouse-teleop 1.5.0-r1 --> 1.5.1-r1*
* *mrpt-generic-sensor 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-map-server 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-msgs-bridge 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-nav-interfaces 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-navigation 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pf-localization 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pointcloud-pipeline 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-rawlog 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-reactivenav2d 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-nmea 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-novatel 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-imu-taobotics 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensorlib 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensors 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-tps-astar-planner 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-tutorials 2.1.0-r1 --> 2.1.1-r1*
* *teleop-tools 1.5.0-r1 --> 1.5.1-r1*
* *teleop-tools-msgs 1.5.0-r1 --> 1.5.1-r1*
* *tf2 0.31.7-r1 --> 0.31.8-r1*
* *tf2-bullet 0.31.7-r1 --> 0.31.8-r1*
* *tf2-eigen 0.31.7-r1 --> 0.31.8-r1*
* *tf2-eigen-kdl 0.31.7-r1 --> 0.31.8-r1*
* *tf2-geometry-msgs 0.31.7-r1 --> 0.31.8-r1*
* *tf2-kdl 0.31.7-r1 --> 0.31.8-r1*
* *tf2-msgs 0.31.7-r1 --> 0.31.8-r1*
* *tf2-py 0.31.7-r1 --> 0.31.8-r1*
* *tf2-ros 0.31.7-r1 --> 0.31.8-r1*
* *tf2-ros-py 0.31.7-r1 --> 0.31.8-r1*
* *tf2-sensor-msgs 0.31.7-r1 --> 0.31.8-r1*
* *tf2-tools 0.31.7-r1 --> 0.31.8-r1*
* *turtle-nest 1.0.1-r1*
* *warehouse-ros-sqlite 1.0.3-r3 --> 1.0.5-r1*

Jazzy Changes:
--------------
* *ament-black 0.2.5-r1 --> 0.2.6-r1*
* *ament-cmake-black 0.2.5-r1 --> 0.2.6-r1*
* *autoware-lanelet2-extension 0.5.0-r1 --> 0.6.0-r1*
* *autoware-lanelet2-extension-python 0.5.0-r1 --> 0.6.0-r1*
* *draco-point-cloud-transport 4.0.0-r1 --> 4.0.1-r1*
* *ffmpeg-encoder-decoder 1.0.1-r1*
* *joy-teleop 1.5.0-r3 --> 1.5.1-r1*
* *key-teleop 1.5.0-r3 --> 1.5.1-r1*
* *libcamera 0.3.1-r1 --> 0.3.1-r4*
* *marti-can-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-common-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-dbw-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-introspection-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-nav-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-perception-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-sensor-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-status-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-visualization-msgs 1.6.0-r1 --> 1.6.1-r1*
* *mola-lidar-odometry 0.3.1-r1 --> 0.3.3-r1*
* *mouse-teleop 1.5.0-r3 --> 1.5.1-r1*
* *mrpt-generic-sensor 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-map-server 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-msgs-bridge 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-nav-interfaces 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-navigation 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pf-localization 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pointcloud-pipeline 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-rawlog 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-reactivenav2d 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-nmea 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-novatel 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-imu-taobotics 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensorlib 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensors 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-tps-astar-planner 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-tutorials 2.1.0-r1 --> 2.1.1-r1*
* *openvdb-vendor 2.5.1-r1 --> 2.5.2-r1*
* *point-cloud-interfaces 4.0.0-r1 --> 4.0.1-r1*
* *point-cloud-transport-plugins 4.0.0-r1 --> 4.0.1-r1*
* *python-mrpt 2.13.7-r1*
* *robot-upstart 1.0.3-r1*
* *ros-gz 1.0.3-r1 --> 1.0.4-r1*
* *ros-gz-bridge 1.0.3-r1 --> 1.0.4-r1*
* *ros-gz-image 1.0.3-r1 --> 1.0.4-r1*
* *ros-gz-interfaces 1.0.3-r1 --> 1.0.4-r1*
* *ros-gz-sim 1.0.3-r1 --> 1.0.4-r1*
* *ros-gz-sim-demos 1.0.3-r1 --> 1.0.4-r1*
* *simple-term-menu-vendor 1.5.7-r1*
* *spatio-temporal-voxel-layer 2.5.1-r1 --> 2.5.2-r1*
* *teleop-tools 1.5.0-r3 --> 1.5.1-r1*
* *teleop-tools-msgs 1.5.0-r3 --> 1.5.1-r1*
* *test-ros-gz-bridge 1.0.3-r1 --> 1.0.4-r1*
* *topic-tools 1.3.0-r3 --> 1.3.1-r1*
* *topic-tools-interfaces 1.3.0-r3 --> 1.3.1-r1*
* *turtle-nest 1.0.2-r1*
* *turtlebot4-description 2.0.0-r1*
* *turtlebot4-desktop 2.0.0-r1*
* *turtlebot4-gz-bringup 2.0.0-r1*
* *turtlebot4-gz-gui-plugins 2.0.0-r1*
* *turtlebot4-gz-toolbox 2.0.0-r1*
* *turtlebot4-msgs 2.0.0-r1*
* *turtlebot4-navigation 2.0.0-r1*
* *turtlebot4-node 2.0.0-r1*
* *turtlebot4-simulator 2.0.0-r1*
* *turtlebot4-viz 2.0.0-r1*
* *warehouse-ros-sqlite 1.0.4-r1 --> 1.0.5-r1*
* *zlib-point-cloud-transport 4.0.0-r1 --> 4.0.1-r1*
* *zstd-point-cloud-transport 4.0.0-r1 --> 4.0.1-r1*

Noetic Changes:
---------------
* *dataspeed-pds-lcm 1.0.6-r1*
* *image-transport-codecs 2.3.9-r1 --> 2.4.2-r1*
* *mrpt-apps 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-ekf-slam-2d 0.1.17-r1 --> 0.1.18-r1*
* *mrpt-ekf-slam-3d 0.1.17-r1 --> 0.1.18-r1*
* *mrpt-graphslam-2d 0.1.17-r1 --> 0.1.18-r1*
* *mrpt-icp-slam-2d 0.1.17-r1 --> 0.1.18-r1*
* *mrpt-libapps 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libbase 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libgui 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libhwdrivers 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libmaps 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libmath 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libnav 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libobs 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libopengl 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libposes 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libros-bridge 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libslam 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-libtclap 2.13.7-r4 --> 2.13.7-r5*
* *mrpt-local-obstacles 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-localization 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-map 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-msgs-bridge 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-navigation 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-rawlog 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-rbpf-slam 0.1.17-r1 --> 0.1.18-r1*
* *mrpt-reactivenav2d 1.0.5-r1 --> 1.0.6-r2*
* *mrpt-slam 0.1.17-r1 --> 0.1.18-r1*
* *mrpt-tutorials 1.0.5-r1 --> 1.0.6-r2*
* *mvsim 0.10.0-r1 --> 0.10.0-r2*
* *timed-roslaunch 0.2.0-r1*

Rolling Changes:
----------------
* *ament-black 0.2.5-r1 --> 0.2.6-r1*
* *ament-cmake-black 0.2.5-r1 --> 0.2.6-r1*
* *autoware-lanelet2-extension 0.5.0-r1 --> 0.6.0-r1*
* *autoware-lanelet2-extension-python 0.5.0-r1 --> 0.6.0-r1*
* *draco-point-cloud-transport 5.0.0-r1 --> 5.0.1-r1*
* *ffmpeg-encoder-decoder 1.0.1-r1*
* *joy-teleop 1.5.0-r2 --> 1.5.1-r1*
* *key-teleop 1.5.0-r2 --> 1.5.1-r1*
* *libcamera 0.3.1-r1 --> 0.3.1-r5*
* *liblz4-vendor 0.28.0-r1 --> 0.29.0-r1*
* *marti-can-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-common-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-dbw-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-introspection-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-nav-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-perception-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-sensor-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-status-msgs 1.6.0-r1 --> 1.6.1-r1*
* *marti-visualization-msgs 1.6.0-r1 --> 1.6.1-r1*
* *mcap-vendor 0.28.0-r1 --> 0.29.0-r1*
* *mola-lidar-odometry 0.3.1-r1 --> 0.3.3-r1*
* *mouse-teleop 1.5.0-r2 --> 1.5.1-r1*
* *mrpt-generic-sensor 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-map-server 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-msgs-bridge 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-nav-interfaces 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-navigation 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pf-localization 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-pointcloud-pipeline 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-rawlog 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-reactivenav2d 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-sensor-bumblebee-stereo 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-nmea 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-gnss-novatel 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensor-imu-taobotics 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensorlib 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-sensors 0.2.2-r1 --> 0.2.3-r1*
* *mrpt-tps-astar-planner 2.1.0-r1 --> 2.1.1-r1*
* *mrpt-tutorials 2.1.0-r1 --> 2.1.1-r1*
* *point-cloud-interfaces 5.0.0-r1 --> 5.0.1-r1*
* *point-cloud-transport-plugins 5.0.0-r1 --> 5.0.1-r1*
* *python-mrpt 2.13.7-r1*
* *ros-gz 2.0.0-r1 --> 2.0.1-r1*
* *ros-gz-bridge 2.0.0-r1 --> 2.0.1-r1*
* *ros-gz-image 2.0.0-r1 --> 2.0.1-r1*
* *ros-gz-interfaces 2.0.0-r1 --> 2.0.1-r1*
* *ros-gz-sim 2.0.0-r1 --> 2.0.1-r1*
* *ros-gz-sim-demos 2.0.0-r1 --> 2.0.1-r1*
* *ros2bag 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-compression 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-compression-zstd 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-cpp 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-examples-cpp 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-examples-py 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-interfaces 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-performance-benchmarking 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-performance-benchmarking-msgs 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-py 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-storage 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-storage-default-plugins 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-storage-mcap 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-storage-sqlite3 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-test-common 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-test-msgdefs 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-tests 0.28.0-r1 --> 0.29.0-r1*
* *rosbag2-transport 0.28.0-r1 --> 0.29.0-r1*
* *rqt-bag 2.0.0-r1 --> 2.0.1-r1*
* *rqt-bag-plugins 2.0.0-r1 --> 2.0.1-r1*
* *shared-queues-vendor 0.28.0-r1 --> 0.29.0-r1*
* *sqlite3-vendor 0.28.0-r1 --> 0.29.0-r1*
* *teleop-tools 1.5.0-r2 --> 1.5.1-r1*
* *teleop-tools-msgs 1.5.0-r2 --> 1.5.1-r1*
* *test-ros-gz-bridge 2.0.0-r1 --> 2.0.1-r1*
* *topic-tools 1.3.0-r2 --> 1.4.0-r1*
* *topic-tools-interfaces 1.3.0-r2 --> 1.4.0-r1*
* *turtle-nest 1.0.2-r1*
* *warehouse-ros-sqlite 1.0.4-r1 --> 1.0.5-r1*
* *zlib-point-cloud-transport 5.0.0-r1 --> 5.0.1-r1*
* *zstd-point-cloud-transport 5.0.0-r1 --> 5.0.1-r1*
* *zstd-vendor 0.28.0-r1 --> 0.29.0-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] protobuf-compiler-grpc
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-influxdb
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-seaborn
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

