### PR TITLE
rviz2: remove hardcoded $PREFIX/opt path

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -204,6 +204,15 @@ in {
     '';
   };
 
+  rviz-rendering = rosSuper.rviz-rendering.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    postPatch = postPatch + ''
+      substituteInPlace src/rviz_rendering/render_system.cpp \
+        --replace-fail /opt/rviz_ogre_vendor ""
+    '';
+  });
+
   shared-queues-vendor = lib.patchVendorUrl rosSuper.shared-queues-vendor {
     url = "https://github.com/cameron314/readerwriterqueue/archive/ef7dfbf553288064347d51b8ac335f1ca489032a.zip";
     sha256 = "sha256-TyFt3d78GidhDGD17KgjAaZl/qvAcGJP8lmu4EOxpYg=";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -204,6 +204,15 @@ in {
     '';
   };
 
+  rviz-rendering = rosSuper.rviz-rendering.overrideAttrs ({
+    postPatch ? "", ...
+  }: {
+    postPatch = postPatch + ''
+      substituteInPlace src/rviz_rendering/render_system.cpp \
+        --replace-fail /opt/rviz_ogre_vendor ""
+    '';
+  });
+
   sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
     version = "15.0.0";
     hash = "sha256-d9PKTgUIFPX1rc1HlKCQPxcUcTn2ivObMvkGz/HBExw=";


### PR DESCRIPTION
Fixes https://github.com/lopsided98/nix-ros-overlay/issues/512

On startup Rviz2 searches for some core libraries inside a $PREFIX/opt/rviz_ogre_vendor path hardcoded into the executable, assuming it's being run under a regular ROS 2 installation.

As of recently nix-ros-overlay installs everything into standard directories, including stuff that was previously put into opt/, so Rviz2 would crash on startup.

This fixes the lookup path and makes it go search in normal directories.