### PR TITLE
rosdistro sync, Fri Oct 11 13:52:59 2024

### DIFF
--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "fedea5ea439dc9e0c3be8f1511170568663264c3efb6e3255fed49f6c7bbd12c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "339836294909960602d486ace0b4cf87cd5efcb4c1ea0c7112234063656fd94a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "55aeb8cdab188074c1359ae4bdf904641c351c584d1751f6e3970944ab8d3a07";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "dc090659b0ac69032b6cd33b240fec5d2620b2c846e00ffedce1d2990a3a7fe8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "f1d5b172b5f45b537130ea68dcd7fce55d2627c64950d49ef5e35c4fdf5833c5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "251e4d875637dc9aa5ada8866bdbcbc02c183e7260936ed71799467bd981e657";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "7c4ae159bed131b00d4dfeaf305ea63505e428dd0984ef5fb1be431436a31000";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ae52e86cd42cadaca9c1528606d2f7cfb7e6e844dee189336786430f0b7bb114";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6e917d1801b65ff6367a35c05738d3cd053b48eafe36bd778c23c2d0bd564d14";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "7948cea108150bf9530ced12f95040f1a5677e8f433b6f8209c441996b618b5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, clearpath-platform, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "f245eb52ff7174e95f51c249b2de169beed5b7eb56a63c9b537ae16677fac4cc";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "4e150b0ddfef0bf53144274ab6ec1c15d393add61883a55b0a937f2e386a2c11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, kortex-description, robot-state-publisher, robotiq-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c40c5a12ee0f155d3338fec8e375883a652c558d0a38ba5bab2316ca650978f8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "08714fd4b4d4f99e4b831bcc0fa8cca3bf9e66c85502089619f626eeeff80e6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "10a7fb7490e22aee89138e80e1146fc6cc5913f1a953c604ac28b8982e8657a1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "88d02df5725b43739ab39256e79e388ca3362b72aa80171807b9e0c55085ce32";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "57a04a6ff92170f2072e4fe9615749ed400dec324e04739666c76dedf0d06025";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "3de214307d713f2a62549d7f4751703faea3004269388bdf6c4410b6c34c7a1a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "040431d54e39cfd48ca97b75b18776fedeed2a1ed99a1c604a835faa53526777";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "cd33c2b665f11a23b20dd3e2db25e4d4c97da351796fb09d6129f83d897e2518";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform/default.nix
+++ b/distros/humble/clearpath-platform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-platform-description, clearpath-platform-msgs, controller-interface, controller-manager, controller-manager-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, puma-motor-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "95195d8773962aae7b776afcc6c998bc4a84e7d3190020ae6257f92a7b274ee1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0c8d0f76d1cd3328a5e5ada777aa1fa4a61f38f6a5720e0993692f4e14340af9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.3.2-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "febe3a3ad1a664b6403ed8110c335d15bd209612a09fb34fe7faef465d1cbd90";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0b8ab42b662ca1cde54bb364df9a3a71fee5f02594933777e5c1e743c93985c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-socketcan-interface/default.nix
+++ b/distros/humble/clearpath-socketcan-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, console-bridge, linuxHeaders, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-clearpath-socketcan-interface";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/clearpath_socketcan_interface/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "098c5c8f4b05701bd1579127e3a4dc887ace3f337254cae4ad6d29cd18c64454";
+    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/clearpath_socketcan_interface/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "094db2f3686f4067b728fac267636bc4e9ce90c6a34f13031f609e8f11461ab7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "eb367d4860dc848dcb8a59ea16bf189c3521aaff99f366394c7c626da8dcb8ad";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "56180b344d23628aa509142ab7b49b3ac5895cb1f1591dee47ff5efdb274593f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "13ff9e3f80a87fa907b3c98be66d8aa2554f1e8fe8bb79f278d8a6526879689d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "cccffb30a416a83a295c99e483d3b271aa683c60208ca44c40c977ab2ce8ebc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "11e5c96501d28701eda015086922072c59a7d3b1744a65462682f489a0971711";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "b2c51c1f809f8ae451e1883cea4e082e58f2ff9ba67024be88d9cbbc515e9e3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "a04b40683ebdc2ff9eba7d6d991c0a0e9fe336de6a1fb7a220d9212143a6be76";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "bee01795f58c5e0191b105691643365abf90ef00fac3e02bb8db2f9f8362bb73";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "1b99a3ebe43202da8df0790818cb517203d91c0b50b8b2e2af21379b593b4c08";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "291b2f9cd70ddd83e404c170a927ed3b5d6911faef29f36149a9449f8f364b47";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "e4d0f15c090b98f08f16218fe6be6f5a7bbd132ad277ec045546e645b11be1c3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "419f04b3f87bfcb50f4132740d7d7e0dd8dbd08f19031141971178213955e04e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "5834ee604795ae1786a2a3b8ecee21d53365077c38c01f686131308c3f0efd2f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "48cf7b2f417d664663cfb3774ee9129ce8dba252add35a42b7932150bc5d8a99";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/libmavconn/default.nix
+++ b/distros/humble/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-libmavconn";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "6c5209a8ee8693b7fb22516223a85624cb043b80b2854d41a0e53839c5a6c8b8";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/libmavconn/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "91572dd10ad921f30c7bd58325e8d02fda0690a354c2bf697f6919fbd482333e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavlink/default.nix
+++ b/distros/humble/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mavlink";
-  version = "2024.6.6-r1";
+  version = "2024.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2024.6.6-1.tar.gz";
-    name = "2024.6.6-1.tar.gz";
-    sha256 = "a4102ec7f705bdf9ca5096d379ae0a6540d6c1577782e3f2fe378ac2897bb636";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/humble/mavlink/2024.10.10-1.tar.gz";
+    name = "2024.10.10-1.tar.gz";
+    sha256 = "6add90d6d4f83911cf0a9a0303c9e4b86d66e2697978f4bb3a47c60aceddfcd3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mavros-extras/default.nix
+++ b/distros/humble/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-mavros-extras";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "285fb016e6a88b16ebf6d00fbcef99c5ce7fcea829a96f5f4f9d679a82e6039b";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_extras/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "31bfae3490c2e463d517d4794e773ae30267354af98fa305cbfb1a1e3e381397";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros-msgs/default.nix
+++ b/distros/humble/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros-msgs";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "96725601d553e095b5c8b682dd324fbcd7f49712f4d896ca470c66590a87583e";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros_msgs/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "9350110c3717cc57b51e394356aaccb9a236502c793298480c96d38c5010bcc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mavros/default.nix
+++ b/distros/humble/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-mavros";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "03603f13329e7e679420961d30c689a384f29f851358efb1fe850d7067d65f57";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/humble/mavros/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "1b2e40bd683b3685013bc8842924e4c381e6e74d7d9cac352a245b07c223f0eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-description/default.nix
+++ b/distros/humble/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-description";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_description/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "b342f317714233cf063e61fd98d321ebac6d7d1a29a3aae588080169dc515df4";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_description/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "c6a59f34b3030523e30b4d7fb83352b5447e656b1dad920df83d1b47f7209d2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-driver/default.nix
+++ b/distros/humble/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-driver";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "11eb8c27f5e4ee980e186ae3f466439911ec8b158434ebe348f10a8e93562f9c";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_driver/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "3eee438aed4f2a45f9540ec70aeb94fb44325648d54589abfc7c974ce4010677";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-examples/default.nix
+++ b/distros/humble/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-examples";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "46ac9845c897d80e5f9fc98e53ec392b5ff6f0bd411ac12da273f55588a1bbbf";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_examples/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "f16fe1addc47ed800cc13d8b8783f178f110e25d2ad17aa70994fe4a03cccf14";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-msgs/default.nix
+++ b/distros/humble/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-msgs";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "c41d5bf8f5729d8ac8bd26f1a8c0723f08a9853e03d3f0aaab3202a334abda0d";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_msgs/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "de5fd074085f35bedaef368bfcaa9865d4acabd79e4dcf12a5edcaf169d1ec30";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/microstrain-inertial-rqt/default.nix
+++ b/distros/humble/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-microstrain-inertial-rqt";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "e3e95a8a7cc7cc74ce9634ca3191a4384abe72d29db364fe51eec4e610df6878";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/humble/microstrain_inertial_rqt/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "832060a5a1b964ec22caf8701a8ce95ab0122f5a7a62f16684cc1946d3f425d1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/mrpt-apps/default.nix
+++ b/distros/humble/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-apps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "af02d49afdaefe8a10bcb8f5fe895bca340e78a417c1f117b9950b42510feafd";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_apps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "d2962d6f9ac0b272c1fad0f2116bcb1eba03c8c6198976116b64a84370bfd1f5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libapps/default.nix
+++ b/distros/humble/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libapps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "df68b62adc3c77144d6759a9655061eee122f0ee444173301a5621cd2548d73f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libapps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "d540ba37ac3ecfdb7a9d7cbc3692006c7c76fd530887a0aca69cd30ab5fcb667";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libbase/default.nix
+++ b/distros/humble/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libbase";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "38fb15f0b64e3c7cf817cd7e321026503138f34f6f04954e261082eb5f2f2f73";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libbase/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "e86422af24a4f8c91a61bf4c4987325dbe62bdf96b6afe37681764be4ca7e2b9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libgui/default.nix
+++ b/distros/humble/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libgui";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "800ee41244b14a79e2a0bcc7b4bf66cecc41fc22d64ce3886c199c3b112278c2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libgui/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "b92cc6063bd97cd64ac12aa86a703cbc54c2dc6b1b8d9713d27333885e330591";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libhwdrivers/default.nix
+++ b/distros/humble/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libhwdrivers";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "00dcea5224bb53c0849725c9974d1c681b3e884890d8f1db9f577222697a53a2";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libhwdrivers/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "50a66fe50faa811c6e862c9ee5100f150812bf318afdd87c9c2d05ce5fc656ef";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmaps/default.nix
+++ b/distros/humble/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmaps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "c4d03b4aea45f90c2ce8133c2233264934d33083279e6b3b6dcf7a777e2eed74";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmaps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "30e3f35ca3c7e9f9fa86f4a7c9054ab992f27180224ab4628acd2a501b6d09eb";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libmath/default.nix
+++ b/distros/humble/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libmath";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "bde9069e4039e533576e27231b4adce70d0e382272cf52b8c715bf3c32e90c4b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libmath/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "187dfda877d0fc2d9c3e82d071bcda064988c2ab5d950d814cc33c8203f4f5cf";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libnav/default.nix
+++ b/distros/humble/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libnav";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "0f7e241829064503b14e9c166805c7bf7a0e87286eaebe689ecb9a78ae961d7f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libnav/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "add8368be091f74b319f1072a8ced78172c9ebb652b107610e300a2d765929ec";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libobs/default.nix
+++ b/distros/humble/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libobs";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "2be3be13afe95a9b19f987f20e573faae0a337782708dd9be4188074b7655026";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libobs/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "60452c4c864f7b37abcbab65a607c1691fcaf913119454e2057c3102012c02f2";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libopengl/default.nix
+++ b/distros/humble/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libopengl";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "8a002be1efb9ad447f46e0564028b3aed5ea594b587fcc4bd7578df02fa63250";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libopengl/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "f633311d84ef5d8b5a8bf6a924491e54930110165a5d7974b12d8c4a7f242929";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libposes/default.nix
+++ b/distros/humble/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libposes";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "31bb5dd2f786421c83a2771332584ea746aa35a0bc7f5db77670abcb74c71bda";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libposes/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "3d90f2d8016f0b9f247013116c62cda93346867ece8f96d8493095558b756d7d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libros-bridge/default.nix
+++ b/distros/humble/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libros-bridge";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "bb9e269278a554ee3e51ff6934f8134ead4d29a3929e0bcd3144409edf790759";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libros_bridge/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a914ddd9b4d250e85cb50ebe456ebb186abcd66efd6c46b8b0915e4e1f1f4c8d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libslam/default.nix
+++ b/distros/humble/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libslam";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "532388d85f6bc1068451345575db93517426e30875d1b99060d3908a2bbc615a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libslam/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "5da1050cd70c25545e6fc1db5e828a122d1d4766d56e165fe0df875fdc0fefe8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-libtclap/default.nix
+++ b/distros/humble/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-mrpt-libtclap";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "e1e596818550039f74c9a8f8ba2d135ffb50f6d4e9ffec481fba5cb3c8e8a372";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/humble/mrpt_libtclap/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a9fe4084116ae380ba148c0d3cc40bcef8f09146610a637bc5f8fa047519a531";
   };
 
   buildType = "cmake";

--- a/distros/humble/mrpt-msgs/default.nix
+++ b/distros/humble/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-mrpt-msgs";
-  version = "0.4.7-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/humble/mrpt_msgs/0.4.7-1.tar.gz";
-    name = "0.4.7-1.tar.gz";
-    sha256 = "1c9165db91ac7c60354c9ad92d965c903ba30e89ac089f0d897b53bb353a4064";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/humble/mrpt_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "08c589a52ce8317b89c3d1142edb68d357f0bf21e89e4810effd03b451436092";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mrpt-path-planning/default.nix
+++ b/distros/humble/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-humble-mrpt-path-planning";
-  version = "0.1.5-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "45463691cf4176657bd25fa1252bf5d3fdc27757e5559722422b1add49d75f70";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/humble/mrpt_path_planning/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "fd174f58ca4bea5731ef6a6602f6998ff623e9fa779024da1fdee84a46420eab";
   };
 
   buildType = "cmake";

--- a/distros/humble/openeb-vendor/default.nix
+++ b/distros/humble/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-humble-openeb-vendor";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/humble/openeb_vendor/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1eb0329310d022c6008ed2f28da42fa59f10b4c0be08680558f747d0d8ee25ab";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/humble/openeb_vendor/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b5ae87c3af4c9195a4255683d3f78ae9bf3e5d8f22bbfe202a628722afdc3053";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/puma-motor-driver/default.nix
+++ b/distros/humble/puma-motor-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, can-utils, clearpath-socketcan-interface, diagnostic-updater, joy, puma-motor-msgs, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-puma-motor-driver";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/puma_motor_driver/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f21374b241ad1792c1f5e82135d038d24621972a8ca3d5a818b31a9c8002d71c";
+    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/puma_motor_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "be0eed3a0626b1970a86552236f1a5e0cdc71051b9f890ac623fc9cb63a780e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/puma-motor-msgs/default.nix
+++ b/distros/humble/puma-motor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-puma-motor-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/puma_motor_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "81d584c594ce8844be527942d710ffe1ed8fb1b65f635709bc388428935da7c7";
+    url = "https://github.com/clearpath-gbp/puma_motor_driver-release/archive/release/humble/puma_motor_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "74041378f0fd6bbd6e056f903e85da21d3709ed34242f3dada0fd583691b6a0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/python-mrpt/default.nix
+++ b/distros/humble/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-humble-python-mrpt";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/humble/python_mrpt/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "78d11644a98d9c4acb56725a6d20cc4b4dc53b972b9e6d21e2d14c82a825292c";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/humble/python_mrpt/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "fdf5a010b9d3e011bbabf6c22767bef859836e5ba8714c6632bd2cc6e82a6dc2";
   };
 
   buildType = "cmake";

--- a/distros/humble/rosapi-msgs/default.nix
+++ b/distros/humble/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosapi-msgs";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "593765a7bebe4083fb57e2c40dc1ae2b9b5aa0f84781e58f8036d267b2fe2806";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "494c6dcbd09aad147f8353401f12e039ab58c4c220964f6d4128ade05867067a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosapi/default.nix
+++ b/distros/humble/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosapi";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "f709148e3c9dbbb68822642d4a578191940dc2b57042a34c40aa84004c9ca2ad";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosapi/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "ea0996970a6b37c358d3630f6755c488f5b0a6446aa35b98fb7bb29c73e72aab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-library/default.nix
+++ b/distros/humble/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-library";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "973fad1ffed13bfda0efb52c88baaf240b39a672c9c0930ce7b9ab1c24385bc9";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_library/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "2f3601ab0d8714060f570a496d84b4edda55f5690d1004b5d23ee84262f33b65";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/humble/rosbridge-msgs/default.nix
+++ b/distros/humble/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-msgs";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "c54700a985e435b8c5be72a104446cbf3c377bdcea5b434400e3c405df198ab1";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bd9ccdbca768fadfd2116b30443f2ea2fcbd04bd3dcfff01d9d3563257861cb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-server/default.nix
+++ b/distros/humble/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-server";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "14b6093760298794b6194bdc1427ff162d739af5f61d6c1791a6838c696e1628";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_server/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c3570749fc2d339229eb7cddb11bf158f14cdf7a19816b31af1503395a3dc35e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/humble/rosbridge-suite/default.nix
+++ b/distros/humble/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-suite";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "2701fbe8ab7aa6de2416373e92990a726e132d19d2a2dc4c80eed7e8fc3b47da";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_suite/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "80b77f39efc426c80c4bd68969b5bad1f89eac0a8defb3cca98b7abcf8f13fbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbridge-test-msgs/default.nix
+++ b/distros/humble/rosbridge-test-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbridge-test-msgs";
-  version = "1.3.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "734f8fc2a34d367527a203917b1e06b3e954b71b377e279182b0a22e2b78e7f5";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/humble/rosbridge_test_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "10af1fa6a9f5150e6bdce0c9960d8544b1a699e3674643aaea5b69c5eeb39744";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/scenario-execution-control/default.nix
+++ b/distros/humble/scenario-execution-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, scenario-execution, scenario-execution-interfaces, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-control";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_control/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "bb78d76fb00f4b74ef19933f7de8d2f9f51e49fd60843920f35ff335fcfff4f9";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_control/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "c1e7ef7e7d077365b339f040f2b28d90192fb9cb63a679cdf347efdea6bd3591";
   };
 
   buildType = "ament_python";

