### PR TITLE
Reduce the number of systems offered by the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     with nixpkgs.lib;
     with flake-utils.lib;
-    eachSystem allSystems (system: let
+    eachSystem systems.flakeExposed (system: let
       pkgs = import nixpkgs {
         inherit system;
         overlays = [ self.overlays.default ];


### PR DESCRIPTION
This gets rid of evaluation error for armv7a-darwin. It makes no sense to support this platform in this overlay. According to the discussion around around https://github.com/NixOS/nixpkgs/pull/324155#issuecomment-2362297603, it is better to support just the systems exposed by the nixpkgs flake.

Currently, these are:
- aarch64-darwin
- aarch64-linux
- armv6l-linux
- armv7l-linux
- i686-linux
- powerpc64le-linux
- riscv64-linux
- x86_64-darwin
- x86_64-freebsd
- 86_64-linux

Closes #484