### PR TITLE
Extend release.nix and add a link to public Hydra

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ You can use the following command to use the above template easily:
 ## Current status
 
 What works:
-1. More than 1400 packages successfully built for ROS Noetic
+1. More than 1400 packages successfully built for ROS Noetic (for
+   up-to-date numbers and other distros, look at our experimental
+   [Hydra instance][] controlled by [@wentasah][])
 2. Fully functional ROS development environment using `nix-shell`
 3. Automated generation of Nix package definitions using standard ROS tools ([superflore](https://github.com/lopsided98/superflore))
 
@@ -94,6 +96,9 @@ What still needs to be done:
 2. Test on more Linux distributions
 3. aarch64 binary cache
 4. macOS support
+
+[Hydra instance]: https://hydra.iid.ciirc.cvut.cz/project/nix-ros-overlay
+[@wentasah]: https://github.com/wentasah
 
 ## Configure Binary Cache
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
       };
       checks = {
         x86_64-linux = import ./release.nix { system = "x86_64-linux"; };
+        aarch64-linux = import ./release.nix { system = "aarch64-linux"; };
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,9 @@
         path = ./examples/flake;
         description = "Basic ROS flake";
       };
+      checks = {
+        x86_64-linux = import ./release.nix { system = "x86_64-linux"; };
+      };
     };
 
   nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -36,10 +36,6 @@
         path = ./examples/flake;
         description = "Basic ROS flake";
       };
-      checks = {
-        x86_64-linux = import ./release.nix { system = "x86_64-linux"; };
-        aarch64-linux = import ./release.nix { system = "aarch64-linux"; };
-      };
     };
 
   nixConfig = {

--- a/release.nix
+++ b/release.nix
@@ -25,5 +25,8 @@ let
       "mkRosDistroOverlay"
       "foxy" # No CI for EOL distro
     ];
+    examples = builtins.mapAttrs
+      (file: _: import (./examples + "/${file}") { inherit pkgs; })
+      (builtins.readDir ./examples);
   };
 in if distro == null then releasePackages else releasePackages.rosPackages.${distro}

--- a/release.nix
+++ b/release.nix
@@ -23,6 +23,7 @@ let
     rosPackages = removeAttrs releaseDistros [
       "lib"
       "mkRosDistroOverlay"
+      "foxy" # No CI for EOL distro
     ];
   };
 in if distro == null then releasePackages else releasePackages.rosPackages.${distro}

--- a/release.nix
+++ b/release.nix
@@ -8,9 +8,8 @@ in
 {
   nixpkgs ? lockedNixpkgs,
   nix-ros-overlay ? ./.,
-  distro ? null,
+  distro ? null, # what to build: null = everything, .* = top or examples, anything else = specific ROS distro
   system ? builtins.currentSystem,
-  toplevelOnly ? false,
 }:
 let
   pkgs = import nix-ros-overlay { inherit nixpkgs system; };
@@ -45,8 +44,7 @@ let
       (readDir ./examples);
   };
 in
-if toplevelOnly
-then toplevelPackages
-else if distro == null
-then releasePackages
+if distro == ".top" then toplevelPackages
+else if distro == ".examples" then releasePackages.examples
+else if distro == null then releasePackages
 else releasePackages.rosPackages.${distro}

--- a/release.nix
+++ b/release.nix
@@ -13,7 +13,7 @@ in
 }:
 let
   pkgs = import nix-ros-overlay { inherit nixpkgs system; };