--- a/distros/humble/scenario-execution-gazebo/default.nix
+++ b/distros/humble/scenario-execution-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, py-trees, python3Packages, pythonPackages, rclpy, scenario-execution-ros }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-gazebo";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_gazebo/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e8d6dcb3e7ec15f9fb2ccc87d3b6378f196dd32ef00c60b21e346142ac65934e";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_gazebo/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "bf241da62679f8ede0802e040cb62dd4b6c86b07cfda85b9c91ab569e5fa5249";
   };
 
   buildType = "ament_python";

--- a/distros/humble/scenario-execution-interfaces/default.nix
+++ b/distros/humble/scenario-execution-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-interfaces";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_interfaces/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "1558c499bb6e30333f5d72bf67d6b83066f1d903b69d432a73cfa54727ea4a0f";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_interfaces/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "fab1194fd027aa91c1827f64a7436532bee19fbf08da1092e9c80007a50f226d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/scenario-execution-nav2/default.nix
+++ b/distros/humble/scenario-execution-nav2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, nav2-simple-commander, pythonPackages, rclpy, scenario-execution-ros, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-nav2";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_nav2/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5a8d9427f55d592a30157d7f65545cdf8361f67bf5a4738c4546897c0121a920";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_nav2/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "7ab9aa6869c14e8ff63db9f5cdc36a927edd4a112c1d7944a8959931b65ebbe8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/scenario-execution-os/default.nix
+++ b/distros/humble/scenario-execution-os/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, scenario-execution }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-os";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_os/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ea1357c32e9f5f9cca156c82ae0234e07ef6a9636037e19251fdc41d75a94bfe";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_os/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "3ac736ce354718851f6df5c8eb734e7711884e383252da61974d7658fc9ad7ab";
   };
 
   buildType = "ament_python";

--- a/distros/humble/scenario-execution-py-trees-ros/default.nix
+++ b/distros/humble/scenario-execution-py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, py-trees-ros }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-py-trees-ros";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_py_trees_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "55e0f955154f4c6f9ebfae3dbaa14952cf0885417a3d0300c3d189ec4838581c";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_py_trees_ros/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "1ebb9773c4ca8343aa4d9ce7064691d5023bdffc0cefa4d32c185e93b4cfb07e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/scenario-execution-ros/default.nix
+++ b/distros/humble/scenario-execution-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, py-trees, py-trees-ros, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, scenario-execution, scenario-execution-py-trees-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-ros";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "23161372be59030f644107627bfb2f53a0acf9f0deff5b9624cf82dd55e14aea";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_ros/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "ec7bc6ad9c591d5f73ec701add3cb0f05d7c3349ccd24f59eb3850628064416b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/scenario-execution-rviz/default.nix
+++ b/distros/humble/scenario-execution-rviz/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, py-trees-ros-interfaces, qt5, rclcpp, rviz-common, scenario-execution-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, py-trees-ros-interfaces, qt5, rclcpp, rviz-common, scenario-execution-interfaces, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-rviz";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_rviz/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2ff2f9afbf2a3eed7936284282ca289d26cfb9a473981615eacf75ce4f8dff2d";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_rviz/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "d91dbbcab21c14ca21b2f40c3537d4ae0aa92b7adf2ca5742aed34a48d4c1810";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake std-srvs ];
   propagatedBuildInputs = [ geometry-msgs nav-msgs py-trees-ros-interfaces qt5.qtbase rclcpp rviz-common scenario-execution-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/scenario-execution-x11/default.nix
+++ b/distros/humble/scenario-execution-x11/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ffmpeg, scenario-execution }:
 buildRosPackage {
   pname = "ros-humble-scenario-execution-x11";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_x11/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "d1da4bf798ebbf2fef5eeb302965d75787c62b3522e76bade684a7255581925a";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/humble/scenario_execution_x11/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "86bcb1877b727689ebb5f4aa78fef7709a4ab3c575256b09a8040b8ff0d52312";
   };
 
   buildType = "ament_python";

--- a/distros/humble/srdfdom/default.nix
+++ b/distros/humble/srdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-humble-srdfdom";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/humble/srdfdom/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "611afe6f307eb4ac073e1cbbbfd46c4566817b7ff5dd11b33aff8d31ba8072bb";
+    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/humble/srdfdom/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "8714a541c1d41a8b2f9d54e19cb5b17e048e1565b406d6c7589a217034e4ffe6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-msgs/default.nix
+++ b/distros/humble/ur-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-msgs";
-  version = "2.0.0-r2";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/humble/ur_msgs/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "9d6f6e4d5f6a20293562660e60d1c2ec7a631a89d01752cfb7b1a9f5d3cb312b";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/humble/ur_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a3d55c7a752d2510cfa840fb8c713112ca2617b69b7e4cc6fefab3330e8c81a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/apriltag-mit/default.nix
+++ b/distros/iron/apriltag-mit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, eigen, opencv }:
 buildRosPackage {
   pname = "ros-iron-apriltag-mit";
-  version = "1.0.3-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag_mit-release/archive/release/iron/apriltag_mit/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "cc3b2e08015e2572d6e1118319c4cc8c1678256171233cc7a01607772b4f9e42";
+    url = "https://github.com/ros2-gbp/apriltag_mit-release/archive/release/iron/apriltag_mit/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "54665f0fd4a78fb376c6b25446ca99d3cc3d05073c069c855a63294562ce69c0";
   };
 
   buildType = "cmake";

--- a/distros/iron/depthai-bridge/default.nix
+++ b/distros/iron/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-bridge";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "b0dccc9644a021cf5a9ffad92a5931a64b2cdf8ccad160f9c3276a894a9dfbc0";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "f7bc9a1e14c826f2d4db05c55a48d83e2bda403ba90f1359e1ce5b7b72d05a9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-descriptions/default.nix
+++ b/distros/iron/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-descriptions";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "6755ad1faf8eff21382b72f365c814df531519144af27bab51ceb7596b79c925";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "0fadc3996444044423a8f5174e93a30a2cbcdfc65a98454720aa279a704b5f58";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-examples/default.nix
+++ b/distros/iron/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-examples";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "b4e8e3b944a7f4db6649a6496b59bf70b6735c3fc430506d08d87086e217f579";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "58a57eabd3be74a75b847247136d13535d35f39da41f1530898871f60d1776ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-filters/default.nix
+++ b/distros/iron/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-filters";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "3b4a550c2f6fc476e4523d91e3ec3fdc1df7f9dd56745e6087dceae3d3a84a23";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "db351ab6517a1327dd68729edf85eb2101442abcaa5196b9ae004b052ecf15fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-driver/default.nix
+++ b/distros/iron/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-driver";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "e718bcb78d77a8defdd88fd4575f593e5ffb1fb0ab607e066af9238ec6b71d3d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "36a0100078fde11f44f8730c7063fa9abddd4e34e27b26d93522b8e2c2d8ea00";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-msgs/default.nix
+++ b/distros/iron/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-msgs";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "da7f6e4ea300f180446b65c8e4f30d84da0ae7eceb564121447a1c13fc751884";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "9ee78cc943fb67327bca04d803b63bfca7ec2804e604470516ca2d0f71b2b8ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros/default.nix
+++ b/distros/iron/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "4e1c14412a2239c31220ec01bd137892fe5481254511bd09a76cf7f555820905";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "5338cd38f533a54dd8e3fbbf94144e012f482a59fd0cc00bcb3ae62e0adaa67b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/libmavconn/default.nix
+++ b/distros/iron/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-libmavconn";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/libmavconn/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "129098c40602ef8795f9c658dde05bfaac5d9189ef6284ae1d4f640b4a987783";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/libmavconn/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "19c288b717c1c1197efa7ee9d1c66be0edff99c76f3d4dce8a011d08c6ac1c1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mavlink/default.nix
+++ b/distros/iron/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-iron-mavlink";
-  version = "2024.6.6-r1";
+  version = "2024.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/iron/mavlink/2024.6.6-1.tar.gz";
-    name = "2024.6.6-1.tar.gz";
-    sha256 = "5608bb5044801ec23066d1ff288ddc7f1d395c5fd8220ce8a8e26fd664defb3b";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/iron/mavlink/2024.10.10-1.tar.gz";
+    name = "2024.10.10-1.tar.gz";
+    sha256 = "7c487adff340adb7d9e6782c4b1523dcbfafc73338cfcac0fd0f68bc0eb73aba";
   };
 
   buildType = "cmake";

--- a/distros/iron/mavros-extras/default.nix
+++ b/distros/iron/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-mavros-extras";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/mavros_extras/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "b5b9df5b2e1b880f4f007e642856663f5ca0d30ebef13b22d6c3a11dde3fd84f";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/mavros_extras/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "7e66e46a054fd7a7cc71e66a5b55bba6b508ce0164ceaf3812bffc20c90b9af0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mavros-msgs/default.nix
+++ b/distros/iron/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-mavros-msgs";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/mavros_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "5a26ed2fbdd2f7f2ff7df6cc65114d35ff9fa40db4dd49d821cc8aa31a2bffc7";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/mavros_msgs/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "3602ffb43e65d57144521156444ae5c3e5755d02a514d8cbd91a07eca9ad12b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mavros/default.nix
+++ b/distros/iron/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-mavros";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/mavros/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "d3fc099a350fddb32846690bcc06297328e96bf873e9482f7971df2545e0459e";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/iron/mavros/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "6908278f9372522a629c1658af3ce683476b825fc544b64a10398bbe185614d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-description/default.nix
+++ b/distros/iron/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-description";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_description/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "9b84ec04908f22da6bf160657487c2289bf3277ee43be17bd4ded9622b12cdfe";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_description/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "754abb949da5116ec54cc4b19238744f9fc7578b7b72ede3cf00f5998fdfc1f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-driver/default.nix
+++ b/distros/iron/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-driver";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_driver/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "20ec0a30d3f29f669b7b52db02eaa4a237eaa388f6d911086fd68a3c9285c5c4";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_driver/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "32320ed40803356c4f5564994e3fbf3727d7051f5e83f1a0204527e079412a5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-examples/default.nix
+++ b/distros/iron/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-examples";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_examples/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "b50fcffd992cdd20a8ad5ccf6ed32b87588dec69ada586095701bfff2c7186cf";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_examples/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "d2564f57f8496e1d33db3b4bd9d9ec745dc03028440cb2e2652db70e00deeec7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-msgs/default.nix
+++ b/distros/iron/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-msgs";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_msgs/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "da0cdf8b3ffed6b2870acf7e3ac935d7f9588b40e77eaeea79710a81edc08a70";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_msgs/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "c60722fa858185d4666964e0eeb1e842edf024cc0728607eee9b0194fad22307";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/microstrain-inertial-rqt/default.nix
+++ b/distros/iron/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-microstrain-inertial-rqt";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_rqt/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "123133e43789032bc8fafe1128f3e3b48b586f17603bb66ed820cb60b5950011";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/iron/microstrain_inertial_rqt/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "6aba21a2c1db2744478127a6ce2f4e45e3340248c5861e2b9b9aa474e4c7f4b9";
   };
 
   buildType = "ament_python";

--- a/distros/iron/mrpt-apps/default.nix
+++ b/distros/iron/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-apps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_apps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "a35af2b13301127e2968dd8f5dbe763a651439ec0f739c6eb2e2964681ae8f2d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_apps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "15e30190f4b7f0365f4e5978ad11e212f6c2f70dcb54cd3ebeaca2841490deef";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libapps/default.nix
+++ b/distros/iron/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libapps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libapps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "528d4fc1b8a990ad271be34694022d220bb42c8735d434d8c76de70c85b01c61";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libapps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "ba0b63b67559421f5631b3befde51c6a287ee05fa42a5646ddf8a4b6603f5e10";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libbase/default.nix
+++ b/distros/iron/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libbase";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libbase/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "5dacc49de495083a72522f206da4652516bef6eec37f05f684b8f7153faaba42";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libbase/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "fc5ac702d7ec01ed7b8ffd5cfbcf228fab49a283fa552576fc66e5da9de4aa84";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libgui/default.nix
+++ b/distros/iron/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libgui";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libgui/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "f45d648dcb291c6c26734f8f2fdc4fee65ab5ee04aa4ea2aa96d61b7717335fe";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libgui/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "9b31dc008419b1ea1503b92b11115bd58140df3bd0722810b0cdd28eaf70f198";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libhwdrivers/default.nix
+++ b/distros/iron/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libhwdrivers";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libhwdrivers/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "5ea3d4534e33a37110e13aaacc64adc133fcd2e56b1a4135b6fa1a005eaafe22";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libhwdrivers/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "b6074a143d9a669fda8d9e0dc4e513a158831d2a06640b0857cd2e788f824b07";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libmaps/default.nix
+++ b/distros/iron/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libmaps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmaps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "324a0e1266908de96b9601ea100736b5c396e93fdaa717203e32434cb9978fb9";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmaps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "b3ec4fb48d41faac7a6d0604d4311edc421c4c07082630409c892d5b93a43929";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libmath/default.nix
+++ b/distros/iron/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libmath";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmath/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "1d8bd2bb481baf97d448d33e76cdaccaea96253ca02865dcb9040fe92911e7ae";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libmath/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a5ee5945d07d93b0f9d4730312b1c8cccb3c3da9e30551f1072899e0ad904440";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libnav/default.nix
+++ b/distros/iron/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libnav";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libnav/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "83f9ea0a0d30148acf7ab004b8063305ad9cf8260263f074751d234ebd284643";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libnav/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "afbbd6341e3b9e1b3228f5cd50e9fd85ab09118b021cf3581d65d586a5c12c86";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libobs/default.nix
+++ b/distros/iron/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libobs";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libobs/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "d6a8806191934ed4d478c71fb0af1279f1299424654c29bbf7e543708a560354";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libobs/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "1ae63830f9a70ca402f6c20ef7a813f61a873af70d8a3d0c9b2ad0fca98c64ba";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libopengl/default.nix
+++ b/distros/iron/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libopengl";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libopengl/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "122421e8b720373a4698944dd45ea0be99eb2b36e9500c62a20ab5b1db46edb7";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libopengl/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a3307daf9d20afdcd94fb9a4ef4481c35644777d6ac96e5835ed92fcabefafb0";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libposes/default.nix
+++ b/distros/iron/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libposes";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libposes/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "0707abd01f521e77c3a8a2cc18b259d118226b750c0ff2fa4b620465f97a5003";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libposes/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a6ed9f5fe8019243143a466c3839e2ce9dfd7366c798889e04ff04b18b000688";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libros-bridge/default.nix
+++ b/distros/iron/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libros-bridge";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libros_bridge/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "94a095a986fb9fa2cec9ef6a45fcd13bd0cc7d5f916940a5d032ac3d48fc3f5d";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libros_bridge/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "05c24488dacc34dd4c7746ae5b17f000339b2d4f35981bf99f51088e10959d8a";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libslam/default.nix
+++ b/distros/iron/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libslam";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libslam/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "688da8cb1886c375d6f1d6970ae7ea5062af006c84b285086e914d816a368b87";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libslam/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "17637ad1f1cee3bc98c3b5701978fd3de5034b1560d1f715a85534d85f22e2f1";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-libtclap/default.nix
+++ b/distros/iron/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-mrpt-libtclap";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libtclap/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "af652c969468743a37f95bb620af6c1509a16ba6c2b3d53851de5a036846dd3a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/iron/mrpt_libtclap/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "ad141b008ea7f664e6e341264fed19ace55ee3cb6d0b2b1083cc3f97de44b732";
   };
 
   buildType = "cmake";

--- a/distros/iron/mrpt-msgs/default.nix
+++ b/distros/iron/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-mrpt-msgs";
-  version = "0.4.7-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/iron/mrpt_msgs/0.4.7-1.tar.gz";
-    name = "0.4.7-1.tar.gz";
-    sha256 = "fa988be6db32a3f9413149839446567570a6c7d629ce0fdc1f0741a69f05b23c";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/iron/mrpt_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "726f5f3d736b2cb18345fa461668987cef9303455fbd47174dcc75635d7ebef0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mrpt-path-planning/default.nix
+++ b/distros/iron/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-iron-mrpt-path-planning";
-  version = "0.1.5-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "eff0cfe384b76d44b17d2f7d526d6543716b8ac2482247740c18059d0aa48881";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/iron/mrpt_path_planning/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "e8f002a1c6dccd49af4ecc192bce5a0eb3238cb7798357ce8c0f7cfdc863f258";
   };
 
   buildType = "cmake";

