### PR TITLE
moveit2: fix build for Jazzy

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -93,6 +93,16 @@ let
       setupHook = ./gazebo-ros-setup-hook.sh;
     });
 
+    geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({
+        postPatch ? "", ...
+    }: {
+        postPatch = postPatch + ''
+          substituteInPlace CMakeLists.txt --replace-fail \
+            'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' \
+            'find_package(octomap REQUIRED)'
+        '';
+    });
+
     gmapping = patchBoostSignals rosSuper.gmapping;
 
     image-cb-detector = patchBoostSignals rosSuper.image-cb-detector;
@@ -165,6 +175,60 @@ let
         patchShebangs scripts
       '';
     });
+
+    moveit-core = rosSuper.moveit-core.overrideAttrs({
+      postPatch ? "", ...
+    }: {
+      postPatch = postPatch + ''
+        substituteInPlace CMakeLists.txt --replace-fail \
+          'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' \
+          'find_package(octomap REQUIRED)'
+      '';
+    });
+
+    moveit-ros-occupancy-map-monitor = rosSuper.moveit-ros-occupancy-map-monitor.overrideAttrs({
+      postPatch ? "", ...
+    }: {
+      postPatch = postPatch + ''
+        substituteInPlace CMakeLists.txt --replace-fail \
+          'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' \
+          'find_package(octomap REQUIRED)'
+      '';
+    });
+
+    osqp-vendor = pipe rosSuper.osqp-vendor [
+      # Make CMakeLists.txt amenable to automatic patching by the next step.
+      (pkg: pkg.overrideAttrs ({ prePatch ? "", ... }: {
+        prePatch = prePatch + ''
+          substituteInPlace CMakeLists.txt --replace-fail \
+            'set(git_tag "v0.6.2")' \
+            'set(git_tag "v0.6.2")' # fail when upstream version changes
+          substituteInPlace CMakeLists.txt --replace-fail \
+            'GIT_TAG ''${git_tag}' \
+            'GIT_TAG v0.6.2'
+        '';
+      }))
+
+      (pkg: patchExternalProjectGit pkg {
+        url = "https://github.com/osqp/osqp.git";
+        rev = "v0.6.2";
+        fetchgitArgs = {
+          hash = "sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=";
+          leaveDotGit = true;
+        };
+      })
+
+      # osqp installs into both lib/cmake/ and lib64/cmake/ which is problematic
+      # because moveLib64 doesn't attempt to merge overlapping directories but
+      # fails instead. Here we do the merge manually.
+      (pkg: pkg.overrideAttrs ({ preInstall ? "", ... }: {
+        preInstall = preInstall + ''
+          mkdir -p ./osqp_install/lib/cmake/osqp
+          mv ./osqp_install/lib64/cmake/osqp/* ./osqp_install/lib/cmake/osqp
+          rm -r ./osqp_install/lib64/cmake
+        '';
+      }))
+    ];
 
     ompl = rosSuper.ompl.overrideAttrs ({
       patches ? [], ...

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -25,14 +25,6 @@ in {
 
   gazebo = self.gazebo_11;
 
-  geometric-shapes = rosSuper.geometric-shapes.overrideAttrs({
-    postPatch ? "", ...
-  }: {
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail 'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' 'find_package(octomap REQUIRED)'
-    '';
-  });
-
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";
     rev = "344117638c8ff7e239044fd0fa7085839fc03021";
@@ -191,52 +183,6 @@ in {
     url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.3.0.tar.gz";
     hash = "sha256-Qaz26F11VWxkQH8HfgVJLTHbHwmeByQu8ENkuyk5rPE=";
   };
-
-  moveit-core = rosSuper.moveit-core.overrideAttrs({
-    postPatch ? "", ...
-  }: {
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail 'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' 'find_package(octomap REQUIRED)'
-    '';
-  });
-
-  moveit-ros-occupancy-map-monitor = rosSuper.moveit-ros-occupancy-map-monitor.overrideAttrs({
-    postPatch ? "", ...
-  }: {
-    postPatch = postPatch + ''
-      substituteInPlace CMakeLists.txt --replace-fail 'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' 'find_package(octomap REQUIRED)'
-    '';
-  });
-
-  osqp-vendor = lib.pipe rosSuper.osqp-vendor [
-    # Make CMakeLists.txt amenable to automatic patching by the next step.
-    (pkg: pkg.overrideAttrs ({ prePatch ? "", ... }: {
-      prePatch = prePatch + ''
-        substituteInPlace CMakeLists.txt --replace-fail 'set(git_tag "v0.6.2")' 'set(git_tag "v0.6.2")' # fail when upstream version changes
-        substituteInPlace CMakeLists.txt --replace-fail 'GIT_TAG ''${git_tag}' 'GIT_TAG v0.6.2'
-      '';
-    }))
-
-    (pkg: lib.patchExternalProjectGit pkg {
-      url = "https://github.com/osqp/osqp.git";
-      rev = "v0.6.2";
-      fetchgitArgs = {
-        hash = "sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=";
-        leaveDotGit = true;
-      };
-    })
-
-    # osqp installs into both lib/cmake/ and lib64/cmake/ which is problematic
-    # because moveLib64 doesn't attempt to merge overlapping directories but
-    # fails instead. Here we do the merge manually.
-    (pkg: pkg.overrideAttrs ({ preInstall ? "", ... }: {
-      preInstall = preInstall + ''
-        mkdir -p ./osqp_install/lib/cmake/osqp
-        mv ./osqp_install/lib64/cmake/osqp/* ./osqp_install/lib/cmake/osqp
-        rm -r ./osqp_install/lib64/cmake
-      '';
-    }))
-  ];
 
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
     url = "https://github.com/OGRECave/ogre.git";


### PR DESCRIPTION
This fixes the build of MoveIt2 for Jazzy. The patches likely apply equally for Rolling but I have no time to test this currently.

It's been a while since I did this so exact details escape me, and again, I lack time to re-research, but in short:

1) Several packages have constrained their version requirement on `liboctomap` to <1.10 to fix some distro specific issues on Ubuntu, while what we have is =1.10. As far as I understand the issue is irrelevant on Nix. The fix is to relax the version requirement.
2) `osqp_vendor` required a bit of convincing to get it to build and install like we want.