### PR TITLE
rosdistro sync, Fri Sep 20 13:28:27 2024

### DIFF
--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "f15c855cbbd494261ddda4f47f42d8f2da8bcd493ad9e150241986dcb93c7d2a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "c114217ffddf6a4ea7b30682e58fa733091beec0e4fce2dd1311dc231eebc4fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "0.1.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "55445dbd03483852c595a8e3bf0ded6097d39bbd2fada7ee44543219dc43326a";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9fde631240bd6f010b038d8fa8557d4ef3e8c5e01161f8e64485a919e5be3f28";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.2.11-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "e9220859ea12b41f0b52b21b5c5c03a0cd287bf8e15753fc1bef06b191ca6011";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "3315603c128d071ec3aabd7c53bc3fb3735f312f84ec1834d45233a490db2519";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "467cdd59b91f37341dd1e19d65344f342c2fa39e589467c0ef4776b9019bcfc4";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3ec02c17e04b6d34f4e5f6d5c65762a4653cab349a174fd5feaed133ebbe395c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ controller-manager diff-drive-controller imu-filter-madgwick interactive-marker-twist-server joint-state-broadcaster joint-trajectory-controller joy-linux robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
+  propagatedBuildInputs = [ clearpath-mecanum-drive-controller controller-manager diff-drive-controller imu-filter-madgwick interactive-marker-twist-server joint-state-broadcaster joint-trajectory-controller joy-linux robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "525b443d122be96c0ae8c2035ee37fe14350e34a688b1b99e5dee430aea35311";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "34df0fb4a43f2f1c6848003417bfef05050ec91ccb06419f7d9c8209264aac33";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "f614e1447194193b6018ef2dd0e38f66ddfd683416b27a1d1c7fbe286eb8b8d2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "528a5d77ab4d38430dc58ac9371879377f7735ce8ca88b47735491982de3cce6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "0.1.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "24e5572aba43dbddd2cc28769c0fc0ae449b57367ca54d82cc3e55bf1e9a5925";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1c20de72609fca45d7a58d1c0a19331a08c3aa996d669901991bbb89c1892c38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-platform, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "65edc295a783b9df2b6d0bdd7c8267b1de3b6149a4db17e81c65495683891330";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "f845fc2b309c71c4877c6b4cc2574526ad544c8129c8ad56dd37f95d3bc61a80";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake moveit-setup-srdf-plugins ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ clearpath-config clearpath-control clearpath-description clearpath-platform ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.2.6-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "74d6401db3514b9cdcb58e3caf7a002da7b78c0d70d1edcb320855f6109902df";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "17c6bfcc0a52d2a0dc76fe64014a771ee6337fb9d614f00a03fcc45f35d221a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.2.6-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "459099e99e86b4ff6d8aa5879b02cdfa55c95d0b4842652dd1a3726d38d8fd3b";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3bcdcd0214a869e03b6c777dc07a690dcdb3b1c2a1a62b7d7b9ce1bd5236234c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, kortex-description, robot-state-publisher, robotiq-description, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-manipulators-description";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "7dac9d13776d6418527fd2f2f3e7ccf6961f16f3c7935067c80da74db5f8ed57";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ kortex-description robot-state-publisher robotiq-description urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath manipulator URDF descriptions";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-manipulators";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "521938cb0adf533038b303c093e518e9ff7813ece74653ac81c06f3fce78e5ab";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-manipulators-description gripper-controllers moveit-configs-utils moveit-kinematics moveit-planners moveit-planners-chomp moveit-ros-move-group moveit-ros-warehouse moveit-simple-controller-manager position-controllers tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "MoveIt configuration built around Clearpath Configuration";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "384cf581494129ed1ea1d174089b7d93fd90e583330433389726abe50dbfff25";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "25f55e7b140166fd439c1249f92e7e66c0390851ada6a9238678b2513b4a9393";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-msgs/default.nix
+++ b/distros/humble/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-msgs";
-  version = "0.2.0-r1";
+  version = "0.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "506e283e487c92b5dbe7c7b38fdb9ccbe2123cc28f4447ab24a958df0e07cd66";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "68a1d94888e10affea8bd632ae7b3b307d25a01d7ea9d6a2f81a85774d95ae22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "78082e485fbad1a71a2c0329338d283e4f50ad7da27beaad9157b7353ee45d2a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b91cfd091ff7d637db6e340dce3d916b0c1fb94291677494183b4d66c99b1cb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-msgs/default.nix
+++ b/distros/humble/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-msgs";
-  version = "0.2.0-r1";
+  version = "0.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "ef0a5b9cabf444a95e969b31444587f9a3ab00855d5080114c5838b8fdca69f7";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "a5b33324a41d0bc08a872777b0148786b9ba14e9ac48441fcbc60dd0b258eb12";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, puma-motor-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "f599cc2b0dd44e7f80adc64eed34aed29ece2d03cc46ee5cdc4dee5439632590";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "e2701683435de54f0fd720055564d5a1907381cfe1b222d35e3bf68e0bd64bcc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-control clearpath-platform-description clearpath-platform-msgs controller-interface controller-manager controller-manager-msgs geometry-msgs hardware-interface nav-msgs pluginlib rclcpp sensor-msgs std-msgs std-srvs tf2 tf2-ros xacro ];
+  propagatedBuildInputs = [ clearpath-control clearpath-platform-description clearpath-platform-msgs controller-interface controller-manager controller-manager-msgs geometry-msgs hardware-interface nav-msgs pluginlib puma-motor-msgs rclcpp sensor-msgs std-msgs std-srvs tf2 tf2-ros xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.2.11-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "1cb5d7a8192a2d749353d5bc9e1955525a4d87838d3ad3a32d6c22567ec798cb";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "40d8eed078f2af95a6f57365284316373e086c5b1541d068cc1944b024a82ef6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.2.6-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.2.6-1.tar.gz";
-    name = "0.2.6-1.tar.gz";
-    sha256 = "96b9b0c9366af9ea214e2e634603b39a241a7629238e7fdee09f6cb53af658bc";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "d3af91b4d468db5890ab459ecabca1661f2b7f0b0b4db7935c74ce46af238d0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "0.1.2-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "9fe165c5664e633560c10045783c283f92fd598ec79189a6d747f182ee27992f";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b5727670409dd096cd9420e63d691ee495fd5ce35d78646089acae231310ae73";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-compressed-video-transport/default.nix
+++ b/distros/humble/foxglove-compressed-video-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-foxglove-compressed-video-transport";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/humble/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a04b755b1b120b782ef9b79aa2d4266494b891490f08b6d7cd1b0e3a73057b48";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ffmpeg-encoder-decoder foxglove-msgs image-transport pluginlib rclcpp rcutils sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
+
+  meta = {
+    description = "foxglove_compressed_video_transport provides a plugin to image_transport for
+    transparently sending an image stream encoded in foxglove compressed video packets.";
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/humble/gazebo-ros2-control-demos/default.nix
+++ b/distros/humble/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control-demos";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "af0fa2c0bd0441b2bb9709c4d599a8760a4496c2ce6e837dbce3f0c3c3e68efd";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control_demos/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "480d9eb3d9d77da9b28d09733715c7de01505b7c67cfe55fa6810fa50e833910";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/gazebo-ros2-control/default.nix
+++ b/distros/humble/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-toolbox, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-gazebo-ros2-control";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "98d363f647a579306c76f10a1a900bca8887c5c2372e9a525424f61ac1600f76";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/humble/gazebo_ros2_control/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "0fd779c3ee60c43b5507fa9a3c4c46f00362397502afa360789e6d73184e5ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -448,6 +448,10 @@ self: super: {
 
  clearpath-gz = self.callPackage ./clearpath-gz {};
 
+ clearpath-manipulators = self.callPackage ./clearpath-manipulators {};
+
+ clearpath-manipulators-description = self.callPackage ./clearpath-manipulators-description {};
+
  clearpath-mecanum-drive-controller = self.callPackage ./clearpath-mecanum-drive-controller {};
 
  clearpath-mounts-description = self.callPackage ./clearpath-mounts-description {};
@@ -959,6 +963,8 @@ self: super: {
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
  foxglove-bridge = self.callPackage ./foxglove-bridge {};
+
+ foxglove-compressed-video-transport = self.callPackage ./foxglove-compressed-video-transport {};
 
  foxglove-msgs = self.callPackage ./foxglove-msgs {};
 
@@ -1681,8 +1687,6 @@ self: super: {
  mqtt-client = self.callPackage ./mqtt-client {};
 
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
-
- mrpt2 = self.callPackage ./mrpt2 {};
 
  mrpt-apps = self.callPackage ./mrpt-apps {};
 

--- a/distros/humble/hri-rviz/default.nix
+++ b/distros/humble/hri-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, cv-bridge, hri, hri-msgs, rclcpp, rcpputils, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-hri-rviz";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/humble/hri_rviz/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "58a29b2f2c8119921bf0d45abf3a32348c5263ded73bbae53b6f44e2dd11183a";
+    url = "https://github.com/ros4hri/hri_rviz-release/archive/release/humble/hri_rviz/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "af23a87890a63829488935aba4e8e6f3d2235f80df317a1c005f34b374324885";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "46a83c804639a071b06a484028b7efb64838743b7ef01b0bacc7e0e98a859c54";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a23c8f375a3c40481918dc8cac67ce854e834131d71d6609444de66c8742cca7";
   };
 
   buildType = "cmake";

--- a/distros/humble/launch-pal/default.nix
+++ b/distros/humble/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-pal";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "990c236839599a0b4f22661829c408b09f76c6ad0b2a78ba535b72a0a16d0150";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/humble/launch_pal/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "2b2d68f787b7f1f6f991ad3dd4ad8272de118b3279f17692d91a578ccb3abf06";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mapviz-interfaces/default.nix
+++ b/distros/humble/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mapviz-interfaces";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "9f9625dca062343192c247a5af574c40e6574727e366f26afffc67af52c61e4b";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_interfaces/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "ce2becefeff42485a8eb9b6d9a5ea3408a46c066e4294eccf30dbfa3c23ebe4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz-plugins/default.nix
+++ b/distros/humble/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-mapviz-plugins";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "1d106db87053eeb26a7b32dffaad6a644236c1ca7ba88b95404fa46740fbee5e";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz_plugins/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "874f3888798afa2ae43a6bfac62cc97581220666308f48b1794b6c53508f2211";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mapviz/default.nix
+++ b/distros/humble/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-mapviz";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "1cf1e58008eb4a3be39ff60733c8c4c3e381be165f46ffe66e74a034125711de";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/mapviz/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "5a1ec4839fd4a5c6cf9d1c012e683151bc3e74c1de7329c364ce7fa16d11b933";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "491cde12535798f842491a7719bb688151fc8a6685112ef181c9563b3bad5635";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d8256558ff03d086214482a574ce1502f14b4f3d77b3cd8f4905b86a6b357d62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "17ea44f92aeca6a1b65f8aa5b4a4dedf864402ed5b2ffae48e7b0832d375925b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d5a263d0b84aa67d60fd5aed9df6f49013df2d76b6349a4751e801c0ad004169";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "4511646ee7948778ec897391be86cabb1f2f7ba056c8f368e2f41aa219577323";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8f131c3d916eed6fee3a7007ffb4fd2c3c0a59030eb0a7ffe6633b28eeb1cfd8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "aab52d3713a9a98118365f469212fe69d0a08641d9b8a2abc74b0905fd1c6395";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e2dab012f69029c0e774a905cd93d0710c4c65ad7dbcdca27fc76a8aee207510";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "fd014bdf3f81f2d32f87cbdf6704b32d4da19fa12c5898b4eec1a1e1e3e2cdaf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5d6120655acb9d75d482737cdb44aa86ec2e6b280daa8fd7e635de81ed2760aa";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e04ca6266042acc545584f2efabddf66be93557151762110da20d8f5958341de";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7a69e8893d70e9fa86df2d69aaca82375ac89011088558b04f1a5fcc69dfda46";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "46537e157eb46806bdd1eb6faee7c9b605da14060c21e77afe45402c0940bd7b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5cdfa8a6acaaf9b032b0177e98c0155da5bde9c8cbfbd2b093084c5102cf2155";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ffbf9a314f5a49f94a5aabeb8fdc5f17e199654529b0351f44011d374de611c7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7ec7322991724071e99fe790f537d9112593d64772e8336b3631bc6b9137bb32";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "f3ff9ccde167aa2390d78fd94f31ce8d4d9c095c06cf86cefd507ab73003539e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8f56aade81c8c6451ddaa293341bc5f599736f29bcfbb7108f728b9733194a73";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9fa1e491404089381d2bbad779acae352cfed284b0d6af039ef68411cb0622e9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e093fc6b4ee3bedcfd5ed5f15a502c900afd53c291ab2aed137b8fcbd08b1d90";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "3b91485a5b4852b643185c5949be419daa8fd58d41ca6298086ebdbc85e0f6f7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ecad2db872a57c2e465eb4a2981820a7b46adcc9cff6efcbe479b8cfbadcb2ec";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "5963ed945c2656916f675ea0c51b187ce9e923542cd6b814b7b4b5ade2633743";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7e8be5f4817216cb9a47500e48e65a5aef200b06ab0f4b56ba05079770a83d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt-libmaps, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "11f1f73360a70d67d1c2c6dd26800e24de0ce594d9ca44c472c9aaed6b4103fb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e2645a0c7c3b4101744367651b1d357240dd40ca2a1038dc1c3566cc2ad4ae31";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ mola-common mrpt-libmaps ];
+  propagatedBuildInputs = [ mola-common mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "70740cac25adc317d1bede42d75c1283e51aa1345134a7fa5f41003b37eaacb6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "1f53459ad9a885d4e60852d0cbd6442b873cf7970d9fb98cc99ff86b38860225";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-navstate-fg/default.nix
+++ b/distros/humble/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fg";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fg/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ed3f4fdf8af900dca0b35dff4f8cfabc9918c45a76d8f0d222ed4f40f5b0e580";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fg/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "6e64aced428076b508fa55cab6accfff163728d94ac8691d2f2bfdd7d3e9710d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-navstate-fuse/default.nix
+++ b/distros/humble/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-navstate-fuse";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a929268d6abcb4dd106caab8121047436d546ae4f1423687c63bc01874cdc60b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_navstate_fuse/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f33f504d55b4240457e739260aaf5d560ee1f3564358bb8b8b588952d363b258";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b19caabc8fa9277f3b9f4ccc6f86cdef44903345c3ad2440c46c7285b082705a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "675b2b124decd288bf30bc19900e2b48bfc5f1a5ddfab1abe0e0213b6de59ccc";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ad5c4e3907bf06451bd9921d97420c62b6609e2a7127d13e125c6aeb0f4f084c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4ab74b52e38b18b0522a8d391503b6404e4a00b6a336911e83e7e07e7bb2d54f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "07e954c93eac76e7a9ea1693165a34de1ad89e6adee4b89d15a3697dd72363c9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2fb9e4c07358e5f3b0f8a08a3c7d69ac225c4a9f392464cb69c0d97f0a6b4a2c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "6bb3c9925e9c16ca3fb8a7665e892b8be2ece99d2cea3eeb5516528275eaeecd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "478c379a9fba1b10757e9b92efa9c73d759d3dafd57050a2c3bb0b56a385a064";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "d2b8dc9d07e97faef2f2ee1243c10694de0bc1e78cbd1d9e2d327773f246a409";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e7bf3fb5f90b88c3546301955bc4aa572d5b955d4c0dd3a608b2f16b8cf44b3f";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c691b57751eeda6bf530e0b1661d581aa2dc80a4a14dd2535479c80f83fa9f38";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9556a836e319bff90adbf28d534c38f7738a28a90cedf7e4a157665ee1f9f51d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, tbb_2021_11 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.6.0-r2";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.6.0-2.tar.gz";
-    name = "1.6.0-2.tar.gz";
-    sha256 = "23c368a8c9ef7413d1bb8cd69800d12e2407938640c52d8bdf3bbb25142aa1aa";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "2710e815430ec4d9986e246c9c0ee403d91dd9e06dd4322a1fd5e88756a4e3de";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildInputs = [ ament-cmake cmake ros-environment ];
   propagatedBuildInputs = [ mola-common mrpt-libbase mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libposes mrpt-libtclap tbb_2021_11 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {
     description = "A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++";

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "2f823d15b3ef957a298af2685f18083a82531dbd2cdd4d4603e4f554f6a2f953";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "7a92480c96d7376453f7ca8b45621f60e4643967b6440492fca6c113f2594406";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "12afba13dfd16f1c2f2a826f99d031294e11781b290cf0efdb9d775ecdef841b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6b0beb729b557b57920324892997e26f3ab8058fe0c5b77a4a61a161271c627c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "7890a52ef3628adda16b4a0d14e2d942ebbb16695303d17f872a7f778195a889";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "597594bdf3b0c545089f007baae6eb9a9024997acb2d4e2a9b39a7922f3720d9";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tbb_2021_11 tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "604b8eb7b320c8665b6eb2d7b1645139af88e72044ee4868bfba5dc87e9a893c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "678991d2424300e452f2961abd45fc7a6cbe908084146dffb11c3fe8d79d8aa4";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "5e26e25e27ee6f48c0e93445180ca46654abda10f00f52b939adadf798b944cb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "30ebfacc9a8f6e8c6a8474e771d96c219391fd3cf31957e7b311d1883cd31aaf";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "a6c6af6625457f96cb7188d99b94220b81a1bf419709d6ffc7a373e9ff86250e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "9c7875c0bfb940c6054f867e4e4c7252c90bb792f12e9b91db79288e8bc0d254";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "9d2b75f6c68356aeaee31de6735b6ad8b95e9285e82b130a3ea48e74099c4a44";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "869b43b3a40dc7ee465c4709b204ab137ebc3dc4b6c0175ba77f282de8d7b288";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "90cc54db7d2c8e6b87b42606266ac811be3c0df6b36274cd6e9d79bd214425aa";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1a1e49a2d493700022d67b65b7271053696e9b4dda059014fe992278dabc7582";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "26867c58847f4975ccc4b6b04f57c1f4f0dceb3f01484cc42104e07fefc50efe";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c5627a93b15a5844eebe2e043cc5d49c4c36ce6a4246ef0a0c9b549e955ec738";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "1744dc0686bfff19f6c9d84a9e4575a218d89d74183e3e71b0d52f9458c0c08a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c7e3928c381c9b223d7fc767ce8ef5235b474ef03f3754d026f8f2b1a9d2d739";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "b017f025f0c6ebcfa0a3fda4c9cbd3d053451b2c906284023015425536285c94";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6a61c44c6dfae1347f94bc8818fa622dbd318d7dc6b789cc4cca7f0bc7c6f54a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libros-bridge/default.nix
+++ b/distros/humble/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros-bridge";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "62c3c9359a561e73acb31fd824f993691fa31f1091197f87759ed3f5a4468b7e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "40f22bb9b2dc67c8478f52503e5f9e07367c9ae049b1e6cf769348fcc325aaef";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "bdd7955194efd20866210bd96aefb3c4d920005f045a6f86b73354c4c92294cb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f75414b42e309c1df9092783ba0d15283ea20089fd06971759f5f8b86977d06f";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
-  propagatedBuildInputs = [ mrpt-libmaps ];
+  propagatedBuildInputs = [ mrpt-libmaps tbb_2021_11 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "bd42c4ba9f5d74ba4d0a040530a909aceb5f3cea5d937cb83378fdc0336bff71";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f2183b58de226071fb3debf868be7feae33687456677f88adca689a0eb7f272c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-path-planning/default.nix
+++ b/distros/humble/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-humble-mrpt-path-planning";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "bd2f9a854bd286916f36fb2b9ac489c8ca730863d15fc4fecf42a5d7bde241cc";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "45463691cf4176657bd25fa1252bf5d3fdc27757e5559722422b1add49d75f70";
   };
 
   buildType = "cmake";

--- a/distros/humble/multires-image/default.nix
+++ b/distros/humble/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, gps-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-humble-multires-image";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "de5f94d21d596ebcdf40901a64f881afa62bc46bbee830e8f78f60aeb0574569";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/multires_image/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "eb8ee6fa5a83555031a0772733512e36ed4d297fb21e39d9c2c8f3ff63efce8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-2dnav/default.nix
+++ b/distros/humble/omni-base-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, nav2-bringup, omni-base-laser-sensors, pal-maps, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-omni-base-2dnav";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "1b9b410c4d2904f466303d59027ff75eebe2ea692ce7c000ef5eba5ae6d89898";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_2dnav/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "31033c8f5de1879a0b7ce02977538bdad08efaf35f506031f5ba59739b2d4a0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-bringup/default.nix
+++ b/distros/humble/omni-base-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy-linux, joy-teleop, launch-pal, omni-base-controller-configuration, omni-base-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-omni-base-bringup";
-  version = "2.2.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e3671d16e3e668a7aa57ac9aa0a36e5177532223540420f85189bddfd8452603";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_bringup/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5295ca280723a30bbb531ea0f5aeb347ede13a2a56f0099bfdd4a49eda41eab1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-controller-configuration/default.nix
+++ b/distros/humble/omni-base-controller-configuration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, imu-sensor-broadcaster, joint-state-broadcaster, ros2controlcli }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, imu-sensor-broadcaster, joint-state-broadcaster, ros2controlcli, topic-tools }:
 buildRosPackage {
   pname = "ros-humble-omni-base-controller-configuration";
-  version = "2.2.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "16150eace15393c22df946a17750b8f1772441768d949914c2937840b42ab876";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_controller_configuration/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "cf82f54b6f9bc466bb38f6a9abe2b2387e7f803aae4292779352daffc914a042";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ controller-manager imu-sensor-broadcaster joint-state-broadcaster ros2controlcli ];
+  propagatedBuildInputs = [ controller-manager imu-sensor-broadcaster joint-state-broadcaster ros2controlcli topic-tools ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/omni-base-description/default.nix
+++ b/distros/humble/omni-base-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, gazebo-planar-move-plugin, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, realsense2-description, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-omni-base-description";
-  version = "2.2.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4711c18339ce893fb797d037e5184a5f4b937473811833cbcfc7d2c3900a1062";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_description/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d84168b381adadce0418b8b39c41ce8d4295afec2bcc198092298674f56b21e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-gazebo/default.nix
+++ b/distros/humble/omni-base-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, omni-base-2dnav, omni-base-bringup, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-humble-omni-base-gazebo";
-  version = "2.0.9-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.0.9-1.tar.gz";
-    name = "2.0.9-1.tar.gz";
-    sha256 = "01fe43f9c3c7fd67a67912369ac7805d293dc7e2cbb61349d9cfeef54fcb6fa2";
+    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_gazebo/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6b729ed1b82794072de36a353d3e095971017b011dfc3e4bdc2e37327c8a6da5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-laser-sensors/default.nix
+++ b/distros/humble/omni-base-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-omni-base-laser-sensors";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "4e32afe60a0468e60e7beeac797685a0e46a9034a5054541fcb38e77cdbe88d0";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_laser_sensors/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "7d3e70a48c774b53870ca10e66f15a06b9d51561f76d1eb55aecad449030ed3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-navigation/default.nix
+++ b/distros/humble/omni-base-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-2dnav, omni-base-laser-sensors, omni-base-rgbd-sensors }:
 buildRosPackage {
   pname = "ros-humble-omni-base-navigation";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "680de37dbcd61657a2fb733f7078894ef295cbc0e43714dffe7b8dccf64ebcef";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_navigation/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e79a3d62e8772e7eb4833e745cc94a702b3a4b35dfbf05fdfecc7fd7cf79102a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-rgbd-sensors/default.nix
+++ b/distros/humble/omni-base-rgbd-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-omni-base-rgbd-sensors";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a47dec86e5fcb1e0dce3afb9686e825a85949f9aaefedc11aaa8288dc44304a0";
+    url = "https://github.com/pal-gbp/omni_base_navigation-release/archive/release/humble/omni_base_rgbd_sensors/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "b1acfe76143e1b3e3e2655f521a9e51d26e2b78afb1efa401acefdaac8c39bd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-robot/default.nix
+++ b/distros/humble/omni-base-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-bringup, omni-base-controller-configuration, omni-base-description }:
 buildRosPackage {
   pname = "ros-humble-omni-base-robot";
-  version = "2.2.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2c5ed3346a80c7bee073213968e85219a946d450bf35465e4170c3c4e9181525";
+    url = "https://github.com/pal-gbp/omni_base_robot-release/archive/release/humble/omni_base_robot/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "2179e54cdbd4f4f16f271a404d90c9f8dbfc6b1e84d62b14fa37565167ca995d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/omni-base-simulation/default.nix
+++ b/distros/humble/omni-base-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, omni-base-gazebo }:
 buildRosPackage {
   pname = "ros-humble-omni-base-simulation";
-  version = "2.0.9-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.0.9-1.tar.gz";
-    name = "2.0.9-1.tar.gz";
-    sha256 = "269e2cce64189cfeed1685b72a7134724035d87120cc8f3b8350023f593aaef3";
+    url = "https://github.com/pal-gbp/omni_base_simulation-release/archive/release/humble/omni_base_simulation/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6e30ea7d1ffd5885dab57f8aaae92add387c3135a0980914de4cda7bce18a350";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gazebo-worlds/default.nix
+++ b/distros/humble/pal-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-pal-gazebo-worlds";
-  version = "4.0.4-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release/archive/release/humble/pal_gazebo_worlds/4.0.4-1.tar.gz";
-    name = "4.0.4-1.tar.gz";
-    sha256 = "756704a33ef1e4000bfe667ff2c56bc7a6c0b50db79579d493131d8878d309bd";
+    url = "https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release/archive/release/humble/pal_gazebo_worlds/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "dee25b1a7adce511c32314b827d3cf9c1da46dec014e081c70637bb1f91f28da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics-msgs";
-  version = "2.2.4-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "ef2cc6b26c4270c96aef723ea9c93967d5f128d3b74e3a62940e4bcf40672f06";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "600934b5250715d9b74df44c67e7fe478bac9600a7cfba0b8822da415a45d926";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics";
-  version = "2.2.4-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "c999b1b19fe231f20bf5a69659a533a19a0888b72d90b8a80a6d6a82fb9576d5";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "edeefd7bb10b75730fed43cf05b2d09a848acb696c1f1a5580c3e71e774f8338";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  buildInputs = [ ament-cmake-auto ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclcpp-lifecycle rclpy ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 
   meta = {
     description = "The pal_statistics package";

--- a/distros/humble/play-motion2-msgs/default.nix
+++ b/distros/humble/play-motion2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-msgs";
-  version = "1.1.2-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "e60c78ea2f2a3c09db96adb52f2edc78675584539e155742f9f5918bb602331f";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "14180b79ec6eb039349034cd9376d7ce1957d9f3285b48e6df88dd52165fb48d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2/default.nix
+++ b/distros/humble/play-motion2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, sensor-msgs, trajectory-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-play-motion2";
-  version = "1.1.2-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "0cc3e94146ec680961a365e0affe11443a1259ee8916fc75851b1527cb3d0bfa";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0ad3fa0dac28d73b774170b98b3366ea2b20bf9bf6aeef5643d471dde52d104b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common controller-manager hardware-interface joint-state-broadcaster joint-trajectory-controller launch-pal launch-testing-ament-cmake pluginlib robot-state-publisher xacro ];
-  propagatedBuildInputs = [ control-msgs controller-manager-msgs launch launch-ros lifecycle-msgs moveit-ros-planning-interface play-motion2-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs launch launch-ros lifecycle-msgs moveit-ros-planning-interface play-motion2-msgs rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, pmb2-laser-sensors, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "4.1.1-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "7f8b1cfabd981e015fddf409c265242dbac301bf24a8daf2938ab1a717eed7bd";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "436c00ec1ff4e4c3b8b243ae09ba8a85628f5e3b25be8882770d13cac961f0e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "5.1.2-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.1.2-1.tar.gz";
-    name = "5.1.2-1.tar.gz";
-    sha256 = "c235c2f04b5a1d24b980b55777e544ebed5fd84afb8601883d9dbb97cec13b9a";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "17f371218b741b918100be8710535a02338c5e520872f0e87d61fe7164aa42e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "5.1.2-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.1.2-1.tar.gz";
-    name = "5.1.2-1.tar.gz";
-    sha256 = "04852040c1ed4160093fd0714b201aeac739913e244ab265d5591a875735b2cf";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "5c1e7415128ccb60faa1758d07f65bc51864aea2a077daccef2cf9ac384d1b18";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "5.1.2-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.1.2-1.tar.gz";
-    name = "5.1.2-1.tar.gz";
-    sha256 = "5cc4358552c2d612a95ea8fadfd376ea1d1533bd065790d89404f9ff2f2c2577";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "87beca3b83442ed5a4cfda57c0b3bf1c4d91b183a5ab2e12ad862ef488ee0a7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-pmb2-laser-sensors";
-  version = "4.1.1-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "abb115a7a8716c92e737b1a1b6f4f512b3ca1d9f1de760660719adb96a293c8c";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "4fa82af71ec2e8673b8aee2b51ea316b20198485e960b9bab06fa79ea63768c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "4.1.1-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "6c3901a9b9e8108e0d3cfa03b68fef630d559ef2b0e8ebdab5d29e9167697396";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "3a041989b9061d2213359fe6f6a7e3d23285ba168922e03a91cd7d9a119065cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "5.1.2-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.1.2-1.tar.gz";
-    name = "5.1.2-1.tar.gz";
-    sha256 = "cf412d3a274cdf25c4097aad7ef20da8c2ce25b6666cdf8c4cd932b05d186c09";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "1e738352ef333595044f422235977d71520e318395ad5a2ce14e40066c469677";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/polygon-demos/default.nix
+++ b/distros/humble/polygon-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, color-util, geometry-msgs, polygon-msgs, polygon-rviz-plugins, polygon-utils, rclcpp, rviz-common, rviz-default-plugins, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-polygon-demos";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_demos/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "f21943b9241a4738e01055587cefc767ecfbe5df3322f2a437645d7282b06127";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6075e07bea7be3b92a278d7f92c6ea25d7ba9a4360db7d45fa16e4ed74fbf51f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/polygon-msgs/default.nix
+++ b/distros/humble/polygon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-polygon-msgs";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0c25d241f9a001906a4d59d62f94fbe132fdf97feda4a749c601349667957002";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ff9d2af0b47297dbd9ef166652c3959ad10bfe7d2640f8693fd2998608ec38f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/polygon-rviz-plugins/default.nix
+++ b/distros/humble/polygon-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, color-util, geometry-msgs, pluginlib, polygon-msgs, polygon-utils, rviz-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-polygon-rviz-plugins";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_rviz_plugins/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "f66f9b02b0abddfd0f7d251b7c9af425530f781bc20dfc69621f07a785abf257";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_rviz_plugins/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3e4405797fd4a2c09f1e1d3145d53a27bd41c18fc5a6e408e09b92f59ce11e90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/polygon-utils/default.nix
+++ b/distros/humble/polygon-utils/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, polygon-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, geometry-msgs, polygon-msgs, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-polygon-utils";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_utils/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b54f35d9f5ffaf46684c6621270b5ae0f796b9298152bb8be3b4b7172a575cab";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/humble/polygon_utils/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "1d5b2a5613986b493eb2d4b23b98f6baa2697a87793c2116dd1d25067062c13c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ geometry-msgs polygon-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ];
+  propagatedBuildInputs = [ geometry-msgs polygon-msgs python3Packages.shapely ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Utilities for working with polygons, including triangulation";

--- a/distros/humble/python-mrpt/default.nix
+++ b/distros/humble/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-python-mrpt";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/humble/python_mrpt/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "38d2374b6f2dab475ba49cbd0400e735693ac10cf9d1ccbd5f90b8ad9066590f";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/humble/python_mrpt/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "07b8382d8de180745f849d6dded3f1209392266c94cd208fa37c3f6a586db92a";
   };
 
   buildType = "cmake";

--- a/distros/humble/swri-cli-tools/default.nix
+++ b/distros/humble/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-humble-swri-cli-tools";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "3ac0f92d82c619ddf0b573ab3679326a3fd5641c0c7ef2d6f69fd8be4f35edb1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "f307cb9abd9ee7b481a9257354f5714eb02147d081491f9ce6987af9286df315";
   };
 
   buildType = "ament_python";

--- a/distros/humble/swri-console-util/default.nix
+++ b/distros/humble/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-console-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "e038cc66a3d7b4e21d43a9ffc7b3633e2735818fd942adf7523c71a22dc6f89d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "ef4fc5e6b1fee7bb035744312e98dc2c670182bdca2d404498809dc8b04cd953";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-dbw-interface/default.nix
+++ b/distros/humble/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-dbw-interface";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "c76f614167612295057abaf11037860b0fd9f8791e08160c8a4015482e892dd1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "3510813a0002f95cf2b368ed6985f8aa3a3fc50056421d9ab8ccdca5ca6c29da";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-geometry-util/default.nix
+++ b/distros/humble/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-geometry-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "09e961e76bf8f9650cf773c2355c11c69710bf73239b6278d9c31a47db1da9d8";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "97638e874cd0f993d2cbd2c9a34f73ae3883e6f3e42a4c91bd86036e3a02e620";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-image-util/default.nix
+++ b/distros/humble/swri-image-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, ros-environment, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-image-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "a0b1d46b87fef02d3f84b9e8d3b3c80e522299b965377bfed10e36adf690c98a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "a5053a45875a9d85827e8df6cf99c17000578274b944538254184c2850b2c061";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config ];
+  buildInputs = [ ament-cmake pkg-config ros-environment ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp boost camera-calibration-parsers cv-bridge eigen geometry-msgs image-geometry image-transport message-filters nav-msgs rclcpp rclcpp-components rclpy std-msgs swri-geometry-util swri-math-util swri-opencv-util swri-roscpp tf2 ];
   nativeBuildInputs = [ ament-cmake pkg-config ];

--- a/distros/humble/swri-math-util/default.nix
+++ b/distros/humble/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-math-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "efc81aa8cbe37a281d79e696fad1fa9db7ec843baab30b5108e6c5e4bffe213c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "128fa61c73cef8139e5a132d951f4b4045d6e2aaad72f0bf08d642d92eb4b498";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-opencv-util/default.nix
+++ b/distros/humble/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-humble-swri-opencv-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "fe8ec301f39f5b6672fd92b73dad7f3185c3a27b6a8b1cab1c0b5715b8944e51";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "333bd8d1ccaa148e67c8f3b8c3bf372e7d1f432fb4992f3e92c03c2a4aa41cf0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-roscpp/default.nix
+++ b/distros/humble/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-swri-roscpp";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "b50aeff6e522709a242fa7fbb51feddc662590be67098cc0e3904b983d57bf8b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "ee61033fbe50e2cf68ba55cedccee8a41cceb34825842629c0abd3c97531bb67";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-route-util/default.nix
+++ b/distros/humble/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-swri-route-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "2ddf49e0605bbcdf8723d0d83f6f5dffab1d1c9429e14b8d31cf92c4b8f72794";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "18c36f294a1fafd886046840bb8c0d3530ea36eee452c7ccf7a92c577d5fedf7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-serial-util/default.nix
+++ b/distros/humble/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-humble-swri-serial-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "80b1f749eb1e6df40e5b8bac58c69fd3672a747b0df7be9edf32f7ab9980fd6e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "2019c3e545ca6e0132a2f07288329773d922baf64835d77dfdd41107344cedad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-system-util/default.nix
+++ b/distros/humble/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-system-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_system_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "4113367bd24d14692fd35f57353be5b4ce916da7c2ac77e95dce13985a36b7ec";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_system_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "aba36865db4d82d4a5edae8a58abebffffa1d740867ca4fd2e5d1b818c70133f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-transform-util/default.nix
+++ b/distros/humble/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-swri-transform-util";
-  version = "3.7.1-r1";
+  version = "3.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "da5163880bd2e57e4dffa87dc9f7e8f74edc2a78de26a88d83ada89ffcb5cb0a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.7.2-1.tar.gz";
+    name = "3.7.2-1.tar.gz";
+    sha256 = "0d2e2cdf7567d75ac92fe027a84f2e808be1a27b8188420a848d67c95210dde1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-2dnav/default.nix
+++ b/distros/humble/tiago-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, ros2launch, rviz2, tiago-description, tiago-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-2dnav";
-  version = "4.1.7-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.1.7-1.tar.gz";
-    name = "4.1.7-1.tar.gz";
-    sha256 = "b2fb3180ab4cc2190419e705b103f87db4bd073e362dc95238974e941243d852";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "b2451cdb7ccec8ff060e0061fcdcf861cba77cc7df04cf85fa040e6a474f5232";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-bringup/default.nix
+++ b/distros/humble/tiago-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, play-motion2, teleop-tools-msgs, tiago-controller-configuration, tiago-description, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-tiago-bringup";
-  version = "4.3.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "008674cc8ed774c6b9658ba0907ea4ce682130ade8535e81a774bb585ad25ae5";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "041cee7b2ee2004d290d657b0b4c3114aeffee8450f939c5f0a1f9e52699d33b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-controller-configuration/default.nix
+++ b/distros/humble/tiago-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, force-torque-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, omni-base-controller-configuration, pal-gripper-controller-configuration, pal-hey5-controller-configuration, pal-robotiq-controller-configuration, pmb2-controller-configuration, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-tiago-controller-configuration";
-  version = "4.3.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "7e8d6ca8fbb97b2bd6280c36c9f092a3d5078685f305ecc3f15646002747bb68";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "8c2fe33798d168a061642a5529d17d0bd69602b65c5e2d25411cb4455d94f68f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-description/default.nix
+++ b/distros/humble/tiago-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gripper-description, pal-hey5-description, pal-robotiq-description, pal-urdf-utils, pmb2-description, robot-state-publisher, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-description";
-  version = "4.3.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "acaa1ad0984b2177fc1078f2fb36e2af7805516a6667aa7d00494acbb855cc8b";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "61efac847b2a34a1af68dbddb05be5f3142d8856fb0e588f769576948462a91b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-gazebo/default.nix
+++ b/distros/humble/tiago-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch, launch-pal, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds, play-motion2-msgs, rclcpp, sensor-msgs, tiago-2dnav, tiago-bringup, tiago-description, tiago-moveit-config }:
 buildRosPackage {
   pname = "ros-humble-tiago-gazebo";
-  version = "4.1.9-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.1.9-1.tar.gz";
-    name = "4.1.9-1.tar.gz";
-    sha256 = "a3393d410c96dabf0ed5c6c83936264310c3da53d992b7a5bccf6068303b25bc";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "a2a0000f5f4ef624005056c6b58ea4627c7eeabb66adb7cb86ec924f81974b3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-laser-sensors/default.nix
+++ b/distros/humble/tiago-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-tiago-laser-sensors";
-  version = "4.1.7-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.1.7-1.tar.gz";
-    name = "4.1.7-1.tar.gz";
-    sha256 = "6cca8e7c0f76b967147d06ca1fb650fc19ead57ecad3eb9fdd8955cdb3996b44";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "4bbabaadbae272584423e395fa28518e65a70fa31c438b8d66364e9baa3ffcb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-navigation/default.nix
+++ b/distros/humble/tiago-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-2dnav, tiago-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-navigation";
-  version = "4.1.7-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.1.7-1.tar.gz";
-    name = "4.1.7-1.tar.gz";
-    sha256 = "1be61c9351d4fb7b23f0a276295b176561e5aff587d572a2988c0810d860afbf";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "4f38c9172df302ab2f9b28169b03f068e372f2dc6001c2aa824e6991521dcfc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-robot/default.nix
+++ b/distros/humble/tiago-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-bringup, tiago-controller-configuration, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-robot";
-  version = "4.3.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "6f6aeae1ad1f7a3af5f43a7b2ade110bfe671536e76ade6b3b053d1caad52239";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "1665820bc83a8945ac3f36005eb0a22ce81f772fcf7e48f3cf9bc28b62246ed0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-simulation/default.nix
+++ b/distros/humble/tiago-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-gazebo }:
 buildRosPackage {
   pname = "ros-humble-tiago-simulation";
-  version = "4.1.9-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.1.9-1.tar.gz";
-    name = "4.1.9-1.tar.gz";
-    sha256 = "fe7826c79a2c189befa82a1887657e1637fee72d776321487c5156c39616aa57";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "6672e57b88b8ca0d8224fc13211e31badc417e945e228b22fb887953ae789754";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tile-map/default.nix
+++ b/distros/humble/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-tile-map";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "6e8c725e97c093e11090fa1a5169d30ae39155ff2c278df81745e8148912bed9";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/humble/tile_map/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "33b0f655c30b5c54a7c2ee6bd6ae7bc93096e8e827ad21945351c9033ccd1aaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-compressed-video-transport/default.nix
+++ b/distros/iron/foxglove-compressed-video-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-iron-foxglove-compressed-video-transport";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/iron/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1c4695663905677d864184d6e2a9bd5302ecbe2c800b8384509e19daccbfc3ff";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ffmpeg-encoder-decoder foxglove-msgs image-transport pluginlib rclcpp rcutils sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
+
+  meta = {
+    description = "foxglove_compressed_video_transport provides a plugin to image_transport for
+    transparently sending an image stream encoded in foxglove compressed video packets.";
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/iron/gazebo-ros2-control-demos/default.nix
+++ b/distros/iron/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, gazebo-ros, gazebo-ros2-control, geometry-msgs, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-gazebo-ros2-control-demos";
-  version = "0.6.7-r1";
+  version = "0.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control_demos/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "fd6a41dabac119914af14e4c989b4b56d6ca2d57145df9a559f47b8e5708bb7f";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control_demos/0.6.8-1.tar.gz";
+    name = "0.6.8-1.tar.gz";
+    sha256 = "62fdda6c84a3f16dbbc5daf07ca8f68c2ab0956f9770d044465d0e446b58ff3c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control std-msgs tricycle-controller velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs diff-drive-controller effort-controllers gazebo-ros gazebo-ros2-control geometry-msgs hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/iron/gazebo-ros2-control/default.nix
+++ b/distros/iron/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-toolbox, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-gazebo-ros2-control";
-  version = "0.6.7-r1";
+  version = "0.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control/0.6.7-1.tar.gz";
-    name = "0.6.7-1.tar.gz";
-    sha256 = "fc43612d65f88d1742b429271011b61eadc50275b5d07f0a92d26b44264676ca";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/iron/gazebo_ros2_control/0.6.8-1.tar.gz";
+    name = "0.6.8-1.tar.gz";
+    sha256 = "6e1b4fd962026ee06e0dfc41f92563d890b10323af7f8121c8425a3890ba300d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -634,6 +634,8 @@ self: super: {
 
  foxglove-bridge = self.callPackage ./foxglove-bridge {};
 
+ foxglove-compressed-video-transport = self.callPackage ./foxglove-compressed-video-transport {};
+
  foxglove-msgs = self.callPackage ./foxglove-msgs {};
 
  fuse = self.callPackage ./fuse {};

--- a/distros/iron/kitti-metrics-eval/default.nix
+++ b/distros/iron/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-iron-kitti-metrics-eval";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b7649d874b20e2cb3ddb460a478cb4b45334f6697edb01faff92aceac50664e8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/kitti_metrics_eval/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e3f6c25ee338d1ec0704ef00b45deb4b0ad08cd43e74588a374fd7abadb8d1f8";
   };
 
   buildType = "cmake";

--- a/distros/iron/mapviz-interfaces/default.nix
+++ b/distros/iron/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-mapviz-interfaces";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/mapviz_interfaces/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "25105073516e300ccb0215e04ce5099f3f6a91b0c848151acadf8892fe62deb0";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/mapviz_interfaces/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "a33e2935fdda2b11ab8aabfbeb0e38c3f653c6401c538ff6d63523c1361b2b55";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mapviz-plugins/default.nix
+++ b/distros/iron/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-mapviz-plugins";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/mapviz_plugins/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "cc8a85b396d4f9d7c476d06751cd94a172095323d71b23aef431b6364ee1c61d";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/mapviz_plugins/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "6ab0655abbb8016d4ace91ec733688a43bd9d00562529cac721b2b230abdc29c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mapviz/default.nix
+++ b/distros/iron/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-mapviz";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/mapviz/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "3910ee8aea4f5feec068739db9c006c22ee15f000bd114235df6abe5bf1bfbc0";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/mapviz/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "dd7696d3f7d3332c8d218883ba41d07c126964635de0729484223eb146f893ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-bridge-ros2/default.nix
+++ b/distros/iron/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-mola-bridge-ros2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "0378e989e2e5ea05dda70416eea203d84f04eb2ee90c201783947d030fc1a167";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_bridge_ros2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7110b84daffa2abfb447eef458d0a66ed6d012343c513ecf6fb205738205fda2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-demos/default.nix
+++ b/distros/iron/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-demos";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "5227971246858ccf0083ea9c29429f1b3155e8a26a4d901eb6f6e99e713868f8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_demos/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "81d132080138f91a5f80809e31ef4479419a924e95b8324d75caf5a7dc0d8b40";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-imu-preintegration/default.nix
+++ b/distros/iron/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-iron-mola-imu-preintegration";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a0143521b8ae3d1854b733a7b28c29a383dbb3175a01f10229a5d75e92b7ae02";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_imu_preintegration/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "11d35bc32be22648a4ad68d4c1efd3ff108a851893713f3141d5b684ef34bed5";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-euroc-dataset/default.nix
+++ b/distros/iron/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-iron-mola-input-euroc-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e28e407ff5318d7685f7eb29d241189f52d53ec3d934279d0972c3bc584dcaf3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_euroc_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "450a04bd74c63d357298baf45731cf9adde4143e4a4d80c9f1f8b022e11da4a2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti-dataset/default.nix
+++ b/distros/iron/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "14c54009dfc37332e37c705a40809c50744ad019cbf81881aa8b6286a2aff497";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fbadacb9fcc393041e7a05f4ecac366eb6be43ac312b2127ed92397a6e1c882b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-kitti360-dataset/default.nix
+++ b/distros/iron/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-iron-mola-input-kitti360-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ec068e3d19993f201c7946264230dd36516b9de2db1081e3818a64d17c539cc8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_kitti360_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a19f9fa387e23b326992cd045e5985e7c61f6f42b7db30dfbf8fadf6dd02ac37";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-mulran-dataset/default.nix
+++ b/distros/iron/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-iron-mola-input-mulran-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ffba724ec720ba23b4c3d6781ef8354206ec9e5601acdf7383a5139c66db7b55";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_mulran_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e9b4560ba7fca0f85f18173d81d071601b5d65b6df3402530d4b4525227d3225";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-paris-luco-dataset/default.nix
+++ b/distros/iron/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-iron-mola-input-paris-luco-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "69e05cd398787d6d2fb74c2800e8d87ba6d3a7bfad23ecd9d480591f1256cfd0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_paris_luco_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a73d8efbdca75c569acbab84bd90c9b011d66c8cb610e5d776f90a7430f9e3cc";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rawlog/default.nix
+++ b/distros/iron/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rawlog";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "0eef6e8296679764bddf2f0353d004437f4556be11d58898a4a6660eeac2ffa7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rawlog/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e02efb11c38508a202f2e672c367510e05ad8484d2052de95348180679e2442d";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-input-rosbag2/default.nix
+++ b/distros/iron/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-mola-input-rosbag2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "d4009c1c2336a498a018350b7c4a165d21c1ab997b557ed395e6074b03a85934";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_input_rosbag2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f3e4c9de10ee9db64e9920457166168a5b6089f2e08cc14de50fc70f52d3337b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-kernel/default.nix
+++ b/distros/iron/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-iron-mola-kernel";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "1f531ebb58c37096f2c125a7b34a39e82c26245df8e1c1c8fb988e319d2532f9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_kernel/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "be41c8e011cd9d87fa73243aba700a4346bfb1d17ebfef13837c5bd79fb90d4a";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-launcher/default.nix
+++ b/distros/iron/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-launcher";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "5d0d8efd7020cf145aeebfc4582016a74c3a6f9d50f215d80c10f3156c6ae7f9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_launcher/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ab5d76b4a741261297fdd1008d278300f0048ed809237ac3f7f35cc641127857";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-metric-maps/default.nix
+++ b/distros/iron/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt-libmaps, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mola-metric-maps";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "bcbc7456019c7ff9e07547f13fc9922516e4f9bb8be05c6a01079a28c50da87a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_metric_maps/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a186a2907c00ef60df262c51be499c86849ef0534ebaf64a4d3e32ece25135ad";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ mola-common mrpt-libmaps ];
+  propagatedBuildInputs = [ mola-common mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/iron/mola-msgs/default.nix
+++ b/distros/iron/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-mola-msgs";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b9f94933d4a660e45d3d4be8b7efa89f400a8b3e546b1ab4eded2fd5fa6d5a96";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "54019fed72c615541ce08f12d1594200972db903cac4fc618b369f3fb5cdf230";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mola-navstate-fg/default.nix
+++ b/distros/iron/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fg";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fg/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "d4bb704bbfc53a71aa69a67a07fe8dda3550c70d8f9d60f7d5a76a2c88a2d642";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fg/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e0d2595402202ce09940045fac422fc7d950668404be585d7fb9ee163f753183";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-navstate-fuse/default.nix
+++ b/distros/iron/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-iron-mola-navstate-fuse";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c88393840ac33ded0f0c13054e100e03170a3655fb3765bfa3794e69ed796bc2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_navstate_fuse/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "c99b32c8573be7dcd5db5a0427cb4e336a5f90c158f5231b9c51c4c259a83c93";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-pose-list/default.nix
+++ b/distros/iron/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-iron-mola-pose-list";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a2d22d334fa10e4ba5b96aec7192e24aec5be2349b9df18d67a276be225cd9aa";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_pose_list/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "c94c74ccd4630fe5ea75c17b32b88aa90890dfe3a89c3e13879e9c916a24ec6b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-relocalization/default.nix
+++ b/distros/iron/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-iron-mola-relocalization";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ffcac03e7bbe6e64a7a932de14384c1fd3aa5bdf214c30c7d138cbd6b3d79a5b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_relocalization/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b95b5f5487a0f7801881c9f8f26e287b04f1c7749f11173cc1eba7dd776ea115";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-traj-tools/default.nix
+++ b/distros/iron/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-iron-mola-traj-tools";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "aa01bac77f156d43b1c9c6dfb6f80dbb189416bf7f3dc14407a543ffada8e625";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_traj_tools/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "c53044d206fb07a863b86276c126b0f95daf0cb90005dc498c48a78688e7b6fa";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-viz/default.nix
+++ b/distros/iron/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-iron-mola-viz";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9660b760a7ed4bade019dee670a699d27195917367f7ae9d4ab190385967b06a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_viz/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "1c6c48784e8621fcef8dfa25ccd6f11ae9bc0c85dd38dab642c37f2c1d5b3ea9";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola-yaml/default.nix
+++ b/distros/iron/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-iron-mola-yaml";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "5091906c10f53ecf9a0fe898b9d7bf30eb8ea525610a62db46f85f315f572ae3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola_yaml/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "82894407e3ef1c3af1de8352da89edfd976e37ba4c1619b04958601aa8d0f6be";
   };
 
   buildType = "cmake";

--- a/distros/iron/mola/default.nix
+++ b/distros/iron/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-iron-mola";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "73f3409a0d08d58718cb87b35cf4e8b64e30befc8ae88ee4aee94612e809bb23";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/iron/mola/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "841766a669b797363868a2af63983bc7c7812e6157a0fa7b4c098b6d057ee832";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mp2p-icp/default.nix
+++ b/distros/iron/mp2p-icp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, tbb_2021_11 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-iron-mp2p-icp";
-  version = "1.6.0-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "abe8a324928343898debc15ada733e6600c2864f44f8e954560eef79bf81a2eb";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/iron/mp2p_icp/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "fb249e3ec2ef280be6e7f5f76090c057297c620ef99fb58466322037b2eba28a";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildInputs = [ ament-cmake cmake ros-environment ];
   propagatedBuildInputs = [ mola-common mrpt-libbase mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libposes mrpt-libtclap tbb_2021_11 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {
     description = "A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++";

--- a/distros/iron/mrpt-apps/default.nix
+++ b/distros/iron/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-apps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_apps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "e09cf26ee0738732ba53d97e58d7833e2613ab93d0c1654899f014098d46cdb3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_apps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "854bfa20b849bb416b4082d186f73007af2ebc19ec2313498d8b091105ef2c71";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libapps/default.nix
+++ b/distros/iron/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libapps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libapps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "18cb08ed21e4e9f0950912c72aa1c16418ef6f3b438c2e80f1a82d9e391387be";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libapps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "2ad2bb7c5e28b2b917467531a2b6e80a5a410437fb22e4d5045950d73d15a4a6";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libbase/default.nix
+++ b/distros/iron/mrpt-libbase/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libbase";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libbase/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "75f4012b782e02d3699c57ed0694c973039df66ca8272cbae9fc40b6c17e25e6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libbase/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "06fd8d75912c157ab2a0cbe888d21ff90b44f84113770a2752c25f19e4e53a6d";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tbb_2021_11 tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/mrpt-libgui/default.nix
+++ b/distros/iron/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libgui";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libgui/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "bfb9d9cce1656aaf559f957c15b02ff96083bee47f0f0548d4396c68d286f064";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libgui/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6435c85370d57e21a4c55d42bd5234ffdd0b7ef9731ffcc71cf5ecf712a0f489";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libhwdrivers/default.nix
+++ b/distros/iron/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libhwdrivers";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libhwdrivers/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ad18c1681ceefed07313a5f1d886e2ec7a8eba26fb3219876dd63170212bd952";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libhwdrivers/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "70d53ff83d170b8f4c1f7cb9aa9d3a2e042a7eca2320dcc325c241de378cf9f2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libmaps/default.nix
+++ b/distros/iron/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libmaps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmaps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "0f3b980766489e79cc932e55e317bccffdc29fdcd327fb3cf095112d56fad434";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmaps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "9a36f338cf24ed19b1a1075c1e0f415cc2ea9b4a46d62d745b68110dc5b7f49f";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libmath/default.nix
+++ b/distros/iron/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libmath";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmath/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "c05f4b2d1b81e1c1284384ec62e18a6d156fb310576d9da9772f59200c6d7c47";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmath/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f1b3e5f4210f055755dd83d634cad82c310f0a752aaa81642f6fb5dff7006ec2";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libnav/default.nix
+++ b/distros/iron/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libnav";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libnav/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "32886d4f3eb497ca0b5667cf85b87ae8872dc5572ff85dbbf02abba0c6f8395e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libnav/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e580901db5d85668713967d5a35c6713c9ebdae942589f62fcb2fd6061930693";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libobs/default.nix
+++ b/distros/iron/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libobs";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libobs/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "1451295c979ce40d81b9bdad190ae91ed79d8adb68acd42c1a77e0ee4dc0b665";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libobs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "bdee3c2007f36d1f5ca79b3448bc548c8512f4cac3d31fe8ac2a6b45a2998e58";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libopengl/default.nix
+++ b/distros/iron/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libopengl";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libopengl/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "07e220b481c9ea6fa27e319952a87e1557ee96fba633ddeceef73a6b48d3f584";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libopengl/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "2dc73c319b13693974e5dec0c7e5d06e020140bb099a0a9474f13120199b2a5b";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libposes/default.nix
+++ b/distros/iron/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libposes";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libposes/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ab38732b2e86b8a485ecd7c6276ad70cde8d2ea1397669e8531501d60995945b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libposes/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c7ae787ae4161245b4c81103098126569bf597df320e39547d5f6b34ffe51956";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libros-bridge/default.nix
+++ b/distros/iron/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libros-bridge";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libros_bridge/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "fce50dc20e08acbe7f772473ba1ffeb6b2b8d7fc49051e87b8133b7a903d7f34";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libros_bridge/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "505404f32ee43d8c40163ac4fe0da7a57f384c85f791a25a2edd7ceb312a3ce4";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libslam/default.nix
+++ b/distros/iron/mrpt-libslam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libslam";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libslam/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "9a1334f6dfcaa9fb6ab641d49f10c0c7a17c06c96a2f77bf496f8c13a6e01c0e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libslam/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1df545cecdf32323e9c102db934678cf918c6c01345538654c344825ad86e653";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
-  propagatedBuildInputs = [ mrpt-libmaps ];
+  propagatedBuildInputs = [ mrpt-libmaps tbb_2021_11 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/iron/mrpt-libtclap/default.nix
+++ b/distros/iron/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libtclap";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libtclap/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "8d533087c7f23efb0495c0ee5a04cce0ea9ec8548702e02c41196ca614725038";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libtclap/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1042819b619b70f25fd0db882aedc943122cf43c8a58991bd2c2a7d214c00c68";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-path-planning/default.nix
+++ b/distros/iron/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-iron-mrpt-path-planning";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "52dd87d6ab10510d96e613045180427845a0dafd5dcead3755fdcb1df87f9748";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "eff0cfe384b76d44b17d2f7d526d6543716b8ac2482247740c18059d0aa48881";
   };
 
   buildType = "cmake";

--- a/distros/iron/multires-image/default.nix
+++ b/distros/iron/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, gps-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-iron-multires-image";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/multires_image/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "d17481d7714cc6f7b096d6e3eab6a4f6510eae8c604306a2a548073f1b2366f6";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/multires_image/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "454e560b1f05a0076b629c7eae3f54b5e0e7ab0b2939abeee25333ec227e10c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/polygon-demos/default.nix
+++ b/distros/iron/polygon-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, color-util, geometry-msgs, polygon-msgs, polygon-rviz-plugins, polygon-utils, rclcpp, rviz-common, rviz-default-plugins, rviz2 }:
 buildRosPackage {
   pname = "ros-iron-polygon-demos";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_demos/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "8da8298adcd837ec77b401a2fa7ec02062657e29c2ac4939f2958cb7b66f84c1";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f0a9fef597746d1003c67e57fbee4505312100a031c841e991140cab0210f7aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/polygon-msgs/default.nix
+++ b/distros/iron/polygon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-polygon-msgs";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_msgs/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "aaa275e699632457f195517cbd907fd1b8cc4e005c9281563d954ef5714d0300";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d22978a033864c9aebcb7fea7ae4b7d7b099e6fb016e3c8714ad5886b4f48c19";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/polygon-rviz-plugins/default.nix
+++ b/distros/iron/polygon-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, color-util, geometry-msgs, pluginlib, polygon-msgs, polygon-utils, rviz-common, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-polygon-rviz-plugins";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_rviz_plugins/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "b5c01f222a8e511625c5079b17f342731f34ad20bf0304db1f180fea0deb0c47";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_rviz_plugins/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "609aeacc07963afb1061bf458dd27f9413850150f1fb02dd48e65340c058b911";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/polygon-utils/default.nix
+++ b/distros/iron/polygon-utils/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, polygon-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, geometry-msgs, polygon-msgs, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-polygon-utils";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_utils/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "68222e521de5702484e3e4d41c3122bc30507a1a4425b36a0fb74f5a60a77db2";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/iron/polygon_utils/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d22943407fbf0aba1ae60fef6703f47912370f8fe1e90490d671a2c9e392a591";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ geometry-msgs polygon-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ];
+  propagatedBuildInputs = [ geometry-msgs polygon-msgs python3Packages.shapely ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Utilities for working with polygons, including triangulation";

--- a/distros/iron/python-mrpt/default.nix
+++ b/distros/iron/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-python-mrpt";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/iron/python_mrpt/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "c46b44de58c6cdd3e021e12c2b3275f47558b0f4e03d4cb89efd7ed320eecfcb";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/iron/python_mrpt/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1ac2ba1c125a473562d4d4ad867d2fac9b0fcc990a950fd43f0d51080b024459";
   };
 
   buildType = "cmake";

--- a/distros/iron/rcutils/default.nix
+++ b/distros/iron/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-rcutils";
-  version = "6.2.3-r1";
+  version = "6.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/iron/rcutils/6.2.3-1.tar.gz";
-    name = "6.2.3-1.tar.gz";
-    sha256 = "d8019137d244b4acc17fa551dd5d0125cf1eb4a66ee2396ecb1ca4ff8e758e20";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/iron/rcutils/6.2.4-1.tar.gz";
+    name = "6.2.4-1.tar.gz";
+    sha256 = "9a305f826cac71ef345f8a5154678203a363340bb7f6bf20712693eaee40b8ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-cli-tools/default.nix
+++ b/distros/iron/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-iron-swri-cli-tools";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_cli_tools/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "7cd8a3e7aa49ade95f83f5c686c797d42ae685a1195a837edd2ad7c30c522359";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_cli_tools/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "13a1d07ec4827eb680c4420deeb3314602131461614183f481ef2331e0fd60bc";
   };
 
   buildType = "ament_python";

--- a/distros/iron/swri-console-util/default.nix
+++ b/distros/iron/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-swri-console-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_console_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "5bbdfffd0ea2cdc4b0ee8e35377abbcf910c9e07a4105e749572a2de261bc2c3";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_console_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "28f414b091eb37ef8d5c803533492373a93164484a6273b438b0e0d942ba1a78";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-dbw-interface/default.nix
+++ b/distros/iron/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-swri-dbw-interface";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_dbw_interface/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "7498a426e1a7d4782541bda0fb58e62c1323390d4a329fae54473fdf554e59b0";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_dbw_interface/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "b4f3821e90acd03279ec7c4078c3d065e0ea76bfb6898be9a8172844d3ef22e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-geometry-util/default.nix
+++ b/distros/iron/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-swri-geometry-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_geometry_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "bce671ed37ae5aad1e348c144dd4c0b1b0352b00498c0b93d561d36b307a5cc1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_geometry_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "3ca27e71d63f3401462ea07da6a3f5cbf978d8a291513631d1ebeab0180225e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-image-util/default.nix
+++ b/distros/iron/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-iron-swri-image-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_image_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "966f7e27e13dc7bf6b3535d4baa40c9c052263a8cb3007ad798f429cb9437533";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_image_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "1632d2edbb064221149086ca511c34ccd0085d3b4750ce05307b43eccf5932f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-math-util/default.nix
+++ b/distros/iron/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-swri-math-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_math_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "4599541cba41b0d671dd81b36952689d42051046c873b7f970fbe38fa384d032";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_math_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "dc4f072bd28cc25af35180563bfb78365b9b7e4e6100eb4f9a968d474265ebba";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-opencv-util/default.nix
+++ b/distros/iron/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-iron-swri-opencv-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_opencv_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "55481494f0654f3ba25a17dd10360ae7b74ac63877049fbf91d0975dee8f0e7e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_opencv_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "7636f3a572fb76bef00ea921ac073061b842d758b1b48f9b7ec201de59134865";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-roscpp/default.nix
+++ b/distros/iron/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-swri-roscpp";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_roscpp/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "1ef197d136c5897f76c966afa0786f2041579531b2506dd2a0663a0d377618e4";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_roscpp/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "adc6738aacc9513a2ebea28cf73fe20bd06822c2a185b7115549f8418e06cf9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-route-util/default.nix
+++ b/distros/iron/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-swri-route-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_route_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "b47b94a28fd6a5d4a833cd851b1f445134796179e2bde1709110902fdce2bcdf";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_route_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "d0011e4f2af1763113b41243a3f34a6f01c4f16b527924f4983f4026693cff0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-serial-util/default.nix
+++ b/distros/iron/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-iron-swri-serial-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_serial_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "d00cce33a282f5b287b2511b677cba3bbfbdf55ffa49b87a2fe164857200dafe";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_serial_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "c3d7dd42ded54f9da7ada0aee346f3d41bdfd73d755cd8773f8e4130745ee683";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-system-util/default.nix
+++ b/distros/iron/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-swri-system-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_system_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "3e34ec18d7637814a5224626061e3668176ce69f3c9aa394e736fb364b4debf1";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_system_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "e3ad4e72d3757ed465c23d3868e2a7cb544313075d25213cd32a19b13a052225";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/swri-transform-util/default.nix
+++ b/distros/iron/swri-transform-util/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-swri-transform-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_transform_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "a4fffa84e9ff898e3262e5d407a9bcda4c57410a44fb097809e2e370f1e90b41";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/iron/swri_transform_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "f377e2f7313e7b7e4d4580e2b92da041ff5563baeeaccb582c1e07a954521c00";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/iron/tile-map/default.nix
+++ b/distros/iron/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-tile-map";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/tile_map/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "a5c00c4805d366f1aea0f0cbd735d6e13eeaf2f975a1084c8387d9879fc8ccf7";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/iron/tile_map/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "8e822b340d34cd5fc3ef8fde191317b0053236ab960ab06c386cbafdb260d07e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fastcdr/default.nix
+++ b/distros/jazzy/fastcdr/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-fastcdr";
-  version = "2.2.2-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/jazzy/fastcdr/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "6a34ce32085c84a2be48238e35d0114b732f1aab39f79b57322683f3fc946c32";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/jazzy/fastcdr/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "a639d9a0ade3dd6beed231ce938d5a6414f787a8b3313e442934354224cbdd68";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1322,8 +1322,6 @@ self: super: {
 
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
 
- mrpt2 = self.callPackage ./mrpt2 {};
-
  mrpt-apps = self.callPackage ./mrpt-apps {};
 
  mrpt-generic-sensor = self.callPackage ./mrpt-generic-sensor {};

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8c89ff46b2f64d805e8ef2a401d3716797420359931b7949dd7787af8fa770cd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "0f75d8b10fc500b10f1f3770177deaabe1502ed6bd8ba7f1547c0b2f458f4e24";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "d79ff79967b93c2a9aef9f1851bb3c7a6721ebb9b499e4cc950df5610e28320f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "879feaf8c985b651de2f47bf6356867d388323affc92b06324401f0b39326aaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "92ebde3d3eec9c1d8c1f47b2601f22a6e0843413f406b855763d404986be7008";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b375825e46cebe4a59c3015c3104f3fb5de309aab7729aad339a67eba84d952c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "cc1eb0e7ee812c9c70498b6a03a5145fb8954ffcb95e88585d20f804bf8364ee";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5c90be28295d1c45713c95c50881cf201887e88da511386a075b4f86f3812ce4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c82171de54acaf96d530d71b1dd6c42b1ca83b387102b531472ed187548c28a5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2d5d4f01d97357a80618305824ecc8a27410f1bacb2ba0548a35afee44292f02";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9e14c19ad3a03aafc488af639f0a20c7227912999139bf5162f98d2c92fa145d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "baf6d944b94f2185cfa03978dbeecb6e90f5399aab044325a3579f302cc4fd9d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "897a3717846c652cccb08e35e2a3df45e79dd634bbed52d3f1ac7bed68c18463";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4667f80ca2cf46e1673517a4afe135ca3432634c453f5a4fad6c02541606a9fb";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "16f7cc2431cff231ed4c1773078e561168d46b62e7efbb2405275289548048db";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "792605ce081384e40482eaf9e349dabceef30104121a4ee56368835a73a0571c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "6d30d42d451045b3d1ffeb564765b1e0d0397a323f07ceea682284cc9a8ffe7d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e4e3fc0ea9983a485140b713c161191e8110115615983ef0e64fe76ee6e0b3d8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b61efc0f1a4324c3d2e32802689701d4f30515407bd7b40a29df15759a8e27b3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "0314aa1c920c8857b0736edaea2de2cc9b3c5f4e866ca7e51b19028950c07ea5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e2306020d7e93ff46a35089c8267b4efede838f45a2e026fc101b0391932e139";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ca06681f064aeff12224cc7f072ec48b056bd53bbbc8154114d67b1965848939";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9166eac00708d0a41e88ec861a2a124d758fdd38f30b69e3ca1b88b630c53826";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "6882520ea7b7f6cb66808935e0d96784c71706cd77a34b25f0e95f4258f2b49d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "1249a3e5280d02edad000be7e11e9ef4cd35f74b1ea4688fff5a6af51b38d8fd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ebf8f2c29f350a0c565369428774949d9eaad3f1ccde90face581607cfbc58fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt-libmaps, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "0ccdb285c032962774177b568584d96b545de0335b8879bfd24d12cf511cedcc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4660b520023709bfe60f0a32149d2ecdf91b2b8e96ca9eaf81bfdd32a0016c48";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ mola-common mrpt-libmaps ];
+  propagatedBuildInputs = [ mola-common mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "75d3f2ea9171088f4f2ae6fdb5ed21b8cf06bc1db5c41b17e92371676358a487";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "36c637ea72e2be50c031f98124fb8eb112788430c462e46a4b8327c0c47bf8bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-navstate-fg/default.nix
+++ b/distros/jazzy/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-navstate-fg";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fg/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "91e80676b4b45ffe800e0742cda8d0ba37415823d5cd3a1c5739e2c113cbd3b1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fg/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "19bf58902b54d5e8a69e1c682d5b9f7e3b76b56685e16bc26179b0e17b0b1325";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-navstate-fuse/default.nix
+++ b/distros/jazzy/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-navstate-fuse";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fuse/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e5496c50804d7964a4550b4b6637de1e0cd5ec8de1adc123f009e06add3a6524";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_navstate_fuse/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "7e88bb95ec59d1580ce698c4139929b3902b13e278d894e14547d5507b18af7d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "093f44ce13232997d11d232006523a53629225aa1b25fcb11d95318e8759d892";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b1902a5d6814232d080791478994901686818892c172309febf203806472557b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c65306d49737e4371d17f75b5f55176e0a7dd592439c5d70448cfe7ff0d9c406";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "44529fc210aee2d47aaea5a20b6790a2ea67285145202d05f32fd937815b1e52";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "1a3aa2c77762709845ae2b60016110788aec8d5c5cf126e515de221aff13b573";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8356646ef188f41758c22e321646d588a21603a6036d651be80fc255075fa7e5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e302855be77f139d2b780a91fcf02bc75d2b831ea993a87fed701eebc26205e3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b412c19c33003fa0de48ef1c2bd0680620d9b41a91a70d7553c21384898dfaa4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b2039987014ddea9d38e836490c56c045e532934438318b437b65d96d984bb56";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4490aa976e8372bb26d2515173e830309374385a4f5211da8b6d4277dc0f6552";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "77356a1ed427b38c7b573a878d10308761cc214bf1c297a3dfd1b5b6534a73e8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2806eebc8313286fa4239181663da40605d06af81156eb9d509e15e3bbc059bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, tbb_2021_11 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "1.6.0-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "091d71bc0834a14b7647699e0dca064b1df4896bd5a607c5992f3088dc897cef";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "4ee115548ac02e7c1f5feef6ea537d61489aa79bdf25026fee9f0d5f1876cb7b";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildInputs = [ ament-cmake cmake ros-environment ];
   propagatedBuildInputs = [ mola-common mrpt-libbase mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libposes mrpt-libtclap tbb_2021_11 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {
     description = "A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++";

--- a/distros/jazzy/mrpt-apps/default.nix
+++ b/distros/jazzy/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-apps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "a7561b9387259d5feda50580883f69afd8857a1731d347cf61354327d4639a13";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "8739533c55a1f118c83737d2e1ce55611c275d0fd1623ef503015c8fdbdb45ba";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libapps/default.nix
+++ b/distros/jazzy/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libapps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "fb131227bd7d1c62d2f00b63b7bf54d4e8169b83918e1097f36071054b2bb9e3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "08a29e251889f7747915ee0fb3134b197c543c70759d4bfe1b5d2796d7a23380";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libbase/default.nix
+++ b/distros/jazzy/mrpt-libbase/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libbase";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "5f751de92f42955b121cf6d076be6852810e8d26165ac4b285a4b6252de74368";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "627a6107ea8807370ae7618700dac994daa8573252c554f5c1cb874fbf4c4ed2";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tbb_2021_11 tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-libgui/default.nix
+++ b/distros/jazzy/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libgui";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "9570169537f9d2fbf57d333b3587f0376a8eabf2c98a8fb9f3915c6147b329f7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e80106621396d9d7ec20998f4aff5b84b14b60f31500368cb4c729ffe88dab47";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libhwdrivers/default.nix
+++ b/distros/jazzy/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libhwdrivers";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "5822ced5dc657a9e14a3a5b36d5b3c7aab4725f5568fe466664220f5252227fc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "cac018eeb00af1ffd7f25c0d615467fa6e98da029331c04bd3c9ce7bfd6de854";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmaps/default.nix
+++ b/distros/jazzy/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmaps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "f5df0e1359ad5ad3bb4b6d90a09b808bacd16f85496a8264df581b62d2a045b6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "d60d3d212bf60a75201c5e1b9c33f1f33ff85daef25c46c44528d768b391228b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmath/default.nix
+++ b/distros/jazzy/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmath";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "187e23e463159764c4b2f8600fc2b4dd2594d3d5b1c57ee8fd91a36290383539";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "82767483927c5a090a29e40704144dd83585a5094be8a8c0e39d3618f7386534";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libnav/default.nix
+++ b/distros/jazzy/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libnav";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "926a3df18cfe6076e72b3c822320cd619cba570c4958c007ceda4400319a8837";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "9560d829568c9403a6d39530340e192d06294837af5227610f575260393152c0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libobs/default.nix
+++ b/distros/jazzy/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libobs";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "3d762f12fdc7180f5a791bb17b4871a4ce7440a845b8303732d7a5f85359e329";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "a370b5a6514d2954504368fd9022ecc6420a467a4d2a011d0e1a77f960c2c291";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libopengl/default.nix
+++ b/distros/jazzy/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libopengl";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ca589bc33cf5dba851b9eed745b153e108da66142c558b77657dfdad9b76615d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6ebb76120853fb3781d344cfef77183528652dc0a7d1ede32fe0b27999d9e9a9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libposes/default.nix
+++ b/distros/jazzy/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libposes";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "c8da627212fbfd9d43057854ce818046126bb0ad98b6c9c76ca543c57661fd58";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "0f21612c799013ed67e70b1f31a639cc8872a573c222d895f03f6e52c6da5deb";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libros-bridge/default.nix
+++ b/distros/jazzy/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libros-bridge";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros_bridge/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "810f7454e9fba41bc189a42e91288cd8bc1fb540ba1983574b6b0c3763325dfb";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros_bridge/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "4e8b69e7d9775fd9ce5f09c625ce16614ee00ad3587794502cabdce675b9eadb";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libslam/default.nix
+++ b/distros/jazzy/mrpt-libslam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libslam";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "1e8a307876c0ae492630760591d8cd0e28d34598b2d23c871b100ed2e54a17f8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "dedd3b4d5f541444af67d852fb64219b17ce8accb43c8a4355ff336624f2474b";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
-  propagatedBuildInputs = [ mrpt-libmaps ];
+  propagatedBuildInputs = [ mrpt-libmaps tbb_2021_11 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/mrpt-libtclap/default.nix
+++ b/distros/jazzy/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libtclap";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "efa2360c5bc53b5c1efc13e5c5130594764beb5bf935704d07a667aad9d8fee3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "00f3ce6f1e5278b60b8aafcd1fed8055d42ebaffee6d08e95604c76f09f09d0b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-path-planning/default.nix
+++ b/distros/jazzy/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-path-planning";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/jazzy/mrpt_path_planning/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "194d1dc7a39365f803b7cc878b9bedb2423b2ce0bf7bd1abb30e183286887cb9";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/jazzy/mrpt_path_planning/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "9bcc227bf6ffae66c9f4463baeb0096beae8f458f0e235585ae987f03bc90cf0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/polygon-demos/default.nix
+++ b/distros/jazzy/polygon-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, color-util, geometry-msgs, polygon-msgs, polygon-rviz-plugins, polygon-utils, rclcpp, rviz-common, rviz-default-plugins, rviz2 }:
 buildRosPackage {
   pname = "ros-jazzy-polygon-demos";
-  version = "1.0.2-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_demos/1.0.2-3.tar.gz";
-    name = "1.0.2-3.tar.gz";
-    sha256 = "5c28b97068185c49fc0eb938e6f231f1298dacee46ee80ff77565f59871f5ae9";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "99859b9222266f2d851502c82a08f1cca08b2433be59b8717a4ecb5038d30b4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/polygon-msgs/default.nix
+++ b/distros/jazzy/polygon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-polygon-msgs";
-  version = "1.0.2-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_msgs/1.0.2-3.tar.gz";
-    name = "1.0.2-3.tar.gz";
-    sha256 = "fc814e8f39f368450fc3ac809742ab137b50907f12d2adc82e854cb8df86fa83";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8cdaa14180bce2df80fcf01a31b3fda0d5bcc062cff800399fb0e9da9e92e44f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/polygon-rviz-plugins/default.nix
+++ b/distros/jazzy/polygon-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, color-util, geometry-msgs, pluginlib, polygon-msgs, polygon-utils, rviz-common, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-polygon-rviz-plugins";
-  version = "1.0.2-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_rviz_plugins/1.0.2-3.tar.gz";
-    name = "1.0.2-3.tar.gz";
-    sha256 = "d8a364df3e3388e8eea0a45d7d4fdd514b29ba6ac17ee6cb5799cf8e286ede54";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_rviz_plugins/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3d7f44bd58a58fb2091abc57a51d77bed34096ec0f1a95d38f24d546a03b3f84";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/polygon-utils/default.nix
+++ b/distros/jazzy/polygon-utils/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, polygon-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, geometry-msgs, polygon-msgs, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-polygon-utils";
-  version = "1.0.2-r3";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_utils/1.0.2-3.tar.gz";
-    name = "1.0.2-3.tar.gz";
-    sha256 = "6a13d021809e64dc69bd3648296d6bfd62bdde58a324bc531ec572f71dfdc3d1";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/jazzy/polygon_utils/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5ddac03af96d1733d08254753c8c6840f7ffa8944666e91fdb7652ed81eeffc5";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ geometry-msgs polygon-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ];
+  propagatedBuildInputs = [ geometry-msgs polygon-msgs python3Packages.shapely ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Utilities for working with polygons, including triangulation";

--- a/distros/jazzy/python-mrpt/default.nix
+++ b/distros/jazzy/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-python-mrpt";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/jazzy/python_mrpt/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "fc18c391476efbf5cca1b8dced62c337ac669002f5ca77fb3de769caecc2aa09";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/jazzy/python_mrpt/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "668db2efe71938b4dc36846cdc28d15e22ce1a40d167ec9734dd6e8446253cdf";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/rcl-action/default.nix
+++ b/distros/jazzy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-action";
-  version = "9.2.3-r1";
+  version = "9.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_action/9.2.3-1.tar.gz";
-    name = "9.2.3-1.tar.gz";
-    sha256 = "e89c5a56927b32f9671f3fb81471ea00e69465f7b0944ea62479388fdb31969d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_action/9.2.4-1.tar.gz";
+    name = "9.2.4-1.tar.gz";
+    sha256 = "4f9e607a5a0134a2f9ba896b5ff0b25c8718ff15a32b3828d2da05ecd0c2e13c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl-lifecycle/default.nix
+++ b/distros/jazzy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-lifecycle";
-  version = "9.2.3-r1";
+  version = "9.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_lifecycle/9.2.3-1.tar.gz";
-    name = "9.2.3-1.tar.gz";
-    sha256 = "da5c5e72a167a904af0db86c51082754fd5e577cea2ad9160e77cd857a5203fd";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_lifecycle/9.2.4-1.tar.gz";
+    name = "9.2.4-1.tar.gz";
+    sha256 = "b20eb8043ce8a569dcbb5e3639738968b3d52bfcbe2fee09166f7f7257f41c1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl-yaml-param-parser/default.nix
+++ b/distros/jazzy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-jazzy-rcl-yaml-param-parser";
-  version = "9.2.3-r1";
+  version = "9.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_yaml_param_parser/9.2.3-1.tar.gz";
-    name = "9.2.3-1.tar.gz";
-    sha256 = "7954fe9ee3e7f0917758367a5f73ec3240ce838eb8a36288d732cc376dce2594";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl_yaml_param_parser/9.2.4-1.tar.gz";
+    name = "9.2.4-1.tar.gz";
+    sha256 = "2387f2e0e91805f22af3e86ec9b3f493032e63ae457c63a144b6f5b5ac9d7755";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rcl/default.nix
+++ b/distros/jazzy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-rcl";
-  version = "9.2.3-r1";
+  version = "9.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl/9.2.3-1.tar.gz";
-    name = "9.2.3-1.tar.gz";
-    sha256 = "36693dfecb3939029e4554291b139dc15b3a6dce87df2e36052f1e9d7693c728";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/jazzy/rcl/9.2.4-1.tar.gz";
+    name = "9.2.4-1.tar.gz";
+    sha256 = "64e7eb707a7490c010b4978c2a231701b6388449205843d4dbb286bae2f8d3f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-action/default.nix
+++ b/distros/jazzy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-action";
-  version = "28.1.4-r1";
+  version = "28.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.4-1.tar.gz";
-    name = "28.1.4-1.tar.gz";
-    sha256 = "4ec9dbeedc131e27695e2709f74d4cdbbb4f179209aae6f332de2e3596589208";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_action/28.1.5-1.tar.gz";
+    name = "28.1.5-1.tar.gz";
+    sha256 = "064d9718da0e8187bc329355378b9e909c7dd0ef5f93682df5738cbb8e206734";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-components/default.nix
+++ b/distros/jazzy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-components";
-  version = "28.1.4-r1";
+  version = "28.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.4-1.tar.gz";
-    name = "28.1.4-1.tar.gz";
-    sha256 = "c43a4f3758799adefc49f46d79bbdb7d248c8fb15539c79cacac48daf9ae1540";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_components/28.1.5-1.tar.gz";
+    name = "28.1.5-1.tar.gz";
+    sha256 = "2e9702caf5f8ca104f7d0e532ce41d6ca4a762fab4a92ad0696ef2b418567c23";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp-lifecycle/default.nix
+++ b/distros/jazzy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp-lifecycle";
-  version = "28.1.4-r1";
+  version = "28.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.4-1.tar.gz";
-    name = "28.1.4-1.tar.gz";
-    sha256 = "7707e53053ecb20c49a2eaf77e0212e9d1147fd5ac3e7225428917687622196d";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp_lifecycle/28.1.5-1.tar.gz";
+    name = "28.1.5-1.tar.gz";
+    sha256 = "b53b5013a6b897b828752ac82445c1b0ab4526af4b3fbf15a2ac7dfee6dfb4ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rclcpp/default.nix
+++ b/distros/jazzy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rclcpp";
-  version = "28.1.4-r1";
+  version = "28.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.4-1.tar.gz";
-    name = "28.1.4-1.tar.gz";
-    sha256 = "ecbe4e8ac32d1d803fb32da3d35aad2740d96b161943b06d995ae8f5026a4c92";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/jazzy/rclcpp/28.1.5-1.tar.gz";
+    name = "28.1.5-1.tar.gz";
+    sha256 = "f0ca1509635039bab98213e9bfd7fbfe3464b6b501e2efd38e0f6ba412008565";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-calibration/default.nix
+++ b/distros/jazzy/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-ur-calibration";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "7d0b904c48291aa014aaf9aa7d2cfe7ff18c2bc9ff605c28e2160dfebf7fce36";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "d2aea416ae52bfc05da05e4a2e4079b8aa24db8c62af7f8f1d593ff920ce0202";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-controllers/default.nix
+++ b/distros/jazzy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ur-controllers";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "4e67090719fc322f41adfe3916aae2e6adfcd00e07c8953c58907e94294e759b";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "035546c430b2de7c1f2ddfc9b174aa9b7b39bf6a3b2d9382defd8ee7156fa5e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-dashboard-msgs/default.nix
+++ b/distros/jazzy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-dashboard-msgs";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "2a3078eacb0a6e6b03aefb5d80aa6c2b65556b30ab69affd292349ab33ffd1b1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "085dea8cf19c988efb1a02d1219f698986871f49ff65ece08cb966425da6db1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-moveit-config/default.nix
+++ b/distros/jazzy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-moveit-config";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "d54e60a15492b4ad33744515d823ee487e143b0162af7a1b7be07d1dc5a73e87";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "4c177ca471b37e79665cc37dcf7f3be1e8e169019874130180025e846ad715b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-robot-driver/default.nix
+++ b/distros/jazzy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-robot-driver";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "3cf1e848ec9dfd47c317eef53e132d0548c975dedbb18090c0160ccb0f838da9";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "ffd2b1ac58fd3a7a19805319e1b5f9cc15685fafb02ef5f0a77888804a0f6e00";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur/default.nix
+++ b/distros/jazzy/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-jazzy-ur";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "84668129897f6ffe7ef9c9c835aa24a2dcc1e50e9dd49e9d00b8add6ac37e797";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "30b5aa101ca70bae881f3ab47e5f6d92716e1b18bf4962e8145a66f0eb88bed5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/urdfdom-headers/default.nix
+++ b/distros/jazzy/urdfdom-headers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-urdfdom-headers";
-  version = "1.1.1-r3";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/jazzy/urdfdom_headers/1.1.1-3.tar.gz";
-    name = "1.1.1-3.tar.gz";
-    sha256 = "1b24395aeb073855ddb1c9fec92002e2226d926249fe55a8cc1f2e2185b47713";
+    url = "https://github.com/ros2-gbp/urdfdom_headers-release/archive/release/jazzy/urdfdom_headers/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "6eb8d5ab496296dc3f31fd0d59bb64728652f8bb6a16c250284026b853c02cc4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/urdfdom/default.nix
+++ b/distros/jazzy/urdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, console-bridge-vendor, python3, tinyxml-2, tinyxml2-vendor, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-jazzy-urdfdom";
-  version = "4.0.0-r3";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urdfdom-release/archive/release/jazzy/urdfdom/4.0.0-3.tar.gz";
-    name = "4.0.0-3.tar.gz";
-    sha256 = "a635c5687985d166ceb09ebefecfafc74f344623c7e0fa15c993e6241d34e800";
+    url = "https://github.com/ros2-gbp/urdfdom-release/archive/release/jazzy/urdfdom/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "89e127d74dd777402cc802ac8102d3b9ba475d0d62f51d2056743a1da1882777";
   };
 
   buildType = "cmake";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.4.2-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.4.2-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.4.4-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "1ea4175b9b6160598831af9434bf9fa78bd206eb96942946a2c07716ef75e3d5";
+    sha256 = "49d76941dd2c3e97d9a2782f750e91a89ec74b6095da90db5952da6c0971ee7c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/message-filters/default.nix
+++ b/distros/noetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-message-filters";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "a4af70cc76e8f9b46aedcbe3c7b4de534f6e2e100de2df98cebc61d109f3ff27";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "4f125d0dc081b30eb13297cca905573600b66facec4d825903c04563c0a8611d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mp2p-icp/default.nix
+++ b/distros/noetic/mp2p-icp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, tbb_2021_11 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-noetic-mp2p-icp";
-  version = "1.6.0-r2";
+  version = "1.6.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.6.0-2.tar.gz";
-    name = "1.6.0-2.tar.gz";
-    sha256 = "5426ed9e0fcdae82da7b416088571e120ab455365d4e830b271128100f6deb5d";
+    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.6.2-2.tar.gz";
+    name = "1.6.2-2.tar.gz";
+    sha256 = "866f1505827e455b57735100ac437f94b427f257594d4791dd22cfec350fe69b";
   };
 
-  buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildType = "catkin";
+  buildInputs = [ catkin cmake ros-environment ];
   propagatedBuildInputs = [ mola-common mrpt-libbase mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libposes mrpt-libtclap tbb_2021_11 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ catkin cmake ];
 
   meta = {
     description = "A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++";

--- a/distros/noetic/mrpt-apps/default.nix
+++ b/distros/noetic/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-apps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "7d50fb69291ad209a879c423d66cab65b98ad414d07749350ec44caedbdc018c";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c2511767e27001fe90142340306d6785194c7bbc543042aede1daeab9536cd17";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-ekf-slam-2d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs-bridge, mrpt-rawlog, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-2d";
-  version = "0.1.18-r1";
+  version = "0.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.18-1.tar.gz";
-    name = "0.1.18-1.tar.gz";
-    sha256 = "0fae5bd95d08f8676157fb0b844205fdc3cfe028ebdf34b15d9dc1cab7dbe494";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_2d/0.1.19-1.tar.gz";
+    name = "0.1.19-1.tar.gz";
+    sha256 = "a5a38dcb79b4ea701d01f43589d53b9846a37d5adac2ba7cef91a105e0a54b0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-ekf-slam-3d/default.nix
+++ b/distros/noetic/mrpt-ekf-slam-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs-bridge, mrpt-rawlog, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-ekf-slam-3d";
-  version = "0.1.18-r1";
+  version = "0.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.18-1.tar.gz";
-    name = "0.1.18-1.tar.gz";
-    sha256 = "2514aa8a7961ab1c7e53e94e2e3c8f16075aea1c6860e50fff96913983dd1324";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_ekf_slam_3d/0.1.19-1.tar.gz";
+    name = "0.1.19-1.tar.gz";
+    sha256 = "c563a99101a7f6e49720b1a3610723f4286cea1b2e40ee0935d04b80f4b5df90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-graphslam-2d/default.nix
+++ b/distros/noetic/mrpt-graphslam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-multimaster-msgs, geometry-msgs, mrpt-libapps, mrpt-libgui, mrpt-libros-bridge, mrpt-msgs, mrpt-msgs-bridge, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-graphslam-2d";
-  version = "0.1.18-r1";
+  version = "0.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.18-1.tar.gz";
-    name = "0.1.18-1.tar.gz";
-    sha256 = "5b02ce04f7806786716ac7186984addb6e13e74b82e24a1215a3c9660106130a";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_graphslam_2d/0.1.19-1.tar.gz";
+    name = "0.1.19-1.tar.gz";
+    sha256 = "52ac5481791c82afffd01c730409877c5235e7794b8f53e5c6157398bb9a3a9d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-icp-slam-2d/default.nix
+++ b/distros/noetic/mrpt-icp-slam-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-rawlog, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-icp-slam-2d";
-  version = "0.1.18-r1";
+  version = "0.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.18-1.tar.gz";
-    name = "0.1.18-1.tar.gz";
-    sha256 = "25b7b323e6126c56f24be8270a30d072a86b6921653e1fa011b8d87772ee23d4";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_icp_slam_2d/0.1.19-1.tar.gz";
+    name = "0.1.19-1.tar.gz";
+    sha256 = "a2957783ce3e9dd9607745d476f7a17d8c6fbdf9e95fa9c1feed8fe20b338f95";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-libapps/default.nix
+++ b/distros/noetic/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libapps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "8304ef256cc7185af00039fb232c489ed5f521d9dc344bd9b0ba692bfd0dd980";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "068ac9642c10f524bc74ea935fe34101052e985541b15d06a1d00c7b539da236";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libbase/default.nix
+++ b/distros/noetic/mrpt-libbase/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tbb_2021_11, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libbase";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "01934c3f3a239c174cc6fa2df9f9337673421e5f2157bd5f0f2e97618d660bbe";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "847fdeedf1a17ad945e9323a91a86e3705c09086b499f18bf8a96c1bb52783de";
   };
 
   buildType = "cmake";
-  buildInputs = [ assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp suitesparse tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  buildInputs = [ assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp suitesparse tbb_2021_11 tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/mrpt-libgui/default.nix
+++ b/distros/noetic/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libgui";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "2073d036cdb79083b06b9625f045760799c19c22d2ae0deae53dd357654b611d";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "00ddb8161a4669c12f9e9bae4579fa987ea412ab6bc1656e5a5756a00e59b2e9";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libhwdrivers/default.nix
+++ b/distros/noetic/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libhwdrivers";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "43cc64e5cda60186f71fef86aa3fd046c0b7f6443c5a7bc09af91a37a87895a5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "d489376f5816de0d065307a072c19eba3d0c0bd45871a9852244c1c64c964132";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libmaps/default.nix
+++ b/distros/noetic/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libmaps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "f3c5e70819c6adc00d6982a8825f6201aade62d0b5147ca465e40624f681ca7f";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "dc596d2943ba2b23dfc92acebf256c5ce6879eb7ed860dce9012c42166515a7d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libmath/default.nix
+++ b/distros/noetic/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libmath";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "8650dec0c9ee5285fee1cc2ba43b39e1586cbb9f45e1644c5e9c29d3bdd8a038";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "edda261053706ea94cf489432554e4355d8a768e9cd5629279ce11e31ced9b3a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libnav/default.nix
+++ b/distros/noetic/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libnav";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "37a2a0c4b89438058a3ceeb626685f05a8677428a2aad501f904b582a813d9bb";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "7a8da30270f6cffc9d2b8e4bfb24655be355626a6a5e08230dcb7dc9077cabab";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libobs/default.nix
+++ b/distros/noetic/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libobs";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ac6d8cf01cf10e128bccc0f9433ed96a88a7e8869c8dad6dc40fa33ba22f3407";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "33df1d7b1757f9966dd262ed6505c52a0c7a0df16bda5ec699d0336429846925";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libopengl/default.nix
+++ b/distros/noetic/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libopengl";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "aa697c75ea45df840d53f303b0361513c78211200db42b63ff48ea1a474350ac";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1d0d386b30f35af0efbf875d6f45805ff3c773ccdf0e468542c98b0b2a25af0f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libposes/default.nix
+++ b/distros/noetic/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libposes";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "57a995c7180a7fadc870da662e3b1ec9f2a2356234b6dc037ba5e103f0852cff";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "bb2a7cb3ebe2e6288d96c38b7daf6ac05bdc320ef3653c9051b1d70d3491af6e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libros-bridge/default.nix
+++ b/distros/noetic/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libros-bridge";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros_bridge/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "25f7eb6882bea97bbddec42e388120ed18df8e234c7933b7adf7b46bf9e16547";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros_bridge/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "953df82cf382ae523894ecb7febb7b17d93d0c29c444348c5ebfaa27a65c48de";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libslam/default.nix
+++ b/distros/noetic/mrpt-libslam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tbb_2021_11, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libslam";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "6ae0cc00d2c4eff9d5ac0c291c73951994e421ca0bbd11d3ef6bbf74a7ae3c6e";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "9ea4cefb993307e000692846e28f7b5d46d4fde375f9db9cabd9e2d5ac42d57c";
   };
 
   buildType = "cmake";
   buildInputs = [ assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 ros-environment rosbag-storage roscpp tf2-geometry-msgs tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
-  propagatedBuildInputs = [ mrpt-libmaps ];
+  propagatedBuildInputs = [ mrpt-libmaps tbb_2021_11 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/mrpt-libtclap/default.nix
+++ b/distros/noetic/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libtclap";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ea2375dec1fe7a4708c3af3bd96cc9971c489ed916ed7c25e7279effe918777d";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1b9369a7ecc6204a96ae31339b96f9c881922c11b32b32a4f7542cbf5dc66801";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-local-obstacles/default.nix
+++ b/distros/noetic/mrpt-local-obstacles/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libmaps, mrpt-libros-bridge, mrpt-libtclap, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mp2p-icp, mrpt-libgui, mrpt-libmaps, mrpt-libros-bridge, mrpt-libtclap, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-local-obstacles";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "055f599d64ad8502c352b5f29fa73861eba39e9e33d2006bdf22f464043e57f6";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_local_obstacles/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "cea3025462dbde0671720bf19ffa8b889cbac8840205518a94183ed1f4f7980d";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ dynamic-reconfigure mrpt-libgui mrpt-libmaps mrpt-libros-bridge mrpt-libtclap roscpp sensor-msgs tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure mp2p-icp mrpt-libgui mrpt-libmaps mrpt-libros-bridge mrpt-libtclap roscpp sensor-msgs tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrpt-localization/default.nix
+++ b/distros/noetic/mrpt-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs, mrpt-msgs-bridge, nav-msgs, pose-cov-ops, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-localization";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "52949811e06f4a275f0bf5df8d4e0051ae3bc9f4ba2269cc854b7923e1c4db6e";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_localization/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "cfcc8102a0ffcbd4766a9e392a400336168cb23c75e47e2590c6ba8de2e9fef3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-map/default.nix
+++ b/distros/noetic/mrpt-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-map";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "0f27e86b10d2f1c09886dcdd77f690ebaf80ae667badc0e6624c6a8b0fe36493";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_map/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "402ddc672d0eee1faf3c20412d815662fe6874280e444473bb9a45e7f4cebc62";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-msgs-bridge/default.nix
+++ b/distros/noetic/mrpt-msgs-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, marker-msgs, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, ros-environment, roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs-bridge";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "8535ee14b6ae934eb6fa36b0a74cf98ef074e507917c6f7e4331f33dd22be6b0";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_msgs_bridge/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "af75ae1cdd5dbdaa8e9ed5c04be37aeb2c47f46e9bceaa0a967f291226d55d20";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-navigation/default.nix
+++ b/distros/noetic/mrpt-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-local-obstacles, mrpt-localization, mrpt-map, mrpt-rawlog, mrpt-reactivenav2d, mrpt-tutorials }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-navigation";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "168519b2c792fe1b6667df40a75d70254b98fb1818f85062e66672c47814b6ad";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_navigation/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "c17738b430a3cb070d811f8fef1938aa16bec3c1d05a3163be079f344e0f1a01";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-path-planning/default.nix
+++ b/distros/noetic/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-path-planning";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "24c7e53de887b95b0ea54aac9b03d006bf15bc3c7b4ee9082e7e00c5c726b8fd";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "17a68fafaa254d50ad7431ae47be629d423420fdd31ca2943a796817c9c112d1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-rawlog/default.nix
+++ b/distros/noetic/mrpt-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, marker-msgs, mrpt-libgui, mrpt-libobs, mrpt-libros-bridge, mrpt-msgs, mrpt-msgs-bridge, nav-msgs, rosbag, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rawlog";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "6b034b0ae1c204c3062de2547cc79edd6b7e1a60f2c7e4d66fc7fd9e9b4d7c00";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_rawlog/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "e32d470a6467311f936791e2c4260f12fcc12b82bb4a028adba59d12cb2a52b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-rbpf-slam/default.nix
+++ b/distros/noetic/mrpt-rbpf-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, mrpt-libgui, mrpt-libros-bridge, mrpt-libslam, mrpt-msgs-bridge, mrpt-rawlog, mvsim, nav-msgs, roscpp, roslaunch, roslib, rviz, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-rbpf-slam";
-  version = "0.1.18-r1";
+  version = "0.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.18-1.tar.gz";
-    name = "0.1.18-1.tar.gz";
-    sha256 = "3f64f473e544daa59727ee74b82171d659bf7354c1d8594e1b3f62087c5c0de1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_rbpf_slam/0.1.19-1.tar.gz";
+    name = "0.1.19-1.tar.gz";
+    sha256 = "ec1b871d146219b547a8b92d360ad82367af8351dcde1a0934e4108c4eb22d9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-reactivenav2d/default.nix
+++ b/distros/noetic/mrpt-reactivenav2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mrpt-libnav, mrpt-libros-bridge, mrpt-msgs, nav-msgs, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-reactivenav2d";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "23445b377f0258c7a31710f6bb7d4f123ff361f93085bdeb0f22908d66996f97";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_reactivenav2d/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "79569c3d2ead21c7c01df6c452d53f867be753d3682dba985ffb1339529b8854";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-slam/default.nix
+++ b/distros/noetic/mrpt-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mrpt-ekf-slam-2d, mrpt-ekf-slam-3d, mrpt-graphslam-2d, mrpt-icp-slam-2d, mrpt-rbpf-slam }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-slam";
-  version = "0.1.18-r1";
+  version = "0.1.19-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.18-1.tar.gz";
-    name = "0.1.18-1.tar.gz";
-    sha256 = "ee7d6ba589a47c49b016e2357feff6de7f3d22716d7629c91bd60e90b0b073d8";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_slam-release/archive/release/noetic/mrpt_slam/0.1.19-1.tar.gz";
+    name = "0.1.19-1.tar.gz";
+    sha256 = "c50ee6af17e681d9e70454af0cee84a781037e0e4d5f72a847dcde19813090cc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-tutorials/default.nix
+++ b/distros/noetic/mrpt-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, teleop-twist-keyboard, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-tutorials";
-  version = "1.0.6-r2";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.6-2.tar.gz";
-    name = "1.0.6-2.tar.gz";
-    sha256 = "35e2813cda4ed07d65e0b376e1ef99be915b2a230a9365d316cba9607b74179c";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release/archive/release/noetic/mrpt_tutorials/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "297b7f27b0cf34d2b83675dbcdd2e1fdc71cb078ee3277ccf10ebebf82e47b5c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/python-mrpt/default.nix
+++ b/distros/noetic/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-python-mrpt";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/python_mrpt_ros-release/archive/release/noetic/python_mrpt/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "6d16b0bacd471626ff29b1832c700f4b848ee28a46df75be16f43b56b0b77d18";
+    url = "https://github.com/mrpt-ros-pkg-release/python_mrpt_ros-release/archive/release/noetic/python_mrpt/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "a4a0c3ed123db68d0dc3fd553a8be4803dd4f0162cd4ab5c522e9e3607b853df";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ros-comm/default.nix
+++ b/distros/noetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-ros-comm";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "106117604ebe798acc08dfa9a55433737046d9080b7bc735533ec9e5aa3fca55";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "e9c6b90a4924e1add4d6939a941f5f8f4e5493c47893b91d2868ac08f8439327";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-storage/default.nix
+++ b/distros/noetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-storage";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "24a10974a75d5fb8638f5a51a787831bf89a46b24686acf7d1ec08f86b62309f";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "7d7e8680d8da462023dd8fe31a8f76de2092be8131019134c136fd311f7a5b47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag/default.nix
+++ b/distros/noetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, python3Packages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-rosbag";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "6dabc1fd8ec07b514f9eb822a2ca711f214ba6f75b95c810a491ea10193a4dc0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "cb693a0862df4f1801980effe7d1e970724ef059316cc607c6fbd82d3faf5828";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp/default.nix
+++ b/distros/noetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-roscpp";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "17543a0b69103d973e7c8876e670472c50c16051ef78b7e6cbb8b417587d2b9c";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "534b45dd2132523dd2ff52d9611eab5d545fff3b87997c9f7aaa301d15d2e73c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosgraph/default.nix
+++ b/distros/noetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosgraph";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "7ac2822b7d9cc02c1528c9e22a665f310a017c93d673ec173fe305e2a0d88493";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "be16fd09a2ffab0c07fa263a392ed60db077275237d9aa5014fbca4e98f949ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslaunch/default.nix
+++ b/distros/noetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslaunch";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "0068bf19e7036e0684b50be6807556636c180803bfb0aa123fa3bc52e00ae130";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "7e70afc194bce398c3662f5cafedc6b01967e51533f67a49fe2539abbb66371f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslz4/default.nix
+++ b/distros/noetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslz4";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "a09d34d9fe021b087c24b2fd61f8758bb76273b5c45eae76aaca552858c599be";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "fbbb0722f57ba306be759bbc0c1741589b36462699cf504ecbb6c1360662b1e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmaster/default.nix
+++ b/distros/noetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosmaster";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "78704a97585671665d1b4754248b3ade1154bf5e92fe7a896d22df287bfe4056";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "892794d93b9b34c4ab05e13d890e49fcdbe1f04162494240d04a06f190e1f518";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmsg/default.nix
+++ b/distros/noetic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, genmsg, genpy, python3Packages, rosbag, roslib, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rosmsg";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "da2f4ebc819e522990cc7ead1d352d9796e8040bd768b6ae126b33bff0dad395";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "4ca8979e13d79d9f3334d84849ecc3e035f7cde5e5de90590100e37820e54ae2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosnode/default.nix
+++ b/distros/noetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-rosnode";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "2550153d998061d9c3bc3675fe269a3b42ea0779d58054c229ae4f6665398304";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "ead2ef7c21fd1d786aef6a1404c6f1c1776281ef89e5c52763bb0354426b686e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosout/default.nix
+++ b/distros/noetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosout";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "f0d14643641a30cdc5802ffdfa88b9a62009d3ae42d41924aa166096916de067";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "2c8f58b0499e910b1bddb7aa7da254388ae4b6a761d6d2edf3efbcabfbae25d4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosparam/default.nix
+++ b/distros/noetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosparam";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "1e6a806fee8b1a06da40bc26077dd783326b626708346ff66d79de966bebd5bc";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "ffc331043f5759f4c9437c69599433b23229dc901c4d1418e91f44a5d8ff967f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy/default.nix
+++ b/distros/noetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospy";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "69f8aa884069abf47bfdc06cb44ed0d012ae9582f6b291c08ca8c5c9cb30a8d0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "e6bffc7bb4727b78f7deaf2f7ee0baa4e410fc41752bc6740b5f7e444c21311e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosservice/default.nix
+++ b/distros/noetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosservice";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "611a125b14a27974f2780e23711180c04e2f3b14f5675d17c8f99c125483a84a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "9db6300e3a25d2b10e8f70f9554da89a64cfd31d5e10839cd5acba289021ee1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostest/default.nix
+++ b/distros/noetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-rostest";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "f690b39595dfd1fed040e3981b43a32b7b0dd17775d47d18abdcd062ea5e8503";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "9f5527c6aac448f6c8ef02ff2c542216c8624f5d3adac9fccad528472703f697";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostopic/default.nix
+++ b/distros/noetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rostopic";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "04bb2b1c560686e8957bf681e3aa33b6f2b362e3a4606ca528e27309d873e735";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "fabe657a7887d37299249f71fdf284703bbc047ce0d2f79a9cb410c76efcae27";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roswtf/default.nix
+++ b/distros/noetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, python3Packages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-roswtf";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "3a25ae7f5e81dfb82bfc93fda0e359b36a1f6b4d5ba91262212e110b45665677";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "c62a06b1001bcc3b28d7ac7ac86a3b493b924b6b46446aa70ad359a4fe08b74f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/topic-tools/default.nix
+++ b/distros/noetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-topic-tools";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "22423cc274b8e20d20be1aa6f91d088a5b9a335250ad6c8197e1d16017e3dfcc";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "ceaa0fdb897439a5fc6237087252e353d9dc0d1a22262584711374fe17a475d9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-msgs/default.nix
+++ b/distros/noetic/ur-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ur-msgs";
-  version = "1.3.4-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ur_msgs-release/archive/release/noetic/ur_msgs/1.3.4-1.tar.gz";
-    name = "1.3.4-1.tar.gz";
-    sha256 = "7cc9a63f7604f5bf88f11a0b1fad291ad18714070b9a3bb5f272833523ed6761";
+    url = "https://github.com/ros-industrial-release/ur_msgs-release/archive/release/noetic/ur_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "302d4840bd347c2f3d4371e1ce04e168ce558bd25e290378cc3d377c353e1f75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xmlrpcpp/default.nix
+++ b/distros/noetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-xmlrpcpp";
-  version = "1.16.0-r1";
+  version = "1.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.16.0-1.tar.gz";
-    name = "1.16.0-1.tar.gz";
-    sha256 = "6559437e2e8e7607509a25b1d1ab10a752412ff2576860cad55df5ec66196bc0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.17.0-1.tar.gz";
+    name = "1.17.0-1.tar.gz";
+    sha256 = "3f3de44f546a06f172d9522d23fb371f33c1207f5128b7329c7b84fb18ef3967";
   };
 
   buildType = "catkin";

--- a/distros/rolling/chomp-motion-planner/default.nix
+++ b/distros/rolling/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-chomp-motion-planner";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "fa359fdbf800e8a68579f76d08a6b224d99636b04de95cbbac30ad1ae77d4fb0";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "22f37b36b5cf78a32d08ada03136d5dc9f1c01999b54db7f36a38c2ff0998442";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastcdr/default.nix
+++ b/distros/rolling/fastcdr/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cmake }:
 buildRosPackage {
   pname = "ros-rolling-fastcdr";
-  version = "2.2.2-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a01092b9d35f0209b6eb618546330c1a6091a9d70af3b0ab79bd733ba06cb4c1";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "b8be1f3b259de02e289607bf3f1ffede73dbba290d9f21ad9190931e22c156e7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/foxglove-compressed-video-transport/default.nix
+++ b/distros/rolling/foxglove-compressed-video-transport/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-foxglove-compressed-video-transport";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/rolling/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "438fcd1ffd54a2ff58ad9d0c4b46b571066a1fa3f28e10bea54acf6403db2cd2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
+  checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ffmpeg-encoder-decoder foxglove-msgs image-transport pluginlib rclcpp rcutils sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
+
+  meta = {
+    description = "foxglove_compressed_video_transport provides a plugin to image_transport for
+    transparently sending an image stream encoded in foxglove compressed video packets.";
+    license = with lib.licenses; [ "Apache-2" ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -620,6 +620,8 @@ self: super: {
 
  foxglove-bridge = self.callPackage ./foxglove-bridge {};
 
+ foxglove-compressed-video-transport = self.callPackage ./foxglove-compressed-video-transport {};
+
  foxglove-msgs = self.callPackage ./foxglove-msgs {};
 
  fuse = self.callPackage ./fuse {};
@@ -1170,6 +1172,8 @@ self: super: {
 
  moveit-ros-tests = self.callPackage ./moveit-ros-tests {};
 
+ moveit-ros-trajectory-cache = self.callPackage ./moveit-ros-trajectory-cache {};
+
  moveit-ros-visualization = self.callPackage ./moveit-ros-visualization {};
 
  moveit-ros-warehouse = self.callPackage ./moveit-ros-warehouse {};
@@ -1199,8 +1203,6 @@ self: super: {
  mqtt-client = self.callPackage ./mqtt-client {};
 
  mqtt-client-interfaces = self.callPackage ./mqtt-client-interfaces {};
-
- mrpt2 = self.callPackage ./mrpt2 {};
 
  mrpt-apps = self.callPackage ./mrpt-apps {};
 
@@ -2075,6 +2077,8 @@ self: super: {
  shape-msgs = self.callPackage ./shape-msgs {};
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
+
+ sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};
 
  sick-safevisionary-base = self.callPackage ./sick-safevisionary-base {};
 

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "203d4b55aac7c0997b0be587dc01f3b11434b649afc896220bf5dfe9ef4fe64d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "33b8e4a00cd0b0f7db17ff580a42e0ce63a3ae9ced10fafdf5ded653ca367237";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mapviz-interfaces/default.nix
+++ b/distros/rolling/mapviz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mapviz-interfaces";
-  version = "2.3.0-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "f3d8a86afc28d3b42295f0ec71f33a9cab86166ec423d3447ff4d87f419aa773";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_interfaces/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "17f67548fc0d29faf70cffabb87a6e880e2ca9d69ae08d2309d452fe72fb070b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz-plugins/default.nix
+++ b/distros/rolling/mapviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, cv-bridge, gps-msgs, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, nav-msgs, pluginlib, qt5, rclcpp, rclcpp-action, ros-environment, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mapviz-plugins";
-  version = "2.3.0-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "0a60aa527af419cf142458eaecb2c5f4c40747115675da32015bd84abf6622ce";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz_plugins/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "d06cae95734463269c36e18759dfc161a60377def51be9a4663ec93e42175862";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mapviz/default.nix
+++ b/distros/rolling/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, freeglut, geometry-msgs, glew, image-transport, mapviz-interfaces, marti-common-msgs, pkg-config, pluginlib, qt5, rclcpp, ros-environment, rqt-gui, rqt-gui-cpp, std-srvs, swri-math-util, swri-transform-util, tf2, tf2-geometry-msgs, tf2-ros, xorg, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-mapviz";
-  version = "2.3.0-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "780d734766c149b041aebe168e29933e87cac64aa08a975d6f312be9bbff56f7";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/mapviz/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "5cb450ef0ec4f6fab3120cf559f37deafe44348da5f2e13008dd84b619b68839";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "89416d7fa14ca0bcb51e7e2f16e99fa7b0a030646289ddec074f90cb6386b6d3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9dd54aa1e43088349c8a41bd94cdecc4cddd209885c1a5d8bc2e8fae310d180d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ad2ff9a4b0e41c6e100f8d77cdacd8e57123a8fafedf7f8a14c1c09f32bb8b2b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9daf91e92b24e606f799b880545e2a9ab60894f219bc842f268801f48d3014d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "02c00f4745fd8abca2ee99c25ff2b0e6c3a1e75f98120b179decd05f0b95f928";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a4faeed5a145e633e8f43f6b3248f74af08b8d2aca2e7231b6de998934d43955";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "7cbc21a6fd4f8f833a357478cc612de9002d28dc14f747aa29cd81671d9b55a3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "38fb4fcabcdd9b4b135b84523442a85507a351f9a588b523741164a0eff4dd9e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "fbd6a63a10af58146eec0d9106e6efcee99e88a1e9e0f7c716fbfec2d43991ba";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "3dc89ee35087e4b18eabf9ebf0c201fbd99c3224f9dc2d40424fe2f180747af9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "61770ae0e1239264b693869e9cb1c19a76fa9c30e576e200c5e7451b3114aba8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8b1b5de8bac35e29021ab7bf9e454104be35e23e55f25425c2ab40bfa7dbb617";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8382a735f23c3e0930ea12dccff48a5e5cddc580c0235402d3da3deb539b20fb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "33ac77459f33489ffcda8ccdb996ad12a75935aeca70e2c4e7e247d8e5fa9228";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "da07ab0caaa68bbaf36b0443fd95a5f0da8687b0347053aa385dd9710d0f1981";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8f13ae8985397d2610000ae7fe134812230c0880c4f31062591f782db4915b84";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "cc0eba00ed6ec0b0faaf676dd6275164471b4786562f7bd42c3536ab0293fd7e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f122683335e76bd691ea73952c0ad1ab9876400d175a57914519dd4bfac223c0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "20da49e5b8bffdec036c82e7ac57f2717bb3db0fb624b48852e9e837df509240";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "712c9c7ee71f429566a60ae95861bb899c96da9f90f723b90d8f7dd06e129b84";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8f2dbd423e951a782917046546288c0d7926ec733f615be175c86788c871cef2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8f4d1ab63ba9059fb7b047ec52609691dcb76af3d1fbf87de44131f1d4417c8f";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8aaed536db09015d44f7866f137066b573620d396407ee316533e2f87ea6bc55";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "941171fd0589af4c0bd9eb40e8eaa633316621e068ffed16c31fb9191bfa4208";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mrpt-libmaps, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "dadf17c6246cd966d26c520d479b37bc2cf853c90da6a3cab7a8264b23486532";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "02f7d61d99377986e74eed4dbe2855ef63c1be7544235b41c6161fde132213f9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ mola-common mrpt-libmaps ];
+  propagatedBuildInputs = [ mola-common mp2p-icp mrpt-libmaps ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "35f5d60c332232511c347bc30933f1780bb1e563312225a6339189e979b7ccbc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "218df4b1ac24a8b3cb1c84e724f49673b3b094133c746337eee311ec2b1d172c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-navstate-fg/default.nix
+++ b/distros/rolling/mola-navstate-fg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fg";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fg/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c8265d4350eeb7d00c54e44c978736de34062b05bbcf5c852162b179ea1ac510";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fg/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "10006f6624692590431e2609e3feea0f710f0c375a60babd1077a5d546c2b32b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-navstate-fuse/default.nix
+++ b/distros/rolling/mola-navstate-fuse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-navstate-fuse";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "6004b8413853c77ff3118d549db411ae9dd4070bfa7e5d6e2bf816e4d55f5610";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_navstate_fuse/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "0de3708ad44b45633686a3eef4eb9acf226290f5c85782274af48176ac7156a1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "212214fc22ca5b9e62837a8243d7299a7b2b2ef980936f4ceaed7b27b3926920";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "29d7642938dcbdf1dbdbbe6175262779559372713dafbca5bcecd173f1c849d7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "f69f2334ee1641433ee676b309d18421213bef3e8984ee8fb532cba5fc581dd9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "517f6a98ca0959cb159abb54ab1122aee1a258243ccb876a6912eefb9a6d5de5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "94325b4e0f3faba426823dbd705a08142efc24cef0e89ceff5f246c0690eed6b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fd14d766408ca0fecd5de00a4dd8a8adf532934f528e31abf7f8407cf6723f5c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c41e77536b65378269759cede8cfdbdb639a07274cf718e0f646e7316cc748b7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "db4a6af40a46bcba5aa727c7c5fb464b49cdbe13dfd2d337979ee8eb26a783c2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "14808dc11dbedab6d9f6e99819aa305c02b7f975e9eb7981c4d231a5cf2c96a7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "536dbc52b0b943cdc9c981e2dedf7014e46386fbe6ee9f883cd719d84b5d780e";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-imu-preintegration, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fg, mola-navstate-fuse, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "4e65a4369b6e66459903df7444f24a7027f5067fa4417a1303127583b304a1a1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "dbc51a32efa4222abd9d4b112e0c61198aac7b5255a1655addece2f38d67cb0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-common/default.nix
+++ b/distros/rolling/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-common";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "a933d320bc8c6e895ac75bcd68793cf7c0981c734af512fae1f6f0c4d7c04b77";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "d86cd5ef794e0fdf14af76b7ff6ea174a343e4bd0ddc18ca42b6744f3cb63d76";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-configs-utils/default.nix
+++ b/distros/rolling/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-configs-utils";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "7813e67371e0e986556b9f94a7f8f926a5066dc672e1918251abb5e24a804e77";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "a225268668b894c5adeca5843569315b957ce2a585f503a17b7c6446f5ab7f81";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/moveit-core/default.nix
+++ b/distros/rolling/moveit-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-core";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "81c3ac608cccb1a16593a91ba310d8c75936f151544c969883bac9674158cf90";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "fdd33bd5149ac059874ec10237d053450b5dfe0900017929c7e746a8214cd7bf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake pkg-config ];
   checkInputs = [ ament-cmake-gmock ament-cmake-google-benchmark ament-cmake-gtest ament-index-cpp angles launch-testing-ament-cmake moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl-vendor rcl-interfaces rclpy ];
-  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl generate-parameter-library geometric-shapes geometry-msgs google-benchmark-vendor kdl-parser moveit-common moveit-msgs octomap-msgs osqp-vendor pluginlib random-numbers rclcpp rsl ruckig sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-kdl trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
+  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl generate-parameter-library geometric-shapes geometry-msgs google-benchmark-vendor kdl-parser moveit-common moveit-msgs octomap octomap-msgs osqp-vendor pluginlib random-numbers rclcpp rsl ruckig sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-kdl trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
 
   meta = {

--- a/distros/rolling/moveit-hybrid-planning/default.nix
+++ b/distros/rolling/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-hybrid-planning";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "890ed78c6362ac1bdf2d098252ed9f5ead4822a2c291c0dd78a27e4110456ca0";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "1d22a8b1d1823abfae9e2e1d189a9ee5c95ea337bd342bcd92ac60b0df98ba4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-kinematics/default.nix
+++ b/distros/rolling/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-kinematics";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8fbc4b5ac383d4143b2289eb2ab7fa19abfa5f2efa29055e9f8f47d07df836a6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "c6de6a1b4ae434becdeb156ea7bfdd56c0eea080a234c64d9b41962c2a96b38d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-msgs/default.nix
+++ b/distros/rolling/moveit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-msgs";
-  version = "2.5.0-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_msgs-release/archive/release/rolling/moveit_msgs/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "bbde1f8fed07d4df8a59903b79d0f61ef0b8f9b3299d277ff06add6485b3f09d";
+    url = "https://github.com/ros2-gbp/moveit_msgs-release/archive/release/rolling/moveit_msgs/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "24c032e313dc0594b58cc98834593bd119582b622518adf37dfe9229b43cd8f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-chomp/default.nix
+++ b/distros/rolling/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-chomp";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "3d2ff386b7360beaae2c58f494264107f069cdfb3368cb034948ce14d3d28b8f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "1239318f3bca18377aa5caf259c697acd4f354680f347ba2e61537048e69a076";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-ompl/default.nix
+++ b/distros/rolling/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-ompl";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "653b43a69c5033313af56246becf04ea0199d63d0759131332347820ad7b50b9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "b7ac6550675fc133881da589d9e3e03f99f6737d8b0dcf45948674845e7a7904";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-stomp/default.nix
+++ b/distros/rolling/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-stomp";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "e16207decb2638a780c1ada4bf443be0cd41b1f76d33b7f57a4b7f93fc348f1d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "dd5cc45e1127ea407a10aa9e76caba04e22138e3aecbf2a7361cfc1842bfa79c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners/default.nix
+++ b/distros/rolling/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "cae987d2bc692d7f0bb3792c8df0130dc10b8d56d3e339a1042b0355ca47a067";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "20e71e06dba21d49c25492ce8e1fe9c272b0d3000d3302c690f4aecb9e2b9cc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-plugins/default.nix
+++ b/distros/rolling/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-rolling-moveit-plugins";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "1f15d3a3763366dc39ca42c85e1800d500c7a3c1ba7b36ce37e1a3a8520c5b74";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "ce86238726e21fb0a10aee5a7bd4794e8ee7df97e4702b691c96e2603a1b8037";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-py/default.nix
+++ b/distros/rolling/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, pythonPackages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-moveit-py";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "b2cdef55b0d8de6a46de829d8f9a94f898375f6608242b3fec12afc0ab1956db";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "9d15bac9579e9d562866b277583f19334bf8e27ef87cfafc65ec8cd6a7436400";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "a2557c6ad44874a7ecfdd8b25f225774202a7942eb2a70e61cad971d0f8836a8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7e8e2281f84f2016b77ddee46f19a7d7bc8361c3e3f868e4c04db371fdc1f217";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-moveit-config";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8f69699055739d4fa0609d15f1fff95f10dc262ae1bc55dcaef7735a7dd97ce3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "3ae036eb14ef6a4310ec97304fc2aeb752d01466accf8be8773a50a97fdfa6cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-pg70-support";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "28df5fed760208c50c745f82a1b180a99e7abe0af5f0aff7969b80dfcd153d7a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "720352943ee90cd07b0a3d989441f9113a2ba3e908c3ac18ce77c9c8c1af88cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-support";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "94533ba69697ba44e49b017fe368c7988756869ba6dc524b4c9259bcec2ff988";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "cbc9edcb8dbd2d075a6414de1481a32c1e5ebe9de8b09a40608888ece4aee41c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-benchmarks/default.nix
+++ b/distros/rolling/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-benchmarks";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "91bf357ee96556d499beab3eb45433f54d155dcd6f4c4c76f192cd479f553584";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "4ad94c43751753e815fdc82bc67ccace16b9a1e44aa9f6cf533bd5676719efb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-control-interface/default.nix
+++ b/distros/rolling/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-control-interface";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "fe415cd08624b4e0b3252761da2bd4bbb746d2fcc3ac3226cf1cf8cdc7d6a8e7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "72b884b0a39af92c6d4cb0c10e61f5fc7d0c7f62fb0550b2f1f2478143e4e8dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-move-group/default.nix
+++ b/distros/rolling/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-move-group";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "b8228439c5af3e26d2f7268e1822da5bfc45cf2975cc78d49569178d9ab68eef";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "ee827e3bb692512353dc313e41e7bfbc7310e6a50534feb0864f690e553a7adf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, pluginlib, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-occupancy-map-monitor";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "1593caf67b81ef1b3ec3f7ef921f2f19d49ad855bf7b1a3a84f6b8cbad95e0a7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "c1c7c42c27c97411ebd04728267da9589148867a19c49905749ee82c3cc6d7ec";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ];
-  propagatedBuildInputs = [ eigen eigen3-cmake-module geometric-shapes moveit-common moveit-core moveit-msgs pluginlib rclcpp tf2-ros ];
+  propagatedBuildInputs = [ eigen eigen3-cmake-module geometric-shapes moveit-common moveit-core moveit-msgs octomap pluginlib rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/rolling/moveit-ros-perception/default.nix
+++ b/distros/rolling/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-perception";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "7030483a2b8c202c051cd8b1d414cf89383ab69df86c1cc951097f11d2fa1fff";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "0be9cb0ddd03aecb392ce1cb2b6216aca6f57ff002134fb87d33955f37936b4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning-interface/default.nix
+++ b/distros/rolling/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning-interface";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "47bf9875e3eb29b1fbc0a8c9e67a5afcceb767951ff5f6423ec7827b72b47cca";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7f0663adae50547d406e62d1d49b7f802c570a85a96c2af365a72f3711a8cef1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning/default.nix
+++ b/distros/rolling/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "68d7da76f93b5ada631ffd40467fda43a6f27d18941ebb3881fd044755122cb3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "4be57fcb06ac6c57150c7274a212681dc453948ca388f60258240134dd68affa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-robot-interaction/default.nix
+++ b/distros/rolling/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-robot-interaction";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "0949c0ebc1511eebc8fff8f72e0b5d5df83205c537540283b54fd14261b5a637";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "474d4d8e7ff537db4793e3541050304c1a42acfc328ba51c17376a2dd50411d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-tests/default.nix
+++ b/distros/rolling/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-tests";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "8ccfbec0b8fb7ca94083095cf1a4d1924f1d93523b72be0832c63ceae6dfeb0c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "122b8373a0693e384edf54ee36be49c7079df90e849caa07b5390d86f67a1698";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-trajectory-cache/default.nix
+++ b/distros/rolling/moveit-ros-trajectory-cache/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, pythonPackages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-moveit-ros-trajectory-cache";
+  version = "2.11.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "498f5aa30cc389aaebcf61f3df4442f995e34b5ad6fdb608443bea32871541b7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-pytest ament-cmake-uncrustify launch-pytest launch-testing-ament-cmake moveit-configs-utils moveit-planners-ompl moveit-resources pythonPackages.pytest rmf-utils robot-state-publisher ros2-control warehouse-ros-sqlite ];
+  propagatedBuildInputs = [ geometry-msgs moveit-common moveit-ros moveit-ros-planning-interface python3Packages.pyyaml rclcpp rclcpp-action tf2-ros trajectory-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A trajectory cache for MoveIt 2 motion plans and cartesian plans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/moveit-ros-visualization/default.nix
+++ b/distros/rolling/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-visualization";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "c2f2ca9ab56274f70ef2f9f0feda44efa0381f8c1cdca42d9ead8b3ec4e89b71";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "a3350a646f6b61c2b41f085ad61bc93d64086058666c2d4830a93efafcca6d76";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-warehouse/default.nix
+++ b/distros/rolling/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-warehouse";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "86db971166beefdd00e4d729f87e0f718c01da53e7143ff75e6381bb69cb03e4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "eceab755bf2bab607ef68e4df7deac9e4455330c2f89831283d2f652fa999a84";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros/default.nix
+++ b/distros/rolling/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "ad8f6f6d86069e48191dbd4c26eb1a98343edf3ef78aaeede04825dd9a272b8a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "f3adfda491daebe2b03c437380f7669e98c37d179ca156affe292c6731821ba4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-runtime/default.nix
+++ b/distros/rolling/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-runtime";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "563f001c5366f4c87304a650ee9abc33bffc85816d54b56f1d89dfdcfa98b98b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "322f3e41a92cace27966bba79853f5167beffcfd3dd67ac9da74af9f4ff436ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-servo/default.nix
+++ b/distros/rolling/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-servo";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "117caf7898764343ae5fb32e624ff5ad2257a444c52bd4c8a803399f42b05639";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "52929dd3138ffb8e43e991015b337e077f4b8ee8c4f527bce7ea2370b8946db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-app-plugins/default.nix
+++ b/distros/rolling/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-app-plugins";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "732a18488f66260187571893d327766cfbb16d7dba995a1beca1b8ecafbf8d00";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "386a1b9ab0e586846182edd700f909fff0724adc93cb4ca097a81d3aa37b59a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-assistant/default.nix
+++ b/distros/rolling/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-assistant";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "fcfe24ea7a2b2b5c1caacb60f43e4bd394c9748be67921747d487e829ebdeebb";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "a9ea7a980c3e2f5b58224c5c483b539ea4a43db0762209cdaab67c5bacaac95d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-controllers/default.nix
+++ b/distros/rolling/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-controllers";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "0c53107b4d51af2d58e0e516c5045768d240ab44a86a61cc2af480d5bc272adb";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "e240eceea34363e824f398c99ca90b8d90569c47d7b6ab176c07b6c0906c9e95";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-core-plugins/default.nix
+++ b/distros/rolling/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-core-plugins";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "719688fc2a59ce65e7d43c7b6390868da80e5c555ef72f57e8331bd8f05f261b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7c52278b7a96cc26a57cf78360b87c1be85b7a76bc335676dc598dc8bf202395";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-framework/default.nix
+++ b/distros/rolling/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-framework";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "b9123f7eba92c303117ee2af98c02e413c9fe1ed76495e133e1673fb5e9a35f9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "39d864f079c34ce558031b4fbf4106bcb98393b5cb5d416b12517db217fed593";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-srdf-plugins/default.nix
+++ b/distros/rolling/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-srdf-plugins";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "c7c2d437b7f2f6fe90dc63a0992dfb8679052fe02bc3c3c97f6bede4512fdb22";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "4faa04a98fc684abbf95625902343041cdd526f0e4d153c26b9c017c40762b7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-simple-controller-manager/default.nix
+++ b/distros/rolling/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-moveit-simple-controller-manager";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "e055ca086ceecfddd8c6d8a974a0962a71ee4816a28fedff09b81b3a69e9670c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "11481eaa9bdc35f0bca1a4bc2507e9bee1b8ab5165dd47757b76695e1f8ab38e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit/default.nix
+++ b/distros/rolling/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-rolling-moveit";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "4285cae995212a3ccc9b3fb6cf28e2287cc86901303b5b6164b9445ff64bf55e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "1171a3a9f5d479d33ee6308d68f0c50e5267066b78d11583de51b53ca4db0ca3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, tbb_2021_11 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.6.0-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1d46a7051366a13bd18342a45d88d40e4ce91b14c041530449a655f129e3e7b5";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c4797417867446171e36e5ac947e361309b3ac20fdd3dc508c38289f1a294b0f";
   };
 
   buildType = "cmake";
-  buildInputs = [ cmake ];
+  buildInputs = [ ament-cmake cmake ros-environment ];
   propagatedBuildInputs = [ mola-common mrpt-libbase mrpt-libgui mrpt-libmaps mrpt-libobs mrpt-libposes mrpt-libtclap tbb_2021_11 ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake cmake ];
 
   meta = {
     description = "A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++";

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "98632c9dfe86ec6dc4dd11a1921704d17f06ebc29d63526d4fc948a1866b2b75";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "d9ab0ae61db046ad7d94e68efe3c6d2b9467ab24cb7441033af562b5afb91f3c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "7138cd185241f571c5d230f0cc3bd9e76f51925fcd7e0ff14351bcfed15af2c6";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "ca80ce1adcadada5b0316651d7a97d4d3e307ee3111332a4184b9dfe0d4bc246";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "d9569902d0f39dd93bb76f7302d777df1847edf4cb125feb1bed5672c663c9f1";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6f09c288d583ddaf5be5ad556fc78671252d4ea2a4008b50d572b549d07a852f";
   };
 
   buildType = "cmake";
-  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
+  buildInputs = [ ament-cmake assimp cmake cv-bridge eigen ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage suitesparse tbb_2021_11 tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "feed4b631672c3d4e95e20889c12926454c5d9e99c943e80270fba7fc44e54c8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "01de7a91c4d45d5e7562ad045388433a4214e55aa3cfc3124ffbe666b0a37657";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "740a0e730c2d3293014f8fd1266d2aad87885b0b655bd02128d43e51e175c3e9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "d5dd088fd166d046616fb078ab546f9d34531c09219cec514ff110e4096b117d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ea2c5a64c2d7656e90790e59ba479e570d0205a3416151a5bfd9ab1bb063dcaa";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "bbcf7d245a7e48e1ebf8f974d3834d00e5a71c75ba029ac27d3fc85c918b9196";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "e3d31e6ae06e243b2d7b289d1965dbd119af1007eb083dde05e72df6a724ab47";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "cb71d3aa47fef3ad2b35f3142aef7a8e07d9abe34c9c403229a70f3e6ecdddf0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "85510a99b5674719b3dad246a11a6f41a047da43372207a4678315f6dad04f5a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e1898b831491a037e77465be6dae21aa588362a990ae0c0d6a380338e1ed7e40";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "301227621954f0f3200204246f052117626054804ad82b3f6f91e02d3c9bcbd8";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1df2743602f6014253a6422884fc6872357ad74d7fc18266a1bfae94d1cd9cc6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "8f84138169bad0524bd2fb81ef6549f41df107a18c0b855f86df79bd29ba23d3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "adaa57e4ece527f80640b724bfe96ed10999dc4043cf47b29fbaae53d01f69b1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "b9ba4268c76421780a1a68383cfe556ea882509f41cacecf751a6832e19a096c";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "ca4f4c11613f47356c190b1f7d95c1a05c8d22cde25ad81332fb836ea3d09cae";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libros-bridge/default.nix
+++ b/distros/rolling/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros-bridge";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "b477b1abce22ca22c939b1f04dbbc90781aecb4d4626f8a47e99bbcf5b50df6b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6541c3a3f36f87aad4396af69e851d96e20db2ce4f8b7d0c11d7ec6ee7165347";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "bf042fc261cb5fc8efb4cb5abc9e4d8df9e7e56c4e8e5565d05aef96087991a0";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "9fba5f9b25ddaac66ff288120284d73ab7efabe54eebe1a2d15360170a33f6e6";
   };
 
   buildType = "cmake";
   buildInputs = [ ament-cmake assimp cmake cv-bridge ffmpeg freeglut freenect glfw3 libGL libGLU libjpeg libpcap libusb1 octomap opencv opencv.cxxdev openni2 pkg-config python3Packages.pip pythonPackages.pybind11 rclcpp ros-environment rosbag2-storage tinyxml-2 udev wxGTK32 xorg.libXrandr xorg.libXxf86vm zlib ];
-  propagatedBuildInputs = [ mrpt-libmaps ];
+  propagatedBuildInputs = [ mrpt-libmaps tbb_2021_11 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "781a7fe83cd5d6badba956bb15249889cefc9e52638ecfcd45acb4364d01799a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "04111d606acabe3b7bd73cc89659bb2ba960f4a984627aa6e7550ecc00b711b7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-path-planning/default.nix
+++ b/distros/rolling/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-path-planning";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "03b4ff929e6975a0b022dddcd4a675df62377dcda1ace7abc4b4f0d11464ce85";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "886591a1fe80db626afb045e9cbfd55c699f83d9b06c1b23942cd8b8887193e4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/multires-image/default.nix
+++ b/distros/rolling/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, gps-msgs, mapviz, pluginlib, qt5, rclcpp, rclpy, swri-math-util, swri-transform-util, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-multires-image";
-  version = "2.3.0-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "168a574be48a5a72bf3f950e874a473b11f3d536addeef3043ab6468770fd116";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/multires_image/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "96934363477164ad7da1df18e9225e6881c692992bff4e9cadd6eee2cb09f2fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner-testutils";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "9edf1070d4f9a5c9ffb395c64415dddac4b7fcc9e119b8b6fc2b9e180069b8e5";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "7bf8819709da10cd11d6da796ae1efaf659afa65729e34b49da7b3eda34637f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "ba8649aa1196c7c13cae86a51b01d179f1d95cef1c38d06eb7d94fcee8d389b4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "4e889ce59205aefe9668d2a74ff65e3c8e5327d80e3fecf8760ef92896750cc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pinocchio/default.nix
+++ b/distros/rolling/pinocchio/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-pinocchio";
-  version = "2.6.21-r2";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/2.6.21-2.tar.gz";
-    name = "2.6.21-2.tar.gz";
-    sha256 = "c5e50effc5ac6505c0b86c863028de5e12dd46876378e621a3e9c68ef67b959e";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "5237586b2b2b88069161419b1e40830dc76197941a25ac075ff125bc0f642a1f";
   };
 
   buildType = "cmake";
   buildInputs = [ clang cmake doxygen git ];
-  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy urdfdom ];
+  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy ros-environment urdfdom ];
   nativeBuildInputs = [ clang cmake ];
 
   meta = {

--- a/distros/rolling/polygon-demos/default.nix
+++ b/distros/rolling/polygon-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, color-util, geometry-msgs, polygon-msgs, polygon-rviz-plugins, polygon-utils, rclcpp, rviz-common, rviz-default-plugins, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-polygon-demos";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_demos/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "26049467bd10f9ba8959b4e24bf2098b25b184b0d70298888b4185ff53c0cc94";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "670f997786033ad4e47ad68fe221a01da647125df6ba00503d5647cdf84e9899";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-msgs/default.nix
+++ b/distros/rolling/polygon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-polygon-msgs";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_msgs/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "91a986d4eed08962d9dfd093e610310821ed34139595c24a65ac4534fcfc8bbb";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d5747eda77d185c70f3dc7bab99318d9fb708fb4bd90a24bcb9309fa2066d6d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-rviz-plugins/default.nix
+++ b/distros/rolling/polygon-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, color-util, geometry-msgs, pluginlib, polygon-msgs, polygon-utils, rviz-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-polygon-rviz-plugins";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_rviz_plugins/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "9228448e9bc901d2333459ecb18b5089ad0f367b832925ad46cc4295de61b8e1";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_rviz_plugins/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8cb0ddafee28e3771a054a7251862650826d1e12995aad6b97906a7b4b5441f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-utils/default.nix
+++ b/distros/rolling/polygon-utils/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, polygon-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, geometry-msgs, polygon-msgs, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-polygon-utils";
-  version = "1.0.2-r2";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_utils/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "21a1b229e087cbcc0b60af797466e4f990f2bb6a15b0e58e1ecfe544b74c6613";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_utils/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2de1d0f6f672f76e88d2632b1001b40060d8d69f1bc52abe7979e2a3179aa074";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ geometry-msgs polygon-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ];
+  propagatedBuildInputs = [ geometry-msgs polygon-msgs python3Packages.shapely ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Utilities for working with polygons, including triangulation";

--- a/distros/rolling/python-mrpt/default.nix
+++ b/distros/rolling/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-python-mrpt";
-  version = "2.13.8-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/rolling/python_mrpt/2.13.8-1.tar.gz";
-    name = "2.13.8-1.tar.gz";
-    sha256 = "ba1370f26d885410efd3f604e9a877ce4517a716f31c382373560c275eebc12f";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/rolling/python_mrpt/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "ac231796f4a32e87df8100dec846d6624b7d7094c723d38d6ff686f902dfb6c5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.9.1-r1";
+  version = "6.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.9.1-1.tar.gz";
-    name = "6.9.1-1.tar.gz";
-    sha256 = "6421a623f7c693f004bb853849da53176c2b08fb8d16ec309a2ca44c95e38bfe";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.9.2-1.tar.gz";
+    name = "6.9.2-1.tar.gz";
+    sha256 = "a3b015824cb645ca4bdbca881c48394ceeecba1a80158b703ee10a20e073e30f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a5667d844694538756c4a3a2735ffce05a4ce8f71dece0de97d7a9e37ed6c0aa";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "abfca221ebaf179dce7f05d24eb9302c39b30c4dc0377e51eadaa43d09153e48";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "2416282358bdef55f92038803dee354cc8e1a0a0482853899fe144a43b19dec8";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0fc9d365b9f2728392029e676029a0b02027327b05a3b04c10199e0c797003c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "9e0125fde5d5f296203189b13a031d2cc19b4e7c50b8525a97f61de7e7c5f334";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "eea991bdc2262e3569bd796ec328ceacf23f3202f796f273bfc72e70bfabb949";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "962a03f908d8257984eb1155a588549783e83fa8447d77d099814358353b8c88";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "50d61f863d719b80c7802a52268d9472251a168e9f2ef3e8ad93e9887c31a015";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f0f72e6e0de9b42cfc9cdce5398727a459370847da75917a727575dad6006442";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "da5b39ed359de581297118574a4f5372e07b88197717a879ed172cb6f8b9176e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "0797c33bac32e257f9c2021c7b15f9efc30ff0dd3ffdba6377fbb9da866e2b61";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "fea079b1dbd80dbba68ac388244185c7a555caa36c80f3c4954bbbfb592cd1e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sick-safetyscanners2-interfaces/default.nix
+++ b/distros/rolling/sick-safetyscanners2-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-sick-safetyscanners2-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/sick_safetyscanners2_interfaces-release/archive/release/rolling/sick_safetyscanners2_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c0777aadd36daa148e840228e8eb145a4c9829d5f6c9b8380cd7d6db5bca77a1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Interfaces for the sick_safetyscanners ros2 driver";
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/rolling/swri-cli-tools/default.nix
+++ b/distros/rolling/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-rolling-swri-cli-tools";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_cli_tools/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "0bffa17dbfd83c4f2f05ce7a0e1664f8d53193189a2fd42f15d4bb455989031b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_cli_tools/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "f9522d6e1ce6a60b6003d1de25bbdaf22572c90136fddbb9ac656a20a7e087df";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/swri-console-util/default.nix
+++ b/distros/rolling/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-console-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_console_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "5732efdf1b3d2a52c15950e363a50816cb1f98323a8df5c2269a85f81f05fbce";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_console_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "087a812c05b2c27554f2f0ba078873e536020877d8b2b94b9c869a9e02487e31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-dbw-interface/default.nix
+++ b/distros/rolling/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-swri-dbw-interface";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_dbw_interface/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "d6dcbba92b6297ee01f12d95e493b1b62451b472ccee2b37ccfda938111a3911";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_dbw_interface/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "87756663a79d0fb9026695d14504b9e2a35e66a9f5cf8a67bf5a58177ea18007";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-geometry-util/default.nix
+++ b/distros/rolling/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-swri-geometry-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_geometry_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "a8ec2d76a50627f33b5fe5cb1aa8913365402ffa3025880037b895d80d26a164";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_geometry_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "25b67ceada4279ca158a6539d91c52f042dd9e28d599f2c09357145d78451baf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-image-util/default.nix
+++ b/distros/rolling/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-swri-image-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_image_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "e50d9c859cb1bb6894ab5f7eaea23536f17942c4799dbb77810f06a398d7032a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_image_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "0ae2cd24bb1370363a32f46c06eac16819ca81d1821e8c625de8e70eb7f81405";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-math-util/default.nix
+++ b/distros/rolling/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-math-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_math_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "14099eac58726e9e55bb2e47d84b9f0457f34a1e4701e6ea1b6714321a1cd44b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_math_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "e7c0bc66bb310912b23702adafb35d4fdb1072c4a6a61fc37f7f364d03fdd973";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-opencv-util/default.nix
+++ b/distros/rolling/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-rolling-swri-opencv-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_opencv_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "8caba858c374fd0053db30a2d7dad02c9aa3c51cfcc0aed1430cc71cc8e6bd38";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_opencv_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "2fb616328cb2707c7b2219c8ff4ad1086419c18aebbfc71a6fe0cd6b7669ba5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-roscpp/default.nix
+++ b/distros/rolling/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-swri-roscpp";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_roscpp/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "7cf85feca38332ff45cd8a100ec96ac93e48ecdb28e19b916dc1271093ab1b96";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_roscpp/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "581232e3729f18931813ab89a893ae41047fae03fe35f93dc7e997913f22881d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-route-util/default.nix
+++ b/distros/rolling/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-swri-route-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_route_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "6ce7d837f5c8bc655f8fa1a48de20eddb4155b3660c037373eda9bdf0dc15ebd";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_route_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "b53fd29dac228a898ae4adc939570491f33f7cb735b30ec1f8874f54393f9009";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-serial-util/default.nix
+++ b/distros/rolling/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-rolling-swri-serial-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_serial_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "b608d8d4d68021b933a50195f72c545a98b7f677213a016cdc5a583b0f5a7091";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_serial_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "7a07575530b4d8146dcaab10434e2f55ef7cfc01fc92ca9eed992124ed815c94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-system-util/default.nix
+++ b/distros/rolling/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-system-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_system_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "5a3847db309a1160bb7c4e8dff370e8d9b170886aa330d1e3c2abd1da0fba52e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_system_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "e79ce720587d50c7599296e51adae4176b85c61b2ac62973001b6e34a50f66c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/swri-transform-util/default.nix
+++ b/distros/rolling/swri-transform-util/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-swri-transform-util";
-  version = "3.7.1-r1";
+  version = "3.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_transform_util/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "eb58fcdb843dcb6595e68b382ffdb11c22a9cd00e7af283aab29cce5e048c14e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/rolling/swri_transform_util/3.7.3-1.tar.gz";
+    name = "3.7.3-1.tar.gz";
+    sha256 = "3e1ec2317c57e8a15ea8f855837519d9053acb49515a8df889df96b97e663ee9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs diagnostic-updater geographic-msgs geographiclib geometry-msgs geos gps-msgs marti-nav-msgs proj python3Packages.numpy python3Packages.pyyaml rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros yaml-cpp ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/rolling/test-ros-gz-bridge/default.nix
+++ b/distros/rolling/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-rolling-test-ros-gz-bridge";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "2bb7daa0669553d98b4e072dbeff66224456096c6f903caef9f873c5f581fcc8";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6a0e9cdaa41dbb834caef24e1e4a437c91bebbe3c133754197b2f2710be5dfc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tile-map/default.nix
+++ b/distros/rolling/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glew, jsoncpp, mapviz, pluginlib, qt5, rclcpp, swri-math-util, swri-transform-util, tf2, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tile-map";
-  version = "2.3.0-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/2.3.0-2.tar.gz";
-    name = "2.3.0-2.tar.gz";
-    sha256 = "9f052223d6b0f05bcc5a6e098df2c0f71805b82c283cd0db10a0dbea1fb74689";
+    url = "https://github.com/ros2-gbp/mapviz-release/archive/release/rolling/tile_map/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "b82702a50eba87debac16463cd4d3aa2547f98c9aeffa06a5437cf1519272ea0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "ced439365b9de504607693d816b2a0a809003dbe645697598bfec0131eaf948a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "db89e6ff36250a15858f57927b1b48836397629c6adca3a891cb7ce9dc46573c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "7bcb5b7721b30713314a104b4162b8e2d1fae1775428d10373f4c221eda8908a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "caa25de6831473068ced1db2baa0a4cf84a04e711fae59d8446c874907383e70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "c98a927fe0b255fe531b000564cf87c5ff6c8f945edf1921454d19a2a17999ce";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "864c46e9cc86ecb91e5b818ca423403b0ea8c4101a32cae29f798a091532cc84";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "f4603654d35c94d651c3cdf25438d8ac8ce89b30bb9d869904e6cd2eccdf7e23";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "16cb5ed71481f87d5f543ca3bf9c559f27419b0e6817a46a1816ea4c92696759";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-robot-driver/default.nix
+++ b/distros/rolling/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-robot-driver";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "08903633a1ea993abb3b894644896fb756672b5e506de4940a4f92e55628c65c";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "e113ca8dc7b5ba2d889a7d2c2d8558505339b88950155ee771953445d0a572c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "2.4.9-r1";
+  version = "2.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.9-1.tar.gz";
-    name = "2.4.9-1.tar.gz";
-    sha256 = "3373ef30ac0ad15303a68355259a21b73bec1d241021c8c021598c80da559c9f";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/2.4.10-1.tar.gz";
+    name = "2.4.10-1.tar.gz";
+    sha256 = "8bd082bcef2473af5e5a8d72a651259eede3ac5929fbea8fe1adb4f78a92917b";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit dde852afc9f761d150950d44c8b03ee5a19dc73e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-config 0.2.11-r1 --> 0.3.1-r1*
* *clearpath-config-live 0.1.2-r1 --> 0.3.0-r1*
* *clearpath-control 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-customization 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-description 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-desktop 0.1.2-r1 --> 0.3.0-r1*
* *clearpath-generator-common 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-generator-gz 0.2.6-r1 --> 0.3.0-r1*
* *clearpath-gz 0.2.6-r1 --> 0.3.0-r1*
* *clearpath-manipulators 0.3.0-r1*
* *clearpath-manipulators-description 0.3.0-r1*
* *clearpath-mounts-description 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-msgs 0.2.0-r1 --> 0.3.0-r2*
* *clearpath-platform 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-platform-description 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-platform-msgs 0.2.0-r1 --> 0.3.0-r2*
* *clearpath-sensors-description 0.2.11-r1 --> 0.3.0-r1*
* *clearpath-simulator 0.2.6-r1 --> 0.3.0-r1*
* *clearpath-viz 0.1.2-r1 --> 0.3.0-r1*
* *foxglove-compressed-video-transport 1.0.0-r1*
* *gazebo-ros2-control 0.4.9-r1 --> 0.4.10-r1*
* *gazebo-ros2-control-demos 0.4.9-r1 --> 0.4.10-r1*
* *hri-rviz 2.0.0-r1 --> 2.1.0-r1*
* *kitti-metrics-eval 1.1.3-r1 --> 1.2.0-r1*
* *launch-pal 0.3.0-r1 --> 0.4.0-r1*
* *mapviz 2.4.2-r1 --> 2.4.3-r1*
* *mapviz-interfaces 2.4.2-r1 --> 2.4.3-r1*
* *mapviz-plugins 2.4.2-r1 --> 2.4.3-r1*
* *mola 1.1.3-r1 --> 1.2.0-r1*
* *mola-bridge-ros2 1.1.3-r1 --> 1.2.0-r1*
* *mola-demos 1.1.3-r1 --> 1.2.0-r1*
* *mola-imu-preintegration 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-euroc-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti360-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-mulran-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-paris-luco-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rawlog 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rosbag2 1.1.3-r1 --> 1.2.0-r1*
* *mola-kernel 1.1.3-r1 --> 1.2.0-r1*
* *mola-launcher 1.1.3-r1 --> 1.2.0-r1*
* *mola-metric-maps 1.1.3-r1 --> 1.2.0-r1*
* *mola-msgs 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fg 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fuse 1.1.3-r1 --> 1.2.0-r1*
* *mola-pose-list 1.1.3-r1 --> 1.2.0-r1*
* *mola-relocalization 1.1.3-r1 --> 1.2.0-r1*
* *mola-traj-tools 1.1.3-r1 --> 1.2.0-r1*
* *mola-viz 1.1.3-r1 --> 1.2.0-r1*
* *mola-yaml 1.1.3-r1 --> 1.2.0-r1*
* *mp2p-icp 1.6.0-r2 --> 1.6.2-r1*
* *mrpt-apps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libapps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libbase 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libgui 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libhwdrivers 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmaps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmath 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libnav 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libobs 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libopengl 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libposes 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libslam 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libtclap 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-path-planning 0.1.4-r1 --> 0.1.5-r1*
* *multires-image 2.4.2-r1 --> 2.4.3-r1*
* *omni-base-2dnav 2.2.1-r1 --> 2.3.0-r1*
* *omni-base-bringup 2.2.0-r1 --> 2.4.0-r1*
* *omni-base-controller-configuration 2.2.0-r1 --> 2.4.0-r1*
* *omni-base-description 2.2.0-r1 --> 2.4.0-r1*
* *omni-base-gazebo 2.0.9-r1 --> 2.1.0-r1*
* *omni-base-laser-sensors 2.2.1-r1 --> 2.3.0-r1*
* *omni-base-navigation 2.2.1-r1 --> 2.3.0-r1*
* *omni-base-rgbd-sensors 2.2.1-r1 --> 2.3.0-r1*
* *omni-base-robot 2.2.0-r1 --> 2.4.0-r1*
* *omni-base-simulation 2.0.9-r1 --> 2.1.0-r1*
* *pal-gazebo-worlds 4.0.4-r1 --> 4.3.0-r1*
* *pal-statistics 2.2.4-r1 --> 2.3.1-r1*
* *pal-statistics-msgs 2.2.4-r1 --> 2.3.1-r1*
* *play-motion2 1.1.2-r1 --> 1.3.0-r1*
* *play-motion2-msgs 1.1.2-r1 --> 1.3.0-r1*
* *pmb2-2dnav 4.1.1-r1 --> 4.2.0-r1*
* *pmb2-bringup 5.1.2-r1 --> 5.3.0-r1*
* *pmb2-controller-configuration 5.1.2-r1 --> 5.3.0-r1*
* *pmb2-description 5.1.2-r1 --> 5.3.0-r1*
* *pmb2-laser-sensors 4.1.1-r1 --> 4.2.0-r1*
* *pmb2-navigation 4.1.1-r1 --> 4.2.0-r1*
* *pmb2-robot 5.1.2-r1 --> 5.3.0-r1*
* *polygon-demos 1.0.2-r1 --> 1.1.0-r1*
* *polygon-msgs 1.0.2-r1 --> 1.1.0-r1*
* *polygon-rviz-plugins 1.0.2-r1 --> 1.1.0-r1*
* *polygon-utils 1.0.2-r1 --> 1.1.0-r1*
* *python-mrpt 2.13.8-r1 --> 2.14.0-r1*
* *swri-cli-tools 3.7.1-r1 --> 3.7.2-r1*
* *swri-console-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-dbw-interface 3.7.1-r1 --> 3.7.2-r1*
* *swri-geometry-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-image-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-math-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-opencv-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-roscpp 3.7.1-r1 --> 3.7.2-r1*
* *swri-route-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-serial-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-system-util 3.7.1-r1 --> 3.7.2-r1*
* *swri-transform-util 3.7.1-r1 --> 3.7.2-r1*
* *tiago-2dnav 4.1.7-r1 --> 4.2.0-r1*
* *tiago-bringup 4.3.0-r1 --> 4.5.0-r1*
* *tiago-controller-configuration 4.3.0-r1 --> 4.5.0-r1*
* *tiago-description 4.3.0-r1 --> 4.5.0-r1*
* *tiago-gazebo 4.1.9-r1 --> 4.2.0-r1*
* *tiago-laser-sensors 4.1.7-r1 --> 4.2.0-r1*
* *tiago-navigation 4.1.7-r1 --> 4.2.0-r1*
* *tiago-robot 4.3.0-r1 --> 4.5.0-r1*
* *tiago-simulation 4.1.9-r1 --> 4.2.0-r1*
* *tile-map 2.4.2-r1 --> 2.4.3-r1*

Iron Changes:
-------------
* *foxglove-compressed-video-transport 1.0.0-r1*
* *gazebo-ros2-control 0.6.7-r1 --> 0.6.8-r1*
* *gazebo-ros2-control-demos 0.6.7-r1 --> 0.6.8-r1*
* *kitti-metrics-eval 1.1.3-r1 --> 1.2.0-r1*
* *mapviz 2.4.2-r1 --> 2.4.3-r1*
* *mapviz-interfaces 2.4.2-r1 --> 2.4.3-r1*
* *mapviz-plugins 2.4.2-r1 --> 2.4.3-r1*
* *mola 1.1.3-r1 --> 1.2.0-r1*
* *mola-bridge-ros2 1.1.3-r1 --> 1.2.0-r1*
* *mola-demos 1.1.3-r1 --> 1.2.0-r1*
* *mola-imu-preintegration 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-euroc-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti360-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-mulran-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-paris-luco-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rawlog 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rosbag2 1.1.3-r1 --> 1.2.0-r1*
* *mola-kernel 1.1.3-r1 --> 1.2.0-r1*
* *mola-launcher 1.1.3-r1 --> 1.2.0-r1*
* *mola-metric-maps 1.1.3-r1 --> 1.2.0-r1*
* *mola-msgs 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fg 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fuse 1.1.3-r1 --> 1.2.0-r1*
* *mola-pose-list 1.1.3-r1 --> 1.2.0-r1*
* *mola-relocalization 1.1.3-r1 --> 1.2.0-r1*
* *mola-traj-tools 1.1.3-r1 --> 1.2.0-r1*
* *mola-viz 1.1.3-r1 --> 1.2.0-r1*
* *mola-yaml 1.1.3-r1 --> 1.2.0-r1*
* *mp2p-icp 1.6.0-r1 --> 1.6.2-r1*
* *mrpt-apps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libapps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libbase 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libgui 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libhwdrivers 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmaps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmath 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libnav 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libobs 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libopengl 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libposes 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libslam 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libtclap 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-path-planning 0.1.4-r1 --> 0.1.5-r1*
* *multires-image 2.4.2-r1 --> 2.4.3-r1*
* *polygon-demos 1.0.2-r2 --> 1.1.0-r1*
* *polygon-msgs 1.0.2-r2 --> 1.1.0-r1*
* *polygon-rviz-plugins 1.0.2-r2 --> 1.1.0-r1*
* *polygon-utils 1.0.2-r2 --> 1.1.0-r1*
* *python-mrpt 2.13.8-r1 --> 2.14.0-r1*
* *rcutils 6.2.3-r1 --> 6.2.4-r1*
* *swri-cli-tools 3.7.1-r1 --> 3.7.3-r1*
* *swri-console-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-dbw-interface 3.7.1-r1 --> 3.7.3-r1*
* *swri-geometry-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-image-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-math-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-opencv-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-roscpp 3.7.1-r1 --> 3.7.3-r1*
* *swri-route-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-serial-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-system-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-transform-util 3.7.1-r1 --> 3.7.3-r1*
* *tile-map 2.4.2-r1 --> 2.4.3-r1*

Jazzy Changes:
--------------
* *fastcdr 2.2.2-r1 --> 2.2.4-r1*
* *kitti-metrics-eval 1.1.3-r1 --> 1.2.0-r1*
* *mola 1.1.3-r1 --> 1.2.0-r1*
* *mola-bridge-ros2 1.1.3-r1 --> 1.2.0-r1*
* *mola-demos 1.1.3-r1 --> 1.2.0-r1*
* *mola-imu-preintegration 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-euroc-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti360-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-mulran-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-paris-luco-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rawlog 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rosbag2 1.1.3-r1 --> 1.2.0-r1*
* *mola-kernel 1.1.3-r1 --> 1.2.0-r1*
* *mola-launcher 1.1.3-r1 --> 1.2.0-r1*
* *mola-metric-maps 1.1.3-r1 --> 1.2.0-r1*
* *mola-msgs 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fg 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fuse 1.1.3-r1 --> 1.2.0-r1*
* *mola-pose-list 1.1.3-r1 --> 1.2.0-r1*
* *mola-relocalization 1.1.3-r1 --> 1.2.0-r1*
* *mola-traj-tools 1.1.3-r1 --> 1.2.0-r1*
* *mola-viz 1.1.3-r1 --> 1.2.0-r1*
* *mola-yaml 1.1.3-r1 --> 1.2.0-r1*
* *mp2p-icp 1.6.0-r1 --> 1.6.2-r1*
* *mrpt-apps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libapps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libbase 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libgui 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libhwdrivers 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmaps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmath 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libnav 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libobs 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libopengl 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libposes 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libslam 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libtclap 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-path-planning 0.1.4-r1 --> 0.1.5-r1*
* *polygon-demos 1.0.2-r3 --> 1.1.0-r1*
* *polygon-msgs 1.0.2-r3 --> 1.1.0-r1*
* *polygon-rviz-plugins 1.0.2-r3 --> 1.1.0-r1*
* *polygon-utils 1.0.2-r3 --> 1.1.0-r1*
* *python-mrpt 2.13.8-r1 --> 2.14.0-r1*
* *rcl 9.2.3-r1 --> 9.2.4-r1*
* *rcl-action 9.2.3-r1 --> 9.2.4-r1*
* *rcl-lifecycle 9.2.3-r1 --> 9.2.4-r1*
* *rcl-yaml-param-parser 9.2.3-r1 --> 9.2.4-r1*
* *rclcpp 28.1.4-r1 --> 28.1.5-r1*
* *rclcpp-action 28.1.4-r1 --> 28.1.5-r1*
* *rclcpp-components 28.1.4-r1 --> 28.1.5-r1*
* *rclcpp-lifecycle 28.1.4-r1 --> 28.1.5-r1*
* *ur 2.4.9-r1 --> 2.4.10-r1*
* *ur-calibration 2.4.9-r1 --> 2.4.10-r1*
* *ur-controllers 2.4.9-r1 --> 2.4.10-r1*
* *ur-dashboard-msgs 2.4.9-r1 --> 2.4.10-r1*
* *ur-moveit-config 2.4.9-r1 --> 2.4.10-r1*
* *ur-robot-driver 2.4.9-r1 --> 2.4.10-r1*
* *urdfdom 4.0.0-r3 --> 4.0.1-r1*
* *urdfdom-headers 1.1.1-r3 --> 1.1.2-r1*

Noetic Changes:
---------------
* *image-transport-codecs 2.4.2-r1 --> 2.4.4-r1*
* *message-filters 1.16.0-r1 --> 1.17.0-r1*
* *mp2p-icp 1.6.0-r2 --> 1.6.2-r2*
* *mrpt-apps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-ekf-slam-2d 0.1.18-r1 --> 0.1.19-r1*
* *mrpt-ekf-slam-3d 0.1.18-r1 --> 0.1.19-r1*
* *mrpt-graphslam-2d 0.1.18-r1 --> 0.1.19-r1*
* *mrpt-icp-slam-2d 0.1.18-r1 --> 0.1.19-r1*
* *mrpt-libapps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libbase 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libgui 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libhwdrivers 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmaps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmath 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libnav 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libobs 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libopengl 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libposes 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libslam 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libtclap 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-local-obstacles 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-localization 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-map 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-msgs-bridge 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-navigation 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-path-planning 0.1.4-r1 --> 0.1.5-r1*
* *mrpt-rawlog 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-rbpf-slam 0.1.18-r1 --> 0.1.19-r1*
* *mrpt-reactivenav2d 1.0.6-r2 --> 1.0.7-r1*
* *mrpt-slam 0.1.18-r1 --> 0.1.19-r1*
* *mrpt-tutorials 1.0.6-r2 --> 1.0.7-r1*
* *python-mrpt 2.13.8-r1 --> 2.14.0-r1*
* *ros-comm 1.16.0-r1 --> 1.17.0-r1*
* *rosbag 1.16.0-r1 --> 1.17.0-r1*
* *rosbag-storage 1.16.0-r1 --> 1.17.0-r1*
* *roscpp 1.16.0-r1 --> 1.17.0-r1*
* *rosgraph 1.16.0-r1 --> 1.17.0-r1*
* *roslaunch 1.16.0-r1 --> 1.17.0-r1*
* *roslz4 1.16.0-r1 --> 1.17.0-r1*
* *rosmaster 1.16.0-r1 --> 1.17.0-r1*
* *rosmsg 1.16.0-r1 --> 1.17.0-r1*
* *rosnode 1.16.0-r1 --> 1.17.0-r1*
* *rosout 1.16.0-r1 --> 1.17.0-r1*
* *rosparam 1.16.0-r1 --> 1.17.0-r1*
* *rospy 1.16.0-r1 --> 1.17.0-r1*
* *rosservice 1.16.0-r1 --> 1.17.0-r1*
* *rostest 1.16.0-r1 --> 1.17.0-r1*
* *rostopic 1.16.0-r1 --> 1.17.0-r1*
* *roswtf 1.16.0-r1 --> 1.17.0-r1*
* *topic-tools 1.16.0-r1 --> 1.17.0-r1*
* *ur-msgs 1.3.4-r1 --> 1.4.0-r1*
* *xmlrpcpp 1.16.0-r1 --> 1.17.0-r1*

Rolling Changes:
----------------
* *chomp-motion-planner 2.10.0-r1 --> 2.11.0-r1*
* *fastcdr 2.2.2-r1 --> 2.2.4-r1*
* *foxglove-compressed-video-transport 1.0.0-r1*
* *kitti-metrics-eval 1.1.3-r1 --> 1.2.0-r1*
* *mapviz 2.3.0-r2 --> 2.4.3-r1*
* *mapviz-interfaces 2.3.0-r2 --> 2.4.3-r1*
* *mapviz-plugins 2.3.0-r2 --> 2.4.3-r1*
* *mola 1.1.3-r1 --> 1.2.0-r1*
* *mola-bridge-ros2 1.1.3-r1 --> 1.2.0-r1*
* *mola-demos 1.1.3-r1 --> 1.2.0-r1*
* *mola-imu-preintegration 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-euroc-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-kitti360-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-mulran-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-paris-luco-dataset 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rawlog 1.1.3-r1 --> 1.2.0-r1*
* *mola-input-rosbag2 1.1.3-r1 --> 1.2.0-r1*
* *mola-kernel 1.1.3-r1 --> 1.2.0-r1*
* *mola-launcher 1.1.3-r1 --> 1.2.0-r1*
* *mola-metric-maps 1.1.3-r1 --> 1.2.0-r1*
* *mola-msgs 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fg 1.1.3-r1 --> 1.2.0-r1*
* *mola-navstate-fuse 1.1.3-r1 --> 1.2.0-r1*
* *mola-pose-list 1.1.3-r1 --> 1.2.0-r1*
* *mola-relocalization 1.1.3-r1 --> 1.2.0-r1*
* *mola-traj-tools 1.1.3-r1 --> 1.2.0-r1*
* *mola-viz 1.1.3-r1 --> 1.2.0-r1*
* *mola-yaml 1.1.3-r1 --> 1.2.0-r1*
* *moveit 2.10.0-r1 --> 2.11.0-r1*
* *moveit-common 2.10.0-r1 --> 2.11.0-r1*
* *moveit-configs-utils 2.10.0-r1 --> 2.11.0-r1*
* *moveit-core 2.10.0-r1 --> 2.11.0-r1*
* *moveit-hybrid-planning 2.10.0-r1 --> 2.11.0-r1*
* *moveit-kinematics 2.10.0-r1 --> 2.11.0-r1*
* *moveit-msgs 2.5.0-r1 --> 2.6.0-r1*
* *moveit-planners 2.10.0-r1 --> 2.11.0-r1*
* *moveit-planners-chomp 2.10.0-r1 --> 2.11.0-r1*
* *moveit-planners-ompl 2.10.0-r1 --> 2.11.0-r1*
* *moveit-planners-stomp 2.10.0-r1 --> 2.11.0-r1*
* *moveit-plugins 2.10.0-r1 --> 2.11.0-r1*
* *moveit-py 2.10.0-r1 --> 2.11.0-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.10.0-r1 --> 2.11.0-r1*
* *moveit-resources-prbt-moveit-config 2.10.0-r1 --> 2.11.0-r1*
* *moveit-resources-prbt-pg70-support 2.10.0-r1 --> 2.11.0-r1*
* *moveit-resources-prbt-support 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-benchmarks 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-control-interface 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-move-group 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-occupancy-map-monitor 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-perception 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-planning 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-planning-interface 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-robot-interaction 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-tests 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-trajectory-cache 2.11.0-r1*
* *moveit-ros-visualization 2.10.0-r1 --> 2.11.0-r1*
* *moveit-ros-warehouse 2.10.0-r1 --> 2.11.0-r1*
* *moveit-runtime 2.10.0-r1 --> 2.11.0-r1*
* *moveit-servo 2.10.0-r1 --> 2.11.0-r1*
* *moveit-setup-app-plugins 2.10.0-r1 --> 2.11.0-r1*
* *moveit-setup-assistant 2.10.0-r1 --> 2.11.0-r1*
* *moveit-setup-controllers 2.10.0-r1 --> 2.11.0-r1*
* *moveit-setup-core-plugins 2.10.0-r1 --> 2.11.0-r1*
* *moveit-setup-framework 2.10.0-r1 --> 2.11.0-r1*
* *moveit-setup-srdf-plugins 2.10.0-r1 --> 2.11.0-r1*
* *moveit-simple-controller-manager 2.10.0-r1 --> 2.11.0-r1*
* *mp2p-icp 1.6.0-r1 --> 1.6.2-r1*
* *mrpt-apps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libapps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libbase 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libgui 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libhwdrivers 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmaps 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libmath 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libnav 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libobs 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libopengl 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libposes 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libros-bridge 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libslam 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-libtclap 2.13.8-r1 --> 2.14.0-r1*
* *mrpt-path-planning 0.1.4-r1 --> 0.1.5-r1*
* *multires-image 2.3.0-r2 --> 2.4.3-r1*
* *pilz-industrial-motion-planner 2.10.0-r1 --> 2.11.0-r1*
* *pilz-industrial-motion-planner-testutils 2.10.0-r1 --> 2.11.0-r1*
* *pinocchio 2.6.21-r2 --> 3.2.0-r1*
* *polygon-demos 1.0.2-r2 --> 1.1.0-r1*
* *polygon-msgs 1.0.2-r2 --> 1.1.0-r1*
* *polygon-rviz-plugins 1.0.2-r2 --> 1.1.0-r1*
* *polygon-utils 1.0.2-r2 --> 1.1.0-r1*
* *python-mrpt 2.13.8-r1 --> 2.14.0-r1*
* *rcutils 6.9.1-r1 --> 6.9.2-r1*
* *ros-gz 2.0.1-r1 --> 2.1.0-r1*
* *ros-gz-bridge 2.0.1-r1 --> 2.1.0-r1*
* *ros-gz-image 2.0.1-r1 --> 2.1.0-r1*
* *ros-gz-interfaces 2.0.1-r1 --> 2.1.0-r1*
* *ros-gz-sim 2.0.1-r1 --> 2.1.0-r1*
* *ros-gz-sim-demos 2.0.1-r1 --> 2.1.0-r1*
* *sick-safetyscanners2-interfaces 1.0.0-r1*
* *swri-cli-tools 3.7.1-r1 --> 3.7.3-r1*
* *swri-console-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-dbw-interface 3.7.1-r1 --> 3.7.3-r1*
* *swri-geometry-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-image-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-math-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-opencv-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-roscpp 3.7.1-r1 --> 3.7.3-r1*
* *swri-route-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-serial-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-system-util 3.7.1-r1 --> 3.7.3-r1*
* *swri-transform-util 3.7.1-r1 --> 3.7.3-r1*
* *test-ros-gz-bridge 2.0.1-r1 --> 2.1.0-r1*
* *tile-map 2.3.0-r2 --> 2.4.3-r1*
* *ur 2.4.9-r1 --> 2.4.10-r1*
* *ur-calibration 2.4.9-r1 --> 2.4.10-r1*
* *ur-controllers 2.4.9-r1 --> 2.4.10-r1*
* *ur-dashboard-msgs 2.4.9-r1 --> 2.4.10-r1*
* *ur-moveit-config 2.4.9-r1 --> 2.4.10-r1*
* *ur-robot-driver 2.4.9-r1 --> 2.4.10-r1*


Missing Dependencies:
=====================
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] protobuf-compiler-grpc
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