--- a/distros/iron/openeb-vendor/default.nix
+++ b/distros/iron/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-iron-openeb-vendor";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/iron/openeb_vendor/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1d3b45d7898fb3ee751ebf3569388d01de06ebb4fa2542ca2dfc0e322127f8dc";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/iron/openeb_vendor/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "be732db57cb7f63d198453b19547de53cb29789a6847580e3f751cbf0370d4ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/python-mrpt/default.nix
+++ b/distros/iron/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-iron-python-mrpt";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/iron/python_mrpt/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "35046a11066e8b3aa915cc245c2d324c26ff162faf79b9f08a850190e580d05e";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/iron/python_mrpt/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "04bd8b1d02805603d0c3f60af12f22753e2da22333d66f7201768ddebcb44df7";
   };
 
   buildType = "cmake";

--- a/distros/iron/rosapi-msgs/default.nix
+++ b/distros/iron/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosapi-msgs";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "7c580a7a65ae5718edc03384d47490619baeca7549aff0bf38c1c720a12e64ca";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d2f917fa84941e34c04b84372eaccae6c6ed0e8033276f95e23f4ceb843399f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosapi/default.nix
+++ b/distros/iron/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosapi";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "e70bf23428b3610962529b5afc4e5ca3e8aefc924913e91f5dacaba8487aafab";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosapi/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1afdeff992b4189afc87d979bc1e9eff09724d2ecdffc867f1e197ef0cc83fa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-library/default.nix
+++ b/distros/iron/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-library";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_library/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "78b32f280bfe77de1d651cdd27c329e2104d339331446ef97f62b29967db1581";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_library/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1341b1086fc0158a155a71bcc4d37cc21f3771f24a1d12df4b44035a1cc08de0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/iron/rosbridge-msgs/default.nix
+++ b/distros/iron/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-msgs";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "023219ec16b43659d576ced3fe863615800376f4bb15676169b41cad39a5eaec";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "fab033b01264f60132ae749a1f38f944f8c0f0b59ba26f58c6546f73c9386bfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-server/default.nix
+++ b/distros/iron/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-server";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_server/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "528e8adddb43de6ecf6c344c7510445f6ac1b6ddcca578f2fdd3c9078d2d748f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_server/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "69ddfa20f80beddc9e02df6a83fecb28b59352f1914a9ee7ba3488c85c37d643";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/iron/rosbridge-suite/default.nix
+++ b/distros/iron/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-suite";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_suite/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "4150a9f0770201acc4ed103c96ddb2a2b806c6749c4999733b36b666227722e9";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_suite/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "f0a4f13695e19bb37f52d4b0b895f4f38eeda47d448ac5199a1e849d8515dad5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbridge-test-msgs/default.nix
+++ b/distros/iron/rosbridge-test-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbridge-test-msgs";
-  version = "1.3.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_test_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "f6e65bd810b035781e39aa6bb2b4ea41304bc9bdfe85d12a61f2b232a767f0c3";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/iron/rosbridge_test_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "5f72ac0085366c2729ec61b1ed0f4682ad7070793b2e4eb457179f7af31e83a4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/srdfdom/default.nix
+++ b/distros/iron/srdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-iron-srdfdom";
-  version = "2.0.4-r3";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/iron/srdfdom/2.0.4-3.tar.gz";
-    name = "2.0.4-3.tar.gz";
-    sha256 = "da51082d045ed44e9f58185850bc576857a4caae3f6d9d01fd2e8cdcbcc9601f";
+    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/iron/srdfdom/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "150c38f5a3fe0b7bb4ecff04c0122f1a7294e99f5931f19c1c39c4a607a54a46";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-msgs/default.nix
+++ b/distros/iron/ur-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ur-msgs";
-  version = "2.0.0-r3";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/iron/ur_msgs/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "147cc2fb117d00a79888328aaa562a47fa4e6eb08ca75698a33021a67b03bf2c";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/iron/ur_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "aad7eacba4e5f88ea7a4865945552d34d1fad85a67c6254e22d14097d2210081";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "d2a6996472589fc579d23c88193a6f2990f259786c5dd8c01808d0bb1bda1ee8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "efc680b0538123e22714d4f8cea3e29e2d55e7035b188caf893d2cf731e411ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "0dde627e7c7f2280f10da185e82c4ed3c313e39ed588cfae401494c4d932d47d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "b21d7dd54977f33c7646b7a6ded3337d075a2e5be901e099a18b69997f2feb15";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "4947c4033ad10085282925da9355815be2bf773035a17351309f26089ebec1bb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "8495cbccc1715880cf24c1937e1b4572f37a8dbf13a5c17713bec0203ee3118d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "aed4a722c10ac433ed2fa2522ab288440a606c561fc443ab8c67d5714818e70b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "a155cfa69fa385e6ec8352eb8c1f67ddec6790dcd121b4656040bfb2c3d56082";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "ee1ac41b334a9c5f5ba0419dfbdb4586cbb8f05d9afc2f032afcea40861a09bf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "f6cf8695c18e77a86fe1531ed48ea3138630dff07feee6fd728df4036c92a940";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "811e8e9f9fbb262b70e1e668154284cdf7a901b04125454e07d8ce32fac74494";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "4b88475a49e7c6dbaf3e6d7eb96739286075b894f6c01e830afcbdb234085c5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-bridge/default.nix
+++ b/distros/jazzy/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "f514a0f95c9655cb92ec5446dc64f7e9a73e72dea789118d71f11255fc019fde";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "291a4101bfc3630c4e93657642ec6afa69b688a424333eee45943972f375d7d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-descriptions/default.nix
+++ b/distros/jazzy/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "d4abd55650d8682d2346a4c5a8fbf80f3bc2aad094a840105b2d3faa210b6a47";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "fb10fe1e37254e2f2fe074e39aa0bd3714478eaaf557ee4fee84be19245e3025";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples/default.nix
+++ b/distros/jazzy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "898f4566aed505852591b697388e0e68a59b5aaf087dfeb0c492f8d4cbccd1ef";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "046d07810f78d407491c05343ca98ef454136a556f377f448420bf7b0a43976f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters/default.nix
+++ b/distros/jazzy/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "1ca6d24655f2b1359221fd4af6f70908b94cfa656115a3b7ab45c7b3f4414a79";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "81660ff9975d2fcdd9d49889f639461d06d23ca4e535ba8730758d75f468a41f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver/default.nix
+++ b/distros/jazzy/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "50ff75a9616149dedeb6b0ea6f66f530f7519b28fe107d7f564abd5c6a6bf536";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "95c2c65f31a6a034e2fb7d5d329b795fc2d0c1d9fcc697ebee54de97aca5bc79";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-msgs/default.nix
+++ b/distros/jazzy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "db49fb576ed184f8fbf84e7498f850b5fbab8ebd89ccbc6c1d5838f1948fd463";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "0641bf62992281ca1a257140c841c20d1c0a04972ca91264cdfaff6c1fc2f298";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros/default.nix
+++ b/distros/jazzy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "8749fd9ba54c520f7ba76381c4b0e1cce4460c9475431cdc7adb6087314fe4cb";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "8f46545d92ed4b08a942ceaf8c7487a6e09945e6b8315d05f4223652b9284257";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "b11dc69b5c741ad32ed208a9fe53b1e0007d635912945a4c5abaa57fadf6e8db";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "b29b669c7431edd17baa07842e56a8800b2c4ed70f5797a2aa61f1e89503c5fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "1a856cb55c90504b774ad205cd61ddfd21ba7536c6d030b7304990d11d789948";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "88618a69baac82830695427ff0ce6ea2561e48a775aab819769fa753aa7339fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "2bf0c441eee380c9f481b2d79c2c5a3b63e4c99513dd969e1aa13f255ba77d5d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "40dbd1d6bb09e86cb177c607afc1545b5bdec7dab415fac9746b2a563b32f9aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "7a58a503061f6358dd9fc986ea48157342ae72cd22e14709b9ecfe947ebae3a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "43271c16df08c8aabc1d18b403e7a4b14972257fd25f52a14e39f7a1c1149464";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "70d6f15699d1a9d88c8ff540417e994641a9f0bcb63a3e038ce23010166e5e7f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "4629fe82d06e2b1ee191d066869cf58a65e822e74c6a3f71d88752773103b935";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "3caec67c1adf63ab78b097ac74f21da186309d811baf0eedbd3914f71b1a0c9f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "c46e5afc36ab4eb0596d9691d0e9cfea2e2468dffcf7cf5eda6a47b2c4688b53";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "a042c62891f386af53e85a676a778b1399149c32fdec733235cdf0fc501a4d34";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "7b1ddf302546505a405332c453670569681b783279708442ab7937465a78f807";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "a7d412ebca4a83215c5aae8ea12d155fe61abc7928e757ebdd61fc16974ba0d6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "3886729ea46086366440b6f355ce319ae7eb52a25101d2c2a8eadf6685cd47e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "3235c11a7b0ab521eced601e735e815146f9bbe5b5edf98a34324818b06d7a06";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "5357165e1b589811f820438dbc701256cbf1b7de645aaaf412e11ff9ebb4526a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "3156c441d5d52ba269a486953abdf30a8994afc508ce565c7e0b5e93d9df4d6f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "baeb9d6e20bfdb161ba825bbc5604c806164c675f9164be78d0e66a30b8b235a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "2c951c29b0af16204313a5f9deb94591610f4c24c037bb96d82c30bba17915ca";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "6b98d4bed3d0dfee9e66906d57d1ba0bc39243c41721a29e7374653958088baa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/libmavconn/default.nix
+++ b/distros/jazzy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-libmavconn";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "873bde30f3727d8d553f8b65b5e4c6d828a4df6ef16d8a9d5794f53366972487";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/libmavconn/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "70867887770e689088dc0e73aa4113a11621d8f44accfd48c58d5bcf68f32fab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavlink/default.nix
+++ b/distros/jazzy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mavlink";
-  version = "2024.6.6-r1";
+  version = "2024.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/jazzy/mavlink/2024.6.6-1.tar.gz";
-    name = "2024.6.6-1.tar.gz";
-    sha256 = "5456252e66eb9063fcae5bf6c09148c44b3b7ad23c79370208067d9005e7be0f";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/jazzy/mavlink/2024.10.10-1.tar.gz";
+    name = "2024.10.10-1.tar.gz";
+    sha256 = "02d9f48ba37bebc2f8b306c70449589f597313a967c6db34ff027f3f0f81c5b8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mavros-extras/default.nix
+++ b/distros/jazzy/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-extras";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "bf6b6f144d1ec4b533508d88bfe1b7007bbd67d11d5cccf73e16b2825e637713";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_extras/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "9f3248dce72fbce30486f6b9929542d1d58548f7e30335bf0c34cf563827cc0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros-msgs/default.nix
+++ b/distros/jazzy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros-msgs";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "f08ac355e5bc7febcc151cae6402d8300978ded870cfe82fcc6bb2e31f390b92";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros_msgs/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "4a276b5da9cd0f38299e0861471ef559a83f75b6d65b0efc19c97b654ccf2f6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mavros/default.nix
+++ b/distros/jazzy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mavros";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "4f0ff4978adfdf2abc1988930e84daee10db142da7538c2db063b9925fc29cf2";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/jazzy/mavros/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "3457c533c445137f2b828b297a607a1c4fd32b6df0c7615cad313da0242d4295";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/microstrain-inertial-description/default.nix
+++ b/distros/jazzy/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-microstrain-inertial-description";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_description/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "6cbce3c03dc5266050139fb901259add75fdbd7ea73444ff94dd90104e0686e0";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_description/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "cf14a846bd09b76ce7068ab45431d2d04711c7df513593910091f9b5cfef2df4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/microstrain-inertial-driver/default.nix
+++ b/distros/jazzy/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-microstrain-inertial-driver";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_driver/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "3efc12940312eb20b73bd4592407e69086540b3b5411f8bfb96dc01bc2898189";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_driver/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "5b025ac8a7694d702ddd2feffc3b0328605a00be2524725d1f46ee427edeba7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/microstrain-inertial-examples/default.nix
+++ b/distros/jazzy/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-microstrain-inertial-examples";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_examples/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "efc01fcfcca0e2b856b285aa87fc4003b02feec5ef4b7bef1860ef5e3d51c811";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_examples/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "9fe29e74b52c11e14ca6ce26851db111a9213f0a0dd4f33ad884b1e68c2f47c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/microstrain-inertial-msgs/default.nix
+++ b/distros/jazzy/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-microstrain-inertial-msgs";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_msgs/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "98c40baf074c21e86ed7e9cf7ce461fca7583860ab732097d27322a35b368597";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_msgs/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "700ba831b610e69eb8f85599906040604518d4fce36c037f1275524e4592c9d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/microstrain-inertial-rqt/default.nix
+++ b/distros/jazzy/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-microstrain-inertial-rqt";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_rqt/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "d77f0c29a8267bc035af50eb3612fec5b1f7199526553572219df4d5c6dbd3c1";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/jazzy/microstrain_inertial_rqt/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "3999e87892f8716cd87d3f99a8ee6772e76bd3fccd6a3ca20a5ccb5772cea87c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/mrpt-apps/default.nix
+++ b/distros/jazzy/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-apps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "3ea96a9309de3d6125298d6ad751f90918d524aa6f248d950abb483e39d81bd3";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_apps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "e709e62925110b2db55012d0564c1a2b339eb36913fce93b385f2135e7ed0c9e";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libapps/default.nix
+++ b/distros/jazzy/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libapps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "98f20e96ae34b8758b20938f32c02ba1f7deba88c8e67dcf4f77b812c1937207";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libapps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "50b7d8b2a2494f84054be7b79421ec41ccc59c8f9af08377212d88ece5f5fddf";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libbase/default.nix
+++ b/distros/jazzy/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libbase";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "dafafb18877236cd29c06c26e05161707944c171079f4ebfc360653c5bbae6ea";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libbase/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "1ecc599e3da9c3b8a04c880bab0533e5ee3ce2322433b841db9f2615042556a8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libgui/default.nix
+++ b/distros/jazzy/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libgui";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "9c50141e65bdba471c25af223d74178eee7d68aa9fb9b7ecfe355b14adfb0052";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libgui/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "11dfc4e9ecfa2d25ee7369040224f840bff0c1aa72af4a2d7d9dd4eb950fac4c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libhwdrivers/default.nix
+++ b/distros/jazzy/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libhwdrivers";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "c15d182c634de71a5b0d0c5140dd420811387771f309784b6191a1c8cb40f95b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libhwdrivers/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "d7c0d9a1d6646fffbcf9f33f747619ea1f414955bbceef886a2bedffd4868963";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmaps/default.nix
+++ b/distros/jazzy/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmaps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "7ea6cfc7b0a5393759320b0691e05f01c2203626192fbf8f1610d445c2982bba";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmaps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "4bf25f7f0a11f55723445f8dc1c5d4dae77ca97106c31fc5ecb52937dbcaca54";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libmath/default.nix
+++ b/distros/jazzy/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libmath";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "82d6655eea84d871b8dd45f1383a5416775dfa7ced47769142d4a93cfa2f2d3f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libmath/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "c79574adbf3beda13c47c743053990e927a5a2d911c73e861e45f6df5744f4f2";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libnav/default.nix
+++ b/distros/jazzy/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libnav";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "20208ca8aff01f9bf96612e733bee8af4a8d884981b5eb3546025eb632beb7cc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libnav/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "1d02f686357859de41dacaaf3e8647fbbb189da3bcb4bfb4f4b73848ac8dc0e9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libobs/default.nix
+++ b/distros/jazzy/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libobs";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "39d58fb3f5dc9a22703a107568b0a68680f5f4cf751800c31db834366c3a8f4b";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libobs/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "8a79e6a41c740dca3f0df99c333c267e914a5dc1f3f00ac29f6b12c09e351af0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libopengl/default.nix
+++ b/distros/jazzy/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libopengl";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "f82579fce50f3521999c15de78175a99ac56315762cdeb5c9ab3ef575f2a0c6e";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libopengl/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "fbef5fc444c5c92f68f155e349896aa27b2a040f313efeac333cc762c34719d9";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libposes/default.nix
+++ b/distros/jazzy/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libposes";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "43069bcdb30c86c918aecb585aa0e6c4b0f980baccd46d995e6973aa3e20d0fd";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libposes/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "c9c46ba979b4699ca10949cc1028971458b9a86614a8a8bd5ac184cc28af0306";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libros-bridge/default.nix
+++ b/distros/jazzy/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libros-bridge";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros_bridge/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "dc2ef1012f73f301f013d8b559c58cce5422d927c79e28529a98a88917c2a833";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libros_bridge/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "ff34f26e922963e21b23e87d99c223c78847bf48543c0600fa287967e09d684d";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libslam/default.nix
+++ b/distros/jazzy/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libslam";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "1aa5d497f19e5328fd7923f447f9235ff447d3dee16d839c06f32117fea80b25";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libslam/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "dd162001649fcb4a29adbe757d3b902c7e813b03c49121093640f61c3d167ccd";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-libtclap/default.nix
+++ b/distros/jazzy/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-libtclap";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "a84b13c5563fc295feb2c7b2b51e6e254ca6cda78151b6e31593c28a32824fd5";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/jazzy/mrpt_libtclap/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "644fdb397dd67e7203e8c9a3d4a59a555aeb1daee19a0bc75ccbc43a1593cc32";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mrpt-msgs/default.nix
+++ b/distros/jazzy/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-msgs";
-  version = "0.4.7-r3";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/jazzy/mrpt_msgs/0.4.7-3.tar.gz";
-    name = "0.4.7-3.tar.gz";
-    sha256 = "3f56212680290c005fb56ce66b89cdf887f7ed348a4d62e65c7f21f8e4af020f";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/jazzy/mrpt_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "21d69087833538193f23e98bd10cd94c93268857168aa8794dbd2aa803fa5022";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mrpt-path-planning/default.nix
+++ b/distros/jazzy/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-jazzy-mrpt-path-planning";
-  version = "0.1.5-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/jazzy/mrpt_path_planning/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "9bcc227bf6ffae66c9f4463baeb0096beae8f458f0e235585ae987f03bc90cf0";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/jazzy/mrpt_path_planning/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "76ca40ca46d3d80e9fd1c7bf96635cfdd32e1d7ea58cd9782510ba8badcecea3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/openeb-vendor/default.nix
+++ b/distros/jazzy/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-jazzy-openeb-vendor";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/jazzy/openeb_vendor/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "13d05d93514a405d8aa6f7fb0bdd3c81b38e74c162d1fc87ad9a43127c907414";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/jazzy/openeb_vendor/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "683804040ec43c2a666b917ada8856241b139bc8e416c7a820dc3b7501aa3205";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "2b4b74adfdc5c378c291e1afa03cc10cdcd8722a5b9f75099432195e54f55eb4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "726fe1cbe3c2a58308236680e73da2e440175176c26502ee98222b3e4d4a1ca9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "808049bed24adaed87380333df3800ff1b69ee45a4e1d8cf259117667457ee85";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "f8b22d638d61167bb2ffa599aa95b27dc3e5b089fff1749f31e5461b15f0b9cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "f71856fd537f3418f5dd5cc910c03f0ba570d3c567e77a7240511f94d658282c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "27751efcc04f26058b2cc8a51b59958ea9fcedb38a8c3ac94e1981640b881bed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/python-mrpt/default.nix
+++ b/distros/jazzy/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-python-mrpt";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/jazzy/python_mrpt/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "0f04a077c0e44d31f3e52daec67c2f2b5ba966a9e43c28a5cf9e37c17c6af854";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/jazzy/python_mrpt/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "c97fc34b260fe79aefc368d36bebfd3efc1c5f8ec1e79fade4276862d8364064";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "65552f2c18e8b82ec19a02e6f3edd2f3b40688df7964f4e9ad180f3f6a723879";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "df44e403a29d47768f50f51217821c26f28c06ed0f8273e2fd0be10a8fc0329d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "276a0b3859b1f98294aee35599b52e27cc5e069a57fe6d1df41277ce115ddea9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "558f81fb16e9cf2c00c787cb163c89c55930b89d4e585ea36a8490699ec566c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "e7a92c23dab56e83b69459fea66da19efeac9f8532489ab601e49bdabb371073";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "2d0307b042ee01327cab92bf6f64543d00ef2c26f8c6aff9b032b3dfc3b3b65e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "5aad50639f31ea1e41d21b526d37179d572056f11fd07a7e7fc14ec8100dca8d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "96a43055a9a574924ba37596173baabacfb5780287bff569b1b2905bdb374a61";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "b16af3fa694a2e0ec3c3b748b301851014a30f5ba21c08e7e1ffd7e68bfb86b4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "9f00fcb38ff4012f6ba4a963055cfdb94d66788c547669d63025bea4b6a77dea";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "a61519ada465a7520a093ed349e20fbbce214571163c2daf6bbb725b68d7b40b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "278c6f7ed6856e5fb7e7f46aec4c010b42b501cbf11d4b79144bb3238d38d0bf";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rosapi-msgs/default.nix
+++ b/distros/jazzy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi-msgs";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "dfb0d5b4499ef0f814c5128246b0600c3eee60c74b002693f2f6eb58f16fb78e";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b6c3ed4a465f98c0950cad840eb9cefbb614cb92a52a89c36e6e60889a6232a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosapi/default.nix
+++ b/distros/jazzy/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "14d5bfac4a6434b7826f4341e214403e8722cfc88c158b1d8d01ba20438dd360";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "4c97ead7a072adbe1c28061151fa593af621e19610716b7b38760e46951c46a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-library/default.nix
+++ b/distros/jazzy/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-library";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "cea6107b87a8388fd55a4e3873f860de605430ebb3bd36298bebd84d8de5d1a9";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "480c31fcb705efec657fd65eaade555126a862d1030c94e88461c6faa8c7f51b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/jazzy/rosbridge-msgs/default.nix
+++ b/distros/jazzy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-msgs";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "2e0bdf1537c731da4fdc864d19189f9face7e1dcc35cf11171ec2408c503bffb";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "0e898807bcc4b73d7a7d02e477c282441517166ffe424825e7406ba101c87e9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-server/default.nix
+++ b/distros/jazzy/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-server";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "4de7638e581fc8b7b45a6a988c9514039f9b2999b9cb98a7db1a0aab4102321b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "c38ae48fdd47570d1dfa403b7e737dbac5d95e1664889a293003248abe0545d4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/jazzy/rosbridge-suite/default.nix
+++ b/distros/jazzy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-suite";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "a76f792389f3097ae251fee42c92453b74ec32e8694985da07aa62b3640528f1";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "45edc8921c5dc6ca4479e4f61b9ec4d855af820a4e95ffb82290c07ebd9ade91";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-test-msgs/default.nix
+++ b/distros/jazzy/rosbridge-test-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-test-msgs";
-  version = "1.3.2-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/1.3.2-3.tar.gz";
-    name = "1.3.2-3.tar.gz";
-    sha256 = "28ab766fa86a92d306d69e73ad8485bd7f8044eaebba886b5d290a72d67c0180";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6dd7e7c24d596b4bc0df3e20ef5ec1ae505f55a8e5329d6a2eee3bd09a7dbd55";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "a50e66b55640b34eb100520489c7473f70f8c738d16c21d89742c45a574497dd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "328ba6a15f5d7a71986683580ac670e2b64d841796eec9f719bf63e2dbed007d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "d68a66e2babbfcb230eb16d9ab89691414be9702959f6f29b7b8e1865431dbd4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "e36d5f778484675c65980f1f27aeb60a782fb02a9008a398bd62a41318f82a71";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-control/default.nix
+++ b/distros/jazzy/scenario-execution-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, scenario-execution, scenario-execution-interfaces, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-control";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_control/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "99993feed4fa79cd2f0a996090b35193f160e65230a5ac4f932d4ba7535fe22c";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_control/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "eadccee4a5f3343f19e9e70c2d7c008682b52260015692573f875a1aecf6da3c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-gazebo/default.nix
+++ b/distros/jazzy/scenario-execution-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, py-trees, python3Packages, pythonPackages, rclpy, scenario-execution-ros }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-gazebo";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_gazebo/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "3faeb5bc44cb074cb4b1223757c236949c8fa122a7de6f306796bc6c0b1c2fb2";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_gazebo/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "72670031cb3f9f5a4fdeb3f1d1f43685a0e70803a074e66e8d5e63e3aaa4a473";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-interfaces/default.nix
+++ b/distros/jazzy/scenario-execution-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-interfaces";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_interfaces/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "b692689573318b8cfc533f3a02ec24448fd3bc4150f6039b3774221980ff2bc3";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_interfaces/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "0d385cc7bc87e26ab87d8c09fd402accbf17f5ab395545276bcdeb9ebdc47e3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/scenario-execution-nav2/default.nix
+++ b/distros/jazzy/scenario-execution-nav2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, nav2-simple-commander, pythonPackages, rclpy, scenario-execution-ros, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-nav2";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_nav2/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "1e696280d81db683d2744d2017f9a03148c11812d190d1c21aac02a9855c0feb";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_nav2/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "56ded924aa33e75e744a96420d3235ba73b40c62cb02aeacace2cbc574ecaa78";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-os/default.nix
+++ b/distros/jazzy/scenario-execution-os/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, scenario-execution }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-os";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_os/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "30953dc7a841235b46da7037a09bd24c320f51fdbe404c1cde432923ac9e6449";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_os/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "9f371fd2ba1283578e3eb5280cc12bccf903ae32bb23a969db4c74c98672eebf";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-py-trees-ros/default.nix
+++ b/distros/jazzy/scenario-execution-py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, py-trees-ros }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-py-trees-ros";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_py_trees_ros/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "ae97e5ec97a96360a0951f40cb9f3e9eda5aa7d8177bcba532416df9bcf29fed";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_py_trees_ros/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "9716904cedab67d9839c589f409171df0686a64edd8f0619e4e94b0eb628fd70";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-ros/default.nix
+++ b/distros/jazzy/scenario-execution-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, py-trees, py-trees-ros, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, scenario-execution, scenario-execution-py-trees-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-ros";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_ros/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "0ecfd343bfffc8ae838da4d493de2eb438156ce3bb3bae0afe052d2f4d4f253c";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_ros/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "6c0c78d73c714e276123cfe18b33858ae577a9112991a2c5a7adde8c925a74d6";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-rviz/default.nix
+++ b/distros/jazzy/scenario-execution-rviz/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, py-trees-ros-interfaces, qt5, rclcpp, rviz-common, scenario-execution-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, py-trees-ros-interfaces, qt5, rclcpp, rviz-common, scenario-execution-interfaces, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-rviz";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_rviz/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "03a6a4320a72c549fadb8e25bf6fd9493cdb75c5285c31d8be386a45ceefebc8";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_rviz/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "b927394ecde1454527e0538df5c73d89e9280a3e83ffb18088a4044a49f37ee4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake std-srvs ];
   propagatedBuildInputs = [ geometry-msgs nav-msgs py-trees-ros-interfaces qt5.qtbase rclcpp rviz-common scenario-execution-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/scenario-execution-x11/default.nix
+++ b/distros/jazzy/scenario-execution-x11/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ffmpeg, scenario-execution }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-x11";
-  version = "1.2.0-r3";
+  version = "1.2.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_x11/1.2.0-3.tar.gz";
-    name = "1.2.0-3.tar.gz";
-    sha256 = "9c3c5fffa62b9b5651f0132f28fdf00f80df53ab9d96250bc43be3be6113e2c9";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_x11/1.2.0-4.tar.gz";
+    name = "1.2.0-4.tar.gz";
+    sha256 = "f62742cfd19866f8cedd6220480792f41dc772faf48c772b90e02eb48100085d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/srdfdom/default.nix
+++ b/distros/jazzy/srdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-jazzy-srdfdom";
-  version = "2.0.4-r4";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/jazzy/srdfdom/2.0.4-4.tar.gz";
-    name = "2.0.4-4.tar.gz";
-    sha256 = "192cf5437af898cb4921c4e2524244615a8bf0fdcb507e47d2ae877ddf28d225";
+    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/jazzy/srdfdom/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "d70fab11a3b4a61f8172c2d09aeb68e1931aac3f4d7480a6f4b28745a8c12543";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "28e2ce3f09300705ffdeb097725f3bd5624823a1d62a3da6c1fb3def2b0dcb86";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "7434cbd7fa5625f3f47ef09a3301ff416b378051941e1485a02a3177fe8b559a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "584ba0aba2daebd1c76060fccd5187f296adde38502349bd3b973cf220b40297";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "05c120e7288728f16d608f5e558a921e8d2f88487e60481ee7a9952e5a66a8ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "aea6c593ed6161b334af164a6a9452187b0bd11cdcf669a339e9e54bc3c3b290";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "e9f36159dbb87fffe5c9a96b6cb13cd36754bf21615b15deba65daa156acf776";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "472cc4ae7d182b594af842e324a62dd4c31246f0ebd4a51912559c812cec6adf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "85163e4d4c77b5790ba7ed083d173238be99f4c2fb1f172e115a3d59cf63dcd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot4-setup/default.nix
+++ b/distros/jazzy/turtlebot4-setup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chrony, curl, networkmanager, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, robot-upstart, simple-term-menu-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chrony, curl, networkmanager, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, robot-upstart, simple-term-menu-vendor, socat }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot4-setup";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/jazzy/turtlebot4_setup/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "cba8afe7c778186b9c0947af007c750fe91e847599c596dd11f0d0b0c8ed7d0a";
+    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/jazzy/turtlebot4_setup/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "85b09da20e741404dabe0dcd65c66b7654a58a1c40ec5489a8afcce38ae95cc5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ chrony curl networkmanager rmw-cyclonedds-cpp rmw-fastrtps-cpp robot-upstart simple-term-menu-vendor ];
+  propagatedBuildInputs = [ chrony curl networkmanager rmw-cyclonedds-cpp rmw-fastrtps-cpp robot-upstart simple-term-menu-vendor socat ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/ur-msgs/default.nix
+++ b/distros/jazzy/ur-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-msgs";
-  version = "2.0.0-r4";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/jazzy/ur_msgs/2.0.0-4.tar.gz";
-    name = "2.0.0-4.tar.gz";
-    sha256 = "a9f3ee2e271b4754a00c61f1d247c884c31512e7224435334a7577b8f4393024";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/jazzy/ur_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "773c7af3e7575cf50655acedee9b7a6c7302f1720032617c1cea266d0f679306";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "1fc783d947dfb4c2b7662446c2f6f9e1f3ecf938586557908d56afa20adad254";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "ac6833c63e443734c28baed5192f2ee887aac67c66e42b13ad4beacd163c6629";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/adi-3dtof-image-stitching/default.nix
+++ b/distros/noetic/adi-3dtof-image-stitching/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, compressed-depth-image-transport, cv-bridge, eigen-conversions, image-geometry, image-transport, image-view, pcl-ros, roscpp, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-adi-3dtof-image-stitching";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/raebelchristo-adi/adi_3dtof_image_stitching-release/archive/release/noetic/adi_3dtof_image_stitching/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "dfe7b7b307da18b147715d0299671f2e30a1d046f9a286e179a5b1bf62004269";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ compressed-depth-image-transport cv-bridge eigen-conversions image-geometry image-transport image-view pcl-ros roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "The adi_3dtof_image_stitching package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/adi-tmc-coe/default.nix
+++ b/distros/noetic/adi-tmc-coe/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ethercat-grant, geometry-msgs, message-generation, message-runtime, roscpp, roscpp-serialization, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-grant, geometry-msgs, message-generation, message-runtime, roscpp, roscpp-serialization, soem, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-adi-tmc-coe";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/adi_tmcl_coe-release/archive/release/noetic/adi_tmc_coe/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e15522a8d1124851fb6575d376499a353387ef5b99fd5d4d00383d9b16ca42eb";
+    url = "https://github.com/ros2-gbp/adi_tmcl_coe-release/archive/release/noetic/adi_tmc_coe/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "282e91770e81f785118f6013e870ccb3f4dc4b38f63982550a7cbaac25ddb9b0";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ ethercat-grant geometry-msgs message-runtime roscpp roscpp-serialization std-msgs ];
+  propagatedBuildInputs = [ ethercat-grant geometry-msgs message-runtime roscpp roscpp-serialization soem std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/adi-tmcl/default.nix
+++ b/distros/noetic/adi-tmcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-adi-tmcl";
-  version = "4.0.0-r1";
+  version = "4.0.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/noetic/adi_tmcl/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "9d621668e2bda3c5365b69d83663de7b5442edd27097a37598eeb36a6c6545c5";
+    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/noetic/adi_tmcl/4.0.1-3.tar.gz";
+    name = "4.0.1-3.tar.gz";
+    sha256 = "ab58d8776f6a84e90ad1e81b9f5fe4cdf26ef662437b4ca1f3a20bec61b83ebc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "3a6bea2898773940b75930fe4f83687c2316314a86726186be979a75b95f0dca";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "53b43ea3a032c3ddf38f476a280983c1af80fdfd0b29380b65a8cdfeab40d515";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, urdf, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "09e842e958052ab3eeda46706a424603bb4430cbbd9dd68bb20477d0201a3315";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "0196dc4bb9dd9f96e649d63aa80fd849e609f96d30a2bf6436624a247b9fbfc7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "a1f9be61e28d4fbe12e955a77b6f5abe359d2322a1700d8754043bdca738d9cf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "03c567ed2cd11d6af3766063b2378e789bbfa5a344f63b98f7127811c7141ee6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "ff2611fce70671194ed1a3b9a6fcb0db4055c7a899d988932b4548f9dbc8d007";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "0b316e76d5663fef569232b5dc141ec45824835f349db64de49343a4afcf32fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, depthai-ros-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "d711720601e30fe82924af729425baefaacd15f208118f5fbfb59e2ed990ba30";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "57cb6801b643884baab1d0dbf8af15247f25a8d79df12adb2a5c31aeb5cdd6bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "db32e6f04d9dfc823b71de67cd0c9973a7b70d0af9855fc5519db9296b674347";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "fc201281f7063b0bcd0425543fc794c7e572c01c3dd4f731963c179b3432b8f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "15ac05f6c81aea4ec6a1171ebccc58a096be319f67d3c2e47976ee9d57f4df5b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "f11578eaca02f0f369223900d8f476aba7585ca23d9b55878a71ad948e808fd2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.10.1-r1";
+  version = "2.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.10.1-1.tar.gz";
-    name = "2.10.1-1.tar.gz";
-    sha256 = "b9ed492d6a377c80de94e7cb317f2a6c81e1e3da78b64103a3fcaa4f42ef7f03";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.10.2-1.tar.gz";
+    name = "2.10.2-1.tar.gz";
+    sha256 = "aecbfbdb143a044b1a18a0140b081d6a2c3094e59ba936b3414b062b80b80814";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  actionlib-tutorials = self.callPackage ./actionlib-tutorials {};
 
+ adi-3dtof-image-stitching = self.callPackage ./adi-3dtof-image-stitching {};
+
  adi-tmc-coe = self.callPackage ./adi-tmc-coe {};
 
  adi-tmcl = self.callPackage ./adi-tmcl {};

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "3379a9549a312f88da86b56b572ccb0b48166682db56a8025b0ea8ca265a8057";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "4fe24fe9e979d25fe6129d5605306b2c1627b733fc3bb443121266fa96c1c158";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2024.6.6-r1";
+  version = "2024.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2024.6.6-1.tar.gz";
-    name = "2024.6.6-1.tar.gz";
-    sha256 = "6995c1f9be291948013d072b514ba6faa8929654225172edc6eae5888cf2f917";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2024.10.10-1.tar.gz";
+    name = "2024.10.10-1.tar.gz";
+    sha256 = "9a4533658b4e92dfbad3e658967654fb1b11d69ee77fe882883a4376ecb4c458";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "880fea7e07b807685c25ef76982b1fa05a23e576c98b74bf7ba991cd00952bd9";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "73193a36af969ac8116e3e321e3357a2b2e2fb3af79bd91bf7dd3086cbc92076";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cmake-modules ];
-  propagatedBuildInputs = [ geometry-msgs mavros mavros-msgs roscpp sensor-msgs std-msgs tf tf2-eigen urdf visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs mavros mavros-msgs roscpp sensor-msgs std-msgs std-srvs tf tf2-eigen urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "90774f022b01421cbb3fc04ec01759ecae81ee0532990b75d58bb21d53382cbd";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "ff14e9dc18d80b4ef00dee50e52fe4c5f43f71719821b4c4ebad2b80a9baf4e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "021b9bc82179dd98f10286db9e2542f26b83b79049e4df06fb43f2847f4021eb";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "d03ac9e057f6937796dc92cf49ffc8ba5fd93a410f18419c7f9d834c41eb2626";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-description/default.nix
+++ b/distros/noetic/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-description";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_description/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "6c49d933c31877b0bb56099f19a5946ee9eb7c5663bbe66f649a21c692d89581";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_description/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "d0b0ba7f2fa7d7fb4efe1c10da640aa335be455eda52dfa50672567f34376569";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, nmea-msgs, roscpp, roslint, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "686e17f70bb6c9c66fe8c9ac86651383b677a2a00fba398e165265a828a0bb91";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "017e52d7a609791b656f48050648e74dafae59c7281b0c0fc5bad62fe7cb40cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, microstrain-inertial-driver, rviz, rviz-imu-plugin, tf }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "535bd08b6f197ac91272727a7d1d50aea6c33e6e3bc7bf396bdb6e239a5489e7";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "e4b61bd7769fe4b3b1e1f10237ad82276e01584ac086c877053842263c11cce6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "699cbc742059a7a6fca866f2bb120ad309aa84fa85d7e2ff1e251ad5e3b7ab6f";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "aa49fd28c005771700729ff5650a83b7a31ba693312a3ece0d1add060905b2fa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-rqt/default.nix
+++ b/distros/noetic/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rospy, rqt-gui, rqt-gui-py, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-rqt";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "918294e37962e817e2a340c7f04e32917b145f7a7ac8247d30c66aaef64a027d";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_rqt/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "3dade50454cb7588380c6288c3e781a8bdfe34d24816cf02f5b5842da61bb284";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "466fc77b70c362202cc2cf3d31112914d8b970cdcd7fd909c6e3ceb2e19e0083";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "1e9b7a2239d315694f9b09914160e149b0f5817af0b05f59a47557f220e6d143";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, gbenchmark, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-catkin, python3, random-numbers, rosconsole, roslib, rostest, rostime, rosunit, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "b6b59adf74114c3ed33b617a536d1b7681edcc40d564d963608ccfebe89daf5b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "e97adff13d8ab50730ebc5be47d1b659d193f753d94a1c3968ea89c423ba0fa2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "db49d1a3e050438c4d77b6016fc5c86a0cf880b1a6d2001cf72e6feb71333093";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "b29a0b1ca54579468939bdea148e174c213684801bce4f2b0d2709296ed3ff52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "57245161fd20bd6c69859bd9c5586f1ce8c8974b8feca6afae564170203127ef";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "05a680760c5621dc10efcadabd6e4972ce37057f547f7e8f018fb2e5a2a9a305";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "dc51a91aeeb2d6e9d901a88126823bc74ab3cc6b0ef72bd3a6689f0e95a3b912";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "ce964540283c19e7ff90e76e370c8be937b2b2dd2c81cfe2c5649a8a0275835a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "ac0c1466fd7244f63da6420bb342b134ee920d3a77dc90eff6b3d5cda283c035";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "3b8628d81aeddc450cef7dd7f250b13d0ffd35659a0adbc619470479051cfc11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "b648e4d899f8977cb8ba10dd27e25a4daecab4ffe05f10b013c46e34276eee4c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "ff3fd07c0a76444e261fa3c7b0fa0c8273a0b35f2ca2aec0571aa018e67f9995";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "1e9e885877a82f6b4c9d1f582bc6db41dbbb8fac2bd7e4326f1d8711257ea522";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "260daefd377c636be6053d5d2c5efe4a3f1deddc01397e54a7e30232c61d4fb2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "69f8534b07090e4d5fa5a014e60af31a3fe5cbea960cc1b331ba44f1c11d3f27";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "69a42608c0f0cd2cdb5cf7f579effa5c2f760be2bd0d8ce07b13986188abc34f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "cf57d2e68859572fbd7b2aab3280e8bb1a7c333ba06c119a5fb2df18b1a05246";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "2fc76d65882b91888182d6f9e7d4b8d0f6fc70fe4f11bf77657a1a3b288c16e6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "3fb449fa94f7fb57cd171125a244a4bdd3b5dfc18381d16989104e059d0d1340";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "7c71e929e6ae809a7d6fb53706ea675795d304a41799f063d0ae64b74061bcf1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "fe8e8f171ec6f7fdaf0a212e6a4937bb537e55cbca26e705aee221dbe154db79";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "19ba21648a4baafaad0eed4dc4d8953a4c19265e2f9d8b946d8101d6ba72cd1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "85220b2dcd4ddac605f0d23e38be971bdd2acfd9924a142bf50467661f2a137f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "c39ff7eec8849ec795a013f275f63f61e2a22b9ed8c4dd7bfe3938ca667139f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-perception/default.nix
+++ b/distros/noetic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, nodelet, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-perception";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "264c262dcfde3519b5c92e5e3a14057dbae5576b672e3d9f2245d5575697259a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_perception/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "c5dfd19660e177fd491c292b4408051f2cbb0120c71000426168af78502dea03";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "94b5ba50a9d05f705a23563580d0f0cf18c9f4aed328a05ceae276e9ea036440";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "aa14d857c857a199368959fa1dc8ab128389de87924bdd1850940170d70532c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "5cb95773ca3bc6e9d0a5265d4a174efbac80f8f6d0853b3b65ec966d671c93dd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "015f09b01429f931b0727da0140db8fcf230541e5cacefc8909fde1e891476c9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "49d77edb1ec470bdfcd0ff084e9abbc0625e727d923744993b32522cdd050c78";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "f9fa22d6260b7ab3d1dcae44a997ad0a6753309491df9f442b4a1a29af6a955f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "f1cb27a55e8bf044c93fbac423dda5ee1590bbf39f14f0ab459f47f7ca3b60ab";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "7fd8edc287805592578e6a234cbbeb9abda6213c63830e26cbf96347a5eb036c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "e564b704fb0620e8c53f73042554410143eeb12292000353dbe63000cf6672dd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "915d65a48f437d218fd31cd1e5f3fbcb659d0de7174d1ae939dd554203739975";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "1c6afe2dc54bafcca82ddab69f067b5874a2ee7a508ddf8ce01f9f5fbc83a63f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "6f8f46f8e3899ee63253d639a6c3e2b19098a126120b687174f38778f4f80752";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "63e9cba72bb6bdbb45ad3c540f57d3e7213c1294944955090512791dbd41052b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "3c44cd7f1e7448a158604715da37aa7297c8f11c840eb9f0410c9bd6fc211bed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "37fad6dbc9889e8649d91e8abbb7941932a60a8130a942f818344a8479dd6a18";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "17842971d533a33d6112f176e29252cdca9bf5f81e272abd87609f9fc9908ab1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "de8dbddf48123b8e2e20c16778f200e972da4ab21f5e9951b05bd10c97ff110a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "5fb13a6c1025a5cdcf4fdeb6bd93a119c3078e9d705737f9023849a7ed616bd3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "ffeaa12a09eb0596b138cb8327c38cedc184c287af05c5fc15a3edb42a463179";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "ede8a29274a3f2882eac590afa364e70f9c54b7f91197b08e35014ab4754e419";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "495a278f19a4315b5a2ea5282731e39038abbb900c752d4b1821b7b06f77d571";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "4ec3d6fc6848b227e0c3d0127ac2c1430933275b406635f6be5c81d3c6ee39ea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-apps/default.nix
+++ b/distros/noetic/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-apps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "798009360c50d05aaedf5be65f0a0beb86c2b73da570be4d94c0b5491bcd1ee8";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_apps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "57e4375e64605b5e25c08048e812202c16fb719884b9d3ef7a2d06eb882347b0";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libapps/default.nix
+++ b/distros/noetic/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libapps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "1a0ed042cdf125cd6f141177e18a08759255f7681c464f714db8d453048b80a6";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libapps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "e207ee679c1c07d4c7fcb8324e9b39643d4a4526a070d26e3e3518870b87082c";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libbase/default.nix
+++ b/distros/noetic/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tbb_2021_11, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libbase";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "0e470baeb7c179c0ba7206bec7b339e1abc33586e38c96e032f125c6e41dddc2";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libbase/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "e6215349d73057a5ae623722a905fa9769ee69f8e16106d0d9a5cfe716fc6b52";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libgui/default.nix
+++ b/distros/noetic/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libgui";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "665b41ff9f8fb89496a7bcc4ea3776db63c23d00715d8981efdc1723de80fd99";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libgui/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "aa81a2325f0d36aa88d741ed3c5cc76f60cf06f48b8daae82a112b8093ddbd64";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libhwdrivers/default.nix
+++ b/distros/noetic/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libhwdrivers";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "e7bd3830076b5e9da852c123865902c8894a0ffd30a79966909f1af6732542a5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libhwdrivers/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "0694b3cfd4eb9d008ac5a05a0567f9f97cd25c7039756a6e499fb6549c068a70";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libmaps/default.nix
+++ b/distros/noetic/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libmaps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "213e1fe9bb915fa8f47c3288f41fcd3122978d62c3fc79401d6bc3299fc20d65";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmaps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "23dbc44aca07f47df34e11ee68e0f9fd50f8692c244439a5ddf64fa2c9c3cdc8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libmath/default.nix
+++ b/distros/noetic/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libmath";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "7e6caf13ca61bb1318150645e9af17404f4a67ad9bb815d4019135158901d5db";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libmath/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "0ec1d1c0a21d013abe6b33b9e30a0c4a93a993d7a7c11751ae49bbc81f4a5409";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libnav/default.nix
+++ b/distros/noetic/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libnav";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "61a159e580fd57ddb7239020e1614f58ecddcba0f88f77b82209ad268cc7df01";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libnav/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "622ff0f3fce6de87341420de439f7e667108ed33d3b64934b627d4a87afec1ff";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libobs/default.nix
+++ b/distros/noetic/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libobs";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "696860168441c88b75ee7a307ef4e2fc3ebfcf27c9193dfcccb1e04fdec4b75f";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libobs/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "57b35181ff715d0977cdefc856eb8837437d945c7a045f287aa0e764d527962a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libopengl/default.nix
+++ b/distros/noetic/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libopengl";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "b8d143d072a52bd651056eee1e4a28f2c497b125dd29926e003d33ebc17e5c18";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libopengl/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "752feddc858091a803f8487f733638cebdbed53eb9fe944eef4a75975e3b9200";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libposes/default.nix
+++ b/distros/noetic/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libposes";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "46eedab6ea73fda1fd3de275d467e1f66d36189b6ef2b48d8ff1c7b088e9fbae";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libposes/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a1ad45e82fd0dbeeb80577bdd4e598a336f6c8d26a698b87d6723730a8c0867e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libros-bridge/default.nix
+++ b/distros/noetic/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libros-bridge";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros_bridge/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "ead2fd6ebb280ab35157b4cbbc8c30437f066d713ba961730956d73980238328";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libros_bridge/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "1c337f440dbaa112a47f9f34381b09a2bedb8f381c2fe9bde7ba91b95d294df8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libslam/default.nix
+++ b/distros/noetic/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tbb_2021_11, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libslam";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "5cae74c38fa48907c920266af1e121e357a629890b72f9e077e3e5dfee4d931e";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libslam/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "cff9d91c565521da20f35ef14ea3a6b7cb87e116297ee56e8c128088e4484d66";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-libtclap/default.nix
+++ b/distros/noetic/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, suitesparse, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-libtclap";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "cd7dbae60cd020f20a66d167c99a3bc6c48f95b79dfb11f9c5a313330d771de5";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_ros-release/archive/release/noetic/mrpt_libtclap/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "cf0b81e1de6b0bc5e7bba52c2db917719be0014e8a2b99ea1d87c556a3c945bb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mrpt-msgs/default.nix
+++ b/distros/noetic/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-msgs";
-  version = "0.4.7-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.4.7-1.tar.gz";
-    name = "0.4.7-1.tar.gz";
-    sha256 = "30b5908a7fe2b661d5782d20cbbc41ef24b333f05b2d1f2cef97448e34c04091";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release/archive/release/noetic/mrpt_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "036aa3355666b8158a946d2784c01f27e94cc656766ceb4d60200f0d13a0970e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mrpt-path-planning/default.nix
+++ b/distros/noetic/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-noetic-mrpt-path-planning";
-  version = "0.1.5-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "17a68fafaa254d50ad7431ae47be629d423420fdd31ca2943a796817c9c112d1";
+    url = "https://github.com/mrpt-ros-pkg-release/mrpt_path_planning-release/archive/release/noetic/mrpt_path_planning/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "2f53fb75e4873b850e7eab1a05e6baf7578bc957d298292966525712517c81b6";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "f6606952bd965c907ffbb84332b8fd15943e7501141156467eb877691c075c1a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "2fffa4181a5663245bfb5a417720ac32b7014a6a162048b814a128f70767cdd0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.15-r1";
+  version = "1.1.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.15-1.tar.gz";
-    name = "1.1.15-1.tar.gz";
-    sha256 = "175fad31720b7f2eab7018200076f83430ddace4c58c61484a2f9bcef4080565";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.16-1.tar.gz";
+    name = "1.1.16-1.tar.gz";
+    sha256 = "1e2fe28f824e9a697dc33a7337ce3d29af46ee48ed37ea265647337dfd48ebe4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/python-mrpt/default.nix
+++ b/distros/noetic/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, ros-environment, rosbag-storage, roscpp, tf2-geometry-msgs, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-noetic-python-mrpt";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/python_mrpt_ros-release/archive/release/noetic/python_mrpt/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "de5415573fc7419f26fddf2f87f77282b19c0b4acdca38aa514e5032b49e0329";
+    url = "https://github.com/mrpt-ros-pkg-release/python_mrpt_ros-release/archive/release/noetic/python_mrpt/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "74b898eb28b1b1eedf2949f317f631f076c08c2fe81891daff2593c15c56499f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sbg-driver/default.nix
+++ b/distros/noetic/sbg-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, nmea-msgs, roscpp, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-sbg-driver";
-  version = "3.1.1-r7";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/noetic/sbg_driver/3.1.1-7.tar.gz";
-    name = "3.1.1-7.tar.gz";
-    sha256 = "4be93a16debf3e9d4a33389e9f9897a43200b94667b286a6a6dca1660de00514";
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/noetic/sbg_driver/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "625a7422ed0c034dfd14686ae39182286c32689b7d659dc4dd8b54f7f53959e6";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs nmea-msgs roscpp rtcm-msgs sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "d0b2ddaea1583cb4a112a4023a541e81af4afec0a02300440817e2bd13b7e9aa";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "f68e519010cc505cdd7e0ebd9e51e4e4548903394eb784679f9a585a499ffeac";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "828fe1b0e8fbe74f5481cb0db70869be51e41513d6fadb693843bae572119aaf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "10194e9c226c07f7be15f2dd42fb00d77b8df74d3de91b8761bdf81db83e62f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "535fb66dae370b0e41d52d46f9f4b77c40a640d9d766ae0c06ded8bb82fab86e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "cb76d6b271ecc630e632ee94b999f725dbdac1a985b0fbbe031b8b6ed9bc9402";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "6412aaafe41e5a9e8f0c1882fefb69ca91476e7c73fc478de6103381b45d35d1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "810ac570c31715b4df42c6a7ba67881f0b16409faf863b02e938f18fe5f6f2cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "6.0.0-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/6.0.0-1.tar.gz";
-    name = "6.0.0-1.tar.gz";
-    sha256 = "b6d7c51156f6873166e158bd0434f3201f9a680298307d0ba3abb235838252ea";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "084f56ca75d2e261fad73e0119fc8391f941ad61bf761c1ba99093245ba78c6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "6.0.0-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/6.0.0-1.tar.gz";
-    name = "6.0.0-1.tar.gz";
-    sha256 = "6b943e31904242e3414dca6ecfa2fb02886587aa2e853c196ad50168e4f24937";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "ff4b63fbcdae0a784279379c45942da863710a4c0f20b93ae8322e9d24186e0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "fbd9611e7b69265c9cce9600519456424651e0691ad96ad50d43d3d480915aa9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "8e45e03a3b51344f52c47228168626e82548e9a60910c887838c811cf525091b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "cf9f992a8e254115dc13fdaff4c854a762d8c1b6e3243424b626dde02cf128c5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "2527e4c639864e446d7c10e9462a0547d9602dbd07e97f520998cfdfe14a0f24";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "14a501930b7235e3e6e0206af4d89dbb07c2775fded7a4b5fc7db0ffae56d988";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "445ba1272aea1b58a112d813cea8e18c3b051eea4bbe10b42366bcdbc63e8f4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/desktop-full/default.nix
+++ b/distros/rolling/desktop-full/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, desktop, perception, ros-gz-sim-demos, simulation }:
 buildRosPackage {
   pname = "ros-rolling-desktop-full";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/desktop_full/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "a2016d5789def716f2e473eb261e440c08a393cb71d4198290a3c7834ceef5bc";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/desktop_full/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "ae99f919f3279035a0db3aa17d8f0cf541129b01c87fdfcb6d02ef0a34ad0378";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/desktop/default.nix
+++ b/distros/rolling/desktop/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-cpp, action-tutorials-interfaces, action-tutorials-py, ament-cmake, angles, composition, demo-nodes-cpp, demo-nodes-cpp-native, demo-nodes-py, depthimage-to-laserscan, dummy-map-server, dummy-robot-bringup, dummy-sensors, examples-rclcpp-minimal-action-client, examples-rclcpp-minimal-action-server, examples-rclcpp-minimal-client, examples-rclcpp-minimal-composition, examples-rclcpp-minimal-publisher, examples-rclcpp-minimal-service, examples-rclcpp-minimal-subscriber, examples-rclcpp-minimal-timer, examples-rclcpp-multithreaded-executor, examples-rclpy-executors, examples-rclpy-minimal-action-client, examples-rclpy-minimal-action-server, examples-rclpy-minimal-client, examples-rclpy-minimal-publisher, examples-rclpy-minimal-service, examples-rclpy-minimal-subscriber, image-tools, intra-process-demo, joy, lifecycle, logging-demo, pcl-conversions, pendulum-control, pendulum-msgs, quality-of-service-demo-cpp, quality-of-service-demo-py, ros-base, rqt-common-plugins, rviz-default-plugins, rviz2, teleop-twist-joy, teleop-twist-keyboard, tlsf, tlsf-cpp, topic-monitor, turtlesim }:
+{ lib, buildRosPackage, fetchurl, action-tutorials-cpp, action-tutorials-py, ament-cmake, angles, composition, demo-nodes-cpp, demo-nodes-cpp-native, demo-nodes-py, depthimage-to-laserscan, dummy-map-server, dummy-robot-bringup, dummy-sensors, examples-rclcpp-minimal-action-client, examples-rclcpp-minimal-action-server, examples-rclcpp-minimal-client, examples-rclcpp-minimal-composition, examples-rclcpp-minimal-publisher, examples-rclcpp-minimal-service, examples-rclcpp-minimal-subscriber, examples-rclcpp-minimal-timer, examples-rclcpp-multithreaded-executor, examples-rclpy-executors, examples-rclpy-minimal-action-client, examples-rclpy-minimal-action-server, examples-rclpy-minimal-client, examples-rclpy-minimal-publisher, examples-rclpy-minimal-service, examples-rclpy-minimal-subscriber, image-tools, intra-process-demo, joy, lifecycle, logging-demo, pcl-conversions, pendulum-control, pendulum-msgs, quality-of-service-demo-cpp, quality-of-service-demo-py, ros-base, rqt-common-plugins, rviz-default-plugins, rviz2, teleop-twist-joy, teleop-twist-keyboard, tlsf, tlsf-cpp, topic-monitor, turtlesim }:
 buildRosPackage {
   pname = "ros-rolling-desktop";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/desktop/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "102103c29c4f8e40a1c2ea81ed6db9f96ec9f0e6bd4fe6eef6f3c8ecc235833b";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/desktop/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "086e05158bccb17e72accc65741ad36f00ae23fadaeb2ea067a155287d930923";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ action-tutorials-cpp action-tutorials-interfaces action-tutorials-py angles composition demo-nodes-cpp demo-nodes-cpp-native demo-nodes-py depthimage-to-laserscan dummy-map-server dummy-robot-bringup dummy-sensors examples-rclcpp-minimal-action-client examples-rclcpp-minimal-action-server examples-rclcpp-minimal-client examples-rclcpp-minimal-composition examples-rclcpp-minimal-publisher examples-rclcpp-minimal-service examples-rclcpp-minimal-subscriber examples-rclcpp-minimal-timer examples-rclcpp-multithreaded-executor examples-rclpy-executors examples-rclpy-minimal-action-client examples-rclpy-minimal-action-server examples-rclpy-minimal-client examples-rclpy-minimal-publisher examples-rclpy-minimal-service examples-rclpy-minimal-subscriber image-tools intra-process-demo joy lifecycle logging-demo pcl-conversions pendulum-control pendulum-msgs quality-of-service-demo-cpp quality-of-service-demo-py ros-base rqt-common-plugins rviz-default-plugins rviz2 teleop-twist-joy teleop-twist-keyboard tlsf tlsf-cpp topic-monitor turtlesim ];