-  inherit (pkgs.lib) isDerivation;
+  inherit (pkgs.lib) isDerivation filterAttrs;
   inherit (builtins) mapAttrs attrNames filter listToAttrs readDir;
   cleanupDistro = (_: a: removeAttrs a [
     "lib"
@@ -41,7 +41,8 @@ let
     ];
     examples = mapAttrs
       (file: _: import (./examples + "/${file}") { inherit pkgs; })
-      (readDir ./examples);
+      (filterAttrs (n: v: v == "regular")
+        (readDir ./examples));
   };
 in
 if distro == ".top" then toplevelPackages

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,11 @@
-{ nixpkgs ? <nixpkgs>, nix-ros-overlay ? ./., distro ? null }:
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  lockedNixpkgs = builtins.fetchTarball {
+    url = "https://github.com/lopsided98/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
+    sha256 = lock.nodes.nixpkgs.locked.narHash;
+  };
+in
+{ nixpkgs ? lockedNixpkgs, nix-ros-overlay ? ./., distro ? null }:
 with import (nixpkgs + /lib);
 let
   releasePackages = mapAttrs (_: a: removeAttrs a [

--- a/release.nix
+++ b/release.nix
@@ -7,7 +7,8 @@ let
 in
 { nixpkgs ? lockedNixpkgs, nix-ros-overlay ? ./., distro ? null, system ? builtins.currentSystem }:
 let
-  releasePackages = builtins.mapAttrs (_: a: removeAttrs a [
+  rosPackages = (import nix-ros-overlay { inherit nixpkgs system; }).rosPackages;
+  releaseDistros = builtins.mapAttrs (_: a: removeAttrs a [
     "lib"
     "python"
     "python3"
@@ -16,5 +17,9 @@ let
     "python2Packages"
     "python3Packages"
     "boost"
-  ]) (import nix-ros-overlay { inherit nixpkgs system; }).rosPackages;
+  ]) rosPackages;
+  releasePackages = removeAttrs releaseDistros [
+    "lib"
+    "mkRosDistroOverlay"
+  ];
 in if distro == null then releasePackages else releasePackages.${distro}

--- a/release.nix
+++ b/release.nix
@@ -6,9 +6,8 @@ let
   };
 in
 { nixpkgs ? lockedNixpkgs, nix-ros-overlay ? ./., distro ? null }:
-with import (nixpkgs + /lib);
 let
-  releasePackages = mapAttrs (_: a: removeAttrs a [
+  releasePackages = builtins.mapAttrs (_: a: removeAttrs a [
     "lib"
     "python"
     "python3"

--- a/release.nix
+++ b/release.nix
@@ -10,6 +10,7 @@ in
   nix-ros-overlay ? ./.,
   distro ? null,
   system ? builtins.currentSystem,
+  toplevelOnly ? false,
 }:
 let
   pkgs = import nix-ros-overlay { inherit nixpkgs system; };
@@ -44,6 +45,8 @@ let
       (readDir ./examples);
   };
 in
-if distro == null
+if toplevelOnly
+then toplevelPackages
+else if distro == null
 then releasePackages
 else releasePackages.rosPackages.${distro}

--- a/release.nix
+++ b/release.nix
@@ -5,7 +5,7 @@ let
     sha256 = lock.nodes.nixpkgs.locked.narHash;
   };
 in
-{ nixpkgs ? lockedNixpkgs, nix-ros-overlay ? ./., distro ? null }:
+{ nixpkgs ? lockedNixpkgs, nix-ros-overlay ? ./., distro ? null, system ? builtins.currentSystem }:
 let
   releasePackages = builtins.mapAttrs (_: a: removeAttrs a [
     "lib"
@@ -16,5 +16,5 @@ let
     "python2Packages"
     "python3Packages"
     "boost"
-  ]) (import nix-ros-overlay { inherit nixpkgs; }).rosPackages;
+  ]) (import nix-ros-overlay { inherit nixpkgs system; }).rosPackages;
 in if distro == null then releasePackages else releasePackages.${distro}


### PR DESCRIPTION
I've setup [a public Hydra instance](https://hydra.iid.ciirc.cvut.cz/project/nix-ros-overlay
), which builds this overlay for x86 and aarch64 linux. Currently, I consider it experimental in the sense, that I might change the configuration in the future depending on how it will behave, but it already gives useful information for users and contributors.

To make it easier to setup Hydra jobsets, I updated release.nix. It's probably not worth reading all commits, one by one, because some later commits override previous ones and I was lazy to redo things cleanly from the beginning. But the final state is hopefully understandable.

Currently, the hydra builds my fork, but once this PR is merged, I'll switch it to the upstream repo. The configuration of the jobsets is generated programmatically and is available in [another repo](https://github.com/wentasah/nix-ros-hydra). 


Closes #510 