### PR TITLE
Add flake template

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ nix develop github:lopsided98/nix-ros-overlay#example-turtlebot3-gazebo
 
 Using the overlay in your `flake.nix`-based project could look like this:
 
+<!-- The following comment is for https://github.com/zimbatm/mdsh -->
+<!-- [$ flake.nix](examples/flake/flake.nix) as nix -->
+
 ```nix
 {
   inputs = {
@@ -59,10 +62,10 @@ Using the overlay in your `flake.nix`-based project could look like this:
             pkgs.colcon
             # ... other non-ROS packages
             (with pkgs.rosPackages.humble; buildEnv {
-                paths = [
-                    ros-core
-                    # ... other ROS packages
-                ];
+              paths = [
+                ros-core
+                # ... other ROS packages
+              ];
             })
           ];
         };
@@ -73,6 +76,9 @@ Using the overlay in your `flake.nix`-based project could look like this:
   };
 }
 ```
+You can use the following command to use the above template easily:
+
+    nix flake init --template github:lopsided98/nix-ros-overlay
 
 [flake]: https://nixos.wiki/wiki/Flakes#Enable_flakes
 

--- a/examples/flake/flake.nix
+++ b/examples/flake/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nix-ros-overlay.url = "github:lopsided98/nix-ros-overlay/master";
+    nixpkgs.follows = "nix-ros-overlay/nixpkgs";  # IMPORTANT!!!
+  };
+  outputs = { self, nix-ros-overlay, nixpkgs }:
+    nix-ros-overlay.inputs.flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ nix-ros-overlay.overlays.default ];
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          name = "Example project";
+          packages = [
+            pkgs.colcon
+            # ... other non-ROS packages
+            (with pkgs.rosPackages.humble; buildEnv {
+              paths = [
+                ros-core
+                # ... other ROS packages
+              ];
+            })
+          ];
+        };
+      });
+  nixConfig = {
+    extra-substituters = [ "https://ros.cachix.org" ];
+    extra-trusted-public-keys = [ "ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=" ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,10 @@
       nixosModule = nixpkgs.lib.warn
         "'nix-ros-overlay.nixosModule' is deprecated, use 'nix-ros-overlay.nixosModules.default' instead"
         self.nixosModules.default;
+      templates.default = {
+        path = ./examples/flake;
+        description = "Basic ROS flake";
+      };
     };
 
   nixConfig = {


### PR DESCRIPTION
With this change, one can initialize a ROS project by running:

    nix flake init --template github:lopsided98/nix-ros-overlay

Besides adding the template, this commit also updates the README to list the same template as the one from the flake. The listing in the README can be easily updated to match the flake.nix file by running the "mdsh" tool.