+  propagatedBuildInputs = [ action-tutorials-cpp action-tutorials-py angles composition demo-nodes-cpp demo-nodes-cpp-native demo-nodes-py depthimage-to-laserscan dummy-map-server dummy-robot-bringup dummy-sensors examples-rclcpp-minimal-action-client examples-rclcpp-minimal-action-server examples-rclcpp-minimal-client examples-rclcpp-minimal-composition examples-rclcpp-minimal-publisher examples-rclcpp-minimal-service examples-rclcpp-minimal-subscriber examples-rclcpp-minimal-timer examples-rclcpp-multithreaded-executor examples-rclpy-executors examples-rclpy-minimal-action-client examples-rclpy-minimal-action-server examples-rclpy-minimal-client examples-rclpy-minimal-publisher examples-rclpy-minimal-service examples-rclpy-minimal-subscriber image-tools intra-process-demo joy lifecycle logging-demo pcl-conversions pendulum-control pendulum-msgs quality-of-service-demo-cpp quality-of-service-demo-py ros-base rqt-common-plugins rviz-default-plugins rviz2 teleop-twist-joy teleop-twist-keyboard tlsf tlsf-cpp topic-monitor turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "97681f0b758f32879a999902372941c74ae92d5a55a79706ba76f497c7f9c760";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "586bcdf54fa488a3923e470c1fc478784eb548e7ed7017727a142e2f47709e0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "3092e3df1320c640f84c8b95480e4391f155153ec225bc9771afe74670a76993";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "f70593595b090ef027ddb88cfca7a696cb7572e1dc7cbf20c6ed14761b01195f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "6cfff689519560bb7acebb09e506fdca4490fae928474f1ecc2de631e8ef7fa8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "51e9b33ce9b7646fa37823e51c59b5f2ef6070ae8a353a62a835ce0fe1400f44";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "ce2364aff3d5b8688810bf62f864ffa366ba4c839ce42acda1bfe94d1b5cf8c4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "4badbfee74dfab47c6a743709b6b955d60344c4420a4911dff0c1df63caed7a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -372,6 +372,8 @@ self: super: {
 
  derived-object-msgs = self.callPackage ./derived-object-msgs {};
 
+ desktop = self.callPackage ./desktop {};
+
  desktop-full = self.callPackage ./desktop-full {};
 
  diagnostic-aggregator = self.callPackage ./diagnostic-aggregator {};
@@ -785,6 +787,8 @@ self: super: {
  image-transport = self.callPackage ./image-transport {};
 
  image-transport-plugins = self.callPackage ./image-transport-plugins {};
+
+ image-transport-py = self.callPackage ./image-transport-py {};
 
  image-view = self.callPackage ./image-view {};
 

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "45af2abf177b744dec824e433044db925741854e6998c1e60f05164d09a5a979";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "a43fd6d82b96b76fe4c2b718ff1647207c95ea6ff61d096b1515a878160d55d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-msgs-vendor/default.nix
+++ b/distros/rolling/gz-msgs-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, pythonPackages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-msgs-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "8abc3176f3f8ab590d5921618d7bb7d0999ac7cc4dbb729c3a8271fbb5a1e1e5";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "0283dc1b05719ef3240abfd097eee3507689b7cdc3f55550cf3ec56d6a2b43d7";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-msgs11 11.0.0
+    description = "Vendor package for: gz-msgs11 11.0.1
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "9928ba96d1cebd9bef1dc4565bbc84402d624a1f0b4096134d8db5c2d2e33005";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "db45cc9eff6459081f231d211dd8b6572b3cce0e606b14b63cb36dafc939ff1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "0c5069e172d84d0d053479759dc11a3fb978ea1d2dd11f1be1be0b706e25f4ea";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "cef371b0049861724a68c80dac91a89d21e8d70e8f64428f4991c7794bc0189d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "6.0.0-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/6.0.0-1.tar.gz";
-    name = "6.0.0-1.tar.gz";
-    sha256 = "d88d4913d0e2ca4d9d47402b7a1bdf83497d0558582e878a00d9d8938ac02faa";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "da6228c2e72fc6443c290f3f2472d11ef52efb2b0e5229794ecb9a68da5ca485";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport-py/default.nix
+++ b/distros/rolling/image-transport-py/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, pybind11-vendor, rclcpp, rpyutils, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-image-transport-py";
+  version = "6.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "6ae8ca0f3076dd6998857c12960844e84c0ae33c15948faf939e16aefe5cc0d0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-python ament-cmake-ros pybind11-vendor ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ image-transport rclcpp rpyutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros ];
+
+  meta = {
+    description = "Python API for image_transport";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "6.0.0-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/6.0.0-1.tar.gz";
-    name = "6.0.0-1.tar.gz";
-    sha256 = "246a2212b17700f739a2a587b7ff34798067f196528ced0ab63fd3c73a7cc039";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "ec295c4dd7cb8e444e6e1b8d349d43aa6c086cb70845bf2dc49716126fc70ec7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "3da98936f94a65c3533adfd8cd1816a9c321c479875644cf4a13f06e48a3a8db";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "f4958c4cabc39c2e48680660eb7f1fab8f9976a1e5384df1687aa0c9a9f6b52a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "92f41aa72ba804fb512a3c6107d2dd5de8e14ccef5c9dccd163dfdf9ac814b97";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "b6fcb5c88b36739c1719c5583c6c3c7a6f088cf696e7b69dfff134dd45f964f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "90f96450238b01ff1dc97fff253596801038c7a6e33d111ede6f41a03b33e32c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "991b5a33f9e3dc21bc3832ada552ecb2df8c2482f1f2600e395dd5986dc97afd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "83de58aed934b2ef2c19e1e7f8ba08219244150b42d0f925b77983fd0d75ca08";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "6410fd97191e13b283767e8bdd07035a33fea413fad48c8ae60c69904bad2419";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libmavconn/default.nix
+++ b/distros/rolling/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-libmavconn";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "118cc0a7105261832681190483a0889664f0a99f9358a5422e4b9804701fc298";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/libmavconn/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "84e15d81da92f7df6a232ea9c5b388636573d26e0347d771bcf8c54172cf5692";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavlink/default.nix
+++ b/distros/rolling/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mavlink";
-  version = "2024.6.6-r1";
+  version = "2024.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2024.6.6-1.tar.gz";
-    name = "2024.6.6-1.tar.gz";
-    sha256 = "db56b920c8f07dc966aa31668dc9f87859b7d2fcbd972f67735cb56030130e88";
+    url = "https://github.com/ros2-gbp/mavlink-gbp-release/archive/release/rolling/mavlink/2024.10.10-1.tar.gz";
+    name = "2024.10.10-1.tar.gz";
+    sha256 = "667cbdcbddf9c8fb12e67903e80c8b7a0897ac66fe44283836ceb507109f6937";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mavros-extras/default.nix
+++ b/distros/rolling/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros, mavros-msgs, message-filters, nav-msgs, pluginlib, rclcpp, rclcpp-components, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs, urdf, visualization-msgs, yaml-cpp, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mavros-extras";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "d0551a6a8494e4cd6beb5558a8dde9e6e7d2acea80cb064c108e891fcb3b59cd";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_extras/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "cfab7003e67773e1474837dcd9f1977a20d0e7d242ec2e587da528b6b54b17e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros-msgs/default.nix
+++ b/distros/rolling/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros-msgs";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "f72d89f9745e0f4f423ac107aacde62cabc987bd321d4e46c3c79b2cef623d41";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros_msgs/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "0193307df6c206989797f888ced749a9de9e3a7562b6556ba900484b9418ffbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mavros/default.nix
+++ b/distros/rolling/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mavros";
-  version = "2.8.0-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "8e8e36d3562d454a367861caaf98f6398e0f546bd6fcba115c6a766fbdbd8d1d";
+    url = "https://github.com/ros2-gbp/mavros-release/archive/release/rolling/mavros/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "7b68759612e8d90e0d570f0dc37bb8824ff8407cdaa4a299dca7c303d2a426fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-description/default.nix
+++ b/distros/rolling/microstrain-inertial-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-description";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_description/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "c2f2b398edf1c4f6c948326c1fe477ce9c3dd4f5b652a03869b29581b0fc0699";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_description/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "ff4c4c5eda274cbcc937723a34465b88e79aecb14449a2df449ee856580ef269";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-driver/default.nix
+++ b/distros/rolling/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cpplint, curl, diagnostic-aggregator, diagnostic-updater, eigen, geographiclib, geometry-msgs, git, jq, lifecycle-msgs, microstrain-inertial-msgs, nav-msgs, nmea-msgs, rclcpp-lifecycle, ros-environment, rosidl-default-generators, rosidl-default-runtime, rtcm-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-driver";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "f0cca5497cc27cc91a25c1064e213d02f2b05646230f100ba48063786eab21a4";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_driver/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "4ed069101dd0949d2fb928b3910cb981bb6196958f9550c8dbddd26f5fc19033";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-examples/default.nix
+++ b/distros/rolling/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-driver, rviz-imu-plugin, rviz2, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-examples";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "6f5ecebc53d61fa55835894d46be54ca33278b369676b4b224400a243db95bcb";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_examples/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "c48533ede3591c1c7e0c14880602551b41dc5c084f6d5700f6d0af32b1e6f6c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-msgs/default.nix
+++ b/distros/rolling/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-msgs";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "df076e614d2851da917e8924f43380b43ccfed5f8e938a471cb2bb7adda7cf49";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_msgs/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "86c9568473ae6331d71b5f0e7c37b18868ac9c38148022afcc7fc92696d2b616";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/microstrain-inertial-rqt/default.nix
+++ b/distros/rolling/microstrain-inertial-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, microstrain-inertial-msgs, nav-msgs, rclpy, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-microstrain-inertial-rqt";
-  version = "4.3.0-r1";
+  version = "4.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/4.3.0-1.tar.gz";
-    name = "4.3.0-1.tar.gz";
-    sha256 = "e977fdb8ccf0479e26a58b0b37a7cde267d7aeb8f9f2da3174017bab9e988c75";
+    url = "https://github.com/ros2-gbp/microstrain_inertial-release/archive/release/rolling/microstrain_inertial_rqt/4.4.0-1.tar.gz";
+    name = "4.4.0-1.tar.gz";
+    sha256 = "83d54ba1926ae02ad3af300ccf4c53a4c397d4adc34541be81d62ec6aa3ae234";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/mrpt-apps/default.nix
+++ b/distros/rolling/mrpt-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libnav, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-apps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "2ce15044c3173ae6521a56168e5fb8e1e4a1b34993482ea1125fa814e6dffe82";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_apps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "d75964c76b36414e2a629da5e9236f224bd15bd0b9ec4c3b01cece33e18a9fc0";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libapps/default.nix
+++ b/distros/rolling/mrpt-libapps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libhwdrivers, mrpt-libmaps, mrpt-libslam, mrpt-libtclap, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libapps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "574b7b000f54100ed87fabb4947d03d63b526a904175478c9be4bb697d0a2fcd";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libapps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "c74d3f5317eb0cdf5654fe5d47cf0cf1e0d9ee0878c08bc5cc62032cc44ca196";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libbase/default.nix
+++ b/distros/rolling/mrpt-libbase/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libbase";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "a578cbdb83d8be3e40dfba0f641ad3b453387af594b8082044ba4d1540ff5116";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libbase/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "1a9b9dc90c21817f1cc7d88de22cc0cb0522c7043fcba467ba5eca6a1b21b7b8";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libgui/default.nix
+++ b/distros/rolling/mrpt-libgui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libgui";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "c4c7a96d5dc04b9eebce93b8e24c73c5a99463bfa6557e07dafe9f6836d9c957";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libgui/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "3b14325bfcf569c49be908e8632e44ea457f49595f6e2defc3e2d52b6a005577";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libhwdrivers/default.nix
+++ b/distros/rolling/mrpt-libhwdrivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libgui, mrpt-libmaps, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libhwdrivers";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "ba2963f84fe75f0078627ff28dd632cb4778e9d4d9e91be28e86fd758530819f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libhwdrivers/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "36e5135f8dc35462886fe85bc9219d0ee96c05e27d56709421342d72881f6516";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmaps/default.nix
+++ b/distros/rolling/mrpt-libmaps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libobs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmaps";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "d9eb76831f5d86557feaf94b6edbe14c09d52a924a187e11005c020f9ef6b7b4";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmaps/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "dad671eba7d4190765b92103753d2e00449048334e0f87cf13a5d90256a1504c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libmath/default.nix
+++ b/distros/rolling/mrpt-libmath/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libmath";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "1f456a386f0f58f252b8b687f578e422994c01ff6907ae21d8432e8bda89e825";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libmath/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "f008cd409d67ce91555549b3fe3c9beff77d68bef30eae90ae928f2d946fb603";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libnav/default.nix
+++ b/distros/rolling/mrpt-libnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libnav";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "0e3e654b4a6cd8d0eb01877464bd976f3e76b12e5858ebf5b7e3ffd54526b16a";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libnav/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "0dad284556d1dc80fa3d1c1ef00895da180bc4c20471a7861b9110939a581442";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libobs/default.nix
+++ b/distros/rolling/mrpt-libobs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libopengl, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libobs";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "4812e3d4df5cf7d2942c341652e16f29adc8f364589d8f538ab87217caedfb98";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libobs/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "850ff14045af303d3bfbbaa32bc96f63c7fa16d1a9a0d78a70adcca2edc9107a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libopengl/default.nix
+++ b/distros/rolling/mrpt-libopengl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libposes, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libopengl";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "3d5801bb878df24428272c77a3f70a1f8b8845ab8e1cc2749f6f05e0aebfe641";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libopengl/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "76253872f5f3e274aea7486f07848e8dc50cd29da908a1060442f8ec5f16e5c3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libposes/default.nix
+++ b/distros/rolling/mrpt-libposes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, mrpt-libmath, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libposes";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "52a516f71eaf531f3895b58db69abce194b1d37af9ce7f50e729d8cc68b72686";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libposes/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "b52743cd2afa1f834574cb536c024720ac643aa985fe0869d19b116660a620e9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libros-bridge/default.nix
+++ b/distros/rolling/mrpt-libros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, geometry-msgs, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, nav-msgs, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, sensor-msgs, std-msgs, stereo-msgs, tf2, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libros-bridge";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "766ddb82b9587736b71acea115d9f32a77db31130072d8d78b6780c069cd843f";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libros_bridge/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "311383ce9b58ba8430ee619cdebc65b394c25cea492b6e7a252603ac1d3a7d16";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libslam/default.nix
+++ b/distros/rolling/mrpt-libslam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libmaps, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tbb_2021_11, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libslam";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "184eb6caf2c2b95c98cf941da11a6a6fe1ef43be2829905df8a15aa3e99612cc";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libslam/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "47a60ba94c9804d340789368cc9dd2aac2412bade53a02fc8f924e3402dba633";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-libtclap/default.nix
+++ b/distros/rolling/mrpt-libtclap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, eigen, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libbase, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, suitesparse, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-libtclap";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "48b61f4108825970c83d2ccea4d2394af2ec0629df0891eaad61dee88b916731";
+    url = "https://github.com/ros2-gbp/mrpt_ros-release/archive/release/rolling/mrpt_libtclap/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "a89714712e8ae70885940bc3183905a94e79b9df7e10e8baa706f6d71cc9cfab";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mrpt-msgs/default.nix
+++ b/distros/rolling/mrpt-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cppcheck, ament-cpplint, ament-lint-auto, ament-lint-cmake, ament-lint-common, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-msgs";
-  version = "0.4.7-r2";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/rolling/mrpt_msgs/0.4.7-2.tar.gz";
-    name = "0.4.7-2.tar.gz";
-    sha256 = "edc948f2b71247876f645cb2433ed1eefacac263205e76ab8c72e0818ff6a48e";
+    url = "https://github.com/ros2-gbp/mrpt_msgs-release/archive/release/rolling/mrpt_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "a30ac7cf86438d374f330b6c2c0cf45658ff6a50dd8d14d027089a644e5fa76f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mrpt-path-planning/default.nix
+++ b/distros/rolling/mrpt-path-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mrpt-libgui, mrpt-libmaps, mrpt-libnav, mrpt-libtclap, mvsim }:
 buildRosPackage {
   pname = "ros-rolling-mrpt-path-planning";
-  version = "0.1.5-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "886591a1fe80db626afb045e9cbfd55c699f83d9b06c1b23942cd8b8887193e4";
+    url = "https://github.com/ros2-gbp/mrpt_path_planning-release/archive/release/rolling/mrpt_path_planning/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d8dbdb478b385ead095ae91e8ed9049777b1105238b3b2564235e073c69693eb";
   };
 
   buildType = "cmake";

--- a/distros/rolling/openeb-vendor/default.nix
+++ b/distros/rolling/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-rolling-openeb-vendor";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/rolling/openeb_vendor/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "05b2a9703a86fa5c59e9320ff48c079f3313dc7d9fe5ace4b6c396f0c00c92c1";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/rolling/openeb_vendor/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "75fe978448de891989837ee100a043fb497c17c37003d0f7e4024d38c561db57";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "a3e9c257cb3a8cbb915ea690bf3efb1a7879507663791035de2340eae6076f08";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "ef9d2746bf7998c73d4fa375e7d39eb10513fbb3d4e65cd58f817fbfc6aeb23a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/perception/default.nix
+++ b/distros/rolling/perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, image-common, image-pipeline, image-transport-plugins, laser-filters, laser-geometry, perception-pcl, ros-base, vision-opencv }:
 buildRosPackage {
   pname = "ros-rolling-perception";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/perception/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "5632e9f5d355f4a1a1196c95b3bbab081296ef297c2827894cddd342b0a37307";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/perception/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "875940b347be0f99b3207b5a99904fd720c433e646bb0a1c25fb22bde25707a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "7c6ca68b9262a8aa52f87cf13162fd21d640d6bc0aebb6e983284ab1a9f8b2f8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "df8244576e994a1434d26d0b8ce60bad7a5ac3820878d19c651c1b59909166e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "9ebabeb7f18d1eb3dec8feb8e878ff683d31ac4fc30137a330c0b0f3f2e521c3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "26d56a72d74ecd7931df0a62ad154ccc9d52c6267d542b8a80991d64e875578d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-mrpt/default.nix
+++ b/distros/rolling/python-mrpt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp, cmake, cv-bridge, ffmpeg, freeglut, freenect, glfw3, libGL, libGLU, libjpeg, libpcap, libusb1, mrpt-libapps, mrpt-libgui, mrpt-libnav, mrpt-libslam, octomap, opencv, openni2, pkg-config, python3Packages, pythonPackages, rclcpp, ros-environment, rosbag2-storage, tinyxml-2, udev, wxGTK32, xorg, zlib }:
 buildRosPackage {
   pname = "ros-rolling-python-mrpt";
-  version = "2.14.1-r1";
+  version = "2.14.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/rolling/python_mrpt/2.14.1-1.tar.gz";
-    name = "2.14.1-1.tar.gz";
-    sha256 = "f6e21f0b743a8949d7a80d786d0d1d1d926725353d2351575b7bca08f9083a98";
+    url = "https://github.com/ros2-gbp/python_mrpt_ros-release/archive/release/rolling/python_mrpt/2.14.2-1.tar.gz";
+    name = "2.14.2-1.tar.gz";
+    sha256 = "b6aaedc9dab7f628dead8b682123676f3167af34651949eeccfc56d7d08e3677";
   };
 
   buildType = "cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "8393ad3ca7a400326a136d223cb21e0e305d55f1741d184ddb924ccc52ca9f6c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "9dfaa5f3ece8ca4f2e8d4ea7c0560a2f147e9cf69212791d036fdc5b00cfd258";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-base/default.nix
