### PR TITLE
roslint: add a dependency on distutils

### DIFF
--- a/distros/noetic/overrides.nix
+++ b/distros/noetic/overrides.nix
@@ -125,6 +125,12 @@ rosSelf: rosSuper: with rosSelf.lib; {
     sha256 = "sha256-zOtMuTZuGKV0ISjLNSTOX1Doi0dvHlRzekf/3030yZY=";
   };
 
+  roslint = rosSuper.roslint.overrideAttrs({
+    nativeBuildInputs ? [], ...
+  }: {
+    nativeBuildInputs = nativeBuildInputs ++ [ rosSelf.python3Packages.distutils ];
+  });
+
   rviz-map-plugin = rosSuper.rviz-map-plugin.overrideAttrs ({
     buildInputs ? [], ...
   } : {


### PR DESCRIPTION
After b6676bf7dc1b03afe9582c5fd99025b3a4b7f4f9 `roslint` can't find `distutils`. Force it as a dependency.