### PR TITLE
catkin: patch to account for NIXPKGS_CMAKE_PREFIX_PATH

### DIFF
--- a/distros/catkin-nixpkgs-prefix-path.patch
+++ b/distros/catkin-nixpkgs-prefix-path.patch
@@ -1,0 +1,11 @@
+--- a/cmake/all.cmake
++++ b/cmake/all.cmake
+@@ -48,6 +48,8 @@ if(NOT DEFINED CMAKE_PREFIX_PATH)
+     else()
+       set(CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+     endif()
++  else()
++    string(REPLACE ":" ";" CMAKE_PREFIX_PATH $ENV{NIXPKGS_CMAKE_PREFIX_PATH})
+   endif()
+ endif()
+ message(STATUS "Using CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")

--- a/distros/ros1-overlay.nix
+++ b/distros/ros1-overlay.nix
@@ -44,6 +44,13 @@ rosSelf: rosSuper: with rosSelf.lib; {
         url = "https://github.com/ros/catkin/commit/e082348c4992e1850ba5e2bd02bbd7bd0c4c4b82.patch";
         hash = "sha256-NNdV30gNWBf7p8IjyCmnvz9MnU4zFkd4aaXNjs411MA=";
       })
+
+      # Catkin uses CMAKE_PREFIX_PATH to find additional workspaces, but
+      # nixpkgs switched to using NIXPKGS_CMAKE_PREFIX_PATH.
+      # Force CMAKE_PREFIX_PATH to equal NIXPKGS_CMAKE_PREFIX_PATH here.
+      # (https://github.com/NixOS/nixpkgs/commit/8c9c8ade2f88a85ccdd4858cc802d7b7d6c48fe0).
+      # see: https://github.com/lopsided98/nix-ros-overlay/issues/491
+      ./catkin-nixpkgs-prefix-path.patch
     ];
 
     postPatch = postPatch + ''


### PR DESCRIPTION
Alternative to #497. Heavy handed but:

`nix build .#noetic.pluginlib` works.

`nix develop .#noetic.pluginlib` and manually invoking `cmake` to build works.

Fixes #491