### PR TITLE
flake.nix: Expose all top-level packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,8 @@
         overlays = [ self.overlays.default ];
       };
     in {
-      legacyPackages = pkgs.rosPackages;
+      legacyPackages = (intersectAttrs (self.overlays.default null pkgs) pkgs)
+                       // pkgs.rosPackages;
 
       devShells = {
         example-turtlebot3-gazebo = import ./examples/turtlebot3-gazebo.nix { inherit pkgs; };


### PR DESCRIPTION
Previously, the `legacyPackages` output contained only the content of the `rosPackages` attribute, but things like `colcon`, `superflore` or `gazebo` were not available there.

With this change, we expose all packages defined in `pkgs/default.nix` as well as the `rosPackages` attribute. This is the same as when using just `default.nix` without flakes. This means that one can simply use

    nix shell .#colcon

to have `colcon` command available.

To maintain backward compatibility, we still keep ROS distro package sets at the top level. Therefore, the same ROS package is available at two places. For example, `ros-core` from humble is available as:

- `.#humble.ros-core` (before and after this commit)
- `.#rosPackages.humble.ros-core` (after this commit)