### PR TITLE
[fix] replace distutils.spawn in sip_configure.py

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -206,6 +206,7 @@ let
             -e "s#with open(os.path.join(tmpdirname, 'QtCore', 'QtCoremod.sip'), 'w') as outfp:##" \
             -e "s#outfp.write(output)##" \
             -i cmake/sip_configure.py
+        substituteInPlace cmake/sip_configure.py --replace "from distutils.spawn import find_executable" "from shutil import which as find_executable"
       '';
     });
 
@@ -270,7 +271,7 @@ let
         wrapQtApp "$out/lib/rqt_plot/rqt_plot"
       '';
     });
-    
+
     rqt-publisher = rosSuper.rqt-publisher.overrideAttrs ({
       nativeBuildInputs ? [], postFixup ? "", ...
     }: {

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -206,7 +206,6 @@ let
             -e "s#with open(os.path.join(tmpdirname, 'QtCore', 'QtCoremod.sip'), 'w') as outfp:##" \
             -e "s#outfp.write(output)##" \
             -i cmake/sip_configure.py
-        substituteInPlace cmake/sip_configure.py --replace "from distutils.spawn import find_executable" "from shutil import which as find_executable"
       '';
     });
 

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -107,6 +107,21 @@ in with lib; {
     nativeBuildInputs = nativeBuildInputs ++ [ rosSelf.ros-environment ];
   });
 
+  python-qt-binding = rosSuper.python-qt-binding.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      (self.fetchpatch {
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/e78372fd63eda527c9fad5fcdab8ca31eb3f36d2.patch";
+        hash = "sha256-8+58ggPUJmEQIS9C4RzT4PhK1pT9ms98nppn3ZA8AEo=";
+      })
+      (self.fetchpatch {
+        url = "https://github.com/ros-visualization/python_qt_binding/commit/ee4d43bcdb0c5c5d40f81dea3de6185298ab34a7.patch";
+        hash = "sha256-+n7wqQ9jDybwxVeUEjOQSQJh7nnU8JXv5DNCoK/5Sm4=";
+      })
+    ];
+  });
+
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({
     postPatch ? "", ...
   }: let


### PR DESCRIPTION
Replace distutils.spawn in sip_configure.py if present. For jazzy this is fixed upstream but for humble not.