### PR TITLE
OpenNI2 fixes

### DIFF
--- a/pkgs/openni2/default.nix
+++ b/pkgs/openni2/default.nix
@@ -40,6 +40,10 @@ in clangStdenv.mkDerivation rec {
     sed -e "s%/etc/udev/rules.d/%$out/etc/udev/rules.d/%" \
       -e s%exit%% \
       -i Packaging/Linux/install.sh
+    substituteInPlace Source/Drivers/PS1080/Sensor/Bayer.cpp \
+      --replace-fail 'register ' ""
+    substituteInPlace ThirdParty/GL/glh/glh_linear.h \
+      --replace-fail 'register ' ""
   '';
 
   makeFlags = [ "CFG=Release" "ALLOW_WARNINGS=1" ];

--- a/pkgs/openni2/default.nix
+++ b/pkgs/openni2/default.nix
@@ -11,7 +11,7 @@ in clangStdenv.mkDerivation rec {
   version = "2.2.0.33";
 
   src = fetchFromGitHub {
-    owner = "OpenNI";
+    owner = "structureio";
     repo = "OpenNI2";
     rev = "ca2cdcf39d49332fa9462188a952ff9953e9e1d9";
     sha256 = "0mfnyzpq53wnzgjfx91xcbx0nrl0lp1vrk1rk20a3gb3kshsr675";

--- a/pkgs/openni2/default.nix
+++ b/pkgs/openni2/default.nix
@@ -1,5 +1,5 @@
 { lib, clangStdenv, fetchurl, fetchFromGitHub, libusb1, jdk, python3, doxygen
-, libGLU, xorg, freeglut }:
+, libGLU, xorg, freeglut, fetchDebianPatch, libjpeg }:
 
 let
   libopenni2_pc = fetchurl {
@@ -17,8 +17,17 @@ in clangStdenv.mkDerivation rec {
     sha256 = "0mfnyzpq53wnzgjfx91xcbx0nrl0lp1vrk1rk20a3gb3kshsr675";
   };
 
+  patches = [
+    (fetchDebianPatch {
+      inherit pname;
+      version = "${version}+dfsg-18";
+      patch = "0003-Use-system-wide-libjpeg.patch";
+      hash = "sha256-Y4K70tqmbQDIsNCau/XZyNJL5RfBa/VW6xG5+M6XW6Q=";
+    })
+  ];
+
   nativeBuildInputs = [ jdk python3 doxygen ];
-  buildInputs = [ libusb1 libGLU xorg.libX11 freeglut ];
+  buildInputs = [ libusb1 libGLU xorg.libX11 freeglut libjpeg ];
 
   outputs = [ "out" "doc" ];
 


### PR DESCRIPTION
Some ROS packages depend on OpenNI2, which fails to build. I have no clue what it is and it seems unmaintained (at least by upstream), but to be able to build the depending packages, I collected a few fixes which make it build again.