+++ b/distros/rolling/ros-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry2, kdl-parser, robot-state-publisher, ros-core, rosbag2, urdf }:
 buildRosPackage {
   pname = "ros-rolling-ros-base";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/ros_base/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "4d9d73b1293c3b3bff2465806f8ef875a0caaf0ce49a68aef0d455486ab0b412";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/ros_base/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "47e1ffc915f2b5b4a5b4fc4f9a66248dd2ad8ce5e62d79450474f4315f9a9f87";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-core/default.nix
+++ b/distros/rolling/ros-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, class-loader, common-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, launch-yaml, pluginlib, rcl-lifecycle, rclcpp, rclcpp-action, rclcpp-lifecycle, rclpy, ros-environment, ros2cli-common-extensions, ros2launch, rosidl-default-generators, rosidl-default-runtime, sros2, sros2-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros-core";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/ros_core/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "da4d23736d1db9359b2b7465c75177626a6cab54dc31a6557cb1455e3d722586";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/ros_core/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "b39c1a443f0ac47a1623dc56dbf5a56d500b8ad981b2f71731c5494d04a532c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "085e8b31d110578e3c120e1f6779d7c1b7829b10e7e84d1a86bc79e1a0d867af";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "117c07b8a981e55661a069e9d8971e9e3b151239e2a5486fec0134cb284b3bc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "aede27b0a122071c907c23707e14c5dd6afd3c7eaa9ac8de98290603e62d5082";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "fc6b748835e54d3984550f23f69b9fecfaa1a7315e84f0ef64227a30ea1a7dec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "22afb16b4b723c67d3577787e185207d211d38725258796a4cdd6922467850df";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "9a2fb9d711b0327eb259d08fff2aad31d46f267cfdade0ed66b31c3eceb2e150";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "5af21a6122f66474f6bc12ef99e498250bcd910d0f44fd065998702c40a599d6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "b88387cd327f2cdaa4b6664d923b7c76753aa62cf07359960fee2d379729949e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "576f45dfac1a9719cef34444f2ffcb43448c251eda4f074d9ac6b648d71dd5d3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "3714d9019f7b2217ffd45e67312ea31e3a570db7b89906bf698f5a64d2240988";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosapi-msgs/default.nix
+++ b/distros/rolling/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosapi-msgs";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "a1e57618fa5e99376057f1895458080b5231285c6d397077f08e6b66f85d9e06";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "ec2fdf43d400dc2cd55d41e107a29deeaaa590c17c0ec4180dc1db1a1083156f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosapi/default.nix
+++ b/distros/rolling/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosapi";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "25489d60a3068f22c423f6233b6a6bb58e7c7c29dc865fe2aeb63042e3cabbd2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6373d76c7f6ca47b26f90eefa243bfec09d8748a96ca26f853b2001b2e271844";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-library/default.nix
+++ b/distros/rolling/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-library";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "f20a4de6d2d3b1c07c57dc03854d438f9396e08f360ed7ba3805442de975df2a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "2f1209f376bb29a21260930ee1ebd8b64dcb41314412f02e675fb20b3d3f3f35";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/rolling/rosbridge-msgs/default.nix
+++ b/distros/rolling/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-msgs";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "ef480431407be2ce67ee541fa8d7e445902063f4deea2b9a48c241f848275fa2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d2d4d92ec53604f443bff9c8b6366e4ff5e7d4634e84eeeba6d018f681d29b00";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-server/default.nix
+++ b/distros/rolling/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-server";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "c1399a7ad13efbca56f46d054680f76a9d35e0d2aa1efec175c509075909d962";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "30ffea60049813652a0608a55a5362955879fd48280f130601a67e6fc1ba6046";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/rolling/rosbridge-suite/default.nix
+++ b/distros/rolling/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-suite";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "473c8fa03f4e183ea67d56a0bc569dce0d62d1b6166fc9b72ea6b0cb2671beb2";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b30d9a13999ec633a8b7acb1699e635d7fe3c3feee3bbfd1df48add77863c27e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-test-msgs/default.nix
+++ b/distros/rolling/rosbridge-test-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-test-msgs";
-  version = "1.3.2-r2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/1.3.2-2.tar.gz";
-    name = "1.3.2-2.tar.gz";
-    sha256 = "9a3e18ca7af07bc6429f7f823b3132350d2741ca7c1176d95bfc4a0ebad4cf5f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "69a27154c4a291ea0f6d1383ff1c559ac39fb272e6705a706a2afabebbf71364";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
-  checkInputs = [ actionlib-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces diagnostic-msgs example-interfaces geometry-msgs nav-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "b39cc1cb480349c2cda653e0c2b6959363af7a7ee872be41b29784f6df6c0deb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "f9743ccf297924863f757ce5c034c15362057f7a0bd65961c3a3b0fdf4301a20";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "88cc32ad9e8e66a3af409d27d4c84a16b498752615a06d86450fd3b431738f26";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "32afcdbf2c0a4f0f738621142ef15660aefd7529216503b9ec4baa52ea948005";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/simulation/default.nix
+++ b/distros/rolling/simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-base, ros-gz-bridge, ros-gz-image, ros-gz-interfaces, ros-gz-sim }:
 buildRosPackage {
   pname = "ros-rolling-simulation";
-  version = "0.11.0-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/simulation/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "c0bf40f5fdac216ab17530e47ae33865051ee17110cafd3b26eb3681d38fec3e";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/rolling/simulation/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "eb793d642d48fe9ce674462bb5f5f015f8c261d8bf18beff97156aa0db423d6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/srdfdom/default.nix
+++ b/distros/rolling/srdfdom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-rolling-srdfdom";
-  version = "2.0.4-r3";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/rolling/srdfdom/2.0.4-3.tar.gz";
-    name = "2.0.4-3.tar.gz";
-    sha256 = "a3db9515081833bbfbc5ab507d0514e2807c42e4cbe0552d74b7f7cb0bf4ebe5";
+    url = "https://github.com/ros2-gbp/srdfdom-release/archive/release/rolling/srdfdom/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "52eee1e153d3fda3021ed511d3ca6ebcd509784e6427f5bf15e5ec9c29c7d575";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "3e267c49b125bf570d84305b264029002a012975cdcb00120133b0f9948f9fcb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "a4bcd5b284cfd13cbafa86957ef7f8a577af69a3e07a652d0411fae50ef6f6c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.17.0-r1";
+  version = "4.18.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.17.0-1.tar.gz";
-    name = "4.17.0-1.tar.gz";
-    sha256 = "c9f7c08e298896e811261436e1b3bf970d0eb79f834a7dba4c076b183eeee25f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.18.0-1.tar.gz";
+    name = "4.18.0-1.tar.gz";
+    sha256 = "2e468a90d302cfcf5593e45a877c3751db10fbb2a0e21d11f4995f3ee9fbefd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "8190bfce2d7cd44c345f3101af6d9eb4156efb9a23c1e0608309a9053568109b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "c61faedd27a2160d40f50c08ab53974ecbde7f0b1c73e9723a21fc99ba1c1b77";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "103db9441af63c9e40d7af505c1f80f2d6ed6bf98b4caddff1c0f159abfaaa10";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "d6334067b4eea49179e755b53e0a8f25d303dd3a78c53290c8bec586217fdde9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-msgs/default.nix
+++ b/distros/rolling/ur-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-msgs";
-  version = "2.0.0-r3";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/rolling/ur_msgs/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "8d7c0af3c6626d90986af9b07702d014eb0109ef37d0a06e054653efa0297e15";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/rolling/ur_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "3fc331b55e2c942afcf6a32b9d8c6cb64b71d91850bc6098b743039a4d4b4629";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.14.0-r1";
+  version = "4.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.14.0-1.tar.gz";
-    name = "4.14.0-1.tar.gz";
-    sha256 = "e81ab06f691865558c19ac16aa4a9b06898fbd283353e08c59fe719f929edad0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.15.0-1.tar.gz";
+    name = "4.15.0-1.tar.gz";
+    sha256 = "b1435b5d8dc5451d16072c70e3d8c00c5092a12df377b09cd08e72a0c2dc21db";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit cd8b2a1df78f4125fd35476458579f2ff41b3ef0.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-config 0.3.3-r1 --> 0.3.4-r1*
* *clearpath-control 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-customization 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-description 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-generator-common 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-manipulators 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-manipulators-description 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-mounts-description 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-platform 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-platform-description 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-sensors-description 0.3.2-r1 --> 0.3.4-r1*
* *clearpath-socketcan-interface 1.0.0-r1 --> 1.0.1-r1*
* *depthai-bridge 2.10.1-r1 --> 2.10.2-r1*
* *depthai-descriptions 2.10.1-r1 --> 2.10.2-r1*
* *depthai-examples 2.10.1-r1 --> 2.10.2-r1*
* *depthai-filters 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-driver 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-msgs 2.10.1-r1 --> 2.10.2-r1*
* *libmavconn 2.8.0-r1 --> 2.9.0-r1*
* *mavlink 2024.6.6-r1 --> 2024.10.10-r1*
* *mavros 2.8.0-r1 --> 2.9.0-r1*
* *mavros-extras 2.8.0-r1 --> 2.9.0-r1*
* *mavros-msgs 2.8.0-r1 --> 2.9.0-r1*
* *microstrain-inertial-description 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-driver 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-examples 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-msgs 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-rqt 4.3.0-r1 --> 4.4.0-r1*
* *mrpt-apps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libapps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libbase 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libgui 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libhwdrivers 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmaps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmath 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libnav 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libobs 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libopengl 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libposes 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libros-bridge 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libslam 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libtclap 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-msgs 0.4.7-r1 --> 0.5.0-r1*
* *mrpt-path-planning 0.1.5-r1 --> 0.2.0-r1*
* *openeb-vendor 2.0.0-r1 --> 2.0.1-r1*
* *puma-motor-driver 1.0.0-r1 --> 1.0.1-r1*
* *puma-motor-msgs 1.0.0-r1 --> 1.0.1-r1*
* *python-mrpt 2.14.1-r1 --> 2.14.2-r1*
* *rosapi 1.3.2-r1 --> 2.0.0-r1*
* *rosapi-msgs 1.3.2-r1 --> 2.0.0-r1*
* *rosbridge-library 1.3.2-r1 --> 2.0.0-r1*
* *rosbridge-msgs 1.3.2-r1 --> 2.0.0-r1*
* *rosbridge-server 1.3.2-r1 --> 2.0.0-r1*
* *rosbridge-suite 1.3.2-r1 --> 2.0.0-r1*
* *rosbridge-test-msgs 1.3.2-r1 --> 2.0.0-r1*
* *scenario-execution-control 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-gazebo 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-interfaces 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-nav2 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-os 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-py-trees-ros 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-ros 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-rviz 1.2.0-r1 --> 1.2.0-r2*
* *scenario-execution-x11 1.2.0-r1 --> 1.2.0-r2*
* *srdfdom 2.0.4-r1 --> 2.0.5-r1*
* *ur-msgs 2.0.0-r2 --> 2.0.1-r1*

Iron Changes:
-------------
* *apriltag-mit 1.0.3-r1 --> 2.0.0-r1*
* *depthai-bridge 2.10.1-r1 --> 2.10.2-r1*
* *depthai-descriptions 2.10.1-r1 --> 2.10.2-r1*
* *depthai-examples 2.10.1-r1 --> 2.10.2-r1*
* *depthai-filters 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-driver 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-msgs 2.10.1-r1 --> 2.10.2-r1*
* *libmavconn 2.8.0-r1 --> 2.9.0-r1*
* *mavlink 2024.6.6-r1 --> 2024.10.10-r1*
* *mavros 2.8.0-r1 --> 2.9.0-r1*
* *mavros-extras 2.8.0-r1 --> 2.9.0-r1*
* *mavros-msgs 2.8.0-r1 --> 2.9.0-r1*
* *microstrain-inertial-description 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-driver 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-examples 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-msgs 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-rqt 4.3.0-r1 --> 4.4.0-r1*
* *mrpt-apps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libapps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libbase 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libgui 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libhwdrivers 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmaps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmath 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libnav 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libobs 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libopengl 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libposes 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libros-bridge 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libslam 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libtclap 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-msgs 0.4.7-r1 --> 0.5.0-r1*
* *mrpt-path-planning 0.1.5-r1 --> 0.2.0-r1*
* *openeb-vendor 2.0.0-r1 --> 2.0.1-r1*
* *python-mrpt 2.14.1-r1 --> 2.14.2-r1*
* *rosapi 1.3.2-r1 --> 2.1.0-r1*
* *rosapi-msgs 1.3.2-r1 --> 2.1.0-r1*
* *rosbridge-library 1.3.2-r1 --> 2.1.0-r1*
* *rosbridge-msgs 1.3.2-r1 --> 2.1.0-r1*
* *rosbridge-server 1.3.2-r1 --> 2.1.0-r1*
* *rosbridge-suite 1.3.2-r1 --> 2.1.0-r1*
* *rosbridge-test-msgs 1.3.2-r1 --> 2.1.0-r1*
* *srdfdom 2.0.4-r3 --> 2.0.5-r1*
* *ur-msgs 2.0.0-r3 --> 2.0.1-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.14.0-r1 --> 4.15.0-r1*
* *admittance-controller 4.14.0-r1 --> 4.15.0-r1*
* *bicycle-steering-controller 4.14.0-r1 --> 4.15.0-r1*
* *controller-interface 4.17.0-r1 --> 4.18.0-r1*
* *controller-manager 4.17.0-r1 --> 4.18.0-r1*
* *controller-manager-msgs 4.17.0-r1 --> 4.18.0-r1*
* *depthai-bridge 2.10.1-r1 --> 2.10.2-r1*
* *depthai-descriptions 2.10.1-r1 --> 2.10.2-r1*
* *depthai-examples 2.10.1-r1 --> 2.10.2-r1*
* *depthai-filters 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-driver 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-msgs 2.10.1-r1 --> 2.10.2-r1*
* *diff-drive-controller 4.14.0-r1 --> 4.15.0-r1*
* *effort-controllers 4.14.0-r1 --> 4.15.0-r1*
* *force-torque-sensor-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *forward-command-controller 4.14.0-r1 --> 4.15.0-r1*
* *gripper-controllers 4.14.0-r1 --> 4.15.0-r1*
* *hardware-interface 4.17.0-r1 --> 4.18.0-r1*
* *hardware-interface-testing 4.17.0-r1 --> 4.18.0-r1*
* *imu-sensor-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *joint-limits 4.17.0-r1 --> 4.18.0-r1*
* *joint-state-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *joint-trajectory-controller 4.14.0-r1 --> 4.15.0-r1*
* *libmavconn 2.8.0-r1 --> 2.9.0-r1*
* *mavlink 2024.6.6-r1 --> 2024.10.10-r1*
* *mavros 2.8.0-r1 --> 2.9.0-r1*
* *mavros-extras 2.8.0-r1 --> 2.9.0-r1*
* *mavros-msgs 2.8.0-r1 --> 2.9.0-r1*
* *microstrain-inertial-description 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-driver 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-examples 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-msgs 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-rqt 4.3.0-r1 --> 4.4.0-r1*
* *mrpt-apps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libapps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libbase 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libgui 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libhwdrivers 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmaps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmath 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libnav 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libobs 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libopengl 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libposes 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libros-bridge 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libslam 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libtclap 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-msgs 0.4.7-r3 --> 0.5.0-r1*
* *mrpt-path-planning 0.1.5-r1 --> 0.2.0-r1*
* *openeb-vendor 2.0.0-r1 --> 2.0.1-r1*
* *parallel-gripper-controller 4.14.0-r1 --> 4.15.0-r1*
* *pid-controller 4.14.0-r1 --> 4.15.0-r1*
* *position-controllers 4.14.0-r1 --> 4.15.0-r1*
* *python-mrpt 2.14.1-r1 --> 2.14.2-r1*
* *range-sensor-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *ros2-control 4.17.0-r1 --> 4.18.0-r1*
* *ros2-control-test-assets 4.17.0-r1 --> 4.18.0-r1*
* *ros2-controllers 4.14.0-r1 --> 4.15.0-r1*
* *ros2-controllers-test-nodes 4.14.0-r1 --> 4.15.0-r1*
* *ros2controlcli 4.17.0-r1 --> 4.18.0-r1*
* *rosapi 1.3.2-r3 --> 2.1.0-r1*
* *rosapi-msgs 1.3.2-r3 --> 2.1.0-r1*
* *rosbridge-library 1.3.2-r3 --> 2.1.0-r1*
* *rosbridge-msgs 1.3.2-r3 --> 2.1.0-r1*
* *rosbridge-server 1.3.2-r3 --> 2.1.0-r1*
* *rosbridge-suite 1.3.2-r3 --> 2.1.0-r1*
* *rosbridge-test-msgs 1.3.2-r3 --> 2.1.0-r1*
* *rqt-controller-manager 4.17.0-r1 --> 4.18.0-r1*
* *rqt-joint-trajectory-controller 4.14.0-r1 --> 4.15.0-r1*
* *scenario-execution-control 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-gazebo 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-interfaces 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-nav2 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-os 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-py-trees-ros 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-ros 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-rviz 1.2.0-r3 --> 1.2.0-r4*
* *scenario-execution-x11 1.2.0-r3 --> 1.2.0-r4*
* *srdfdom 2.0.4-r4 --> 2.0.5-r1*
* *steering-controllers-library 4.14.0-r1 --> 4.15.0-r1*
* *transmission-interface 4.17.0-r1 --> 4.18.0-r1*
* *tricycle-controller 4.14.0-r1 --> 4.15.0-r1*
* *tricycle-steering-controller 4.14.0-r1 --> 4.15.0-r1*
* *turtlebot4-setup 2.0.0-r1 --> 2.0.1-r1*
* *ur-msgs 2.0.0-r4 --> 2.0.1-r1*
* *velocity-controllers 4.14.0-r1 --> 4.15.0-r1*

Noetic Changes:
---------------
* *adi-3dtof-image-stitching 1.1.0-r1*
* *adi-tmc-coe 1.0.0-r1 --> 1.0.1-r1*
* *adi-tmcl 4.0.0-r1 --> 4.0.1-r3*
* *chomp-motion-planner 1.1.15-r1 --> 1.1.16-r1*
* *depthai-bridge 2.10.1-r1 --> 2.10.2-r1*
* *depthai-descriptions 2.10.1-r1 --> 2.10.2-r1*
* *depthai-examples 2.10.1-r1 --> 2.10.2-r1*
* *depthai-filters 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-driver 2.10.1-r1 --> 2.10.2-r1*
* *depthai-ros-msgs 2.10.1-r1 --> 2.10.2-r1*
* *libmavconn 1.19.0-r1 --> 1.20.0-r1*
* *mavlink 2024.6.6-r1 --> 2024.10.10-r1*
* *mavros 1.19.0-r1 --> 1.20.0-r1*
* *mavros-extras 1.19.0-r1 --> 1.20.0-r1*
* *mavros-msgs 1.19.0-r1 --> 1.20.0-r1*
* *microstrain-inertial-description 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-driver 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-examples 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-msgs 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-rqt 4.3.0-r1 --> 4.4.0-r1*
* *moveit 1.1.15-r1 --> 1.1.16-r1*
* *moveit-chomp-optimizer-adapter 1.1.15-r1 --> 1.1.16-r1*
* *moveit-core 1.1.15-r1 --> 1.1.16-r1*
* *moveit-fake-controller-manager 1.1.15-r1 --> 1.1.16-r1*
* *moveit-kinematics 1.1.15-r1 --> 1.1.16-r1*
* *moveit-planners 1.1.15-r1 --> 1.1.16-r1*
* *moveit-planners-chomp 1.1.15-r1 --> 1.1.16-r1*
* *moveit-planners-ompl 1.1.15-r1 --> 1.1.16-r1*
* *moveit-plugins 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-benchmarks 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-control-interface 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-manipulation 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-move-group 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-occupancy-map-monitor 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-perception 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-planning 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-planning-interface 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-robot-interaction 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-visualization 1.1.15-r1 --> 1.1.16-r1*
* *moveit-ros-warehouse 1.1.15-r1 --> 1.1.16-r1*
* *moveit-runtime 1.1.15-r1 --> 1.1.16-r1*
* *moveit-servo 1.1.15-r1 --> 1.1.16-r1*
* *moveit-setup-assistant 1.1.15-r1 --> 1.1.16-r1*
* *moveit-simple-controller-manager 1.1.15-r1 --> 1.1.16-r1*
* *mrpt-apps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libapps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libbase 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libgui 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libhwdrivers 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmaps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmath 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libnav 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libobs 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libopengl 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libposes 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libros-bridge 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libslam 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libtclap 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-msgs 0.4.7-r1 --> 0.5.0-r1*
* *mrpt-path-planning 0.1.5-r1 --> 0.2.0-r1*
* *pilz-industrial-motion-planner 1.1.15-r1 --> 1.1.16-r1*
* *pilz-industrial-motion-planner-testutils 1.1.15-r1 --> 1.1.16-r1*
* *python-mrpt 2.14.1-r1 --> 2.14.2-r1*
* *sbg-driver 3.1.1-r7 --> 3.2.0-r1*
* *test-mavros 1.19.0-r1 --> 1.20.0-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.14.0-r1 --> 4.15.0-r1*
* *admittance-controller 4.14.0-r1 --> 4.15.0-r1*
* *bicycle-steering-controller 4.14.0-r1 --> 4.15.0-r1*
* *camera-calibration-parsers 6.0.0-r1 --> 6.0.1-r1*
* *camera-info-manager 6.0.0-r1 --> 6.0.1-r1*
* *controller-interface 4.17.0-r1 --> 4.18.0-r1*
* *controller-manager 4.17.0-r1 --> 4.18.0-r1*
* *controller-manager-msgs 4.17.0-r1 --> 4.18.0-r1*
* *desktop 0.11.0-r1 --> 0.12.0-r1*
* *desktop-full 0.11.0-r1 --> 0.12.0-r1*
* *diff-drive-controller 4.14.0-r1 --> 4.15.0-r1*
* *effort-controllers 4.14.0-r1 --> 4.15.0-r1*
* *force-torque-sensor-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *forward-command-controller 4.14.0-r1 --> 4.15.0-r1*
* *gripper-controllers 4.14.0-r1 --> 4.15.0-r1*
* *gz-msgs-vendor 0.2.0-r1 --> 0.2.1-r1*
* *hardware-interface 4.17.0-r1 --> 4.18.0-r1*
* *hardware-interface-testing 4.17.0-r1 --> 4.18.0-r1*
* *image-common 6.0.0-r1 --> 6.0.1-r1*
* *image-transport 6.0.0-r1 --> 6.0.1-r1*
* *image-transport-py 6.0.1-r1*
* *imu-sensor-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *joint-limits 4.17.0-r1 --> 4.18.0-r1*
* *joint-state-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *joint-trajectory-controller 4.14.0-r1 --> 4.15.0-r1*
* *libmavconn 2.8.0-r1 --> 2.9.0-r1*
* *mavlink 2024.6.6-r1 --> 2024.10.10-r1*
* *mavros 2.8.0-r1 --> 2.9.0-r1*
* *mavros-extras 2.8.0-r1 --> 2.9.0-r1*
* *mavros-msgs 2.8.0-r1 --> 2.9.0-r1*
* *microstrain-inertial-description 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-driver 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-examples 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-msgs 4.3.0-r1 --> 4.4.0-r1*
* *microstrain-inertial-rqt 4.3.0-r1 --> 4.4.0-r1*
* *mrpt-apps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libapps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libbase 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libgui 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libhwdrivers 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmaps 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libmath 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libnav 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libobs 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libopengl 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libposes 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libros-bridge 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libslam 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-libtclap 2.14.1-r1 --> 2.14.2-r1*
* *mrpt-msgs 0.4.7-r2 --> 0.5.0-r1*
* *mrpt-path-planning 0.1.5-r1 --> 0.2.0-r1*
* *openeb-vendor 2.0.0-r1 --> 2.0.1-r1*
* *parallel-gripper-controller 4.14.0-r1 --> 4.15.0-r1*
* *perception 0.11.0-r1 --> 0.12.0-r1*
* *pid-controller 4.14.0-r1 --> 4.15.0-r1*
* *position-controllers 4.14.0-r1 --> 4.15.0-r1*
* *python-mrpt 2.14.1-r1 --> 2.14.2-r1*
* *range-sensor-broadcaster 4.14.0-r1 --> 4.15.0-r1*
* *ros-base 0.11.0-r1 --> 0.12.0-r1*
* *ros-core 0.11.0-r1 --> 0.12.0-r1*
* *ros2-control 4.17.0-r1 --> 4.18.0-r1*
* *ros2-control-test-assets 4.17.0-r1 --> 4.18.0-r1*
* *ros2-controllers 4.14.0-r1 --> 4.15.0-r1*
* *ros2-controllers-test-nodes 4.14.0-r1 --> 4.15.0-r1*
* *ros2controlcli 4.17.0-r1 --> 4.18.0-r1*
* *rosapi 1.3.2-r2 --> 2.1.0-r1*
* *rosapi-msgs 1.3.2-r2 --> 2.1.0-r1*
* *rosbridge-library 1.3.2-r2 --> 2.1.0-r1*
* *rosbridge-msgs 1.3.2-r2 --> 2.1.0-r1*
* *rosbridge-server 1.3.2-r2 --> 2.1.0-r1*
* *rosbridge-suite 1.3.2-r2 --> 2.1.0-r1*
* *rosbridge-test-msgs 1.3.2-r2 --> 2.1.0-r1*
* *rqt-controller-manager 4.17.0-r1 --> 4.18.0-r1*
* *rqt-joint-trajectory-controller 4.14.0-r1 --> 4.15.0-r1*
* *simulation 0.11.0-r1 --> 0.12.0-r1*
* *srdfdom 2.0.4-r3 --> 2.0.5-r1*
* *steering-controllers-library 4.14.0-r1 --> 4.15.0-r1*
* *transmission-interface 4.17.0-r1 --> 4.18.0-r1*
* *tricycle-controller 4.14.0-r1 --> 4.15.0-r1*
* *tricycle-steering-controller 4.14.0-r1 --> 4.15.0-r1*
* *ur-msgs 2.0.0-r3 --> 2.0.1-r1*
* *velocity-controllers 4.14.0-r1 --> 4.15.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-antlr4
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-pexpect
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pyside2
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

