### PR TITLE
rosdistro sync, Fri Nov 15 13:25:01 2024

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "497963084124963b13e9ec351bdef35310db22601cadc146722e1e2d5718a31b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "0780905cc7b9674130795c03cabe733d1662e1907ca50c00a3deb5158339bedf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/adi-tmcl/default.nix
+++ b/distros/humble/adi-tmcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, ros2launch, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-adi-tmcl";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/humble/adi_tmcl/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "04c15080e1c109bce9f7223a623926c5e103753ad14c6fb13fc9fbf32bf816d6";
+    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/humble/adi_tmcl/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "8f4e4350799d69a168a42781b35f54152b39f41f6c1554fe4910c8bcd4b5cf89";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "2f4a7cfb66f40e3059a9c4c796946b4dcf58e16db97df0ec9a1b088ef100e68a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "9872e4b01d033aca17d7519cb3a779edc79b35055e565c80a4d7c50b8d005b2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "7f216b6b1add4a253b5a06477427c1dce6de49d2c594df8dd534f392c1d2b116";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "0ccb176b6bbee1f4c590b7514d7be447f45bba2c35e6bf221180a3f1b2f33639";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bosch-locator-bridge-utils/default.nix
+++ b/distros/humble/bosch-locator-bridge-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-util, pcl-conversions, rclcpp, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-bosch-locator-bridge-utils";
-  version = "2.1.11-r1";
+  version = "2.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/humble/bosch_locator_bridge_utils/2.1.11-1.tar.gz";
-    name = "2.1.11-1.tar.gz";
-    sha256 = "45748b88c6e1ce9548c50dc77d3f8c8c13f2f6f7a0e742be23b023f781be76b9";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/humble/bosch_locator_bridge_utils/2.1.13-1.tar.gz";
+    name = "2.1.13-1.tar.gz";
+    sha256 = "279b25b2578b7ff7a90c8eb8a734f8ba1590f61b4a5c7b6421a5cedcb4b3c47d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bosch-locator-bridge/default.nix
+++ b/distros/humble/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-bosch-locator-bridge";
-  version = "2.1.11-r1";
+  version = "2.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/humble/bosch_locator_bridge/2.1.11-1.tar.gz";
-    name = "2.1.11-1.tar.gz";
-    sha256 = "90e7214fa94ea97c978f10eaa333fd1b0c24453d1d1660b31f15913c48674f11";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/humble/bosch_locator_bridge/2.1.13-1.tar.gz";
+    name = "2.1.13-1.tar.gz";
+    sha256 = "876c0ef7c05721e1a5b820ef76933ab043798c7e55bd6d217e42327964890894";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "6c887e3ea4b4d2758a091c7cf52623d8313df0589cf954ecf3ddecdc6b18a56d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "acda35a609d731feb9e91afc29307912e11c3f5d5ae6d38df3af8ac1d7be32d6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ];
+  checkInputs = [ ament-cmake-gmock geometry-msgs sensor-msgs ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "5cbe4462a4921963a0a4305367f66e1c5c4b2eb7453bfa41aef918e85a146056";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "d7f16083777054172220aa6beaf4f5a3d49cfe1b36d8413bee92d31b28348cac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "24342afe3b70ecde4e4b969dbd70254049207729e51a4ff4be80b0fa3d074504";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "325337b29ef47f2f863562cfa7344ec739fa7b7d8cda50c7ccdfe562ee99356c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/costmap-queue/default.nix
+++ b/distros/humble/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-costmap-queue";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "a35f67d120efaefa19f0047edc78d7390ea94af20f30d544fb56e60de244050a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/costmap_queue/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "c52460828437cba3a3cbfbc545bf6ff34edbddf05c82b460c2ed4c52bafb1e94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "892348e99784f282a2d830fe97e6f7e1003d8ab190a6a2625ea3d36e0947aaa4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "26832f244f9fa870ce0c8a3dde14ddfb1d37a2987d28e93e8f0ae2e2061efddd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-core/default.nix
+++ b/distros/humble/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-core";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "4fdfae924b3970385f4423b0e9fbca9777e0c4ac01ead0cf33698f5e00b7bf31";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_core/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "6fb6e7357ae1efa7e3225edba1ba1f3b93f24043ac175c09ee7bca21150c6565";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-critics/default.nix
+++ b/distros/humble/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-critics";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "16c0576aaf667929ab275e53ea8f84ab7eb17abf7e0d87d0254eed9fde1eae02";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_critics/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "fe5e278d0ab1f655e396a74d3a2e547dee0b32536dda83770b556e19c962fe25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-msgs/default.nix
+++ b/distros/humble/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dwb-msgs";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "6e760c2b3587d8e65adb43f60915b26925bfd8e0d43ce8b930b61360e8311d70";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_msgs/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "43faf37f7ebeab0d5e2b4c12adb87f975f02e5601882a92244fec1a949e25798";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dwb-plugins/default.nix
+++ b/distros/humble/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dwb-plugins";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "f5a758c9f002536c139271b7366a7e3376e609c00427a20dedad31bc30bd0f70";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/dwb_plugins/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "07e0a9f5b91b69d72320d60049e1858940e8393f73a5f90db41ae18e4903b35e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "e76f54abf13f773883ceaf66baffccfd444272b7350befc241e94f4b925ff7ea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "5e9935ed1bf053081db4cec62a9cc38ddc20c2759b93681fd0fb04c76446e96c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "16af4e13a94f151287c4824115451320cbc821bef30b8e09de75ff6996e0e9bd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "42a609df4cd7da1c04d7e6c8877fed93ef58538949f2a8c2359baee32e805faf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "47cc8f958447d93a3b184702e1e20e23c412f0092fd8bad3d69c79f449732970";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "d01eb32a5c098bf4bd7d890ee0adeb5d029b1f09d954a9e3f9fd26adc68bf382";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1350,6 +1350,8 @@ self: super: {
 
  laser-proc = self.callPackage ./laser-proc {};
 
+ laser-segmentation = self.callPackage ./laser-segmentation {};
+
  launch = self.callPackage ./launch {};
 
  launch-pal = self.callPackage ./launch-pal {};
@@ -2180,6 +2182,8 @@ self: super: {
 
  popf = self.callPackage ./popf {};
 
+ pose-broadcaster = self.callPackage ./pose-broadcaster {};
+
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
  position-controllers = self.callPackage ./position-controllers {};
@@ -2912,6 +2916,8 @@ self: super: {
 
  simple-actions = self.callPackage ./simple-actions {};
 
+ simple-grasping = self.callPackage ./simple-grasping {};
+
  simple-launch = self.callPackage ./simple-launch {};
 
  simple-term-menu-vendor = self.callPackage ./simple-term-menu-vendor {};
@@ -2927,6 +2933,8 @@ self: super: {
  situational-graphs-wrapper = self.callPackage ./situational-graphs-wrapper {};
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
+
+ slg-msgs = self.callPackage ./slg-msgs {};
 
  slider-publisher = self.callPackage ./slider-publisher {};
 

--- a/distros/humble/grasping-msgs/default.nix
+++ b/distros/humble/grasping-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/grasping_msgs-ros2-gbp/archive/release/humble/grasping_msgs/0.4.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/grasping_msgs-release/archive/release/humble/grasping_msgs/0.4.0-1.tar.gz";
     name = "0.4.0-1.tar.gz";
-    sha256 = "d1782b7c1cd993b36a2a6615c9b79db45608f80c017deabdc313cdfeb9d8da14";
+    sha256 = "f2d865731e1cf99661c3777acd0abe8696179387720d3fe3ac23ff74182b0f57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "5a00db9b8c44f75aa9eeb111b65511d3f3fb95ee5a7bd25162c6e9fa80dc7eae";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "9b50d6269113f30a33546086eaf95a0c4df47ad6b508671dfd36e3bccf096f2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface-testing/default.nix
+++ b/distros/humble/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface-testing";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "962c0b99605f47cd1bde57e640085fdec3d7975a12c165e3644b732344c760b8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "2f3ee2ffcf3e4aa1e103525359e72844c1a3643bb3c0044d7a8d581abe000ee0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "6f2cf3b6705c104bcf0bf1852ec6d8f00269d9a2c8ba9819ca8143df3c0b3145";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "59848b9dc63642efaac3e52d858a8b28b41f7b9a244accf1761fd27a7d1a8f6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "ea5754bc897f6ff545eda40e288ef0147d63875a43a3c6b5975ce2c3db1f6725";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "1253f6bcd24d5f5dfe058b1bf1b9fec27ed42b85f5541f43ef5d6fc431be539b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-ros, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "45e491ebed19ed7bfab157454aa1fa06e87fa90f476b16d4767ffba63553d0d4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "8325cc3438bac0504d4962099376456a4033272649fefaa1adb5aa5bf58260a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "1dd5a5a05a8b26658f119c09eb4e002f0f26c2830a7e071799a489f17395c726";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "7721a1b8100a54342f70ef3536a0a3f4a9e8510965c312aee5ab536ca6f0b2e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "3c57d5f4e7f1958d855e6806d4bdb2951f419704299d1d6e687304c5173076d7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "44f83650ed419ea46d195988424b88e5211b6a7fe3edf4adf50172ad189be3b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/laser-segmentation/default.nix
+++ b/distros/humble/laser-segmentation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, slg-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-laser-segmentation";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/laser_segmentation-release/archive/release/humble/laser_segmentation/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "03314b339d2f4c0f9d0a17ec927276cebb6434eebf7537aa5900c74fd396ab0e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs slg-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Implementation of algorithms for segmentation of laserscans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/leo-description/default.nix
+++ b/distros/humble/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-description";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "3835d73d26c67a245f09ceb5798783b701cda992c71f3ac7bae9ca1390429c1d";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "5db57530f37c1bd4594a712da74434822176d346aa7a71f7d5ce5e228d6ffb25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-gz-bringup/default.nix
+++ b/distros/humble/leo-gz-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, leo-description, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-gz-bringup";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_bringup/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "17680367833b776d6ce06eabb7c92098858b4f042a2cff4131939a9bd7e36c92";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_bringup/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4cb0a44d0d17915992d1e66f41af1904ab4b035ba29160c349f42620c840556c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-gz-worlds/default.nix
+++ b/distros/humble/leo-gz-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-humble-leo-gz-worlds";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_worlds/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "b50de084e695744a6b9e1b43895120288b1cbd064b320f9f57d78adaad386ad9";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_worlds/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "179a2fd729a70b326f1147b4c9c015c60fe316de236309f8347b6d618ff6c14f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-msgs/default.nix
+++ b/distros/humble/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-leo-msgs";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "9b7852096a72ac8477f1984e960a51c147f0834336673f51b45bc8c587b27fbd";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "e746c7ec1d9489786270b74013cd05579439ce8cf0d71fe2d57c2ccfbb9c82ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-simulator/default.nix
+++ b/distros/humble/leo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, leo-gz-bringup, leo-gz-plugins, leo-gz-worlds }:
 buildRosPackage {
   pname = "ros-humble-leo-simulator";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_simulator/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c75eccd43f7d507d446cfd9019b2cad6e2bf9458c540d073536c0edc47e20a49";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_simulator/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4814956b0bfee5810a9f4ef1a1f14a548eeed57237bde83dd2214a4e72f63986";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-teleop/default.nix
+++ b/distros/humble/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-leo-teleop";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "c4a242bda5d5d41042159b42e21d244f755bc967459559179d82d7978e5c7a88";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "e1ea96ae69be9c56ab2dec65272752a61ef406b7db1cd97cb2b87d525735916e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo/default.nix
+++ b/distros/humble/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-humble-leo";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "068fd7029003a470d336a4c909766e922e49cf1e1e1c7504b916f90945472ebd";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "db9463ea2c575db337d4317928b1bea25155b7d89c8665b3f74b3df03d444e97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "2710e815430ec4d9986e246c9c0ee403d91dd9e06dd4322a1fd5e88756a4e3de";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "39f58522735816627491bb3155543dd2b5ce7321e0c7d8e1121fe1bae3275e72";
   };
 
   buildType = "cmake";

--- a/distros/humble/nav-2d-msgs/default.nix
+++ b/distros/humble/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-msgs";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "895708600cdc792e97ed2af37b7f8bc43e50c8fcbb3b0f5df6b4949fbe9dee4b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_msgs/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "5c7454463576e20b6f558f094d980f651a4f9c3a04e5002d27231e3376a5d6c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-2d-utils/default.nix
+++ b/distros/humble/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-2d-utils";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "67b3ef6d2943ee04e935f7eef528d2341b516a3fcda74aaf09fb22f46fb7622e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav_2d_utils/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "74ec188b07106461d0ba64ab33c0dedc160ce1b2fb3880956736948cedb5ca79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-amcl/default.nix
+++ b/distros/humble/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-amcl";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "67e22c5dddf3dbd84c97513e1336760db774fb83d4fd508dbd6452aeacebc5d6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_amcl/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "a4cc2f0351d3ed39f343121da23195b21d84f097fad6dfc4fb57b293e43459f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behavior-tree/default.nix
+++ b/distros/humble/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-behavior-tree";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "c28a360070f13702cbfaec867055ed76fcae42ecec48d2cfa7bbe6721249752b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behavior_tree/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "eddc69e56d0b859cc53d1d2aec3de223e046b5fe44de343a6bbaccf33ce10824";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-behaviors/default.nix
+++ b/distros/humble/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-behaviors";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "46241d9c8e445f45f782ad528d910e610a65248849a782b35e34f78e060d1401";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_behaviors/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "8ad0e607c3ecb39974fe83e334fac7786084549aab77aeeb89e89f18f55a2a0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bringup/default.nix
+++ b/distros/humble/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-nav2-bringup";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "6688244a082c3673192d2ac831298f48a8e88a6a7d1473e314a1ba6cd8f57239";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bringup/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "22c25c74ca6d5c5e078bda4c42afe7d85f1bdfbdf94eef9b6079baa3023f3d8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-bt-navigator/default.nix
+++ b/distros/humble/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-bt-navigator";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "bd768bde24757b89b4f2ec9638b2862efadb0ef5690a30f3e88f12586ab78c09";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_bt_navigator/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "b373564ee32d1caf4f30b2204c5bb2d2f564b43cae9bb73fe99847774a0da4e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-collision-monitor/default.nix
+++ b/distros/humble/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-util, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-collision-monitor";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "d81a4e928782b2aebc839a245ec14ebd15142c14eba8c3dfa417f11bc9af4741";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_collision_monitor/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "f8c7c85c1c74bbd92a8b5b7e846bd6dce35d84cc3557ab8ff9df7b1e69a3fc92";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-common/default.nix
+++ b/distros/humble/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-common";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "6f292191e83926e25a40fa276d76b3e11926a2c96c524a94cc6d1c5a9c78c7f2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_common/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "cf4bb6d6115b74bbf9229df647658188e1d1a2cfd5d5f3b53c60b09e3858c466";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-constrained-smoother/default.nix
+++ b/distros/humble/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-constrained-smoother";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "64b6b9224e41886f19c6df277fb084db212e14fba287597659f53f9538ae0e26";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_constrained_smoother/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "49833091072688792786ae9f483557a9238cc89f6d32d15b91f79a86f6416500";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-controller/default.nix
+++ b/distros/humble/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-controller";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "14701b911d276cbe772afce027096856f1c93a3c94c17f92fd46fe774bf68319";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_controller/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "7c422c1f4ab29d78b4f6ee6551a04d292fc47e7f05c5f6d911b3c9a58a58ddf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-core/default.nix
+++ b/distros/humble/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-core";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "3f2e75f0b5facb505c6d48ed2f740ce3deb6b3c73d2a9eea829e989c237633ca";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_core/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "c2bf2ed2fcdcc818aa2157ffa7c5d9aed0e4d3cba15dac4f1d60947fccade216";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-costmap-2d/default.nix
+++ b/distros/humble/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-costmap-2d";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "41e53218b7094ec742679ca3b459c2cd9e1cd71ec8d76684ecc31075bd5333af";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_costmap_2d/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "c83a26581554211b1cba1bb5dfc6e445b1cdfdcf65436b95fef489730cd59e35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-dwb-controller/default.nix
+++ b/distros/humble/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-humble-nav2-dwb-controller";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "71cc2d4d22ece849742bc99916f358cda75ef11e9498c4193c5cf8f089726c89";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_dwb_controller/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "7c565307804e95fd2e787fefebd2898fc6ad4ca11eece4933e12d8fa178af45d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-graceful-controller/default.nix
+++ b/distros/humble/nav2-graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-2d-utils, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-graceful-controller";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_graceful_controller/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "96f24458a8853c16f4153368b49781b18897baa52f060b2e8d0b5badd53c1d6b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_graceful_controller/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "6c7dfe4ac6dbbd55f21a13fcc35a435ca154a469e1cf2a12226ca066bf5b04e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-lifecycle-manager/default.nix
+++ b/distros/humble/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-lifecycle-manager";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "937f4d2e0845e5d738a191e42fce534bafe331a3c995fcf1e2b29e89a19d6bfb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_lifecycle_manager/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "5fadab805a3bbc392f653cd37116eb3822624a2345d2968bd1fdb6d89249a37d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-map-server/default.nix
+++ b/distros/humble/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-nav2-map-server";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "c5a4a36ff51e2568f11111d2177f9775becf675e25e0c48c489de76310f78a9e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_map_server/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "e253dae324b6abb7cfa19643fdbcc6cceca0ae1cf2664a95052fe82575fa41d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-mppi-controller/default.nix
+++ b/distros/humble/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-humble-nav2-mppi-controller";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "94010601688d9865bdbf12f2a8e2b2e5449c3519cf1360d7075b7dbe96824ab2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_mppi_controller/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "18b87dfbaaff8642c01fbffbd5ad0fa4a355e21e5a6f4d9e556c64c6911b6a1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-msgs/default.nix
+++ b/distros/humble/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-msgs";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "810976f9635cf051c01e673a30ed2574912aff5080074fb94efe6d69961497ae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_msgs/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "57759b29064eac7dff0b137382a3a808df8b1739beedbbfaf954f43a48aa8526";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-navfn-planner/default.nix
+++ b/distros/humble/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-navfn-planner";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "8f7aaac053b57872e5bdf9b5b43799e792953dedc661c936c76e9bfb12f67e8a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_navfn_planner/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "25744bb322d73bb32dc3f5d599b4acf4e4f41eecf3b3e88d22eac3c06b4f76d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-planner/default.nix
+++ b/distros/humble/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-planner";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "46ca4f74ff08e149ead65d3224359f9b9cbf87ce9b2c7d88eb7060ddff455245";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_planner/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "3a5e1cb92974a14440cb570c324eec24a814619fd35509fc51f094a691378cbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/humble/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-regulated-pure-pursuit-controller";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "03d904a0f0bdf590483853b964d001f90c7203f047cc51a7aa6192874a2f27af";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_regulated_pure_pursuit_controller/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "ab83bda5a2ba7477b25263287d3aa44a66c2f04daf56161e811c39f745a3aa79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rotation-shim-controller/default.nix
+++ b/distros/humble/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-nav2-rotation-shim-controller";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "149d74d54c546f0dace5ab0da0dbb5029b8482abf1daab3f093ac1aed8719358";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rotation_shim_controller/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "e031b3bdd45bfcdc0bc28ae07768beaa4b79610c72118f426bb04ab20e6e7f04";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-rviz-plugins/default.nix
+++ b/distros/humble/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-rviz-plugins";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "ea3c7ec1218e253e7169cda707d9e4c4ec925c0fbccaa3a2aaf4e0ca15c07605";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_rviz_plugins/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "7484c9a6262eecfa2645c8a836f1db1c20b85c172980b62ff27d1e98ce81d508";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-simple-commander/default.nix
+++ b/distros/humble/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-nav2-simple-commander";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "f82cf07c0ec0cb5e1f78ec886e60f8c6eb6615b29b7c3999f7ed4dbae463a390";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_simple_commander/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "2818cb0bd64f3bfeb9adc4be31c6000d77d5c90c6639da7061172a30562c39c8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/nav2-smac-planner/default.nix
+++ b/distros/humble/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smac-planner";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "5e49eff5e15209ef492f344862e5f2db305c30ff42e9307ddfcb5678f9003824";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smac_planner/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "69680832f9f69a9311216af6638f16ccf843b3e7f80e92c1c367e8f96d67b44b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-smoother/default.nix
+++ b/distros/humble/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-smoother";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "8d57aade651945d93dc77b0264256c745856e8c65e299aa8c6175d1f869c2c79";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_smoother/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "2af814d6e80c59ee43d2c1160e34b2ee5d54f7e4449e54ba0e29ee8c8d1e1f51";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-system-tests/default.nix
+++ b/distros/humble/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav2-system-tests";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "299e3bcc7869bbf688899310e9a89ba792d3acb5ae8e0dce3447b58eabc65dc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_system_tests/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "19768467d30884e01acf50889a936946d64e35d0533a0217cb3067e850c9d2b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-theta-star-planner/default.nix
+++ b/distros/humble/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-theta-star-planner";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "e7a815001f9e7f86d72114c6b23bd0758df896074a48ddfcf1491b56eb0ae3bb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_theta_star_planner/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "05e40c47b704bf88ca9665ae253e155b4361d826fa4987c1982ae844c10b97a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-util/default.nix
+++ b/distros/humble/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-util";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "0cb6917524d62ae007e1f2f882457b97c4584cc023217c2cea30a24c34ece271";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_util/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "66c1b04d76854e299568f2478e2a60cef4a1f63f343b2ef0c533fb2ff9a13d83";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-velocity-smoother/default.nix
+++ b/distros/humble/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-nav2-velocity-smoother";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "b3a1d97b0fe7f5c057cb055c01082b274ef268e4dd638ea53d34f2b6c2cdf40d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_velocity_smoother/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "73f408c9efe8c298db6e23c6b1907479d558cb77e4dd794f483a69d2052571ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-voxel-grid/default.nix
+++ b/distros/humble/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-nav2-voxel-grid";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "9e471ee30360a1bec26549496ce8638d806dd55a2d01d2817b0ce3a0a783ee92";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_voxel_grid/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "420739d73b2d3acec7042e16b608bb08b88ba7f4c16d10afcb315c6e1ed4d800";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav2-waypoint-follower/default.nix
+++ b/distros/humble/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-nav2-waypoint-follower";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "75712ad9d815b7fec3dc450ad0ff8ec912eb1234b658faa82c5ab55144121060";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/nav2_waypoint_follower/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "99b9e0b062e4b3b572e04f50b163ee3d00ae8d3552b7bbe61bf65d9d0bef11ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/navigation2/default.nix
+++ b/distros/humble/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-humble-navigation2";
-  version = "1.1.16-r1";
+  version = "1.1.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.16-1.tar.gz";
-    name = "1.1.16-1.tar.gz";
-    sha256 = "865cd289e94d7714ddd932cf08f017bd592cb084e4250a08ff5f4603c4caa003";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/humble/navigation2/1.1.17-1.tar.gz";
+    name = "1.1.17-1.tar.gz";
+    sha256 = "ee4b00e5f325c91710901cff673c37ec6b85a4bb52f1ac0dd00ec5c11380bf23";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-driver/default.nix
+++ b/distros/humble/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-driver";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_driver/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "116eb2198a06681859724c43f8b80a282b3cdc97b6924cbe981b96d044820fcb";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "5acdb902078c20b689ea887bf0b957e0cc519bdb478efada81b673dfeb6605eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-gps-msgs/default.nix
+++ b/distros/humble/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-gps-msgs";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_msgs/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "36eabfe81591a30b32682e9106db582f80c7f1753fb95a495da0509539813d27";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/humble/novatel_gps_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "b8404aa3a039b4871f1aff0e15307c8213841f87b96816fbee6795d477de6c6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/octomap-msgs/default.nix
+++ b/distros/humble/octomap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-octomap-msgs";
-  version = "2.0.0-r3";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/humble/octomap_msgs/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "5173b15d1768128786b3e6b15450c73940aa440a849501d5d50b8a9edcf9a6f0";
+    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/humble/octomap_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "bd42f53ebf3c3724d2823a5f41e8f758d3e0d7cac2f422099f20f5fb854c8c1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-controller-configuration/default.nix
+++ b/distros/humble/pal-gripper-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, joint-trajectory-controller, position-controllers }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-controller-configuration";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "01584fd6bd9b8e38563850bc70c2b00be13696917dcfa6d54898550c1839a834";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_controller_configuration/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "1f75bb3000681bb9e8d86e55b21fbf71cef14f0c831377ac65695224e89b8330";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-description/default.nix
+++ b/distros/humble/pal-gripper-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-urdf-utils, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-description";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "9eaf410781ea525f4af6823754b6f200f0787302820e6aa66a775c2391b3f0ce";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_description/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "c661613d768edfeb3f68e1e578bae27a515a11b758b91a9cab3a2cf5efe25044";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper-simulation/default.nix
+++ b/distros/humble/pal-gripper-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pal-gazebo-worlds, pal-gripper-controller-configuration, pal-gripper-description, pal-urdf-utils, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper-simulation";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "92b14c9ddce1137be4b6e90f2f735f50699845054e0dbcbdd36efce216ccfbce";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper_simulation/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "03843b2439224c89916907746dcc54bfd9d7bf79dedcbb98cf2c7e7265d8ddc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-gripper/default.nix
+++ b/distros/humble/pal-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pal-gripper-controller-configuration, pal-gripper-description }:
 buildRosPackage {
   pname = "ros-humble-pal-gripper";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "45c892bf387bc6fc60dbd23b5406cd2d48a05b3452eee7c2c79119f74f7c4cc0";
+    url = "https://github.com/pal-gbp/pal_gripper-release/archive/release/humble/pal_gripper/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "886de4f575adbd0dbe6e98c7d29d96c65d4eb0d73f4df0f3014d8ba2a0fc0270";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-maps/default.nix
+++ b/distros/humble/pal-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto }:
 buildRosPackage {
   pname = "ros-humble-pal-maps";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pal_maps-release/archive/release/humble/pal_maps/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "2bff0d2c72e1087a94187f17031dcc02cc66a26c705cbf895d1c1ab46642651a";
+    url = "https://github.com/pal-gbp/pal_maps-release/archive/release/humble/pal_maps/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "3bb7cdee3302f6cfc694b19fa8005eb7b37743654b79b2eaa8a806db437cec22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "d94470bcd57d31ba86c169111ae3cd725118e054ce0709596359afeda9738fa6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "2778507c9c1988cbef48599b4985e491efbcbc8cbd390eb4cb1f937d9d083ff1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-2dnav/default.nix
+++ b/distros/humble/pmb2-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, pmb2-laser-sensors, ros2launch, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-pmb2-2dnav";
-  version = "4.2.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "436c00ec1ff4e4c3b8b243ae09ba8a85628f5e3b25be8882770d13cac961f0e5";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_2dnav/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "0927ccb4687b0c755d37800490acd7dc90b79202d0895ed479eaf131654643fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-bringup/default.nix
+++ b/distros/humble/pmb2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-pmb2-bringup";
-  version = "5.3.1-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "7c80703b00efb6f92a5f32d51d6ad48e12d9c6acf231ff6eacd99a7747dee4f4";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_bringup/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "c96cc54c59c4d8aa7e2958c0373545895f0ac919054cd461a1cbd9e2e985d654";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-controller-configuration/default.nix
+++ b/distros/humble/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-broadcaster, launch, launch-pal, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-pmb2-controller-configuration";
-  version = "5.3.1-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "e474443f2a157590eb12c76420cb07d5080332f98319b435f29b558506a99719";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_controller_configuration/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "8cd319479e184c214be4b3566b670923fbfc2325363d31c2be64f21849b3e064";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-description/default.nix
+++ b/distros/humble/pmb2-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, rviz2, urdf-test, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, pal-urdf-utils, rviz2, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-pmb2-description";
-  version = "5.3.1-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "715d1bf7c271e2767b94560af14c5b853e97445f21273099e34de7e7eaf1388c";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_description/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "e5f53ee783b6506cbea47d5d64aa26606bf246e61fcddbece7d3e395cf3bd9a1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python ];
-  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
   propagatedBuildInputs = [ joint-state-publisher-gui launch launch-pal launch-param-builder launch-ros pal-urdf-utils rviz2 xacro ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 

--- a/distros/humble/pmb2-gazebo/default.nix
+++ b/distros/humble/pmb2-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, pal-gazebo-plugins, pal-gazebo-worlds, pmb2-2dnav, pmb2-bringup, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-gazebo";
-  version = "4.0.16-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.0.16-1.tar.gz";
-    name = "4.0.16-1.tar.gz";
-    sha256 = "06a334cea496214e6fe8917e7555ece5db96241b96ab67c4af95d7a61197b649";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_gazebo/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "74e5cf2e77341cf41cd8ddbdc2fb61845ae8f57afb8df264a9bdbb44c8325d62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-laser-sensors/default.nix
+++ b/distros/humble/pmb2-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-pmb2-laser-sensors";
-  version = "4.2.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "4fa82af71ec2e8673b8aee2b51ea316b20198485e960b9bab06fa79ea63768c6";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_laser_sensors/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "5077aaa88838c96de317dbffed9992ac1ec651887fe885fc6efbf18a2ae0bf05";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-navigation/default.nix
+++ b/distros/humble/pmb2-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-pmb2-navigation";
-  version = "4.2.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "3a041989b9061d2213359fe6f6a7e3d23285ba168922e03a91cd7d9a119065cb";
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/humble/pmb2_navigation/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "f8983f22cb4c78df49a1bf8eb1d01587a90c179c3b5c49e5be118cb22d1b8c4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-robot/default.nix
+++ b/distros/humble/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-humble-pmb2-robot";
-  version = "5.3.1-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.3.1-1.tar.gz";
-    name = "5.3.1-1.tar.gz";
-    sha256 = "03ae8e1a1d73496f214f44622250f84d7ce65bcc403633ae3d5ff3dc345c6297";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/humble/pmb2_robot/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "4852aed11c34382c80295c26b7e2973d002b3be0351c6eefa4369a2cc0e87702";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pmb2-simulation/default.nix
+++ b/distros/humble/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-humble-pmb2-simulation";
-  version = "4.0.16-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.0.16-1.tar.gz";
-    name = "4.0.16-1.tar.gz";
-    sha256 = "cae7a57b7c074fb60d2cc3dd613062d705ef1b99943ac1dfa8dcccd6af55870e";
+    url = "https://github.com/pal-gbp/pmb2_simulation-release/archive/release/humble/pmb2_simulation/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "6c0b0e4f4bb12e08aec33dd694fe2fe9061ac0b943ecc3ed12a304ba5654afc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-humble-pose-broadcaster";
+  version = "2.38.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "1dcae5b0c42beb0fc459d4234e8092e651ac7f48ea816c12eed4c8d31befedbc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Broadcaster to publish cartesian states.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "8345fca7b68ef43b0b073b1410b5aa96a709b27c51f7bd6a72cac36d92c9f52f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "027c87d602d49e544e862d62d8db6a233d6ca04eb279d25a2d98d618b3ada906";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "3c5e86e537854fdb760ee56bfdc929bd0f9a654a9326998f360143268f6cfb1d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "7c5a4271675b30b8c896c71538867279d52f653fd66761ea250d754071cbef9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration-msgs/default.nix
+++ b/distros/humble/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration-msgs";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "93f34e6c210cb3d68733bbf9ccdb9623672fa88895c010af1b85bc4fbbe7b2fe";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration_msgs/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "9e85312817609b7d7b855e0be032ccd614f3301afc5f2248913a9836161ecb1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/robot-calibration/default.nix
+++ b/distros/humble/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-robot-calibration";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "75d51aa74e27d90f3007b4dcf0e09c5ded1d9dbe4e525bd5c2f21e18edcc7b77";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/humble/robot_calibration/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "1853a7c5b829139c8e0b21125fab069b3d8a16038a8e78c3ba5d11d073792304";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "56dde728eec7423f1b8ac3800c27dd8f72ea8cc10997d3f0437944ee8f04242a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "554c02ba76c1663f33ac7a52d5e2e506ca4bf02d9c003c5fb6f89750d9fa507e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "4a688fdb2c3c4bbcdf8172cb467f011a4cf5c8d3d89de4ccaf9f90e7a9acbdb0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "8868a26ae3dae1a52e35b2710296f82d9950842e23e47a203160655eae84ac16";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "1259447b8a1e090f78d3108267d04561431e1db07968d4c8e6205ea6060cd0d3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "42836be2d1b3b36abf9bbe825b2415ff2e3bc0f5a0b00b0f5ee2290ce22bd556";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "eed5c6c5c8d1836f4a3ba567c8ed3b9551b5c1f4ec2c20776f2f10d04711b87e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "3da2734d2a482d7d69d75eb81922447afc4a224bb0f4c49ec644bf7dcadbc26d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "adf8fd01700ddb1db0a0f53307ca29159c5da725460c4a11e7fe37fa09e5cf4d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "3605677eeea3816cf137f5b5b580f2d60c7a03c179feba7d92533d8fbd90eb8d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "9f221e72de9c32a2a5c36ac479f235af5b761d2799ee4303f5883d339ac11351";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "b675a25b9bf4a84388a74332d0b3e64e22fd0a0719b8da24756fc23f515ac353";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "820f151ecf408c95b47d6d3a1c72e00c64601705788af090f95467bbd857263d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "5e48221edda2d7c3fab73d499dcf7ea08a8bc9136a2fd7e6f7aae55c14c07352";
   };
 
   buildType = "ament_python";

--- a/distros/humble/simple-grasping/default.nix
+++ b/distros/humble/simple-grasping/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, eigen, geometry-msgs, grasping-msgs, moveit-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, shape-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-simple-grasping";
+  version = "0.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/simple_grasping-release/archive/release/humble/simple_grasping/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "a52ec7accce28f9340ad73cec7c76e5b950e4bb31b1bc813f1bac6ea2e97b94a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen pcl ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-gtest ];
+  propagatedBuildInputs = [ geometry-msgs grasping-msgs moveit-msgs pcl-conversions pcl-ros rclcpp rclcpp-action rclcpp-components sensor-msgs shape-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic grasping applications and demos.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/slg-msgs/default.nix
+++ b/distros/humble/slg-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-slg-msgs";
+  version = "3.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/slg_msgs-release/archive/release/humble/slg_msgs/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "655af98521826479275eaffda3324b18bb5afe09ae5fe178e3f818e33e8e9c2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides classes and messages to interact with laser related geometry.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "3ec3e73b44091da48ee577bb38fae25ed0fdd43706ade6f4c1daa912bcd454f8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "7a09f796c4a7d492595f4ff9d6494f030ed30988e607711f59fce6c206ca66b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-2dnav/default.nix
+++ b/distros/humble/tiago-2dnav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, launch-pal, nav2-bringup, pal-maps, ros2launch, rviz2, tiago-description, tiago-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-2dnav";
-  version = "4.2.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "b2451cdb7ccec8ff060e0061fcdcf861cba77cc7df04cf85fa040e6a474f5232";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_2dnav/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "f812c83f83256345e7f3011bb09aca8304347627c768cfb6be685a8e9b7b146b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-bringup/default.nix
+++ b/distros/humble/tiago-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, joy-linux, joy-teleop, launch-pal, play-motion2, teleop-tools-msgs, tiago-controller-configuration, tiago-description, twist-mux, twist-mux-msgs }:
 buildRosPackage {
   pname = "ros-humble-tiago-bringup";
-  version = "4.6.0-r1";
+  version = "4.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.6.0-1.tar.gz";
-    name = "4.6.0-1.tar.gz";
-    sha256 = "c99f07ad7bd1554597994ebaea8070e3eabe29e79a72d6c9d305d3194df291b6";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_bringup/4.7.1-1.tar.gz";
+    name = "4.7.1-1.tar.gz";
+    sha256 = "628d242443b631c4a8761fa731968bd447070fa673073451a49edc28529866c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-controller-configuration/default.nix
+++ b/distros/humble/tiago-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, force-torque-sensor-broadcaster, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, omni-base-controller-configuration, pal-gripper-controller-configuration, pal-hey5-controller-configuration, pal-robotiq-controller-configuration, pmb2-controller-configuration, ros2controlcli }:
 buildRosPackage {
   pname = "ros-humble-tiago-controller-configuration";
-  version = "4.6.0-r1";
+  version = "4.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.6.0-1.tar.gz";
-    name = "4.6.0-1.tar.gz";
-    sha256 = "472302e3b0414fc120d598c651dc3c1949608ecc7668c0b998619e91137495d9";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_controller_configuration/4.7.1-1.tar.gz";
+    name = "4.7.1-1.tar.gz";
+    sha256 = "c600202b5907f346efa535e4ff83a48de36ee7ebb3f2594fd2de2181177b614d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-description/default.nix
+++ b/distros/humble/tiago-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gripper-description, pal-hey5-description, pal-robotiq-description, pal-urdf-utils, pmb2-description, robot-state-publisher, urdf-test, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, launch, launch-pal, launch-param-builder, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gripper-description, pal-hey5-description, pal-robotiq-description, pal-urdf-utils, pmb2-description, robot-state-publisher, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-humble-tiago-description";
-  version = "4.6.0-r1";
+  version = "4.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.6.0-1.tar.gz";
-    name = "4.6.0-1.tar.gz";
-    sha256 = "6cde88c786a3f9e6d763d17334e173f9ce9ca6af6af1eec299c404cff0ba6d97";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_description/4.7.1-1.tar.gz";
+    name = "4.7.1-1.tar.gz";
+    sha256 = "8f05038219faa736d38119660b7ad6e3f040ac6d4a11c38e1d58fc0a05a8d76b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ament-cmake-python ];
-  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
   propagatedBuildInputs = [ launch launch-pal launch-param-builder launch-ros omni-base-description pal-gripper-description pal-hey5-description pal-robotiq-description pal-urdf-utils pmb2-description robot-state-publisher xacro ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 

--- a/distros/humble/tiago-gazebo/default.nix
+++ b/distros/humble/tiago-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch, launch-pal, launch-ros, launch-testing-ament-cmake, omni-base-description, pal-gazebo-plugins, pal-gazebo-worlds, play-motion2-msgs, rclcpp, sensor-msgs, tiago-2dnav, tiago-bringup, tiago-description, tiago-moveit-config }:
 buildRosPackage {
   pname = "ros-humble-tiago-gazebo";
-  version = "4.2.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "a2a0000f5f4ef624005056c6b58ea4627c7eeabb66adb7cb86ec924f81974b3d";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_gazebo/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "9670b84cad4d64958667f80f00d2557b153cac802b1f3fb9fafc7f4e63a53437";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-laser-sensors/default.nix
+++ b/distros/humble/tiago-laser-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-tiago-laser-sensors";
-  version = "4.2.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "4bbabaadbae272584423e395fa28518e65a70fa31c438b8d66364e9baa3ffcb1";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_laser_sensors/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "ce9f1d8e9ef0fd59bd7431113e7f7c3f4f73e6aadeb1e3879dca92ccb9d7e3d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-moveit-config/default.nix
+++ b/distros/humble/tiago-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-pal, moveit-configs-utils, moveit-kinematics, moveit-planners-ompl, moveit-ros-control-interface, moveit-ros-move-group, moveit-ros-perception, moveit-ros-visualization, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-moveit-config";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "08e208ae36597fccb6453b0b00db42dcecbb06bac26c084afff71f0517b5706e";
+    url = "https://github.com/pal-gbp/tiago_moveit_config-release/archive/release/humble/tiago_moveit_config/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "975a951ce3b088eba2a3557a0a351ad62ba946dc550d15732b6926097422f4fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-navigation/default.nix
+++ b/distros/humble/tiago-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, tiago-2dnav, tiago-laser-sensors }:
 buildRosPackage {
   pname = "ros-humble-tiago-navigation";
-  version = "4.2.0-r1";
+  version = "4.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "4f38c9172df302ab2f9b28169b03f068e372f2dc6001c2aa824e6991521dcfc1";
+    url = "https://github.com/pal-gbp/tiago_navigation-release/archive/release/humble/tiago_navigation/4.5.0-1.tar.gz";
+    name = "4.5.0-1.tar.gz";
+    sha256 = "7275a40bfdd9a2735e0e1eee8c2dbe7a7007d37c5de8f871d1faef415ad9cc67";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-robot/default.nix
+++ b/distros/humble/tiago-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-bringup, tiago-controller-configuration, tiago-description }:
 buildRosPackage {
   pname = "ros-humble-tiago-robot";
-  version = "4.6.0-r1";
+  version = "4.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.6.0-1.tar.gz";
-    name = "4.6.0-1.tar.gz";
-    sha256 = "888bd5f2a9111af16e1e72111bf440bbf5ade625e2975ed89036aff03b7ff840";
+    url = "https://github.com/pal-gbp/tiago_robot-release/archive/release/humble/tiago_robot/4.7.1-1.tar.gz";
+    name = "4.7.1-1.tar.gz";
+    sha256 = "d0946c8b859f46fba4cc4eb136764af7821bbecc45fd237d0ff41bd749013387";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tiago-simulation/default.nix
+++ b/distros/humble/tiago-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tiago-gazebo }:
 buildRosPackage {
   pname = "ros-humble-tiago-simulation";
-  version = "4.2.0-r1";
+  version = "4.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.2.0-1.tar.gz";
-    name = "4.2.0-1.tar.gz";
-    sha256 = "6672e57b88b8ca0d8224fc13211e31badc417e945e228b22fb887953ae789754";
+    url = "https://github.com/pal-gbp/tiago_simulation-release/archive/release/humble/tiago_simulation/4.3.0-1.tar.gz";
+    name = "4.3.0-1.tar.gz";
+    sha256 = "33bca9e1d5c36447a3ec174dc11f609c35e96a929ff20ad4b548a8f7b3ac110a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.43.1-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.43.1-1.tar.gz";
-    name = "2.43.1-1.tar.gz";
-    sha256 = "5bb8a10c06aeebdb1436e94b3aefc6597fed5682a6a1d386d465840f5a348145";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "fe821a529f2d189bdba21b8e181300b442fbcbbc5af23d4901b99c673827d0e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "bacf6de6e6748c4af2cef3978d060eaae90be040597cf49805f91d0d89d618d4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "50963c71cc7743c67d400fede3119c5eb36093bdc7b94c10cef547e4a69eadde";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "870776df5be7304f7aeedad42c9725981102d95bc58b52b5ef21c0668a9508a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "0d98b7cc408fbff0552d85b23f2b59f44b9515977399e46407e6ea970599d825";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.37.3-r1";
+  version = "2.38.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.37.3-1.tar.gz";
-    name = "2.37.3-1.tar.gz";
-    sha256 = "9d3490d0abe1e964582b1750e35dad157d6c7eddd2b70ebe8f02ae45a2c5ebfe";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.38.0-1.tar.gz";
+    name = "2.38.0-1.tar.gz";
+    sha256 = "a309c2b86751e8a0e6816ff144a88f7aaf8c50c6701159bf3f1a72db5029568b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ackermann-steering-controller/default.nix
+++ b/distros/iron/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-ackermann-steering-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "17f3cb96afffe2d5b4b43ec96791920060bf02dcf9a66f7a504d3b6424174d21";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ackermann_steering_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "1f7065868683de6fba3fbc30d0312f5d6ae3240b9b5310858d4a6bb23883bbe1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/admittance-controller/default.nix
+++ b/distros/iron/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-admittance-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "f8765b0938df9d594e989d9cff3c2d4ba759d0507a8f5f4e5b61efdfb9c670d7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/admittance_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "b95094072f73b352dd0b4aa9b126e7ffa3a0b17489e11fabaf713686018a9ec2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-auto/default.nix
+++ b/distros/iron/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-auto";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "b573dd48e2839eba160fed7de9b40e5ceb67f9b9c47c5b7029e7dc5b3637aa17";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_auto/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "ca74036d3fb031950c711b85c8749c6e4d8b0954211d65a3acd5d04df927f28b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-core/default.nix
+++ b/distros/iron/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-core";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "b08f00c6edcd72010852aede22fab816549c8814b34f3e32a72029b39dcd4112";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_core/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "821195084f63caad5bf0ba2dc69891dff80db6114eaab3c1d25600aedf50086d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-definitions/default.nix
+++ b/distros/iron/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-definitions";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "e95528c8c05471a1d538ee51471afe5181ebe43fc4d3b36249a74731a97c3da7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_definitions/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "ac9c364af6027295e9302cf977e31fe0023f34f9df6d4e22d4d7e8992bc892ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-dependencies/default.nix
+++ b/distros/iron/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-dependencies";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "d0aadb7fd5169ce32e2fb41894f2f5775925b008d00c6b2eee96ae912f6618e9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_dependencies/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "f01a68501a2101a2ac8a91f49841952c8d79f80e98775279880a8af10492b1eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-include-directories/default.nix
+++ b/distros/iron/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-include-directories";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "22a0d9488290839b32254f08159a7c3dff05c51aa17ba08a22382466f685c879";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_include_directories/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "9c54f18be1a191f9e9579f358302f37c538cb786e343dc131708112e8cf7803e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-interfaces/default.nix
+++ b/distros/iron/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-interfaces";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "0c0188a945582ffbfc27c987091bd829412b2f885f3851f2f531893881b50df2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_interfaces/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "6f7d010e042699d8f30b0d7823ca09160e2485b4c7156971cba78d4d96e50df6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-libraries/default.nix
+++ b/distros/iron/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-libraries";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "3b80ebad2dee89032f6c62de261e867e9d84f3e0651eae687b85f61e71ffceb3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_libraries/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "4eed020f9504b7a9a2f57495b20dcc82bc1a81ea9e850d8c9164d31bfd602e69";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-link-flags/default.nix
+++ b/distros/iron/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-link-flags";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "57a81ce8e1161fcc91f48e6282d25e4d07b60041c11e44df1ef0c4eb5dca4e26";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_link_flags/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "445386c303e693a8ec334797645fca4770ff2e8266e67b1740e1f838a1953fd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-export-targets/default.nix
+++ b/distros/iron/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-export-targets";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "9e05efb491b590f856438b59b49d489550e79a00748f18d92359c1e490202d63";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_export_targets/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "55a5a692cacb3089edb586e84466a27290d9d3f5b1c974e206c97612d9676e44";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gen-version-h/default.nix
+++ b/distros/iron/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gen-version-h";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "911904cd03143e36291635101ef631a031f56947116af5f70dc108385e215be7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gen_version_h/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "730f5d745fdda6963380f53a5df2ed96b142da6c6f7b9f310b87b94d70d4fbdf";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gmock/default.nix
+++ b/distros/iron/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gmock";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "c642d85c8604078ebc7bb3ea14432f95ea327c09c662145e80c99e7c421c371f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gmock/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "794241f39b5608a8b7db4169b469a371ac81bc36147147e9a1f348e132fc0556";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-google-benchmark/default.nix
+++ b/distros/iron/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-google-benchmark";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "faa647b435e71b7082ffc449f677632890dfc0f95f8ae1d7d07257640ea6ac18";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_google_benchmark/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "dc6dca66e166dd064b03b8ef2e415a362503b39c038b83c5e328f760b167b7f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-gtest/default.nix
+++ b/distros/iron/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-gtest";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "7af68281fe42bc33a500706e709965267c8fe8ca342955c7e7e5b89a7ded4834";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_gtest/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "7b504205840522f444562b670f5e8496697fd24c149ace91d788b37606069005";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-include-directories/default.nix
+++ b/distros/iron/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-include-directories";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "19aa2480bb466a176482f74641d842c938e26790a2dcc6a3d49f5c553eaff18f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_include_directories/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "7d9f8ea64417159b6d8367f193ba80e95cc3ed357ac3ec8d1b3b64dafafff048";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-libraries/default.nix
+++ b/distros/iron/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-libraries";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "546d9c3e17ac5d33fecc7bd15d469685a161c4032e8d3c574b1fb7ccec6b0227";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_libraries/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "e2bf57276ab680c0f905fc813e9e9642fb6ceba011bc6494434efb9b8d8bfc47";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-pytest/default.nix
+++ b/distros/iron/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-pytest";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "938e5bb62954a67084863dd2eb400dbe9f3600893bad6fa69492a9b9b9e15ff9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_pytest/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "a21d7c795fd70171e215289d264de36c3c8f4da5d557352d7c92b829a94713a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-python/default.nix
+++ b/distros/iron/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-python";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "651a9f8638292dc02328e742ab6dd4907bb6e716792f713251829e51bc14cc4c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_python/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "f459197fde07081df61b54c291372bf33071e4f64fa96fdc75c49ea1fd4cc131";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-target-dependencies/default.nix
+++ b/distros/iron/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-target-dependencies";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "809d8a8054c2abd1b4c6a99ab18e8b21a312b1e005d2bf9eeb90b6265c5a08de";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_target_dependencies/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "d5ce7fec9df656209ebf9fe495f9190b08e407ad8cd855a900ad31e4dbb9a35c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-test/default.nix
+++ b/distros/iron/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-test";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "94414af0dfe9708e291ebf777f0a2165c6fa0c5f624e8cef1addd51a2bce2869";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_test/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "10676bd539b2a8cca9ee681505886f2ca2cb8435a96378f7979738d287a2801a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake-vendor-package/default.nix
+++ b/distros/iron/ament-cmake-vendor-package/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, git, vcstool }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-vendor-package";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_vendor_package/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "71a57efe2a919fb17dee4dd218ce4d874d584ba0b576d63cf003befb4bac5ede";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_vendor_package/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "0e0920baf9bc92266fe1d21d07b75fe856d330871ff3dfa0cb17b9283d6f3251";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-test ];
-  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
+  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git vcstool ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git vcstool ];
 
   meta = {
     description = "Macros for maintaining a 'vendor' package.";

--- a/distros/iron/ament-cmake-version/default.nix
+++ b/distros/iron/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake-version";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "ffdb043b5a42aacbf95e5bea8aa271af7c8df6686ff000c58b7379d4c75077b2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake_version/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "92c4a682c8f4608bf83680110718c6b6be4aaf06efbde8d63867265279062d1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ament-cmake/default.nix
+++ b/distros/iron/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-iron-ament-cmake";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "8f9caecba5023aa481c71f428ccb1995a62921541f0d700a538459d3e92b4a2e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/iron/ament_cmake/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "a598c99608498fe5a08eea93665c6146f155dcfdbd9a256ac9b36332084a0c93";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/bicycle-steering-controller/default.nix
+++ b/distros/iron/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-bicycle-steering-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "1071fdf493326077888ec0eae824f62eae3698c1cc3e887b68426bf211eaa105";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/bicycle_steering_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "dd5945bde5de991f1cc3a836aaac1f59cb91f638924cfa7c970c805e00f25b25";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-interface/default.nix
+++ b/distros/iron/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-interface";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "3e65e57d339842427dcd4792dff2a6aaf4b762fa23a74c40857d8e23ad3f673c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_interface/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "4ee809d6d1cf101502dee77df81bd68c4e64f76f46005e5fe5339c11e94e3306";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager-msgs/default.nix
+++ b/distros/iron/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-controller-manager-msgs";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "c5cc8bc318b075eae4b00f50d92bb663a1595489fee55faf2afc225492d333c0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager_msgs/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "ae2d4e2ac3c7a625766ab9b08cb9ca45c0fd204498b85e5858acaff51fa6e1f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/controller-manager/default.nix
+++ b/distros/iron/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-controller-manager";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "b6022ef5fbf67cbb03877f3f32effc3ebea12f1712d9f89ce0c242f3a16cedcc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/controller_manager/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "7509234e9383e91a7fe4c1f9887d84a5f643e7864904bc28257297714a0f2bed";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/cyclonedds/default.nix
+++ b/distros/iron/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-binding-c, iceoryx-hoofs, iceoryx-posh, openssl }:
 buildRosPackage {
   pname = "ros-iron-cyclonedds";
-  version = "0.10.4-r1";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/iron/cyclonedds/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "cb30b275eb184596db2c25904c5dd15488a760fb390b688ebf0a510a7f3c07d1";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/iron/cyclonedds/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "f1dc9a4fb8ecb80c3ffaf65e6c1571880f4f657723a778ef16379d9d60a3890a";
   };
 
   buildType = "cmake";

--- a/distros/iron/depthai-bridge/default.nix
+++ b/distros/iron/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-bridge";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "011b04cf6fbd118c7ccf4905d57170b058bcd2a67bf28701cbe6ca5a571d16eb";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_bridge/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "f373c8ca19ae251bb93d2ba80d96c72787df5e76dc9c842497d141c449b5e07a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-descriptions/default.nix
+++ b/distros/iron/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-descriptions";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "5d510fe5621ad1bdaf1a18a2735647776148d0c99646e28964de607838263e53";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_descriptions/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "1a6181dfac2c0952d41d5995733aedec569ab24ad766dc112a5910fdcc4977bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-examples/default.nix
+++ b/distros/iron/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-iron-depthai-examples";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "b97c5a2f87f97892b90a84ce8060956400f87be9c77c6e4a96d011d94f31b65e";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_examples/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "d9a096d890916a6816c6fba0555c61e3f0a3485dcf28ea3772a77d01278c8a48";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-filters/default.nix
+++ b/distros/iron/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-filters";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "4466995a20f405066d41921e3802abf691c3dab2a616528667261be3eb1c1a2f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_filters/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "67d3847b5ff790184caf4677398a377f1f19536f83b763ead572b26ef1f69c7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-driver/default.nix
+++ b/distros/iron/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-driver";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "5b1851d1a5a16b645ea976b3f282c8c25a256d956100fc9a4de88a7fb31df8d6";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_driver/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "09a1aa19e4f9b5b1c50b74b5c1ccb4307d69101338dec16208dc72912e016ea8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros-msgs/default.nix
+++ b/distros/iron/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros-msgs";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "56abf5081523754cd8ef7c47e8d29e27f9b799c4d8ed909dfad6f44396bf0c2a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai_ros_msgs/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "508419674e600c5170c9a54403cf8a53fb05fa6663d0908d13ded2da55f2fcc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/depthai-ros/default.nix
+++ b/distros/iron/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-iron-depthai-ros";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "47aa88d5ca37019df0a17c08af76ebce9fc3c0a5ace84a0d7fb76550b5ae6a5d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/iron/depthai-ros/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "1f90e673ade85428b42f171200d0c76447550d7904668499b1168d3935e29933";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/diff-drive-controller/default.nix
+++ b/distros/iron/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-diff-drive-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "44b0e8f4491b7c99130c1dde78369eeae53ba262a09066c3fdc2653c980c950c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/diff_drive_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "0eae371d24da2be2ce4ede8c5ac474f706bb0fba1597aafbe175461b5819a774";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Controller for a differential drive mobile base.";
+    description = "Controller for a differential-drive mobile base.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/iron/effort-controllers/default.nix
+++ b/distros/iron/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-effort-controllers";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "48d5faa7b712c7ea3c44056246af908e8de45afd0e40f810165a0b4834268598";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/effort_controllers/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "6a16f72c3a6250ee6ac6d9f5f77ca67f781dfbae1434648db486b37add99ae14";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-async-client/default.nix
+++ b/distros/iron/examples-rclcpp-async-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-async-client";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_async_client/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "42de3cd6edbdcecf7dfce7e71bf1c3a6a23f88277823ff394aeaaf6225d79f2e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_async_client/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "1462f18ca7a79da1c40deca7a550905a9ba54dd9637b78ca906390a32d4bbe6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-cbg-executor/default.nix
+++ b/distros/iron/examples-rclcpp-cbg-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-cbg-executor";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_cbg_executor/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "ef5991a7c56f5053416e9d9f553572ad735ee037ea8cd943b1c1fe378c5869af";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_cbg_executor/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "030529a192928a3888c0e1b2a1183426d3149ee06178a2c9f75c181cca856dbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-action-client/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-action-client";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_action_client/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "13f3f25fbaea6fe6c9e88a59fe34c250bc38f8dbd48f37e38e493492608870e6";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_action_client/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "d92bc64fa304ec55cdb4dee6195391b335cceab3c8660dd21219a2e780aa3d7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-action-server/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-action-server";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_action_server/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "dd77c4d0ca69f31c12f352ed56f812a8f2abf939276cd1d71b497fc97ad78026";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_action_server/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "0c3e95475c086e43940b2052b3541e2596fb02f4ba10021dcf183c013a254785";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-client/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-client";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_client/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f2971a126a65cbba0348977fc93ad67d4d90661fbce1d722e2559f8debbe0800";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_client/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "956c206ae6f305f7e0a208998df2f9c0f8ac82e62b5c75b39edb3a5c410c5605";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-composition/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-composition";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_composition/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "6ea23027f68a37ba69090354de9cc61e0fd831fa84761c02eceec2a041314b9b";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_composition/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "f1ac2fd4789fd925410cb62492e424576a05de5f2649b69761387ab25c156a78";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-publisher/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-publisher";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_publisher/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "a58828b28b6218f37fb7767ffa6813a0fcdcb55d126027072f85857d7c7f1213";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_publisher/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "f4daf31441484977f0805dffa6f824b7bcbde0c243c078ea78d55f24d97f6353";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-service/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-service";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_service/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "b2e114dd06f883c3959f4df0f3048a4e471363631f4e7e0f4d414f82988e6c6d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_service/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "9c1a1ba8cb062a257647ee895ac9e7cffc1ad61cc65fc87d835385aac8b5981f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-subscriber/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-subscriber";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_subscriber/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "ddc1be2834b3a65b78ca32ea21bea016e8d7aceac6795503958adc60f362dfd2";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_subscriber/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "3289f01cd3183a028ad4e81b5972aec1a3f68ac4b2248c3a52d0455fc2f4e875";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-minimal-timer/default.nix
+++ b/distros/iron/examples-rclcpp-minimal-timer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-minimal-timer";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_timer/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "716297d15b67ad275edd8aaede41321d1ce293f57f2d2014bd92efdcf78598a3";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_minimal_timer/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "7e909a08cf11b78738cefdaae91bf4dc29cbffc98417da390f9a546091d7e200";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-multithreaded-executor/default.nix
+++ b/distros/iron/examples-rclcpp-multithreaded-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-multithreaded-executor";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_multithreaded_executor/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f7ac9607ef86503bfe6e8bd0b37d7a5b0a0f7b5d4dc1856afbd7984fa6ff6d58";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_multithreaded_executor/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "42f4e659f330fbf70f4875795f82836c8a02a8b5d51cdd176ab6b4593656056d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclcpp-wait-set/default.nix
+++ b/distros/iron/examples-rclcpp-wait-set/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclcpp-wait-set";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_wait_set/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "8ee05471aa776a84986cd6f68fd727042b65d9bf9ec9e257f2423548448c815b";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclcpp_wait_set/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "e638bd7cd397b9b97751d2de9021173bd793769d41f1fdeae8efd7120f6c4b8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/examples-rclpy-executors/default.nix
+++ b/distros/iron/examples-rclpy-executors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-executors";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_executors/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f812dd4d961653684ebce9977db9436ad14806885c21468b6750b02142611f19";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_executors/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "e0c1caf45a43f1ba488a7f6649196d51dc5c1600ae8996f546cf0e5b57057aac";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-guard-conditions/default.nix
+++ b/distros/iron/examples-rclpy-guard-conditions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-guard-conditions";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_guard_conditions/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "178a56e7d3002b978f89c6192505bfe5115e39db04d5734f1ace4fa1c86a4fc4";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_guard_conditions/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "209a609ec4d2b10d515957e41ff81b676eaee83df743212b0397dfb37e4cb15e";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-minimal-action-client/default.nix
+++ b/distros/iron/examples-rclpy-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-minimal-action-client";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_action_client/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "0c8dd264d3b7604bade513f52ee40cd45e289f1d7004ab2782f4af34df14f261";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_action_client/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "45cb124b418099f3ea0eab66e7a06232e95aad5b61acd64849bfb9cec4bfbcef";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-minimal-action-server/default.nix
+++ b/distros/iron/examples-rclpy-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-minimal-action-server";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_action_server/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "accb77e297ea443c05fd8eaabd86cc84017ea94d1f6e4198db33c762df51f93c";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_action_server/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "c39112da78331747e2619c05c5410ac63fa2f7427fc211c56e506e19b926d6af";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-minimal-client/default.nix
+++ b/distros/iron/examples-rclpy-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-minimal-client";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_client/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "ef12789870bcbc61e40573738cb3e1c3a4f81ba438a462b7c32cd74cd60c1267";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_client/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "b91ff3cfe2ba1a8c714c2ddb2f9919fb4c5f9f6af747ed3233c85ac1475d7c09";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-minimal-publisher/default.nix
+++ b/distros/iron/examples-rclpy-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-minimal-publisher";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_publisher/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "1077de27c814cd893a62dad432c7af3b61aa809083edc9fb14a1331730c5f164";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_publisher/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "3fb577c81c2afe41a570d0d0817448d387cc73d78e3a029b31350a74764762a6";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-minimal-service/default.nix
+++ b/distros/iron/examples-rclpy-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-minimal-service";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_service/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "9276960393f12c7a049741fcaba4ffd8e4f3fcfaa2ece37bb74fa439b20ac874";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_service/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "eb17e632cdf4e946faaf8d2e3a4aee4f7c6eeec4633303ca61cd871ae61e5f3f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-minimal-subscriber/default.nix
+++ b/distros/iron/examples-rclpy-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-minimal-subscriber";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_subscriber/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "66a7a8024decfb76be62365040f28fca67e5122b5e89d41a55a99e1dda15e052";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_minimal_subscriber/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "66d77302dfd7e3c345c730ccf79d5e8c6134646b85aa298248ddbe4bcdf21103";
   };
 
   buildType = "ament_python";

--- a/distros/iron/examples-rclpy-pointcloud-publisher/default.nix
+++ b/distros/iron/examples-rclpy-pointcloud-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-examples-rclpy-pointcloud-publisher";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_pointcloud_publisher/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "d751aebc79153cf3104cf4af08c19cb138e4562b8f3773a7585db449e343438d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/examples_rclpy_pointcloud_publisher/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "2f4af5694f39ad982c4ce02fd76be4a0de19757fff997e1fd2e4d3fca3358ef3";
   };
 
   buildType = "ament_python";

--- a/distros/iron/fastrtps/default.nix
+++ b/distros/iron/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-iron-fastrtps";
-  version = "2.10.5-r1";
+  version = "2.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/iron/fastrtps/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "7f9f86efff2494d03c74af44674018a0f5bb4df83e8f821472aa008e2133bae6";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/iron/fastrtps/2.10.6-1.tar.gz";
+    name = "2.10.6-1.tar.gz";
+    sha256 = "8f9beefe4f43e9095fc415a972acb35c74cb3d3e849bd87978ca3130b43b4dbf";
   };
 
   buildType = "cmake";

--- a/distros/iron/force-torque-sensor-broadcaster/default.nix
+++ b/distros/iron/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-force-torque-sensor-broadcaster";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "c5ad5265587585307ae1ba91fb14fdfd8053a77af70305cd16c18a9daba7b863";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/force_torque_sensor_broadcaster/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "3d420e7f5a95fdaa9e74a8bf5ce4af70b31afe2558f012df85bb2d994f591991";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/forward-command-controller/default.nix
+++ b/distros/iron/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-forward-command-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "ca02e2b7cd278c86af17d3d811f5f01454c6a8e771283a0cfedd9b0725fa25c5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/forward_command_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "5b89ad6a07c8dd902428b99e8f103530195d9ae360232e4fa08d4e98f5d7ac2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/generated.nix
+++ b/distros/iron/generated.nix
@@ -2250,6 +2250,8 @@ self: super: {
 
  simple-actions = self.callPackage ./simple-actions {};
 
+ simple-grasping = self.callPackage ./simple-grasping {};
+
  simple-launch = self.callPackage ./simple-launch {};
 
  simulation = self.callPackage ./simulation {};

--- a/distros/iron/grasping-msgs/default.nix
+++ b/distros/iron/grasping-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/grasping_msgs-ros2-gbp/archive/release/iron/grasping_msgs/0.5.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/grasping_msgs-release/archive/release/iron/grasping_msgs/0.5.0-1.tar.gz";
     name = "0.5.0-1.tar.gz";
-    sha256 = "d7dc2967d5d1ec2740be9ec5a89171111377ac3288c0e5365279aeec4a599ddc";
+    sha256 = "11dffe168a1f95e4ca5e7a968f1658992b3f981b70d09469bdebb2d0245fae53";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/gripper-controllers/default.nix
+++ b/distros/iron/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-gripper-controllers";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "a9b6eb8c36ea2ee5c748777ff650c9f410018fe3f96c13af8f19e4e846f33b44";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/gripper_controllers/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "08b3158257cfda75eaa34a5ee7617482669d6e6c371914e23ffe42d434011dc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hardware-interface-testing/default.nix
+++ b/distros/iron/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface-testing";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface_testing/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "4d7fabe34da83427cd95f8b6954fd1259f0206f357f077b85afe94ed432f179b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface_testing/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "79281d5ca1d45c50005c1e467c85f640252376629540017bc5b2908b22c0bb6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/hardware-interface/default.nix
+++ b/distros/iron/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-iron-hardware-interface";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "d1bdd17b4eb175a4442d49e030ede82064100f1727616963a298e6af73006fd2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/hardware_interface/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "1ae7aa2c217a52bb98fe4fe45ae344980fe0d068464581efa0bc9f51d62bf49a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/imu-sensor-broadcaster/default.nix
+++ b/distros/iron/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-imu-sensor-broadcaster";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "6333246c4289f3fdd3f53012e01c703056c9d925859e98d71f137533f676bce9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/imu_sensor_broadcaster/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "7c2c16467a2c4075042878dd3e3084127215ef58be874c4f75f605dfc63b7a03";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-limits/default.nix
+++ b/distros/iron/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, launch-ros, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-iron-joint-limits";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "a518313823241a524c18a969b8fc53789a3a97fa0e0670f78bbd4c581f67796d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/joint_limits/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "4792d1a73691a01724bad68547b41c1049bd60f154b64ac8c283da8339db4331";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-state-broadcaster/default.nix
+++ b/distros/iron/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-state-broadcaster";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "650359c2b4e37ac62cf532bbadcb0d4c62ac5a073bcaabd03c9db44c70cacb6d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_state_broadcaster/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "46755792df91b5acc7328516791107da446f1049c30d662f3013b71492e38d49";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/joint-trajectory-controller/default.nix
+++ b/distros/iron/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-joint-trajectory-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "81da29f9a81a7286bd6302080d27e0b16b9b6ee15bacc3667224215bfd24ddd1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/joint_trajectory_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "85bd4fa59c2ad71c2cf99d4f5a1a0af5179e667d319e1a51367c4784643ffa68";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kinematics-interface-kdl/default.nix
+++ b/distros/iron/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-iron-kinematics-interface-kdl";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/iron/kinematics_interface_kdl/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5b6ce384f2f561c9d591c57476d7c4204a5cbb181007c491b5327b5d947a2b64";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/iron/kinematics_interface_kdl/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "0b01eea42d8a0721506ff6d47169de7d630b223df612158b17e47009b001d2c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/kinematics-interface/default.nix
+++ b/distros/iron/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-kinematics-interface";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/iron/kinematics_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5797fbd2c13be4411539c8ca812d0bbed69d10eac5892e25f48058ba577badc4";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/iron/kinematics_interface/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "7b87a17384e7605ff8d2eb0e45d6da60470113897518c9b2c7212bd13171f4a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/laser-filters/default.nix
+++ b/distros/iron/laser-filters/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, launch-testing-ament-cmake, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tf2, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-laser-filters";
-  version = "2.0.7-r1";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/iron/laser_filters/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "3b2e5a94d00cf35904d82ea05bd57cd84c78127c611a02996f87583831242787";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/iron/laser_filters/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "108fb7aa1cb629be6ed19d383fc287f3083828cb2532c230e0df056dde1cde06";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-lifecycle sensor-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-gtest launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs tf2 tf2-geometry-msgs tf2-kdl tf2-ros ];
 
   meta = {
     description = "Assorted filters designed to operate on 2D planar laser scanners,

--- a/distros/iron/launch-ros/default.nix
+++ b/distros/iron/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-iron-launch-ros";
-  version = "0.24.1-r1";
+  version = "0.24.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_ros/0.24.1-1.tar.gz";
-    name = "0.24.1-1.tar.gz";
-    sha256 = "e89f2ea9e688f59a6653cbcfab598d6da3b0e79c49da9a4599c880a7c6462e44";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_ros/0.24.2-1.tar.gz";
+    name = "0.24.2-1.tar.gz";
+    sha256 = "96be66549cf8b9cfc74c8b7fd45054d6e37b222b0551a563b29b79027e2240e1";
   };
 
   buildType = "ament_python";

--- a/distros/iron/launch-testing-examples/default.nix
+++ b/distros/iron/launch-testing-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, rosbag2-transport, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-launch-testing-examples";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/launch_testing_examples/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "fbe15c2df95a86abcbe317244d49978bdfc63e0a04764c42ae854802cc98607d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/iron/launch_testing_examples/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "081091d1827bfaf2579fc7539f0ac8fdc764b7526d0268d975d97fa507e6a4b6";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
-  propagatedBuildInputs = [ demo-nodes-cpp launch launch-ros launch-testing launch-testing-ros pythonPackages.pytest rcl-interfaces rclpy ros2bag rosbag2-transport std-msgs ];
+  propagatedBuildInputs = [ demo-nodes-cpp launch launch-ros launch-testing launch-testing-ros pythonPackages.pytest rcl-interfaces rclpy ros2bag std-msgs ];
 
   meta = {
     description = "Examples of simple launch tests";

--- a/distros/iron/launch-testing-ros/default.nix
+++ b/distros/iron/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-launch-testing-ros";
-  version = "0.24.1-r1";
+  version = "0.24.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_testing_ros/0.24.1-1.tar.gz";
-    name = "0.24.1-1.tar.gz";
-    sha256 = "56f17cb60f87fd9d407906c2138708ef2e36fa19a1a94294c9d17102c035b977";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/launch_testing_ros/0.24.2-1.tar.gz";
+    name = "0.24.2-1.tar.gz";
+    sha256 = "a760bfc7dfb1ccc25a6ffdca6b8ddffd694e64cb800a31a8f285d681555a5e6c";
   };
 
   buildType = "ament_python";

--- a/distros/iron/leo-description/default.nix
+++ b/distros/iron/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-iron-leo-description";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "78241163b9d24182be0b4a7f37f63afbb98e286f022baa73d7b1b374678eaea7";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_description/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "2b5f4720581e8be5aa423f409aa9ee12a6ec51837bd6084b486d9ef4aeba1d78";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-gz-bringup/default.nix
+++ b/distros/iron/leo-gz-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, leo-description, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-iron-leo-gz-bringup";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/iron/leo_gz_bringup/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "b859dc947e37abb2f63c00274da6532c3d48b8d7fee1143b4cdd9c8d75aaf9e5";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/iron/leo_gz_bringup/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "477aaf837bde8b0b5e2a581b2a98f4b425ca96254c455ae705f4f05a4bb18c89";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-gz-worlds/default.nix
+++ b/distros/iron/leo-gz-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-iron-leo-gz-worlds";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/iron/leo_gz_worlds/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "5a074fc026365072735410b3a6beb780ec6c0c0ffaf39ca404558ffa9fb22546";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/iron/leo_gz_worlds/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "3814f40f5894f457cb3f9760bdc6e02702b568f9984395acf7e19bc313a30796";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-msgs/default.nix
+++ b/distros/iron/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-leo-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "d678aebbfe1031b3dcf0afb20bcdb4b5d630efa0b9034082ffce95f8433e68f5";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "d852fa50bb91631344cbfde0782b8bf40be1067c33f75bb46e17542fb74fbff9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-simulator/default.nix
+++ b/distros/iron/leo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, leo-gz-bringup, leo-gz-plugins, leo-gz-worlds }:
 buildRosPackage {
   pname = "ros-iron-leo-simulator";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/iron/leo_simulator/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "737024acc43366481d828e3b1d3b8162c7985c0ff5b3309624695eb41e4edfe2";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/iron/leo_simulator/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "381ac8ad9fa05685c015abb5e6f1462d82bf1e6644a7c4c764c6ed3bcf525c1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo-teleop/default.nix
+++ b/distros/iron/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-iron-leo-teleop";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_teleop/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "cb08516c2d5fb997836d30e6e0eabee3fd5dbb4fb5b71087212d1a46c66dd845";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo_teleop/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "946b41c95259f3d1c4762dcd27c1e0477e6a280b4bd1f2a70ec602e95c5fe0a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/leo/default.nix
+++ b/distros/iron/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-iron-leo";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "6ac7c2981bf9c78aad48f8f9bb9ffd11596c120153d9355ff4e489aa30471656";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/iron/leo/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "99596b77a172c822545405a177b4460be699352c8c90bbaaea5c4eedacdf512e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/libstatistics-collector/default.nix
+++ b/distros/iron/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-libstatistics-collector";
-  version = "1.5.2-r1";
+  version = "1.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/iron/libstatistics_collector/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "46146d8869230b4a9a4bc95fb8e2d1167788fd303ad9634885990d763c2d119f";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/iron/libstatistics_collector/1.5.3-1.tar.gz";
+    name = "1.5.3-1.tar.gz";
+    sha256 = "53c532c0316e309926bb01d35c121c85b3d467344f3850b785f7d37c4860b1b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/mcap-vendor/default.nix
+++ b/distros/iron/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-mcap-vendor";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/mcap_vendor/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "e4168c1e391cf8f85e3294885aa53507232457891c5610d149f008e4341eb58a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/mcap_vendor/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "0c60fe86631cc20c51f3d9430f35ec33febf9169b1a531c2dc1a6344a493ea8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/novatel-gps-driver/default.nix
+++ b/distros/iron/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-iron-novatel-gps-driver";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_driver/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "71463da5a953deefd872b4b2809332d861ea3d0a5ab8011a199e57b1f24061ea";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "de66dff0e40e6419da8aa008777727cf99818ad9afbda88edaa5a212aac7653c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/novatel-gps-msgs/default.nix
+++ b/distros/iron/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-novatel-gps-msgs";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_msgs/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "eafeeccf7ce31d5c671efae27b07e45279e3c8d4220e93137abb958eb2252a4a";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/iron/novatel_gps_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "03192a97963b462cfc0dfa02899ef4ca745ff3250586552643ec634b97746f2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/octomap-msgs/default.nix
+++ b/distros/iron/octomap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-octomap-msgs";
-  version = "2.0.0-r4";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/iron/octomap_msgs/2.0.0-4.tar.gz";
-    name = "2.0.0-4.tar.gz";
-    sha256 = "521606971c3a74b4ef9e7d9e53549a505ba42dfc8f5e6faacc7b5f19eb41fb19";
+    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/iron/octomap_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "add9971c8676b90e41d6cbd7a48a58eb3c1e6b258bc81feed35a06264206bba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/pid-controller/default.nix
+++ b/distros/iron/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-iron-pid-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/pid_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "05bbc8170f082d10e1ce937f551194b6dcc77f4fb75f46032bcd28f2dd6e31ce";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/pid_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "2d9f106d6ad1bf4fa980159a8a9e365088336699f0574be859078cad1ee492db";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/pose-broadcaster/default.nix
+++ b/distros/iron/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-pose-broadcaster";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/pose_broadcaster/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "0898fc1fd15abb1d57c0fdcf2b28099ff84e56c6f5025b769c725bce53534321";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/pose_broadcaster/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "ba5bb96880d4a2a021f86b047f36b75f9827af3f3a9be122f84061a584e40ab5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/position-controllers/default.nix
+++ b/distros/iron/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-position-controllers";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "5e56f988ea7405ee7690f3b88478009b584ae59df07154427a28165c767d1d5b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/position_controllers/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "4fb4b2d7f05dade025ea7470457f4ea9825183ed7edf9a2e703c37ed07688aa5";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/range-sensor-broadcaster/default.nix
+++ b/distros/iron/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-range-sensor-broadcaster";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "6aecc55b56fdd9385a182e5af7681e737800f5e0fb49cae6c3db3a63dbaa27be";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/range_sensor_broadcaster/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "0c69aaaa5e90047a81c827bd817b12638ce61868a193283aaaf9f20662b084fd";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Controller to publish readings of Range sensors.";
+    description = "Controller to publish readings of range sensors.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/iron/rcl-action/default.nix
+++ b/distros/iron/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rcl-action";
-  version = "6.0.6-r1";
+  version = "6.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_action/6.0.6-1.tar.gz";
-    name = "6.0.6-1.tar.gz";
-    sha256 = "644ba76b92b283a8731949ecfb98428962dd8212b0e68b7c999903ef1209511d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_action/6.0.7-1.tar.gz";
+    name = "6.0.7-1.tar.gz";
+    sha256 = "29d99ce98942d0223932f96fa22c1e9d8bfd6736b4498c5d06cd8b65aabb485e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-lifecycle/default.nix
+++ b/distros/iron/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rcl-lifecycle";
-  version = "6.0.6-r1";
+  version = "6.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_lifecycle/6.0.6-1.tar.gz";
-    name = "6.0.6-1.tar.gz";
-    sha256 = "e7e925864bcb16b18a8e673994500d07c32926bf1ec221888f34e9ce278079f6";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_lifecycle/6.0.7-1.tar.gz";
+    name = "6.0.7-1.tar.gz";
+    sha256 = "045330b9b651e5a9ac3d85554547a3055c5701bbeb28e87f1d2cd57499e1082a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl-yaml-param-parser/default.nix
+++ b/distros/iron/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-iron-rcl-yaml-param-parser";
-  version = "6.0.6-r1";
+  version = "6.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_yaml_param_parser/6.0.6-1.tar.gz";
-    name = "6.0.6-1.tar.gz";
-    sha256 = "a5ae817e46b60290979726632c0fe5a6324bb9242dbe9468904daad766660527";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl_yaml_param_parser/6.0.7-1.tar.gz";
+    name = "6.0.7-1.tar.gz";
+    sha256 = "f181ffbf75d3ea6824357f2bef061802e12466ab19413e69cafd8def708547c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rcl/default.nix
+++ b/distros/iron/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-iron-rcl";
-  version = "6.0.6-r1";
+  version = "6.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl/6.0.6-1.tar.gz";
-    name = "6.0.6-1.tar.gz";
-    sha256 = "28f34907597681d6f4cd9dd7fa50dffb3fc9d28bc40ae416bb2ec51f55c5ea71";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/iron/rcl/6.0.7-1.tar.gz";
+    name = "6.0.7-1.tar.gz";
+    sha256 = "bb12883ce12da7b5a35fa9b3bf36005715b8edaae8101f1bf09e2a3dfdd6cce4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-action/default.nix
+++ b/distros/iron/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-action";
-  version = "21.0.7-r1";
+  version = "21.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_action/21.0.7-1.tar.gz";
-    name = "21.0.7-1.tar.gz";
-    sha256 = "6f49e154096b6ae18da038281911aef3ca7e83f92fc508cdcf33c16e4f787e11";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_action/21.0.8-1.tar.gz";
+    name = "21.0.8-1.tar.gz";
+    sha256 = "b752751811f27e1e42e1c61a14b7c87ca658627e59e550de80fdbb9c773dca74";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-components/default.nix
+++ b/distros/iron/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-components";
-  version = "21.0.7-r1";
+  version = "21.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_components/21.0.7-1.tar.gz";
-    name = "21.0.7-1.tar.gz";
-    sha256 = "3a7479a6a865f5d4bd48e9039a0d2f6d660255bfb6d672d03fbc33169574a730";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_components/21.0.8-1.tar.gz";
+    name = "21.0.8-1.tar.gz";
+    sha256 = "55b96b5fe7765cb568e5498a43a7e2341d06f9620e017f3af4ff5860996affd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp-lifecycle/default.nix
+++ b/distros/iron/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclcpp-lifecycle";
-  version = "21.0.7-r1";
+  version = "21.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_lifecycle/21.0.7-1.tar.gz";
-    name = "21.0.7-1.tar.gz";
-    sha256 = "04a5e786f73e7c1d12fc4f9d614fe2d7d949b365afecfbb367fc9cfb5b79be25";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp_lifecycle/21.0.8-1.tar.gz";
+    name = "21.0.8-1.tar.gz";
+    sha256 = "9bca8994219d5fefea73dd5137d7e4c744598a70acc46fe1ef62d695d8c2e358";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclcpp/default.nix
+++ b/distros/iron/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-iron-rclcpp";
-  version = "21.0.7-r1";
+  version = "21.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp/21.0.7-1.tar.gz";
-    name = "21.0.7-1.tar.gz";
-    sha256 = "e75c1a841d1261aa357a6fa1c0b4eead9f7ad6f73ed78791d46e1c1d97e0489a";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/iron/rclcpp/21.0.8-1.tar.gz";
+    name = "21.0.8-1.tar.gz";
+    sha256 = "781f82ed054b2ed471a42573b2cfd68f74616ae1833b3337f1002de9443f2d59";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rclpy/default.nix
+++ b/distros/iron/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-iron-rclpy";
-  version = "4.1.6-r1";
+  version = "4.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/iron/rclpy/4.1.6-1.tar.gz";
-    name = "4.1.6-1.tar.gz";
-    sha256 = "275836904867a6a910aa4a2549d2b238fded8b32bbd0e0c56637b334ccc11d6f";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/iron/rclpy/4.1.7-1.tar.gz";
+    name = "4.1.7-1.tar.gz";
+    sha256 = "ff3a2b6914ec786592f878705fe29ba4a6385ccbbeeabbddc55d7e7e82955ce9";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-charging-schedule/default.nix
+++ b/distros/iron/rmf-charging-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, rmf-fleet-msgs }:
 buildRosPackage {
   pname = "ros-iron-rmf-charging-schedule";
-  version = "2.2.6-r1";
+  version = "2.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_charging_schedule/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "c3a5f26ce2b91f74459a4fc355e4a920b56b307ee849516d2a75db435c9905e9";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_charging_schedule/2.2.7-1.tar.gz";
+    name = "2.2.7-1.tar.gz";
+    sha256 = "1f7ff2cf9d064dbe7b22e973b56b3266e68df329d1210e05c3f18a72e736dd40";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rmf-fleet-adapter-python/default.nix
+++ b/distros/iron/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter-python";
-  version = "2.2.6-r1";
+  version = "2.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter_python/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "051bc2a2936131e008a517189077bfae586ba1f335b1cff62c0c95318da39d1c";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter_python/2.2.7-1.tar.gz";
+    name = "2.2.7-1.tar.gz";
+    sha256 = "1568b00f53eccfad96d3e350fc723d1a1f8d6add9c6efdeb7ab0da8dc904bf51";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-fleet-adapter/default.nix
+++ b/distros/iron/rmf-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-fleet-adapter";
-  version = "2.2.6-r1";
+  version = "2.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "c4dfc46698ecbded3327582f0d8b15c9fb3d6ccb7829cb0b584281f2c1942ecb";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_fleet_adapter/2.2.7-1.tar.gz";
+    name = "2.2.7-1.tar.gz";
+    sha256 = "74f2896e2e225e34160120a9a280246365e938bc79aaa9e794f6b9a593cda76f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-task-ros2/default.nix
+++ b/distros/iron/rmf-task-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-iron-rmf-task-ros2";
-  version = "2.2.6-r1";
+  version = "2.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_task_ros2/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "ee12132fa361e290f84b6b80d3e44b3ee6621f3b3f21425c023606b616ac0372";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_task_ros2/2.2.7-1.tar.gz";
+    name = "2.2.7-1.tar.gz";
+    sha256 = "3e34263a17543a4117773681b8a5ae4a7dae60999c5792a19109d87b1178aeb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-traffic-ros2/default.nix
+++ b/distros/iron/rmf-traffic-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-rmf-traffic-ros2";
-  version = "2.2.6-r1";
+  version = "2.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_traffic_ros2/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "ad24cd9b7916168937f8dae96581d8ebeba7bbc211cb39125dc27596ce6e251b";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_traffic_ros2/2.2.7-1.tar.gz";
+    name = "2.2.7-1.tar.gz";
+    sha256 = "22e3b6ec9a6fd6fc1f3e651471f2129c661f359ac9749e4d5ff19be7ab7e7232";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rmf-websocket/default.nix
+++ b/distros/iron/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-iron-rmf-websocket";
-  version = "2.2.6-r1";
+  version = "2.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_websocket/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "cb0296a8b633afb91fbb7f46bd67422b0bb3644df9d8f14ca94c10fa24c9b0cf";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/iron/rmf_websocket/2.2.7-1.tar.gz";
+    name = "2.2.7-1.tar.gz";
+    sha256 = "ba6a5897b942ef1d74ddefbfaac18c6343db2e4a889daf5eedf26982175e4266";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robot-calibration-msgs/default.nix
+++ b/distros/iron/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration-msgs";
-  version = "0.8.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration_msgs/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c2b3f063003e105595d0bfa5540ec61fb4e9327ce6857d4641a8c9a458e35ea1";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration_msgs/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "5f78ed131aa4bfbe8fc5d088df8969b5dcc4ab781e6bb61e17332bf5a211a364";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/robot-calibration/default.nix
+++ b/distros/iron/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-robot-calibration";
-  version = "0.8.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "64d1f08611c4db7e99e4d751a683df59d6e0a16c287ccc56fa2027c8dc4f80fd";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/iron/robot_calibration/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "986326b37d0829fad61ad206936486f37a799622f9fab7dabb6b3bf064331e42";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control-test-assets/default.nix
+++ b/distros/iron/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-ros2-control-test-assets";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "19b99784488ebfbf24875ed880710e153a4e707003fd489d3f4d79302aee363e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control_test_assets/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "8cec10aea87ce92004de1c22df20ac2b8b8bd60f26192ac640c6414fc3e56981";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-control/default.nix
+++ b/distros/iron/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-iron-ros2-control";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "3133ec3dc5f26b4fc956927b34cf47e3e399c3cc3105bc17e47995451c5d305d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2_control/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "ccb6c55d8a7d91e070d16d6d404f90d04537b6c973543d9c0c5d44eadfc99a46";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2-controllers-test-nodes/default.nix
+++ b/distros/iron/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers-test-nodes";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "a18a130c886c07ef3ffa5b9be6ea187cf13cbb002197a657bb03cad10d65eb26";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers_test_nodes/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "05701ffd1994f6b5da2f320299e79fde3e6f36cf109d18bac640950edd37f2d9";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2-controllers/default.nix
+++ b/distros/iron/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-iron-ros2-controllers";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "526427b65bdf630518cb37a283fcd94257e4bb2d467d12971108f256326407ba";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/ros2_controllers/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "730262823a79d5db07dd6892a12ae9a3e87d8e8d133ebcb10e321b819c84d6ab";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Metapackage for ROS2 controllers related packages";
+    description = "Metapackage for ros2_controllers related packages";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/iron/ros2action/default.nix
+++ b/distros/iron/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2action";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2action/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "0394a4d92a751c558b3eef6171327e15c07efdcf96fb68018be499d83eeccc99";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2action/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "ce23cd5aace65d1e5208798d338d0947f97320b52375e74df986d5613f399d31";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2bag/default.nix
+++ b/distros/iron/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-iron-ros2bag";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/ros2bag/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "31243f9738cf9f2dbd97201420835f1f925485ebcc47fcdb0a24f1595e5efd6d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/ros2bag/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "75a162f6a165cf3e06df9fcdabf046b45c02a813599ddcf5401bb0b5f47d7fcf";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2cli-test-interfaces/default.nix
+++ b/distros/iron/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ros2cli-test-interfaces";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli_test_interfaces/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "e9fa87ca575897f3cc469834e089aecb68a76b670df62f1703db6792b70d1d6e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli_test_interfaces/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "337ff3b710ffa371f99e80b02d652ecea4497ad75bb7f5235ae05389b700e79b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2cli/default.nix
+++ b/distros/iron/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2cli";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "d969e7748dd3a984da268785f33721f518291fdd2c5cd9c21a5ebfeb348710fc";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2cli/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "d56be412c229807b07b94b7da74908271bf098835c79c463cc76b66dcdaf442b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2component/default.nix
+++ b/distros/iron/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2component";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2component/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "6ab380cdd6498605b03e8d4f37775d9aa51c640b634ff6563284a7e3283bd721";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2component/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "256946db7a8e49b37af4662fec6ea2f6802834fc8481561e3f65d8eb0f378c77";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2controlcli/default.nix
+++ b/distros/iron/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-iron-ros2controlcli";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "1263ad24f491f878bd1d3fb97d9f3bc10fd6d6b7a28d3ab0c6ec47e76bd08c9e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/ros2controlcli/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "81491f6a3c9dc7ccee548be10b5f862947da6d789ba293bdb1748ad5f88963c7";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2doctor/default.nix
+++ b/distros/iron/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2doctor";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2doctor/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "e12e5c1c04fd560fd02004bda0666ed49545256175295639d5d57765043ea35c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2doctor/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "05029c2f60891ec982eae102494f6488c3a08391c3068b842d351b61c1bd2119";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2interface/default.nix
+++ b/distros/iron/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2interface";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2interface/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "8fdfa532e72861647e78b61c3156b11e5bbeadc416d5a64fcdd3346b2507e08b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2interface/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "ef3c9ce2e164baafd0a29676aaa22518ece2e4facd3cad1926316fbbda3c9616";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2launch/default.nix
+++ b/distros/iron/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2launch";
-  version = "0.24.1-r1";
+  version = "0.24.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/ros2launch/0.24.1-1.tar.gz";
-    name = "0.24.1-1.tar.gz";
-    sha256 = "b37ce20d56d12ecd44af9cbd615c1d0cde013ccab0a938e71df343a434c31b9f";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/iron/ros2launch/0.24.2-1.tar.gz";
+    name = "0.24.2-1.tar.gz";
+    sha256 = "211346b993a094fe2e5fa2b96169c2e3a26d10b120328312a2d8d82a7ed2981e";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/iron/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-iron-ros2lifecycle-test-fixtures";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle_test_fixtures/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "e96946596e90c922bb7a4819eb2ec270d3b69f6aa6396873f5bb963bef2fe6c3";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle_test_fixtures/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "cbfd294a8da0545b3cb4c29543c97ffa1de9f7912da54598721002d6b4d4177c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ros2lifecycle/default.nix
+++ b/distros/iron/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-iron-ros2lifecycle";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "daca4f2aa2c5712b5cd3cf39bd6771446d7f542f8611cb6f4509e911b9b24737";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2lifecycle/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "1f9d1d5ce7a52ec88b925386ba9da61e774bd46159b6e1bff43c54ba55abd11a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2multicast/default.nix
+++ b/distros/iron/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-iron-ros2multicast";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2multicast/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "8bd5787c20dddb83f103a6cc6f5a7e0066c7256dbfc5cf6108827b7faaef5f40";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2multicast/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "83cc265544c54564c8ce2755f7d34291f2b75a9d62666bfa74c1f6ca500c4116";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2node/default.nix
+++ b/distros/iron/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2node";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2node/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "e8abe1a2f741134f962608de5ed8f4f1ca49b14d109656152be9c14d90503b4d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2node/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "b493f8dde388e71c040ac49ae8e458befce83d73d23f40a251387c9b4f7ac0f9";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2param/default.nix
+++ b/distros/iron/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-iron-ros2param";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2param/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "87d92d63a2a31304be06e601d1b310e5994528f50e2537cd531e5cfd267e3fc6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2param/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "7ed47538d6e9af22f939d5508adffab5f05611e5ee4a1fbf9200900b5ce2731a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2pkg/default.nix
+++ b/distros/iron/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-iron-ros2pkg";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2pkg/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "a2fcd1a5368f9c6902f88448e3e85de2499fa33a41ecc0cfe2201735a4e18326";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2pkg/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "dbd8e6f77cafe010f7bf39df82cd5d2b7749f8cf6134808bed232341009d6f57";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2run/default.nix
+++ b/distros/iron/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-iron-ros2run";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2run/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "33710e222f9439aa1bb63a035a0c428fbf74200c6a71b938750cb7f2916324a1";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2run/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "f4edffcef4e4ddfe6f369e3aa9b5320c642f673c52fb53f4cf8f208eb6f52338";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2service/default.nix
+++ b/distros/iron/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2service";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2service/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "af562fb1655288a12b1885ee8c08e858a72e49787625922eaddfca9140ffad01";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2service/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "cb8f8a86e341a24b83d8b036a69cd7370a27139303856965be90f1cbd4ccd0e2";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2topic/default.nix
+++ b/distros/iron/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-ros2topic";
-  version = "0.25.7-r1";
+  version = "0.25.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2topic/0.25.7-1.tar.gz";
-    name = "0.25.7-1.tar.gz";
-    sha256 = "634c2580fa2a50745416c3007ab2c53de29c43340f80d564a5d49ffb2359af70";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/iron/ros2topic/0.25.8-1.tar.gz";
+    name = "0.25.8-1.tar.gz";
+    sha256 = "dd2ea2f092600821bb9ea424d9397084047a878c1f6b340cc233cdd838b0d2b0";
   };
 
   buildType = "ament_python";

--- a/distros/iron/ros2trace/default.nix
+++ b/distros/iron/ros2trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages, ros2cli, tracetools-trace }:
 buildRosPackage {
   pname = "ros-iron-ros2trace";
-  version = "6.3.2-r1";
+  version = "6.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/ros2trace/6.3.2-1.tar.gz";
-    name = "6.3.2-1.tar.gz";
-    sha256 = "0efa29130d2349a4362db072bedebb71b87cc3f500875169b9254fa02c8f97ed";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/ros2trace/6.3.3-1.tar.gz";
+    name = "6.3.3-1.tar.gz";
+    sha256 = "e75cb9afa00f47ccf10658c9c535f87e1c4c6fb9ecbe84d2b46e5058e5eb214f";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosbag2-compression-zstd/default.nix
+++ b/distros/iron/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-compression-zstd";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression_zstd/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "7fefbaaaf46e3c6eace65835a00b87165c2526a0482900a30b8919e636e15d7d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression_zstd/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "4e4c4790496e1a8c6023beacf8d61ae507e7e3f746dd461f781e1f848945462e";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-compression/default.nix
+++ b/distros/iron/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-compression";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "62e85bf30ba0493aace1edd4d782248c09fe554c613523e8b5e20e2fcdce5272";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_compression/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "1d7b9ef181930c3f666bf4c0e53baaec11d162ae9bd943e933706e553bbd1a42";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-cpp/default.nix
+++ b/distros/iron/rosbag2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-cpp";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_cpp/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "4a4ad62a901f1b6937202e3f8e8cfb9daef1aca6c5d7b90a2ab01432ffb3f6e3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_cpp/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "ac54c98b4bca8dd7b1e6e1c2b2d97ee8a6c890feb0cdf5fd8f94e09fefba93cc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rmw-implementation-cmake rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs std-msgs test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp shared-queues-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/iron/rosbag2-examples-cpp/default.nix
+++ b/distros/iron/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-examples-cpp";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_cpp/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "ced218db1fe7338ea870db5bd0c58b1e6535610ba9ab6b792681840304e97cad";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_cpp/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "23efa8078b7999a26e7e813183104833f1f0e2841a5b8465ecdd72e4973de5f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-examples-py/default.nix
+++ b/distros/iron/rosbag2-examples-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-examples-py";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_py/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "c8aee6a392c07ad730ff67b9be549085028b83ccb6b68e6b0d1ee6ba33457385";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_examples_py/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "e3c8ba295f095a07a8a9052efc7d0ae1b769e76796358221b2778bd1de729ccc";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rosbag2-interfaces/default.nix
+++ b/distros/iron/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-interfaces";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_interfaces/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "6e3179482a98138970ede5113b366d5f83e605bd16d07faf8bd14b8bfaf609cb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_interfaces/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "e2ea687af6494f71925784aabc5325c759ba469d0a194403f84dc6c494dedfda";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/iron/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-performance-benchmarking-msgs";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking_msgs/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "25ac230de965a625fa96c0f8604f06e0a6a657d3b834942bc704f04ba92a69c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking_msgs/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "2aecc97c3b66a6586691482a2e472eca6024aa22ee81c1105090bf355c37b759";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-performance-benchmarking/default.nix
+++ b/distros/iron/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-performance-benchmarking";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "b8619ffc6d0b6ca771a9a6df169d422611858a8b7c171c33ece04ec2ad98bca3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_performance_benchmarking/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "378a40fda95e236b6ab14cc24180d4d87872f0107d0b58bfe0141708ee0b1e77";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-py/default.nix
+++ b/distros/iron/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-py";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_py/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "74a2e2af631f2f7458209a0acc3a5414f037c9e2d99f87b63a3541cbc56e19dc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_py/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "b55177c701787f0db07ee30cc43cb707ec6942637085de1d3f28b794ff5de501";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-default-plugins/default.nix
+++ b/distros/iron/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-default-plugins";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_default_plugins/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "9c50c0dcd5b4cf8b9f59917a6e4febf995bc3965da2b110c2ec301320732e238";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_default_plugins/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "99612a3c6581b10ddeafc6b05ff0dcc6b287e74e76d63eb189798cfd09456dfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-mcap/default.nix
+++ b/distros/iron/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-mcap";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_mcap/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "baf79f16ec1e2fbb19eb619f3519fe1e955323b52aeab7becb116566bacf329e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_mcap/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "1662c138c109897b4db30d2fb80689953b850a2ecef5222f6f5f3cc879988d1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage-sqlite3/default.nix
+++ b/distros/iron/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage-sqlite3";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_sqlite3/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "99c5a8252188129a3dc2892cc63e94e55dc6daa10472d7a49c98e28bf0a25f0d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage_sqlite3/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "0edbd5d631dbbe892078c841420e56f7b869a0ab18c58166ba2eb4348b652096";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-storage/default.nix
+++ b/distros/iron/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-storage";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "7d0646150a434070a997bde7ad63dde03945d36dfb8980c104c5213855a48147";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_storage/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "12daa53d7bb253f5dbb92c5fd7bc296a567d6f6e61536e65979202b3bf126803";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-test-common/default.nix
+++ b/distros/iron/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-test-common";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_common/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "e7ebd6cc5926fc7667711e6f27b5f10e4e277f746be25569989f2b92ba4046fe";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_common/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "9e2e5daa9f2d14d5a8c3655e3966fb8a25ff96ec3aed160d4a2f9f0e19bc2d04";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-test-msgdefs/default.nix
+++ b/distros/iron/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-test-msgdefs";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_msgdefs/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "f3c88090b012494db5e2448e4a9ae1a9e8ae7dee21a3c6fe7e308e27dd0cc796";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_test_msgdefs/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "7fae72975a40ad09fb691037f668bc2b1666cbf7e2c1df0602712b4cbab6069d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-tests/default.nix
+++ b/distros/iron/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-tests";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_tests/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "9451faccd344fc5b2d7b6fa8920c3cff77c1d5c1d30828f9748e4b4ba7979bcd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_tests/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "d785b98f7deed961baf4aa442d72f9abbc9dceed18c1d6a9aa9c97925c7d9ed4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2-transport/default.nix
+++ b/distros/iron/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2-transport";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_transport/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "df2ed0cee8b2d341c48ce3041f00e1b4207df9ff6f9475b9782ba08cecb72abf";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2_transport/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "28a1df2a4d7ef76e206a218aa40cd9f63c8eb4a5e4131058162e6a9ad44486b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rosbag2/default.nix
+++ b/distros/iron/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
 buildRosPackage {
   pname = "ros-iron-rosbag2";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "01a33b99253bb247e7b0972cfbd3ecc63b6a36f82fc35f314f76862e3f94aa3c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/rosbag2/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "882d08c95dda6eea20a7c8aad5d808d304d80e7cc3a8f6ff32a188fa757a18e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rqt-controller-manager/default.nix
+++ b/distros/iron/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-iron-rqt-controller-manager";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "0eb4bf179c26c89ec605539facfae46b86367be6cbf59523389e1dd66a857f2b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/rqt_controller_manager/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "44eba2b7a82366fde1efe4d36d372e0670fa9815991a6b3e07ce2de251889a8b";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rqt-joint-trajectory-controller/default.nix
+++ b/distros/iron/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-iron-rqt-joint-trajectory-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "29292c77c9200211a1a130f2ad235ff56f1810e2dee225c0866eb9f008be1c02";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/rqt_joint_trajectory_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "7c76dbb5bcea8dda71c96fc1340c80faa83d5d3b114eeb7f970f4fed251c75e8";
   };
 
   buildType = "ament_python";

--- a/distros/iron/rviz-assimp-vendor/default.nix
+++ b/distros/iron/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-iron-rviz-assimp-vendor";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "c2b3eacc3d51dbad7850298f017b892f59175fd78b1b28a32528874dd06bc826";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "7173cc33850c99f8299d06797d59bfddbf8697a7c58e7bf7c66ec2bbd2cdfec4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-common/default.nix
+++ b/distros/iron/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-common";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "63378bbc49d168e94c6d3a2cbec2f9823c4f67055fd02fbaf229bd2046afbb64";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "a38697ba876e515a8da440f7f4a0524c1b0654c7b33920cee23cfdbd8654dd40";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-default-plugins/default.nix
+++ b/distros/iron/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz-default-plugins";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "50525064921806edaac448f971643990b705be9620ade9a1e0a7aadacd7ace66";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "f23438b94b80d0a4e369698a21959e5c461f69c6fd4fc31bb20af73a3c9976b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-ogre-vendor/default.nix
+++ b/distros/iron/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-iron-rviz-ogre-vendor";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "6a5dddfd3c607858b399d67dc79f2857e8551d2e8895cfa81caf550084361b6d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "18d9f32695d2db05c6ea8a2470781b9729da4d0fe7021868d3b5fe557fb6025b";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering-tests/default.nix
+++ b/distros/iron/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering-tests";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "e89215f67074c733d436e07e0decf69b68d9957476c57d4929b46f16383910ca";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "4443cc7fac699e3f708a3df79203305f1159c1e05a15dbd727c5aeea554c6ff7";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering/default.nix
+++ b/distros/iron/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "72844a91acb56e0d4ca7f7ba84853ad54e190b8b13763623e53c12b4461cb354";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "741f0763141c186f59a47453eb226251438d558e5246e74dfb6182409fe74815";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-visual-testing-framework/default.nix
+++ b/distros/iron/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rviz-visual-testing-framework";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "87bd38db312c1f48628ea7bb480f9da88dac31f52fa49f1f4988309a0c7fc6f4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "36ec8db6b9c292d9fc377094e620dff2c6b9b773b06d1f34813e25163a2f191a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz2/default.nix
+++ b/distros/iron/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz2";
-  version = "12.4.8-r1";
+  version = "12.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.8-1.tar.gz";
-    name = "12.4.8-1.tar.gz";
-    sha256 = "21f89c9296c818b4e47f14d1f40c150366f17e7622e7d34fd87161a40366c129";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.9-1.tar.gz";
+    name = "12.4.9-1.tar.gz";
+    sha256 = "915b84ad1a23e447f8b6679ca3b7fb25428c81f97c904c9b87804a7e5c19d345";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/shared-queues-vendor/default.nix
+++ b/distros/iron/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-iron-shared-queues-vendor";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/shared_queues_vendor/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "32f391da36e18e8dc29130bde6918c0bb6effe04f2bc48e41c9ee552e9c7fcf3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/shared_queues_vendor/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "d7cd3fa4dd2cf43e22b210319b261b57e258abb3c494e44704fe74799793c661";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/simple-grasping/default.nix
+++ b/distros/iron/simple-grasping/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, eigen, geometry-msgs, grasping-msgs, moveit-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, shape-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-iron-simple-grasping";
+  version = "0.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/simple_grasping-release/archive/release/iron/simple_grasping/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "ce3417c21aec7775204d5030349fa50b133a0e620ee26103c3d550f495c95ef6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen pcl ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-gtest ];
+  propagatedBuildInputs = [ geometry-msgs grasping-msgs moveit-msgs pcl-conversions pcl-ros rclcpp rclcpp-action rclcpp-components sensor-msgs shape-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic grasping applications and demos.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/iron/sqlite3-vendor/default.nix
+++ b/distros/iron/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-iron-sqlite3-vendor";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/sqlite3_vendor/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "e5bdb37bd87d1cc81d45b3365b25dfc8e155ceab9c1d7c11ba18c97002c104cf";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/sqlite3_vendor/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "f41171ae449132dc9e2de97ab86021eeef9e35df8bf4b7a8db011b81a834ab85";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/steering-controllers-library/default.nix
+++ b/distros/iron/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-steering-controllers-library";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "12d73934dbb26b62faa335501cb38673afddacf057701a1e1a0b35559560d5de";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/steering_controllers_library/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "b901ea98c34abd098426fe40fcb660bbb6e874523ea401ab8105cf2483072513";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tracetools-launch/default.nix
+++ b/distros/iron/tracetools-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-trace }:
 buildRosPackage {
   pname = "ros-iron-tracetools-launch";
-  version = "6.3.2-r1";
+  version = "6.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_launch/6.3.2-1.tar.gz";
-    name = "6.3.2-1.tar.gz";
-    sha256 = "1329cf924fafc8966815dea0f6f2a3e7cf47e173278faf397827db975cb3b042";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_launch/6.3.3-1.tar.gz";
+    name = "6.3.3-1.tar.gz";
+    sha256 = "5d2d4711fad22cdb9527a4f1e2597fd607d093fe15fb8bfa356d576c3265b1dd";
   };
 
   buildType = "ament_python";

--- a/distros/iron/tracetools-read/default.nix
+++ b/distros/iron/tracetools-read/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, babeltrace, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-tracetools-read";
-  version = "6.3.2-r1";
+  version = "6.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_read/6.3.2-1.tar.gz";
-    name = "6.3.2-1.tar.gz";
-    sha256 = "36438dfef78efd945d57fdd3299f79aed6ff362c40e7e53cb6a36a157f05de6c";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_read/6.3.3-1.tar.gz";
+    name = "6.3.3-1.tar.gz";
+    sha256 = "d1b398ed83d052e05ff90c9e33cf204500cc3e377cd11886d75ef9ecbfd66ed9";
   };
 
   buildType = "ament_python";

--- a/distros/iron/tracetools-test/default.nix
+++ b/distros/iron/tracetools-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-launch, tracetools-read, tracetools-trace }:
 buildRosPackage {
   pname = "ros-iron-tracetools-test";
-  version = "6.3.2-r1";
+  version = "6.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_test/6.3.2-1.tar.gz";
-    name = "6.3.2-1.tar.gz";
-    sha256 = "5c53ade154fc5f09c1e1fd5a1d85f85ef7d7aa767f4d561be431f7fcd62347ee";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_test/6.3.3-1.tar.gz";
+    name = "6.3.3-1.tar.gz";
+    sha256 = "01976ee3258682e7d9aa5035b1a97457d1f42a21e58df224f0f171d919130f4a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/tracetools-trace/default.nix
+++ b/distros/iron/tracetools-trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, lttng-tools, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-iron-tracetools-trace";
-  version = "6.3.2-r1";
+  version = "6.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_trace/6.3.2-1.tar.gz";
-    name = "6.3.2-1.tar.gz";
-    sha256 = "fa430a6c4348e0e87f5ea26364d76cedef2fdb69c24f2e2c7d1ae9fc486b8247";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools_trace/6.3.3-1.tar.gz";
+    name = "6.3.3-1.tar.gz";
+    sha256 = "e66ad924d6fb66927ac675e55a993136d68e8ab616b20f522d9c49634e1d434e";
   };
 
   buildType = "ament_python";

--- a/distros/iron/tracetools/default.nix
+++ b/distros/iron/tracetools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lttng-tools, lttng-ust, pkg-config }:
 buildRosPackage {
   pname = "ros-iron-tracetools";
-  version = "6.3.2-r1";
+  version = "6.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools/6.3.2-1.tar.gz";
-    name = "6.3.2-1.tar.gz";
-    sha256 = "556aa0489ae6f42b149fc7e114546b2b7b2b9923b3d85c57edd150728501037b";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/iron/tracetools/6.3.3-1.tar.gz";
+    name = "6.3.3-1.tar.gz";
+    sha256 = "dd73969560a5e3c6c386ffe9af3f1a76a6c55e19891067128b06c550581f46a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/transmission-interface/default.nix
+++ b/distros/iron/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-iron-transmission-interface";
-  version = "3.29.0-r1";
+  version = "3.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.29.0-1.tar.gz";
-    name = "3.29.0-1.tar.gz";
-    sha256 = "a7cbbccc651aeb7754535cdeaa0a129fc8ae94144a09fea28fda70999ab75a39";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/iron/transmission_interface/3.30.0-1.tar.gz";
+    name = "3.30.0-1.tar.gz";
+    sha256 = "d50a7ac31b74823a3269fbecd25dc878351ec8cb498d8926f749bb14f0cc9161";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-controller/default.nix
+++ b/distros/iron/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-iron-tricycle-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "94aa1b847565e887b5bc9523df779015fe29922e9b31adaaf481c90272dd1e5f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "8fac9c7b3af250bf46510f1e64e329e19a17f469264c6f10ba10d058e6fefd00";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tricycle-steering-controller/default.nix
+++ b/distros/iron/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-iron-tricycle-steering-controller";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "753c745edea4104c453e4bfeb6b50d6d30e1fdb6dbd41763b6dbbf6130ecb6eb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/tricycle_steering_controller/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "57cc66930aa5940f8a83b3f1ef8490864da4cb14becca57f4e983906391f7d31";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-calibration/default.nix
+++ b/distros/iron/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-iron-ur-calibration";
-  version = "2.3.11-r2";
+  version = "2.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.11-2.tar.gz";
-    name = "2.3.11-2.tar.gz";
-    sha256 = "1e1f975041156bbf2e420a64706e3a481c6192f03577c7c9a5624eade4c3ea9e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_calibration/2.3.12-1.tar.gz";
+    name = "2.3.12-1.tar.gz";
+    sha256 = "a38fd940715ff2b9b8250dccfc9e44243a7b5cbd387543bb0f065ea42e90522d";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-controllers/default.nix
+++ b/distros/iron/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, controller-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, std-msgs, std-srvs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-iron-ur-controllers";
-  version = "2.3.11-r2";
+  version = "2.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.11-2.tar.gz";
-    name = "2.3.11-2.tar.gz";
-    sha256 = "b8c7aaec4f8109ea124e39146950b1a9f2a882b74d628e03c3964002e871e688";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_controllers/2.3.12-1.tar.gz";
+    name = "2.3.12-1.tar.gz";
+    sha256 = "f74147bbf8f65fa66e2a68d52c66fb932c954a6b274827b1eb07dd4e09cd0ac4";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-dashboard-msgs/default.nix
+++ b/distros/iron/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-iron-ur-dashboard-msgs";
-  version = "2.3.11-r2";
+  version = "2.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.11-2.tar.gz";
-    name = "2.3.11-2.tar.gz";
-    sha256 = "7b9013c6222be49c3322c72b23425b25079d4e61e01c2804514e35e5849c9887";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_dashboard_msgs/2.3.12-1.tar.gz";
+    name = "2.3.12-1.tar.gz";
+    sha256 = "b337c76ef0e81c9a89ff655de7e0a259400940e980f400a3be436cdac87a9099";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-moveit-config/default.nix
+++ b/distros/iron/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-moveit-config";
-  version = "2.3.11-r2";
+  version = "2.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.11-2.tar.gz";
-    name = "2.3.11-2.tar.gz";
-    sha256 = "3aa2f0cef3497f2429e50ffecd43ffd063282823fbf981b8cca52f5384c9db50";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_moveit_config/2.3.12-1.tar.gz";
+    name = "2.3.12-1.tar.gz";
+    sha256 = "67b56308f1216b1d239f173c043908c82cef154682cb147a946224ab8af4f620";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/ur-robot-driver/default.nix
+++ b/distros/iron/ur-robot-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-iron-ur-robot-driver";
-  version = "2.3.11-r2";
+  version = "2.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_robot_driver/2.3.11-2.tar.gz";
-    name = "2.3.11-2.tar.gz";
-    sha256 = "4d6a99fdb266bc7aed1ddf1f9b395f444eab53ba419884661a6650c387b5823d";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur_robot_driver/2.3.12-1.tar.gz";
+    name = "2.3.12-1.tar.gz";
+    sha256 = "9b10c8dbcd6b795b36e3ca1c1a5e71a3d5804df2972d8349503989265bb62aed";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ backward-ros controller-manager controller-manager-msgs force-torque-sensor-broadcaster geometry-msgs hardware-interface joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros pluginlib position-controllers rclcpp rclcpp-lifecycle rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 socat std-msgs std-srvs tf2-geometry-msgs ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs urdf velocity-controllers xacro ];
+  propagatedBuildInputs = [ backward-ros controller-manager controller-manager-msgs force-torque-sensor-broadcaster geometry-msgs hardware-interface joint-state-broadcaster joint-state-publisher joint-trajectory-controller launch launch-ros pluginlib pose-broadcaster position-controllers rclcpp rclcpp-lifecycle rclpy robot-state-publisher ros2-controllers-test-nodes rviz2 socat std-msgs std-srvs tf2-geometry-msgs ur-client-library ur-controllers ur-dashboard-msgs ur-description ur-msgs urdf velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {

--- a/distros/iron/ur/default.nix
+++ b/distros/iron/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-iron-ur";
-  version = "2.3.11-r2";
+  version = "2.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.11-2.tar.gz";
-    name = "2.3.11-2.tar.gz";
-    sha256 = "c22751d98c619c91b3a1d7e432891e1c2bbbdfa6ec690824543dccbf0fc68ad2";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/iron/ur/2.3.12-1.tar.gz";
+    name = "2.3.12-1.tar.gz";
+    sha256 = "6880f2b6db0c1a638fb0b5de3d262ba74360e8a64dfd5729535dd86407fa56b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/velocity-controllers/default.nix
+++ b/distros/iron/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-iron-velocity-controllers";
-  version = "3.27.0-r1";
+  version = "3.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.27.0-1.tar.gz";
-    name = "3.27.0-1.tar.gz";
-    sha256 = "438b6b7cd00ffe9146f4744269878a7043f4e4e15c6eb4db3b91b490408ef03c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/iron/velocity_controllers/3.28.0-1.tar.gz";
+    name = "3.28.0-1.tar.gz";
+    sha256 = "80cffc0f7eccb67fb63dfa29778246b6ebcc2986101c71ad23b9234a42ae229c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/zstd-vendor/default.nix
+++ b/distros/iron/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-iron-zstd-vendor";
-  version = "0.22.7-r1";
+  version = "0.22.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/zstd_vendor/0.22.7-1.tar.gz";
-    name = "0.22.7-1.tar.gz";
-    sha256 = "aadc44a08858ce03a0f5c9210d1860fd00a51df8fc6742fdce29d7611a34c31f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/iron/zstd_vendor/0.22.8-1.tar.gz";
+    name = "0.22.8-1.tar.gz";
+    sha256 = "2a615c39d2eba388764b71f1363724678af49caa36e77e2c71cf5aef09e00e75";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "efc680b0538123e22714d4f8cea3e29e2d55e7035b188caf893d2cf731e411ca";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "9ec57e11acbb5c869c3b3fe25dc5f16b111c22abbf407f17e73b2ebf00ab62df";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "b21d7dd54977f33c7646b7a6ded3337d075a2e5be901e099a18b69997f2feb15";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "534e408103b17da28ba414a2dd57457c7f72e87187da7c7cc56a228001c9fc0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "8495cbccc1715880cf24c1937e1b4572f37a8dbf13a5c17713bec0203ee3118d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "86ef76a61ae61f90f9f4d97e38450a73dee3b6300dcd2bdb3424182274eb48e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "00cbdde34c92586d170706dee8be209e2501b93db2caf70ea4b8932a1301a84f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "3a2b7b707f8fdf298b91c17a6fadf0aa38e8bef386701586827a35be6780659d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "3a2731ed03166f230f18576460628d5db385352820dd20b8a43d46ae27b6ca17";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "23b07438d526275e26af67c6d95ec280a6f1cff2517eb3a6d3c7ae63b376fcad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "fc42f6397c2e2c0b474e8f840759b8180ed8fb9866ec956d08b84b5b86c4069c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "abb1bba0b0b0a6baf8adfbe5fb258cdaff6593c1a52b8f9f6dae90abb51726a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/costmap-queue/default.nix
+++ b/distros/jazzy/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-costmap-queue";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/costmap_queue/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "00a1f5f12e8c3482ef6fc9c269cf8976a524cec62e8b5d2d15b2673030e26ed0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/costmap_queue/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "63c7d2c65604de6a1fb054f2e3e20dc2ac4889f4c5933c99858b14a451bec571";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "b29b669c7431edd17baa07842e56a8800b2c4ed70f5797a2aa61f1e89503c5fc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "53aaf5cd23bc2614d2dd7a8cd22204cabcd206f10330963a532f85d7227eb9e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-core/default.nix
+++ b/distros/jazzy/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-core";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_core/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "002785d7b06f0c850aaf2c74f2d99dde32e05008dade9de1daced2261c940689";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_core/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "d3be9df4efae93541018ba58f02a285f8ae96eec233b650cdbaf749a59ce352b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-critics/default.nix
+++ b/distros/jazzy/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-critics";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_critics/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "b594720f7f301e17269b48b4d3382092e999df4864f5d22168e46932849abb93";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_critics/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "352d449d3ee541152b05ffc7d402a617c5f26975ec633d2a3458d82899952920";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-msgs/default.nix
+++ b/distros/jazzy/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-msgs";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "441a72672122a54ad0af7603525446c8e746b3ad77ab0ddff3a20cd394245054";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_msgs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "035ad65115c6eaaf9645e8af33b6aa64e08e711a6ff0b00f66eaf847151fe611";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dwb-plugins/default.nix
+++ b/distros/jazzy/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-dwb-plugins";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_plugins/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "22b59579f669a5793d549e44ebffc0442bb5250525dc35e0a05b6cc1a5b975b4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/dwb_plugins/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "cfc391425258d1f4f8e7ed0baaf888d47a62bce53c8ad619cc0ee06b13f44b34";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "88618a69baac82830695427ff0ce6ea2561e48a775aab819769fa753aa7339fc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "7b019b2171b542e402bab9996b7842075efcb8956f47ee03e1698a8d8aa27e07";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "40dbd1d6bb09e86cb177c607afc1545b5bdec7dab415fac9746b2a563b32f9aa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "d47f28be7d8268bfe67e4810603019fe108fc512a2c667dc938c5998b7a069de";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "43271c16df08c8aabc1d18b403e7a4b14972257fd25f52a14e39f7a1c1149464";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "2fd62deda238699f9f11700d432ac599d445197767852eafc5ccf143c156e094";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1738,6 +1738,8 @@ self: super: {
 
  popf = self.callPackage ./popf {};
 
+ pose-broadcaster = self.callPackage ./pose-broadcaster {};
+
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
  position-controllers = self.callPackage ./position-controllers {};
@@ -2411,6 +2413,8 @@ self: super: {
  sick-scan-xd = self.callPackage ./sick-scan-xd {};
 
  simple-actions = self.callPackage ./simple-actions {};
+
+ simple-grasping = self.callPackage ./simple-grasping {};
 
  simple-launch = self.callPackage ./simple-launch {};
 

--- a/distros/jazzy/grasping-msgs/default.nix
+++ b/distros/jazzy/grasping-msgs/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/grasping_msgs-ros2-gbp/archive/release/jazzy/grasping_msgs/0.5.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/grasping_msgs-release/archive/release/jazzy/grasping_msgs/0.5.0-1.tar.gz";
     name = "0.5.0-1.tar.gz";
-    sha256 = "12e00b53b08b9ccf74726a5e774cab38dac5d805f933d1e4434f3efc5c87741f";
+    sha256 = "f18f1dde2ce45a3e0e60b5d726feb8e5a2a76f97038a99a0f83df18d36b3d342";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "4629fe82d06e2b1ee191d066869cf58a65e822e74c6a3f71d88752773103b935";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "628ab6c7483022176016c2624c910c04673209205d2fa0565f9f9df24712458f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-msgs-vendor/default.nix
+++ b/distros/jazzy/gz-msgs-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, pythonPackages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-jazzy-gz-msgs-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/jazzy/gz_msgs_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "50ca64cbb15614265024cb8868a72addbfaa53d79345076530dbc7ad24b3c482";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/jazzy/gz_msgs_vendor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "f9db0335909fd39e9831fd6424d4da93e1ef1da14874d7dcd23ee467194dedc2";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-msgs10 10.3.0
+    description = "Vendor package for: gz-msgs10 10.3.1
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-physics-vendor/default.nix
+++ b/distros/jazzy/gz-physics-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-physics-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/jazzy/gz_physics_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "9da774df4b3ed2c4f59f0e208d28958500026b453acdd658d564e5a2b94b8e6a";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/jazzy/gz_physics_vendor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "74b7d3a876e5b734c5b832be16a8fc896d6e45f9e9c48526443d2f360f7bed96";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-physics7 7.3.0
+    description = "Vendor package for: gz-physics7 7.4.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-rendering-vendor/default.nix
+++ b/distros/jazzy/gz-rendering-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-rendering-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/jazzy/gz_rendering_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "6efc3919c1dd18644ac0ce5d31233b4abf8eab25d819506c6c49064b2589219f";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/jazzy/gz_rendering_vendor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "42165a71e671a5c9d72c7f87d15ee92f388cd9faac7727510267df4e8a95fa90";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-rendering8 8.2.0
+    description = "Vendor package for: gz-rendering8 8.2.1
 
     Gazebo Rendering: Rendering library for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-sensors-vendor/default.nix
+++ b/distros/jazzy/gz-sensors-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-sensors-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/jazzy/gz_sensors_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "e1c0f8387a5f90a2e719231ddbf0c83e19e2f093cba7fa320c8372f61e277cb7";
+    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/jazzy/gz_sensors_vendor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "8ca5876444cc7a2c7e1c7550d5f90c9a3fa563beb4a055b7b8082318a1c46d94";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-sensors8 8.2.0
+    description = "Vendor package for: gz-sensors8 8.2.1
 
     Gazebo Sensors : Sensor models for simulation";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-sim-vendor/default.nix
+++ b/distros/jazzy/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, pythonPackages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-sim-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "c895a9bc05fc9cbb0039d20d72bb6e45d68b20d507987ae49a30090a64c45c6d";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "afb6de5715946509dad053d9b2c3e1c7a5f14d9a100a1149b232a29f4a2726c8";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-sim8 8.6.0
+    description = "Vendor package for: gz-sim8 8.7.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "507b602467a3d64dec8af7d5cfdf1545c6a6f13b81a4dc4079d075acfdd5adcd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "68a9fd2bd0f688056615d6cef94cc0d74ed956405ab2bdb252de0b946210f1eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "db78b9ce12bf2c8bc1fd16278facdf812b4d9e5b6ea9cf9c5bf023f9e61cc690";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "97c2752f627a4cddf69393f52cd0e46ccd1bc24c46d0eb463d0cd9d778381ed3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs joint-limits lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor urdf ];
+  propagatedBuildInputs = [ control-msgs joint-limits lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils sdformat-urdf tinyxml2-vendor urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "3886729ea46086366440b6f355ce319ae7eb52a25101d2c2a8eadf6685cd47e4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "dc8ea2302d6ed9b8eed0e1387ba2b05f11c57cf2fb148ed8cfe6e578b2e5a4fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "a712cd81e42ac9843d86196cea742c40b361fb7bc385620e9a37d6cbe3e08344";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "4542b2d88d3a2622d6e9d39fdf1ecd10a94c6f9a467373877a37ef68e1fbfb68";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "baeb9d6e20bfdb161ba825bbc5604c806164c675f9164be78d0e66a30b8b235a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "6f71f8de5f77937c2c7c2f3c26f6c358f560e7d27bb84449dbc0baa54693563e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "6b98d4bed3d0dfee9e66906d57d1ba0bc39243c41721a29e7374653958088baa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "6f324a79dca57ce64093aaf22a074c5c1033c8a8a91c2023c80c5a63e22ef988";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kinematics-interface-kdl/default.nix
+++ b/distros/jazzy/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-jazzy-kinematics-interface-kdl";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface_kdl/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "907db8c8ea898085fc71e4f15e2dfdc5cc01723b5b07e220ecb64e5c93592e04";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface_kdl/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "2d4a1a9b2442e047de2cab8c9f940f7f7580797da356870ad108dc72e10cb594";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kinematics-interface/default.nix
+++ b/distros/jazzy/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-kinematics-interface";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6f155d3da13572aad5040e263d4a763df73a7e1517efb03b0b50b06b794bbb92";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "0f72c880965707289380e712067d45c0c21d5517713c0b6d8fb9e3f88697035a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-description/default.nix
+++ b/distros/jazzy/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-leo-description";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_description/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "51e9231d803c5c20806b41e12abcd0f978028ccdce430a549865f302da66a719";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_description/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "258c6da71458ea110973fc1ee1dd643e1663f6aec6cf797da789609f6fd5ebf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-gz-bringup/default.nix
+++ b/distros/jazzy/leo-gz-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, leo-description, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, launch, launch-ros, leo-description, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-leo-gz-bringup";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_bringup/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "2945beeeea0021bec0b210482a2ab31a22801e973572bb9f16937acc45b6a90e";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_bringup/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "121a740b71a07a0303853fa6f7e92050fbb980976e32bcedb492caa0bfca0c11";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-black ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ ament-index-python leo-description leo-gz-plugins leo-gz-worlds robot-state-publisher ros-gz-bridge ros-gz-image ros-gz-sim xacro ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros leo-description leo-gz-plugins leo-gz-worlds robot-state-publisher ros-gz-bridge ros-gz-image ros-gz-sim xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/leo-gz-plugins/default.nix
+++ b/distros/jazzy/leo-gz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gz-plugin-vendor, gz-sim-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-leo-gz-plugins";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_plugins/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "6ffa912907c2653482125eb6c600cb4bfd48aad3dcaa461975e2f853c836bdc1";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "803a5a36e65eb4c4146e20ff1a02c17bb225f4fe81327103d5db85f0b0dfb6b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-gz-worlds/default.nix
+++ b/distros/jazzy/leo-gz-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-jazzy-leo-gz-worlds";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_worlds/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1a264682eec938c1e40a7a9b1adbe341b8baf568a6eb69c6a8d4be81968feb4a";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_worlds/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c8cb302cae63523497f9a4ee0213556a695355105050afec8e22f1f54be5f57a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-msgs/default.nix
+++ b/distros/jazzy/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-leo-msgs";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_msgs/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "92fa81bb9d67b192c8f5f80b5dd104b7fc2e695020a7939a3d0a728131f78e5d";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "b582607982f13ec9088e52977c283e44b25da60a963da97986b57ab39b20d941";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-simulator/default.nix
+++ b/distros/jazzy/leo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, leo-gz-bringup, leo-gz-plugins, leo-gz-worlds }:
 buildRosPackage {
   pname = "ros-jazzy-leo-simulator";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_simulator/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "95c8dbd1ea68d0c3575d13b165d45a62b201bfef22310655a9a9f3ba11436a5b";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_simulator/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "82c0ebcab09e7f310d408f99cb4fa005548ad06d798f6191b441e8d07b030f61";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-teleop/default.nix
+++ b/distros/jazzy/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-jazzy-leo-teleop";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_teleop/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "39ef530c0365c965474c1662179894380a36fc81e35f83dec7fa6c038f204e59";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_teleop/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "4bb641298a6aa0fb83d2215443024fea0dbe4f23d69bc875f1d845899ef6bd69";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo/default.nix
+++ b/distros/jazzy/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-jazzy-leo";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "7eddf01594dbc4d416500089d9d536cd268b0e3fe65a56aa30c216c05e576bf6";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "4c156ae9962c3958c249386da3adb48b527948cfd3adfe6c203a57cb6020f9f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "4ee115548ac02e7c1f5feef6ea537d61489aa79bdf25026fee9f0d5f1876cb7b";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "836a6ec5e22fcf2c77167169fb40d31b58b57470d43fe520f4040a9202e210a6";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/nav-2d-msgs/default.nix
+++ b/distros/jazzy/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav-2d-msgs";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "1ada18aa3b4857cd72adad91b604bf75b623f3c6856eecf6c14a9f4342b566d9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_msgs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "4b4c19988506b6c67edf1abbca37ea913bc2162fdbb835f21b40ec18bf7a823d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav-2d-utils/default.nix
+++ b/distros/jazzy/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav-2d-utils";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_utils/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "dbd8cbf137d8d6551a85f3d5811a7e182d9639fe2d263538089b1434d317bf4a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav_2d_utils/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "b7b62b68192a85a63fcf90faf6fe34ec8c2cc6d9639b6cba924e15953daff95b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-amcl/default.nix
+++ b/distros/jazzy/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, pluginlib, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-amcl";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_amcl/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "868331ea29bf8141e00a30648b7e16d575c0c9bbdbdee96fb609416fa1fc51ac";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_amcl/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "f6a7d78e18d870cc85758d0e4445f763ac527b312ffa6a3ab67c54970f50d6b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-behavior-tree/default.nix
+++ b/distros/jazzy/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-behavior-tree";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behavior_tree/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "158a3ee4a036196d62f286038ad318667705a11ecd33eb5102e0ca9080993988";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behavior_tree/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9fd906465bf6738270ad175411de01130656e816d8012f0fa0d7639253841551";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-behaviors/default.nix
+++ b/distros/jazzy/nav2-behaviors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-behaviors";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behaviors/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "a5ef5496bd4a9fb6365f0f3e50c53cd6269ce7efe0251c27f2b7dd84e09cbcc8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_behaviors/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "20e0f2c3b70b55a1a8d886e98a15d12913935f0e7e515a12abd60aa5c81c969b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-bringup/default.nix
+++ b/distros/jazzy/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, diff-drive-controller, joint-state-broadcaster, launch, launch-ros, launch-testing, nav2-common, nav2-minimal-tb3-sim, nav2-minimal-tb4-sim, navigation2, ros-gz-bridge, ros-gz-sim, slam-toolbox, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-bringup";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bringup/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "fec4f9fb631163f4451a20c63190f4cb9ac1a91920dd5abb2297d936e2037889";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bringup/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "f295677d86cfd1e9461933f9fa4fdfe89153b0a6dd962789d305a2644c24196b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-bt-navigator/default.nix
+++ b/distros/jazzy/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-bt-navigator";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bt_navigator/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "11b46c816787a77940836106c9936da4a899a486bd4714a7237b0297074b5df5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_bt_navigator/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "a72a606a92b8b894ad95659f525e4765bc9a7a28299662c12196869e8f5d2bd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-collision-monitor/default.nix
+++ b/distros/jazzy/nav2-collision-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-costmap-2d, nav2-msgs, nav2-util, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-collision-monitor";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_collision_monitor/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "deb6af7947b235f1c8d38bed46c90dac01f5e5db18ebada31c423a3c3027ae9a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_collision_monitor/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "db356463663ea7bc411ec5e2fb519cd730a9ea2eab8d2c8a610bf3d86b076490";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-common/default.nix
+++ b/distros/jazzy/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-common";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_common/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "f7ccb28bf1f5ddfb4f4fcdb1e5464f673925ee184460ad97f71d79045ad85955";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_common/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "a1d8583376635e42e206ed240f66337b68c196f30887a97283b4918ddccb1641";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-constrained-smoother/default.nix
+++ b/distros/jazzy/nav2-constrained-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, ceres-solver, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-constrained-smoother";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_constrained_smoother/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "cfaabb560dad7c13583825d2f1a1bfe067c84492a5eb2f885ff3ce4e0f55c516";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_constrained_smoother/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "f29df40e7111dca46ab5adc23a0a32b03987c4a88534828a4dd702e1f971c0dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-controller/default.nix
+++ b/distros/jazzy/nav2-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-controller";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_controller/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "c78700b8c7e64b3a0c8704e2140ccea710fdef881ec4cb003c1e920b460260bc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_controller/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "4cad315735f66259807250ce3c1e4d0240e7f3feff98e1ca27e8ba85f0adc1e4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake nav2-common ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ angles nav-2d-msgs nav-2d-utils nav2-core nav2-msgs nav2-util pluginlib rclcpp rclcpp-action std-msgs ];
+  propagatedBuildInputs = [ angles nav-2d-msgs nav-2d-utils nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp rclcpp-action std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/nav2-core/default.nix
+++ b/distros/jazzy/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-behavior-tree, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-core";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_core/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "76a84f39c081a9be2f63df28a79124c2ece56f4fa055c6470a6e1852ac997cbb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_core/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "12221b0cdb0949f65a43e9465cd073e15b1b57380ef0a03e51ea95e51292a942";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-costmap-2d/default.nix
+++ b/distros/jazzy/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-costmap-2d";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_costmap_2d/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "3c01b04969f0a7e2061f5d56b741e2c3f57dbed0e686241b50795d05a2c6467b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_costmap_2d/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "84661beb9ecff66b0280fe3799820f4fecc747df3891c6613803ab22606ada7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-dwb-controller/default.nix
+++ b/distros/jazzy/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-dwb-controller";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_dwb_controller/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "4e76e2ae87d4f8cb401c67c75ba8c94530dd825d57c0eb1afa684dd22b4c6b01";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_dwb_controller/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "454db00dae8c85aada89e1e029329770c3bf562a1a7b77ab58af7631753a25e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-graceful-controller/default.nix
+++ b/distros/jazzy/nav2-graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav-2d-utils, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-graceful-controller";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_graceful_controller/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "3477dea4378c477c35240b0b5f5fcbfaf855fb526b5017d82607a39dffd74b7e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_graceful_controller/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "0a61274f04acd967b3ebb22e4879223666cd3f21f634d16a62de11486cb46311";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-lifecycle-manager/default.nix
+++ b/distros/jazzy/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, diagnostic-updater, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-lifecycle-manager";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_lifecycle_manager/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "d601911b9335f2b8782ef699988583d834448b63e940d767bcbe8cced3bb6bf3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_lifecycle_manager/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "915476fdf24d904dffee3764133c595d2b2be293dc959dfd5da0c7c50cabcde0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-loopback-sim/default.nix
+++ b/distros/jazzy/nav2-loopback-sim/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, nav-msgs, python3Packages, pythonPackages, rclpy, tf-transformations, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, nav-msgs, pythonPackages, rclpy, tf-transformations, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-loopback-sim";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_loopback_sim/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "51dda58fb52f3dfbc28cc03093fe885dd25918aa00784893cbd8ee4be10601bb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_loopback_sim/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "0a675cf288945161582137fc6f4fbc1325bd8ed71ba2128142fc97055fdf2337";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs nav-msgs python3Packages.transforms3d rclpy tf-transformations tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy tf-transformations tf2-ros ];
 
   meta = {
     description = "A loopback simulator to replace physics simulation";

--- a/distros/jazzy/nav2-map-server/default.nix
+++ b/distros/jazzy/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-map-server";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_map_server/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "939bcb25e5c54b3355a34e2c20456dc6d6c52b1a431a50b9ea0146c2635144f1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_map_server/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "b2559bc4dc0f5f37b54fadc9438951081a2e6f139aacccc153fe38d713bd4ae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-mppi-controller/default.nix
+++ b/distros/jazzy/nav2-mppi-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, gbenchmark, geometry-msgs, llvmPackages, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs, xsimd, xtensor }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-mppi-controller";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_mppi_controller/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "5f1a714dff363c6f04e6ced9b582aae546f5ff1a58155771a92cb484d23c6f29";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_mppi_controller/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "db5249c4a9b0855eff203c89d88b75187348edaf5563373187147947dda56b35";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-msgs/default.nix
+++ b/distros/jazzy/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-msgs";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_msgs/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "1ea8f536827c0a5bd7043b92ecf647f2ed6a827ddc3a9dce231ef67452897b9b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_msgs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "324934feb4764edd89c36a2e305b2e9ff92fd11df6ac0f47e41f752f87195fc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-navfn-planner/default.nix
+++ b/distros/jazzy/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-navfn-planner";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_navfn_planner/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "340bfd78e4277c332c4169f44716afc15b48d9d7f11cd475bfe12b29924de5ea";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_navfn_planner/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "c6d72e3634d4d428f37a21208d5be02c28f4e246146315c734a12b9ddd12c9a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-planner/default.nix
+++ b/distros/jazzy/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-planner";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_planner/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "7e7b7749dc0127c5c7e181544ed9352faabf2ec3177c7b383447aa65b7b56cae";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_planner/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "625156ac9cee3725d5fcb3a207054186129a7d0c46086a07aaabd5eadb8c6fef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/jazzy/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-regulated-pure-pursuit-controller";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "e8a55f7194b6ce188540c9087a4930172446d4c86ea6f6124a9399c2a77557b6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_regulated_pure_pursuit_controller/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "69ef6de70d61575fb683931754b787c23301412ae9fe2632127c061755a51738";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-rotation-shim-controller/default.nix
+++ b/distros/jazzy/nav2-rotation-shim-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, nav2-common, nav2-controller, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-regulated-pure-pursuit-controller, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-rotation-shim-controller";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rotation_shim_controller/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "ccdf44d2baf5d5e2c9cb8b53f49df28f1964219db6dace6e9c6d88af563488ba";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rotation_shim_controller/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "8e407f16dd1d37035c2e0e09746dc9a0a9cf40af881931461a06d18658f9e550";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-rviz-plugins/default.nix
+++ b/distros/jazzy/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, urdf, visualization-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-rviz-plugins";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rviz_plugins/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "644604cb88530c9305ab4425197cebf8207c9416dda05ce1058dd77e6b1d2b83";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_rviz_plugins/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "2cb7e37a103e3b170de13ac3aff12584f9b2a47275647aa0f93695fb3782f00b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-simple-commander/default.nix
+++ b/distros/jazzy/nav2-simple-commander/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-simple-commander";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_simple_commander/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "e36c3f2df245ec5d0ce0e2dd20115aaa7e76cd7ecd4c7d4d7711ca4a7779f8b6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_simple_commander/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "71c6b78fa4e28e94fa0b633ff11bb228e1b13f85bf2ceddb1da30171c322da27";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/nav2-smac-planner/default.nix
+++ b/distros/jazzy/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, nlohmann_json, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-smac-planner";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smac_planner/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "0493670022dfa787d7ae0aadf71fbc2c4e6779a54411c94ffbd68f20ec9f913a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smac_planner/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "5880dda08f192b997c0fa39f1869021dcda0f720026c8c3e5ab0038e442fa625";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-smoother/default.nix
+++ b/distros/jazzy/nav2-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-smoother";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smoother/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "e4e67b8b05e6a8bfdac97e8d793b053dae8caa7de4d4d7dd54e89c3f39856fbf";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_smoother/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9fa6e970aede6cd7b17cd50fe9d1675d4b5e5cc4febb7a25df9d92e009bce4f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-system-tests/default.nix
+++ b/distros/jazzy/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-minimal-tb3-sim, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-system-tests";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_system_tests/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "8f2652139eba96760391fbfd3e80dabb730f5a067474beab9a3b702df40bb8bf";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_system_tests/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9fa024c7431c8d4ff80db3fca5b81bba465abd5af230fc4c5134692809675f78";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-theta-star-planner/default.nix
+++ b/distros/jazzy/nav2-theta-star-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-theta-star-planner";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_theta_star_planner/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "9f6d38b2692910016237ce489563d732123a3d5b93d681eb043462caf1c7d196";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_theta_star_planner/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "1932e11bd98a69a1009c0bd2f0a3b2c35ecb9da2e91db52c5b230739164cef9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-util/default.nix
+++ b/distros/jazzy/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-util";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_util/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "3b366b9257051afe22f3b49d5ddeb360d847c5be66f9e4811033b9dcafb1da31";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_util/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "1ca811fb42dc0846d8f7e644640fe0cef12be62125ac2f709e0d7665f53fe0df";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-velocity-smoother/default.nix
+++ b/distros/jazzy/nav2-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-util, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-velocity-smoother";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_velocity_smoother/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "105e9404512dafdfdf935eb9d50d8920cd0f90341996a8e8a94a4e2365be6b17";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_velocity_smoother/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "f76fe05858470869df9327a86a254674d38a519d6ced69767ebc2a2e70476b32";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-voxel-grid/default.nix
+++ b/distros/jazzy/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-voxel-grid";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_voxel_grid/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "02dfc526c9e4cf8e6ebd0292ec0069abb6efa0a46d87052c858350d89795fd94";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_voxel_grid/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "bb7b0b21055a1aae7ab971e15dcc85326bc00e4d3b0bcf5be74c6e5d023cf15f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/nav2-waypoint-follower/default.nix
+++ b/distros/jazzy/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, geographic-msgs, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, robot-localization, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-nav2-waypoint-follower";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_waypoint_follower/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "cccf6300574332f0d061078de0da6ae2c5f9b49c12f14ac4f97d64e47484dbc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/nav2_waypoint_follower/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9a349ebaad3a055a2c9e3da4dfe3c9bd0cd502d75acd454de1e8bd0ff43b40b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/navigation2/default.nix
+++ b/distros/jazzy/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-behaviors, nav2-bt-navigator, nav2-collision-monitor, nav2-constrained-smoother, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-graceful-controller, nav2-lifecycle-manager, nav2-map-server, nav2-mppi-controller, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-regulated-pure-pursuit-controller, nav2-rotation-shim-controller, nav2-rviz-plugins, nav2-simple-commander, nav2-smac-planner, nav2-smoother, nav2-theta-star-planner, nav2-util, nav2-velocity-smoother, nav2-voxel-grid, nav2-waypoint-follower, opennav-docking, opennav-docking-bt, opennav-docking-core }:
 buildRosPackage {
   pname = "ros-jazzy-navigation2";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/navigation2/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "b3c7b7aeb3c5dd6d6e5c44e9c28e60e1e379ed058829ceb15fa18e440d7b776e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/navigation2/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "58a8ca014f804c57bb52df90ade8e599c256ef1ebbd7253300f582e39295d938";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-gps-driver/default.nix
+++ b/distros/jazzy/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-gps-driver";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/jazzy/novatel_gps_driver/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "ef0e60de51e07b8de36deadb1b9f829e42a31fed13e87e416d4bea7460819b5f";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/jazzy/novatel_gps_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "8518774d07a02483385d35e82689e70ca6da9e24ec192181ffe40bbe61652c50";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-gps-msgs/default.nix
+++ b/distros/jazzy/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-gps-msgs";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/jazzy/novatel_gps_msgs/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "a57084fe89fb6adebe6467a8bdddee5737263bdf40dbb1b6d03f558374301dbf";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/jazzy/novatel_gps_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "85634c51ad935ccb16b5760b7307e0653101262aec6c79c24cdd349898f83094";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/octomap-msgs/default.nix
+++ b/distros/jazzy/octomap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-octomap-msgs";
-  version = "2.0.0-r5";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/jazzy/octomap_msgs/2.0.0-5.tar.gz";
-    name = "2.0.0-5.tar.gz";
-    sha256 = "009eb7d31798b05f1ead69930d87d960ebf71cd417a0660ac16126c3f8417c68";
+    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/jazzy/octomap_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "d89216f512cf3261fef4b526c3dbc5fa01f835f461b024c1b633c2a84554c74d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/opennav-docking-bt/default.nix
+++ b/distros/jazzy/opennav-docking-bt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-jazzy-opennav-docking-bt";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_bt/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "21a616a6eeb0e7fedc1f5a25705adefc3c10c49d2d0a71cf750de9d9c93f18f3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_bt/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "740e1dadadb76386aeaa6e9be37ad729fd083dffad304ee889369331e6036667";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/opennav-docking-core/default.nix
+++ b/distros/jazzy/opennav-docking-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-opennav-docking-core";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_core/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "aea17ed183f739fd71cfa60ac900b358b9095c7065296aefaba911b4cf7f5617";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking_core/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9f2398006420853a7b6b85b107fdf2d0d67db0b73798bf095e34ef01e8ffad1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/opennav-docking/default.nix
+++ b/distros/jazzy/opennav-docking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, builtin-interfaces, geometry-msgs, nav-msgs, nav2-graceful-controller, nav2-msgs, nav2-util, opennav-docking-core, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-opennav-docking";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "4f05116c673a6248d2e1548135e764d97064ded960f3b006a0622cc24c332784";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/jazzy/opennav_docking/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "5c8696b63c469db395bcda4b88f3fa3a68b8e60e07f9e3775ad0808f5b2022a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "726fe1cbe3c2a58308236680e73da2e440175176c26502ee98222b3e4d4a1ca9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "53fe176cca8fe973814fd139ecc83d8047e891eb7b5e5e7967c7e078d6e87f4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pcl-conversions/default.nix
+++ b/distros/jazzy/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pcl-conversions";
-  version = "2.6.1-r4";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/jazzy/pcl_conversions/2.6.1-4.tar.gz";
-    name = "2.6.1-4.tar.gz";
-    sha256 = "d7e9253defb52e0329a6bf49fe2eeaafa7a3c8b9acffb44c650b323d386ee0da";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/jazzy/pcl_conversions/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "9f817bd5164051fedcca6b9912d14c93b25cf2e6702bcf16490df783b12ae7e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pcl-ros/default.nix
+++ b/distros/jazzy/pcl-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-pcl-ros";
-  version = "2.6.1-r4";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/jazzy/pcl_ros/2.6.1-4.tar.gz";
-    name = "2.6.1-4.tar.gz";
-    sha256 = "f2bd9c8a9eaa4e2545321e8b2e9483d3bebac0e016ea4602a7a5e45a69c4f4b2";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/jazzy/pcl_ros/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "5c2ab20bd996143ab6341383cb43fa0201e4d18ddd07850431bf65addb5a7f3c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ros sensor-msgs ];
-  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/perception-pcl/default.nix
+++ b/distros/jazzy/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-jazzy-perception-pcl";
-  version = "2.6.1-r4";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/jazzy/perception_pcl/2.6.1-4.tar.gz";
-    name = "2.6.1-4.tar.gz";
-    sha256 = "8b2f129794819ef1cbf184741c6eb6f9d26e3b364bfc85c442a37ee0b64c60ff";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/jazzy/perception_pcl/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "3399dffaf8dc1676702ad743ed85e00a4c7c199a8857bed6d9da6129adbc6b58";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "f8b22d638d61167bb2ffa599aa95b27dc3e5b089fff1749f31e5461b15f0b9cf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "4131af66ab3e8d5deb8a14041885a7e07a2903fb1d640e1d9f51b83d00e98655";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-pose-broadcaster";
+  version = "4.16.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "713229dfe41cddfad7256ed3f096e4a26f2a79e02c1bc6b645e5d8f73108e7bf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Broadcaster to publish cartesian states.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "27751efcc04f26058b2cc8a51b59958ea9fcedb38a8c3ac94e1981640b881bed";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "6d90a0381c674d3d60e229631a59900a2bc6640c09c46e2aacb66b9eb017572b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "df44e403a29d47768f50f51217821c26f28c06ed0f8273e2fd0be10a8fc0329d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "9c2f59cf9010b122924fb647048ae8887dfef7f122f538efb35e5c6279f409b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/robot-calibration-msgs/default.nix
+++ b/distros/jazzy/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-robot-calibration-msgs";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/jazzy/robot_calibration_msgs/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "26c9e2c7efcac7f47e9eade7959e86ba561865651cc3a24704e4c69c2995468f";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/jazzy/robot_calibration_msgs/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "0e39ed194f1dcc4a3253ac0c87bd4ca8d339987b388c96bb564e79b0c4978171";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/robot-calibration/default.nix
+++ b/distros/jazzy/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-robot-calibration";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/jazzy/robot_calibration/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "da6c0adb4b2456b96f76bc671d9eee46f54c8727dc816bcf1666ca5636ae236a";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/jazzy/robot_calibration/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "af67b1c65fefb524590622275bd1e11c1446c631b50886f48a7f47e97067b765";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-bridge/default.nix
+++ b/distros/jazzy/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-bridge";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_bridge/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "f2926f4aa270feab9c6c2d52dd82189bb83f0640ee047bbd29e104b03700594b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_bridge/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "abf5179557b281e545394819edec86a84026c8ceb2fb8af9898422b54bd1f986";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-image/default.nix
+++ b/distros/jazzy/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-image";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_image/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "39003f4c1d8e31f476386acdd798062620741484c95ef211f86b3a73d044e315";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_image/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "9ac865ec29df24728b53e7de6491dd609be57fee3447041f205975d0a2b3a14d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-interfaces/default.nix
+++ b/distros/jazzy/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-interfaces";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_interfaces/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "0ae7eca840cdd355f6fcc04005b845e9f2206d05e4a94669d36e1dc76eae3ff5";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_interfaces/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "5aff9a2f95ce564ac5897532d8ede85f40c00f735c8bfd526e88f73568e750c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-sim-demos/default.nix
+++ b/distros/jazzy/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-sim-demos";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim_demos/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "02025cf987f358c0c1f414887404fda0c460dd04b96271d4a2bbd4f95283d652";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim_demos/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "e1419192760af9afead5006317cc2b63338f4f098f5a334917c41adbdd126fc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-sim/default.nix
+++ b/distros/jazzy/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-sim";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "23bc4725f74d8f28aba6bb301601083691a8e812bd7d4e8274f29bc6b2bf1e5d";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "60378b0900b880b145ddabdf8d7eef27ba7068b0d7951ae50e76c09baa3bb127";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz/default.nix
+++ b/distros/jazzy/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "fbaf7cf10f6b4741101293b45257c79103fd13cf0d9c5408d52206dac548aa0b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "ef7b6b4289fb47fdd8059a978e7d914052167450316526432b753aed8409fd4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "85e196e106fb06f67aa118697d886d973f58d3368493c4d2791c1f687953d7b7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "a7db862c418b0e7d45b38beca50e45e12c03c6666615ceaddbd26ec5ad83ff85";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "0d2467d4fec07848fb824685115e5e4458a362504e82c3a6341780658fd466cf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "c04969e3b06798239dc916b6b568a0a019ff241c58419a40b540d2b0d23560e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "96a43055a9a574924ba37596173baabacfb5780287bff569b1b2905bdb374a61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "ab73db5a89909a0fb4b60972abead9088ab2ed163f13c5bd86477eff6439f326";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "9f00fcb38ff4012f6ba4a963055cfdb94d66788c547669d63025bea4b6a77dea";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "047be82641ee11b441cc442d18b50183d100b39bd29004eaeb7dabfa0320c51d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "2ff835a513e0c2b7cf19642a88490c6632fa911e20a2ea2899837b2aa5091af5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "85b30b4e09158d12b5c99b2af2cebe3d9c4ccbc195834905a13f608598192403";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "ddbc927c0e86842c773cce3bb434a5eda70043414910df3c14280415a9807dd1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "01a4135b88c2d805b9fcc5998d1af9b8c19ae4a9aef8ead78a0f4f89549caef6";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "e36d5f778484675c65980f1f27aeb60a782fb02a9008a398bd62a41318f82a71";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "670181fdb2fe5dc9e04ac7c30a87745d655d199c576762ce7615b25a6585cbc8";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-control/default.nix
+++ b/distros/jazzy/scenario-execution-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, scenario-execution, scenario-execution-interfaces, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-control";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_control/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "eadccee4a5f3343f19e9e70c2d7c008682b52260015692573f875a1aecf6da3c";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_control/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "b884b5e242d25edeb7eb8fafc01044a3a9a20c2226f1eea5712dd820387a7ac5";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-gazebo/default.nix
+++ b/distros/jazzy/scenario-execution-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, py-trees, python3Packages, pythonPackages, rclpy, scenario-execution-ros }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-gazebo";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_gazebo/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "72670031cb3f9f5a4fdeb3f1d1f43685a0e70803a074e66e8d5e63e3aaa4a473";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_gazebo/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "5624e3ed7396a9415d4dfec5d4ab70306e0814a73b57f3ecf2e490d976bfe8ed";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-interfaces/default.nix
+++ b/distros/jazzy/scenario-execution-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-interfaces";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_interfaces/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "0d385cc7bc87e26ab87d8c09fd402accbf17f5ab395545276bcdeb9ebdc47e3a";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_interfaces/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "73fe0e3d46833eb0c07a76721ed4deb6be5623d60611edd26b83178be76df7c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/scenario-execution-nav2/default.nix
+++ b/distros/jazzy/scenario-execution-nav2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, lifecycle-msgs, nav2-msgs, nav2-simple-commander, pythonPackages, rclpy, scenario-execution-ros, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-nav2";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_nav2/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "56ded924aa33e75e744a96420d3235ba73b40c62cb02aeacace2cbc574ecaa78";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_nav2/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "423989016aff4706d74644fa58dea41dd77387e011cce621bc1cafca82b3757a";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-os/default.nix
+++ b/distros/jazzy/scenario-execution-os/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, scenario-execution }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-os";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_os/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "9f371fd2ba1283578e3eb5280cc12bccf903ae32bb23a969db4c74c98672eebf";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_os/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "6bfb2d71b57d1f6d9b2fbc9660a3bb0bb8b895a597b2151499bef5e1f92e5305";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-py-trees-ros/default.nix
+++ b/distros/jazzy/scenario-execution-py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, py-trees-ros }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-py-trees-ros";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_py_trees_ros/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "9716904cedab67d9839c589f409171df0686a64edd8f0619e4e94b0eb628fd70";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_py_trees_ros/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "d9ed8b8dfc8363657afd09173339e4edb06ea3b8e70a47732d39522b64b1a8ff";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-ros/default.nix
+++ b/distros/jazzy/scenario-execution-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, py-trees, py-trees-ros, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, scenario-execution, scenario-execution-py-trees-ros, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-ros";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_ros/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "6c0c78d73c714e276123cfe18b33858ae577a9112991a2c5a7adde8c925a74d6";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_ros/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "4f136a45109ede555762270b7a2b042299c8955737a540fa54845c211bfd9101";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/scenario-execution-rviz/default.nix
+++ b/distros/jazzy/scenario-execution-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, py-trees-ros-interfaces, qt5, rclcpp, rviz-common, scenario-execution-interfaces, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-rviz";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_rviz/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "b927394ecde1454527e0538df5c73d89e9280a3e83ffb18088a4044a49f37ee4";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_rviz/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "f94027bb426470673cb413bd4de3ca715fc99451d7d9a94a4735eedbc8190667";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/scenario-execution-x11/default.nix
+++ b/distros/jazzy/scenario-execution-x11/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ffmpeg, scenario-execution }:
 buildRosPackage {
   pname = "ros-jazzy-scenario-execution-x11";
-  version = "1.2.0-r4";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_x11/1.2.0-4.tar.gz";
-    name = "1.2.0-4.tar.gz";
-    sha256 = "f62742cfd19866f8cedd6220480792f41dc772faf48c772b90e02eb48100085d";
+    url = "https://github.com/ros2-gbp/scenario_execution-release/archive/release/jazzy/scenario_execution_x11/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "40c5b05e7104a9c96dd7418ba95f3880b6c59887b7bda816559d9654ef19797d";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/simple-grasping/default.nix
+++ b/distros/jazzy/simple-grasping/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, eigen, geometry-msgs, grasping-msgs, moveit-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, shape-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-jazzy-simple-grasping";
+  version = "0.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/simple_grasping-release/archive/release/jazzy/simple_grasping/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "0a3520f21a96429cda3ac785681c9b37ba2d29561d7b1f006518cea7712735e8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen pcl ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-gtest ];
+  propagatedBuildInputs = [ geometry-msgs grasping-msgs moveit-msgs pcl-conversions pcl-ros rclcpp rclcpp-action rclcpp-components sensor-msgs shape-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic grasping applications and demos.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "7434cbd7fa5625f3f47ef09a3301ff416b378051941e1485a02a3177fe8b559a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "ad7de0055d1aa2106d90ee7e52eaec859a9d24cf6f8675523b456986909da015";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/test-ros-gz-bridge/default.nix
+++ b/distros/jazzy/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-jazzy-test-ros-gz-bridge";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/test_ros_gz_bridge/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "08388f37235b15dc89829e2152da1db56959b27d685f6ba1231b3261358eb526";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/test_ros_gz_bridge/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "2377c204548225f9cad59225c1c87309141c5b006d98973d4d16d083e3bedb7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "1e116eb4f8e8a20085fa614088bb2ff39e2746bb36daf193134818678b448dd6";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "c538b17f7f4b6d06ee2bc7b6ffbd17fdbd66d2ec44757845eab41397bea5674e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "e9f36159dbb87fffe5c9a96b6cb13cd36754bf21615b15deba65daa156acf776";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "710b85fe042fbafd0b7913ca74269f764077a3062017181cad930b88eda9bb43";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "85163e4d4c77b5790ba7ed083d173238be99f4c2fb1f172e115a3d59cf63dcd7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "e88add9336a140f4e0c9f9a55960ebf3b89f704b1ea144dbb4f727fef892ceee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "ac6833c63e443734c28baed5192f2ee887aac67c66e42b13ad4beacd163c6629";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "ad2a7ff6b12b3fa5e238e0ffb15feb2d2865f2da74f967af65d45ace1503bd16";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/adi-tmcl/default.nix
+++ b/distros/noetic/adi-tmcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-adi-tmcl";
-  version = "4.0.1-r3";
+  version = "4.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/noetic/adi_tmcl/4.0.1-3.tar.gz";
-    name = "4.0.1-3.tar.gz";
-    sha256 = "ab58d8776f6a84e90ad1e81b9f5fe4cdf26ef662437b4ca1f3a20bec61b83ebc";
+    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/noetic/adi_tmcl/4.0.2-2.tar.gz";
+    name = "4.0.2-2.tar.gz";
+    sha256 = "a1126bafc42a229094d0f21b1b91d0c8a80bcf6edf726a8a36272ccdad2e912b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.11-r2";
+  version = "1.0.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.11-2.tar.gz";
-    name = "1.0.11-2.tar.gz";
-    sha256 = "dfb965ad920f6016832c764214a6e0af67a8d7552ae06d81be4f20b51fffcdd6";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.13-1.tar.gz";
+    name = "1.0.13-1.tar.gz";
+    sha256 = "86527b40f4c845eb42c3c7d6279512cdb3d431ed6174b8753a2541c39f0e643f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "068e841d65f1a28e76b99a24f2067fb8884202763ced83ac880abbe33d8f76e7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "8389779a1068ae3754d4dc0f17544527c639e06e5ed40d489160d2cff72c3ded";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "6231c4fb784d0ce30ca57c4597a2bba83bf777d748683c457702b6dca2cbce74";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "a2c0b76655d50783916c363100103ee4c110c9ccc056ab301b8445a33b939f65";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "ed976b1c5e30d80a8b130a93d12af43fa578e7eb84c65a4fb59a3d938bebe451";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "1cf87e975454cdc8249629e6c6f9cffab8d46904dba481b2b79894e55b72e821";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mp2p-icp/default.nix
+++ b/distros/noetic/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-noetic-mp2p-icp";
-  version = "1.6.2-r2";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.6.2-2.tar.gz";
-    name = "1.6.2-2.tar.gz";
-    sha256 = "866f1505827e455b57735100ac437f94b427f257594d4791dd22cfec350fe69b";
+    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "31cc33ddd8e483230c1445266d5192446ac6e2aceda103a8dea53a27b336d766";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "6a9b0f6dc50fe8ce20ae5c678400fda2d0678823c787f6ff46f0d1add40c4084";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "e3e34168b467448d245fe27948a61b004c04e8b358e9d7dca3b974093c060618";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "f7a97e479f71c5fc22063419a81cd9c76a324d807bc493703b1350f808b092c2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "cf74c6547c8e5c75bc14a3aeb8fdbc70b13a101e78124c76b1c002ad6bdcd63b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "30d663234862c8c0830bc31a27b02a6e6d45aff4cf0c7e5f709cb85e8cb8c1dd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "06c28d5e532c6d2f74509d6bbde7e4cc0a535d5072ef0dd06a6e9483eb71fec9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "c3527344b2b2c39655ca45f7dbe9b59f3290823a96dcdbbfe1c6bbccfa7f9fcb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "1c26fc982fe7e4fabfa9239723fb6f19c63c26e86174ae0eaca59122837499d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "d33892a848349dcafe07281bfe85dd81eb0ff5849c0ea41239a6185edf8ac803";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "eaeddeeb160c5c5c4dd2d5fe55b8f9c1876faa2a23b123850323459128969800";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "5beb3db53df3c47ebbe3d93ce2aab228d2cc34a0e73408ed403aec600b3bb68e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "c25a1a9e50a5ec63b0c31a141f7710e820b8006043aa0667b4ffe13e8188dfa8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "ec60ba623584e21144250a95e3f5f501c71ddc677c25728a9fcfea13822ee213";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "b5ccc2ba22a2ba1b7ada2c95694449d538db453a05a9d956ffbb4df162af4d3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.17.1-r1";
+  version = "0.17.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.1-1.tar.gz";
-    name = "0.17.1-1.tar.gz";
-    sha256 = "3179babaa006b39dd11f8e2f519c5f070d04f5e247ef5f6ab9ebe80650b2bf08";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.2-1.tar.gz";
+    name = "0.17.2-1.tar.gz";
+    sha256 = "ecdd99a855911cede94e133f5d10a15d5039409e76b915703b71cf985778fbad";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "10194e9c226c07f7be15f2dd42fb00d77b8df74d3de91b8761bdf81db83e62f6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "0e2e94ac9a300a4bf1d10c774791594158e78d152b7c583b1f996ab2b19b3438";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "cb76d6b271ecc630e632ee94b999f725dbdac1a985b0fbbe031b8b6ed9bc9402";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "225a710bc7c039b16f5c97b81f2b519833f49590291112cf13dc692a50b61ea1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "810ac570c31715b4df42c6a7ba67881f0b16409faf863b02e938f18fe5f6f2cb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "f019e91f84b7efb548d24a43e9c684062188c305892a821a3ea247089a88a6c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "dcb5f523eda3e6b4ad1a62888db2310f36ccf6f65c748fe4e32f0e27dcc94902";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "f9895d864d8caf4483b1cfac2dd721bb3c6b21a2523f52a78434478e69fef4fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "1205c61249228efcb1b5090897a5f4239a0879bc635da700937841fac9054355";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "d7ba7fd2421a1a0d8f6c33fc49b1856e699b55f1b3438e1dc69e701c97f46cab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "dd051fb610e5bfc2ced73c2c085c040c13cdc2a2a3d060bd10af5ad25a6c629c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "4edd64ac627fa3ea354ef5ac879f014f2b4a2818409e92dae310653bd42d190d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "586bcdf54fa488a3923e470c1fc478784eb548e7ed7017727a142e2f47709e0e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "15b75406a735e53543a55d48e198f3455e86607b43d1968f6cfbfa994be090b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "f70593595b090ef027ddb88cfca7a696cb7572e1dc7cbf20c6ed14761b01195f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "32a28cc8ce24ed9f491d52aa6c5c09caa19feb1556d2fc60a72f604d0da17d64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "51e9b33ce9b7646fa37823e51c59b5f2ef6070ae8a353a62a835ce0fe1400f44";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "56c32cc893b1d38995704d251a59466ec32c0303971efebbc91c35e9c0cd1741";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "4badbfee74dfab47c6a743709b6b955d60344c4420a4911dff0c1df63caed7a0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "4dc74f533ce6ce21a70020121c9bdca3a74a5a949f8910a92e67b8a7f09d2d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -696,6 +696,8 @@ self: super: {
 
  graph-msgs = self.callPackage ./graph-msgs {};
 
+ grasping-msgs = self.callPackage ./grasping-msgs {};
+
  grbl-msgs = self.callPackage ./grbl-msgs {};
 
  grbl-ros = self.callPackage ./grbl-ros {};
@@ -1470,6 +1472,8 @@ self: super: {
 
  polygon-utils = self.callPackage ./polygon-utils {};
 
+ pose-broadcaster = self.callPackage ./pose-broadcaster {};
+
  pose-cov-ops = self.callPackage ./pose-cov-ops {};
 
  position-controllers = self.callPackage ./position-controllers {};
@@ -1527,6 +1531,10 @@ self: super: {
  random-numbers = self.callPackage ./random-numbers {};
 
  range-sensor-broadcaster = self.callPackage ./range-sensor-broadcaster {};
+
+ raspimouse = self.callPackage ./raspimouse {};
+
+ raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -1657,6 +1665,8 @@ self: super: {
  rmf-lift-msgs = self.callPackage ./rmf-lift-msgs {};
 
  rmf-obstacle-msgs = self.callPackage ./rmf-obstacle-msgs {};
+
+ rmf-reservation-msgs = self.callPackage ./rmf-reservation-msgs {};
 
  rmf-robot-sim-common = self.callPackage ./rmf-robot-sim-common {};
 
@@ -2022,6 +2032,8 @@ self: super: {
 
  rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
 
+ rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
+
  rtabmap = self.callPackage ./rtabmap {};
 
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
@@ -2094,9 +2106,13 @@ self: super: {
 
  sick-safevisionary-tests = self.callPackage ./sick-safevisionary-tests {};
 
+ simple-grasping = self.callPackage ./simple-grasping {};
+
  simple-launch = self.callPackage ./simple-launch {};
 
  simulation = self.callPackage ./simulation {};
+
+ slg-msgs = self.callPackage ./slg-msgs {};
 
  slider-publisher = self.callPackage ./slider-publisher {};
 

--- a/distros/rolling/grasping-msgs/default.nix
+++ b/distros/rolling/grasping-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, moveit-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-grasping-msgs";
+  version = "0.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/grasping_msgs-release/archive/release/rolling/grasping_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "9936b2a49d812937cc1ad6aacde27dd4d722e93b274ec3f978765696e5d77b11";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ geometry-msgs moveit-msgs rosidl-default-runtime sensor-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Messages for describing objects and how to grasp them.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "a43fd6d82b96b76fe4c2b718ff1647207c95ea6ff61d096b1515a878160d55d8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "0aa1b5390625d505fb6322d60ef5fe05335bb18663376878c3600216a4cd840e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "9d90d2676fb2671f10d4a7225231531cd59a76188a679b90b338463c679c17ef";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "9b548ccd4309b2bbe9f54cb87d739f0ae68b5c555759475fd32057578b88042a";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-cmake4 4.0.0
+    description = "Vendor package for: gz-cmake4 4.1.0
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9edae8091f09e55c2a4e80437a32675964efeeb63a69c6182f1a36d2b67d9925";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "0182f62d70ffc7337243e5defeaa8e6f420cda816fdd353e9c2bd5f6247737c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "56689b97d656c2dcfda891e42e0bd5838c3c8eea7cde896fefe3ffcef3091b46";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "05a0f1188d23d484bcde67af3efd7231addf61bf1257e9ae7bc6d1af7ce994d4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs joint-limits lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor urdf ];
+  propagatedBuildInputs = [ control-msgs joint-limits lifecycle-msgs pluginlib rclcpp-lifecycle rcpputils rcutils sdformat-urdf tinyxml2-vendor urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "f4958c4cabc39c2e48680660eb7f1fab8f9976a1e5384df1687aa0c9a9f6b52a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "6da721170b9f4737ab22291b6cb22a6dab4cde69ca131634c4511e980d86a96e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "1bcf050d0b30ca9348a22b3654eb18cef7224d085c5f05aad8bdcea8bce629e9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "fb6e3cc841490554d34f6c11ac1afec8147124fa82e6cf8192ca16de4590b0a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "991b5a33f9e3dc21bc3832ada552ecb2df8c2482f1f2600e395dd5986dc97afd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "2d2adcf0e93c143c8b7bfa1fe0196245f6df125bf0d590d08be4970c2e64c150";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "6410fd97191e13b283767e8bdd07035a33fea413fad48c8ae60c69904bad2419";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "71be28a53a856de234f18b08da41467cf14a7f06b9552ca3b6828cc7ab1924c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface-kdl/default.nix
+++ b/distros/rolling/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface-kdl";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "587e4cc0856a13d502db19a5ee0a0ddf4bdbbcaa5bf6646dc1553d618401d5d3";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "0cca0b27f446d278730d59c7bed1645a816b0ca6d148c22109cf7b8733530610";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface/default.nix
+++ b/distros/rolling/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "3936dd074714885ecdaae3e59a0b65a4611910722b639abb9436b9bca90f0644";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "a1d982c5f662c5eb86dbabde55dd5c9b59e5d083d3c421d7039313cb3244d887";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/laser-filters/default.nix
+++ b/distros/rolling/laser-filters/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, launch-testing-ament-cmake, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tf2, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-laser-filters";
-  version = "2.0.7-r2";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/rolling/laser_filters/2.0.7-2.tar.gz";
-    name = "2.0.7-2.tar.gz";
-    sha256 = "5d5bf4d749a734ab52834c02e98c60b01b79091d727be3e59cedb58105ce411b";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/rolling/laser_filters/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "73e366ed0f24aacf79885139ba7f350fb187b67bd3be60005ecc8710970522ed";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-lifecycle sensor-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-gtest launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs tf2 tf2-geometry-msgs tf2-kdl tf2-ros ];
 
   meta = {
     description = "Assorted filters designed to operate on 2D planar laser scanners,

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c4797417867446171e36e5ac947e361309b3ac20fdd3dc508c38289f1a294b0f";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "4798743f486dd16df8d108a5bcbff04604552aa64df5a06d0eeb8ee7a700aa94";
   };
 
   buildType = "cmake";

--- a/distros/rolling/novatel-gps-driver/default.nix
+++ b/distros/rolling/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-driver";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_driver/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "a3d8e87a231df4d62f1f5d4de1f500d4838d3008a7c635123554ea80d97f796d";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_driver/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "be87f31044a977ba4a6118e8e8e70bda3b17a5c1ae0a60994ff8aa96dedea7f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/novatel-gps-msgs/default.nix
+++ b/distros/rolling/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-novatel-gps-msgs";
-  version = "4.1.3-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_msgs/4.1.3-1.tar.gz";
-    name = "4.1.3-1.tar.gz";
-    sha256 = "ccf257414448fb78305d0da9b59a60543c159593de6f313a2218da81ea520dc7";
+    url = "https://github.com/ros2-gbp/novatel_gps_driver-release/archive/release/rolling/novatel_gps_msgs/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "31c369e75f82b3b9a7c1c29de06b3cd74ff5cfaa606ae9ec4c01e1410201a81d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/octomap-msgs/default.nix
+++ b/distros/rolling/octomap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-octomap-msgs";
-  version = "2.0.0-r4";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/rolling/octomap_msgs/2.0.0-4.tar.gz";
-    name = "2.0.0-4.tar.gz";
-    sha256 = "ca8db2d940a6cbb3a7d4ef820b844e49dc2530b4ca7c7231aa4d251eb0fe255b";
+    url = "https://github.com/ros2-gbp/octomap_msgs-release/archive/release/rolling/octomap_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e23aba395430fc3ad2d2ee2c26bbb3d56337afdab67723ac788aa7e999b28872";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "ef9d2746bf7998c73d4fa375e7d39eb10513fbb3d4e65cd58f817fbfc6aeb23a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "6c41eb6808d01bbdea035ad74571c2fd960bfb30bb1c3ea9e126af5823347207";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "df8244576e994a1434d26d0b8ce60bad7a5ac3820878d19c651c1b59909166e5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "698584f5e2dbdc8f5fd0355f4eb3e672b1dd0fb84e30c94d8873c1c230bc4780";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-pose-broadcaster";
+  version = "4.16.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "b8f40d7c5689a0070f440ff20318a99b523f275996fd7bf2cb32d0aa56513cc7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Broadcaster to publish cartesian states.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "26d56a72d74ecd7931df0a62ad154ccc9d52c6267d542b8a80991d64e875578d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "67e1c31ea85ea91d2f9bd4088a53641d05d8974205177c16c2359556508108a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "9dfaa5f3ece8ca4f2e8d4ea7c0560a2f147e9cf69212791d036fdc5b00cfd258";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "e4caaa50acc28b21b78c2361c399094e4a570563e63b6e1d1b198618e127d0f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/raspimouse-msgs/default.nix
+++ b/distros/rolling/raspimouse-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-raspimouse-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/rolling/raspimouse_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "95c32957d7a3d826a5173a8e842428c77efc50398f6c26344b40e9fea7b7e5b4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "RaspiMouse messages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/raspimouse/default.nix
+++ b/distros/rolling/raspimouse/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-raspimouse";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/rolling/raspimouse/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d50e90f942980e85c825d6b23088880ea38b390a1d4cdaf1234f5355a6bfdb3a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs lifecycle-msgs nav-msgs raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RaspiMouse ROS 2 node";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/rmf-building-sim-gz-plugins/default.nix
+++ b/distros/rolling/rmf-building-sim-gz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gz-gui-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sim-vendor, gz-transport-vendor, menge-vendor, qt5, rclcpp, rmf-door-msgs, rmf-fleet-msgs, rmf-lift-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-building-sim-gz-plugins";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_building_sim_gz_plugins/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "0488951250b45f5f98167d628ee8c791a3cd30f84d717b02f8975bc6e69fba85";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_building_sim_gz_plugins/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "c982eaf997e7fd6099d86b0a3f99ec2889f82e68cce5171580c0a4600c83c6fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-charger-msgs/default.nix
+++ b/distros/rolling/rmf-charger-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-charger-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_charger_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "2110a246e4c44d8366fe63cd5b4726bdd7fa39fb9df020d55ee610e37d72e2ce";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_charger_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "c1a00a95e6fb1137b8bd60c7fd5d6ce758e565ed1465fc7a8d5cee8a5dc188cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-dispenser-msgs/default.nix
+++ b/distros/rolling/rmf-dispenser-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-dispenser-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_dispenser_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "8be1a52405a55baaa668d4bb431c6b5b7f820f760fc7d8a20d37553c0ef9d855";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_dispenser_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "2f383cefc6ad44b316b84bb6c64434672a4e7f7b0d50c32be3c6151774ff37df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-door-msgs/default.nix
+++ b/distros/rolling/rmf-door-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-door-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_door_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "0c866a3b29373e3e47a93096b960e62b73c954363ace5c0527ac88bbebca2fcf";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_door_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "e4fc9e59d928a7ed8aa68cef9597a547ca3307ff44d27c9f171bc43d3ba27b4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-msgs/default.nix
+++ b/distros/rolling/rmf-fleet-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_fleet_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "62c704c7bb384703f99ffc40e20ab7ac3742c5d5557046e6abc8d9c3b122872a";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_fleet_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "52c7a4a3fc17d49d8ee9816a6e7b5f3de5d2473b3b5a33182604f659c9c09206";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-ingestor-msgs/default.nix
+++ b/distros/rolling/rmf-ingestor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-ingestor-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_ingestor_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "af4f8a971b8438418eeb54b76902643f9f9218c3ac169e1d96e5ce69cd64aa22";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_ingestor_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "e76573a239eef89a453fdcb4ff65eef917b7fa12348877d68fd126ab6d3a6fbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-lift-msgs/default.nix
+++ b/distros/rolling/rmf-lift-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-lift-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_lift_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "968385aabc9ac0ed25efd7202f7d29f53ad349a86ffc42bc769c8c94ee9a9a04";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_lift_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "3177ee2174bef107a57cd5ef557aab264735190ddb5d78a8044a9d223ec34ac7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-obstacle-msgs/default.nix
+++ b/distros/rolling/rmf-obstacle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-obstacle-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_obstacle_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "2233b29dde5f812ce3cd68a5b481e2d9c05e5130f0b5e54d505da5c5df3cba8f";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_obstacle_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "432f1db338ff97305a0597eae021a23c60fcde4497a666b3c9a3a390ed6a6fc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-reservation-msgs/default.nix
+++ b/distros/rolling/rmf-reservation-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-rmf-reservation-msgs";
+  version = "3.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_reservation_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "a724ea4d149a1e7f1db5b6a2859e9e15136640e0282a40e99958108dc0c0581a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for the reservation and queueing system";
+    license = with lib.licenses; [ "Apache" ];
+  };
+}

--- a/distros/rolling/rmf-robot-sim-common/default.nix
+++ b/distros/rolling/rmf-robot-sim-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, rclcpp, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rmf-robot-sim-common";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_common/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "b42ae60bbd6100c4309e5aa30a10247e6120cb89c9852254351eb3f00d018fc5";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_common/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "d2b21add6660b03a6f3612da17c89762e637c7f00c268823379be1379d7bc491";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-robot-sim-gz-plugins/default.nix
+++ b/distros/rolling/rmf-robot-sim-gz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, gz-gui-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sim-vendor, gz-transport-vendor, qt5, rclcpp, rmf-building-map-msgs, rmf-building-sim-gz-plugins, rmf-fleet-msgs, rmf-robot-sim-common }:
 buildRosPackage {
   pname = "ros-rolling-rmf-robot-sim-gz-plugins";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_gz_plugins/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "7a26b6280455b64dd92b265598d241d58dd61ffb497656a4e747bdea6702fa10";
+    url = "https://github.com/ros2-gbp/rmf_simulation-release/archive/release/rolling/rmf_robot_sim_gz_plugins/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "f0f76b2ccb4744d002ca9ad1c1f7a1a2b4eb492e4f7453f8fd44122a1a180d7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-scheduler-msgs/default.nix
+++ b/distros/rolling/rmf-scheduler-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-scheduler-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_scheduler_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "60af315c07bbf4d428630e2b3de93f98fff9eeeb70794fb4fa54c5fe9ab6d9a1";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_scheduler_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "391f079039008410675dbbf6a643a5d95133c674035ab5a81137f5ad69283705";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-site-map-msgs/default.nix
+++ b/distros/rolling/rmf-site-map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-site-map-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_site_map_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "85728c08a25ffee979a77afd8bf37b3c1ac7b3d8ecbff9949238d69448b78109";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_site_map_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "8e7e9cbfab903765cb096bc89daef44dc1187c212180a1872cffeec74ad9e7e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-task-msgs/default.nix
+++ b/distros/rolling/rmf-task-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_task_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "93d440cab5e0bbc1d680ec610633a078485a66f032043efd28454b2b34aa36c0";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_task_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "039ed01a57f00fec27759c7786578704e23800647027fe825c4f3e764d23c8e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-traffic-msgs/default.nix
+++ b/distros/rolling/rmf-traffic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_traffic_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "7f3a1f0244948ee2b5db7eeacd88ad63da5ddca7f3eafcd1b00416f747bee48e";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_traffic_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "ba6f384d35d9a05ff45364aae5b51f540ece2062b1344bcc123af2b612d2ec41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-workcell-msgs/default.nix
+++ b/distros/rolling/rmf-workcell-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rmf-workcell-msgs";
-  version = "3.4.0-r1";
+  version = "3.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_workcell_msgs/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "170ee51752da2343d85c2f20d416ec4ce28f9142a6e255c0f17cff72748aca97";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/rolling/rmf_workcell_msgs/3.4.1-1.tar.gz";
+    name = "3.4.1-1.tar.gz";
+    sha256 = "2cb3cea62983e0e496f7d618c53bc28fe0b9589809439c605edea1714986da55";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-calibration-msgs/default.nix
+++ b/distros/rolling/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration-msgs";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration_msgs/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "b8c4e07eceee494be79453ab5d4d2b03153297f1dbf96b6678332cb09f9e9265";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration_msgs/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "fcef55201e646214e85dfddf2ffd5bf353716ad7c9c6e16c1811d38f65018b2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/robot-calibration/default.nix
+++ b/distros/rolling/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, camera-calibration-parsers, ceres-solver, control-msgs, cv-bridge, eigen, geometric-shapes, geometry-msgs, gflags, kdl-parser, launch, launch-ros, launch-testing, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, rclcpp, rclcpp-action, robot-calibration-msgs, rosbag2-cpp, sensor-msgs, std-msgs, suitesparse, tf2-geometry-msgs, tf2-ros, tinyxml-2, tinyxml2-vendor, visualization-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-robot-calibration";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "bb504e4303dfa03df9abd9cd29d28b1fa7235a4fb69bd348c66e5ee1f62f1805";
+    url = "https://github.com/ros2-gbp/robot_calibration-release/archive/release/rolling/robot_calibration/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "e402530f659097f913d889e5910bdd7312eb20c1b095837487438ba1c9de5cea";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "b18d47e6f321373b224d9b32c8af2387f3455b41089a750b912b415e5e701f45";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "8d044477677b139ed933a85ecd40a17aef2498117b8a5ff5711db9dfe1b44cc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "a5fd175fa349a6c256bd479949e741070f80cbe357a508aff853a74e0ff13d74";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "f98082950838d3c73e29fa07b260ed322d69de7d1f3b016736683b96f034ee58";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rclpy, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "9a2fb9d711b0327eb259d08fff2aad31d46f267cfdade0ed66b31c3eceb2e150";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "8af81c138913a1c7f0e644fd71976bb716bddc2c0c834d11648038b2bcb3500f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "b88387cd327f2cdaa4b6664d923b7c76753aa62cf07359960fee2d379729949e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "494b83350b3d532cb4c95ad9382161fbabfb28af4012073163fdea3719208189";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9320092f8f2ba8c947effcf6b74c4099b121247d17b7316300d0291e475bd1ef";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "45e000b60071cf85ded69c174ad75112680ea3f6b6c32c2b08fffee6756d73f8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "7897c5c62c2a396b7c8ca9a1ad1b132bef11736ad5288d6ac0835e3821e02978";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "5057296bb2c425d7eda3f72b8bfb943bf7405add9bfba273b547d71c4e8d1558";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "32afcdbf2c0a4f0f738621142ef15660aefd7529216503b9ec4baa52ea948005";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "9e1cda46e7aebb20c498a621f4aab929205e48aec659fd2920dcb0ae21ac28f8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rt-usb-9axisimu-driver/default.nix
+++ b/distros/rolling/rt-usb-9axisimu-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-rt-usb-9axisimu-driver";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release/archive/release/rolling/rt_usb_9axisimu_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "6609c371f73a235d85dba02da0baa209f003aae6ffc864015a36c8a175ecdbba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The rt_usb_9axisimu_driver package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/sdformat-vendor/default.nix
+++ b/distros/rolling/sdformat-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, pythonPackages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-sdformat-vendor";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "f5af51da83208016cd6c4c1384db49fbbd51717441ca9bb2e8777070a8c89ccc";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "07e37776297e46c61069cdd1223fbc2909801fbbcf2b0ba6450819cda921d7a1";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: sdformat15 15.0.0
+    description = "Vendor package for: sdformat15 15.1.0
 
     SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications";

--- a/distros/rolling/simple-grasping/default.nix
+++ b/distros/rolling/simple-grasping/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-gtest, eigen, geometry-msgs, grasping-msgs, moveit-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-action, rclcpp-components, sensor-msgs, shape-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-rolling-simple-grasping";
+  version = "0.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/simple_grasping-release/archive/release/rolling/simple_grasping/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "a071bd8ac453535ea1d62b20ce0dc701f3e0bb7282d92d5f6c81727f195ac091";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen pcl ];
+  checkInputs = [ ament-cmake-cpplint ament-cmake-gtest ];
+  propagatedBuildInputs = [ geometry-msgs grasping-msgs moveit-msgs pcl-conversions pcl-ros rclcpp rclcpp-action rclcpp-components sensor-msgs shape-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Basic grasping applications and demos.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/slg-msgs/default.nix
+++ b/distros/rolling/slg-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-slg-msgs";
+  version = "3.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/slg_msgs-release/archive/release/rolling/slg_msgs/3.9.1-1.tar.gz";
+    name = "3.9.1-1.tar.gz";
+    sha256 = "caf9b4396016d0baa1328c5155daa7fb5506f228eef3ee1736591bdaa3f8c467";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides classes and messages to interact with laser related geometry.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "a4bcd5b284cfd13cbafa86957ef7f8a577af69a3e07a652d0411fae50ef6f6c2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "cc6a49eb72b18ef1b4bb25e453766df6732fda52961ae4e77482246e4570a472";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "df4defba3783c99527a0008d9743dedfab7eb8ef27d8ed74a6f19da37f6c87c1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "06cec3ff8a326942b7bbc7edfd25baa8701115f0328073ef80285c43956bfe12";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "c61faedd27a2160d40f50c08ab53974ecbde7f0b1c73e9723a21fc99ba1c1b77";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "cddc63f1c901dc904cc7758e1783fae7d06787912a9437544a7b04740c4ea9b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "d6334067b4eea49179e755b53e0a8f25d303dd3a78c53290c8bec586217fdde9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "bc7e62f0146c141e6ca6df56b91f7108e9d9ff9621e3619907c788431d8de62f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.15.0-r1";
+  version = "4.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.15.0-1.tar.gz";
-    name = "4.15.0-1.tar.gz";
-    sha256 = "b1435b5d8dc5451d16072c70e3d8c00c5092a12df377b09cd08e72a0c2dc21db";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.16.0-1.tar.gz";
+    name = "4.16.0-1.tar.gz";
+    sha256 = "19647e379d08727ebeb08297d404cef74622183bc9559b783e15ab53487bfb58";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit ea81eccfe96525380e86b1313dd014f086898da9.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.37.3-r1 --> 2.38.0-r1*
* *adi-tmcl 2.0.2-r1 --> 2.0.3-r1*
* *admittance-controller 2.37.3-r1 --> 2.38.0-r1*
* *bicycle-steering-controller 2.37.3-r1 --> 2.38.0-r1*
* *bosch-locator-bridge 2.1.11-r1 --> 2.1.13-r1*
* *bosch-locator-bridge-utils 2.1.11-r1 --> 2.1.13-r1*
* *controller-interface 2.43.1-r1 --> 2.44.0-r1*
* *controller-manager 2.43.1-r1 --> 2.44.0-r1*
* *controller-manager-msgs 2.43.1-r1 --> 2.44.0-r1*
* *costmap-queue 1.1.16-r1 --> 1.1.17-r1*
* *diff-drive-controller 2.37.3-r1 --> 2.38.0-r1*
* *dwb-core 1.1.16-r1 --> 1.1.17-r1*
* *dwb-critics 1.1.16-r1 --> 1.1.17-r1*
* *dwb-msgs 1.1.16-r1 --> 1.1.17-r1*
* *dwb-plugins 1.1.16-r1 --> 1.1.17-r1*
* *effort-controllers 2.37.3-r1 --> 2.38.0-r1*
* *force-torque-sensor-broadcaster 2.37.3-r1 --> 2.38.0-r1*
* *forward-command-controller 2.37.3-r1 --> 2.38.0-r1*
* *gripper-controllers 2.37.3-r1 --> 2.38.0-r1*
* *hardware-interface 2.43.1-r1 --> 2.44.0-r1*
* *hardware-interface-testing 2.43.1-r1 --> 2.44.0-r1*
* *imu-sensor-broadcaster 2.37.3-r1 --> 2.38.0-r1*
* *joint-limits 2.43.1-r1 --> 2.44.0-r1*
* *joint-state-broadcaster 2.37.3-r1 --> 2.38.0-r1*
* *joint-trajectory-controller 2.37.3-r1 --> 2.38.0-r1*
* *laser-segmentation 3.0.2-r1*
* *leo 1.2.3-r1 --> 1.2.4-r1*
* *leo-description 1.2.3-r1 --> 1.2.4-r1*
* *leo-gz-bringup 1.1.0-r1 --> 1.1.1-r1*
* *leo-gz-worlds 1.1.0-r1 --> 1.1.1-r1*
* *leo-msgs 1.2.3-r1 --> 1.2.4-r1*
* *leo-simulator 1.1.0-r1 --> 1.1.1-r1*
* *leo-teleop 1.2.3-r1 --> 1.2.4-r1*
* *mp2p-icp 1.6.2-r1 --> 1.6.3-r1*
* *nav-2d-msgs 1.1.16-r1 --> 1.1.17-r1*
* *nav-2d-utils 1.1.16-r1 --> 1.1.17-r1*
* *nav2-amcl 1.1.16-r1 --> 1.1.17-r1*
* *nav2-behavior-tree 1.1.16-r1 --> 1.1.17-r1*
* *nav2-behaviors 1.1.16-r1 --> 1.1.17-r1*
* *nav2-bringup 1.1.16-r1 --> 1.1.17-r1*
* *nav2-bt-navigator 1.1.16-r1 --> 1.1.17-r1*
* *nav2-collision-monitor 1.1.16-r1 --> 1.1.17-r1*
* *nav2-common 1.1.16-r1 --> 1.1.17-r1*
* *nav2-constrained-smoother 1.1.16-r1 --> 1.1.17-r1*
* *nav2-controller 1.1.16-r1 --> 1.1.17-r1*
* *nav2-core 1.1.16-r1 --> 1.1.17-r1*
* *nav2-costmap-2d 1.1.16-r1 --> 1.1.17-r1*
* *nav2-dwb-controller 1.1.16-r1 --> 1.1.17-r1*
* *nav2-graceful-controller 1.1.16-r1 --> 1.1.17-r1*
* *nav2-lifecycle-manager 1.1.16-r1 --> 1.1.17-r1*
* *nav2-map-server 1.1.16-r1 --> 1.1.17-r1*
* *nav2-mppi-controller 1.1.16-r1 --> 1.1.17-r1*
* *nav2-msgs 1.1.16-r1 --> 1.1.17-r1*
* *nav2-navfn-planner 1.1.16-r1 --> 1.1.17-r1*
* *nav2-planner 1.1.16-r1 --> 1.1.17-r1*
* *nav2-regulated-pure-pursuit-controller 1.1.16-r1 --> 1.1.17-r1*
* *nav2-rotation-shim-controller 1.1.16-r1 --> 1.1.17-r1*
* *nav2-rviz-plugins 1.1.16-r1 --> 1.1.17-r1*
* *nav2-simple-commander 1.1.16-r1 --> 1.1.17-r1*
* *nav2-smac-planner 1.1.16-r1 --> 1.1.17-r1*
* *nav2-smoother 1.1.16-r1 --> 1.1.17-r1*
* *nav2-system-tests 1.1.16-r1 --> 1.1.17-r1*
* *nav2-theta-star-planner 1.1.16-r1 --> 1.1.17-r1*
* *nav2-util 1.1.16-r1 --> 1.1.17-r1*
* *nav2-velocity-smoother 1.1.16-r1 --> 1.1.17-r1*
* *nav2-voxel-grid 1.1.16-r1 --> 1.1.17-r1*
* *nav2-waypoint-follower 1.1.16-r1 --> 1.1.17-r1*
* *navigation2 1.1.16-r1 --> 1.1.17-r1*
* *novatel-gps-driver 4.1.3-r1 --> 4.2.0-r1*
* *novatel-gps-msgs 4.1.3-r1 --> 4.2.0-r1*
* *octomap-msgs 2.0.0-r3 --> 2.0.1-r1*
* *pal-gripper 3.3.0-r1 --> 3.4.0-r1*
* *pal-gripper-controller-configuration 3.3.0-r1 --> 3.4.0-r1*
* *pal-gripper-description 3.3.0-r1 --> 3.4.0-r1*
* *pal-gripper-simulation 3.3.0-r1 --> 3.4.0-r1*
* *pal-maps 0.0.4-r1 --> 0.0.5-r1*
* *pid-controller 2.37.3-r1 --> 2.38.0-r1*
* *pmb2-2dnav 4.2.0-r1 --> 4.5.0-r1*
* *pmb2-bringup 5.3.1-r1 --> 5.4.0-r1*
* *pmb2-controller-configuration 5.3.1-r1 --> 5.4.0-r1*
* *pmb2-description 5.3.1-r1 --> 5.4.0-r1*
* *pmb2-gazebo 4.0.16-r1 --> 4.1.0-r1*
* *pmb2-laser-sensors 4.2.0-r1 --> 4.5.0-r1*
* *pmb2-navigation 4.2.0-r1 --> 4.5.0-r1*
* *pmb2-robot 5.3.1-r1 --> 5.4.0-r1*
* *pmb2-simulation 4.0.16-r1 --> 4.1.0-r1*
* *pose-broadcaster 2.38.0-r1*
* *position-controllers 2.37.3-r1 --> 2.38.0-r1*
* *range-sensor-broadcaster 2.37.3-r1 --> 2.38.0-r1*
* *robot-calibration 0.8.1-r1 --> 0.8.2-r1*
* *robot-calibration-msgs 0.8.1-r1 --> 0.8.2-r1*
* *ros2-control 2.43.1-r1 --> 2.44.0-r1*
* *ros2-control-test-assets 2.43.1-r1 --> 2.44.0-r1*
* *ros2-controllers 2.37.3-r1 --> 2.38.0-r1*
* *ros2-controllers-test-nodes 2.37.3-r1 --> 2.38.0-r1*
* *ros2controlcli 2.43.1-r1 --> 2.44.0-r1*
* *rqt-controller-manager 2.43.1-r1 --> 2.44.0-r1*
* *rqt-joint-trajectory-controller 2.37.3-r1 --> 2.38.0-r1*
* *simple-grasping 0.5.0-r1*
* *slg-msgs 3.9.1-r1*
* *steering-controllers-library 2.37.3-r1 --> 2.38.0-r1*
* *tiago-2dnav 4.2.0-r1 --> 4.5.0-r1*
* *tiago-bringup 4.6.0-r1 --> 4.7.1-r1*
* *tiago-controller-configuration 4.6.0-r1 --> 4.7.1-r1*
* *tiago-description 4.6.0-r1 --> 4.7.1-r1*
* *tiago-gazebo 4.2.0-r1 --> 4.3.0-r1*
* *tiago-laser-sensors 4.2.0-r1 --> 4.5.0-r1*
* *tiago-moveit-config 3.1.0-r1 --> 3.1.1-r1*
* *tiago-navigation 4.2.0-r1 --> 4.5.0-r1*
* *tiago-robot 4.6.0-r1 --> 4.7.1-r1*
* *tiago-simulation 4.2.0-r1 --> 4.3.0-r1*
* *transmission-interface 2.43.1-r1 --> 2.44.0-r1*
* *tricycle-controller 2.37.3-r1 --> 2.38.0-r1*
* *tricycle-steering-controller 2.37.3-r1 --> 2.38.0-r1*
* *velocity-controllers 2.37.3-r1 --> 2.38.0-r1*

Iron Changes:
-------------
* *ackermann-steering-controller 3.27.0-r1 --> 3.28.0-r1*
* *admittance-controller 3.27.0-r1 --> 3.28.0-r1*
* *ament-cmake 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-auto 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-core 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-definitions 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-dependencies 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-include-directories 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-interfaces 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-libraries 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-link-flags 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-export-targets 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-gen-version-h 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-gmock 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-google-benchmark 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-gtest 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-include-directories 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-libraries 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-pytest 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-python 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-target-dependencies 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-test 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-vendor-package 2.0.6-r1 --> 2.0.7-r1*
* *ament-cmake-version 2.0.6-r1 --> 2.0.7-r1*
* *bicycle-steering-controller 3.27.0-r1 --> 3.28.0-r1*
* *controller-interface 3.29.0-r1 --> 3.30.0-r1*
* *controller-manager 3.29.0-r1 --> 3.30.0-r1*
* *controller-manager-msgs 3.29.0-r1 --> 3.30.0-r1*
* *cyclonedds 0.10.4-r1 --> 0.10.5-r1*
* *depthai-bridge 2.10.3-r1 --> 2.10.5-r1*
* *depthai-descriptions 2.10.3-r1 --> 2.10.5-r1*
* *depthai-examples 2.10.3-r1 --> 2.10.5-r1*
* *depthai-filters 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros-driver 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros-msgs 2.10.3-r1 --> 2.10.5-r1*
* *diff-drive-controller 3.27.0-r1 --> 3.28.0-r1*
* *effort-controllers 3.27.0-r1 --> 3.28.0-r1*
* *examples-rclcpp-async-client 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-cbg-executor 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-action-client 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-action-server 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-client 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-composition 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-publisher 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-service 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-subscriber 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-minimal-timer 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-multithreaded-executor 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclcpp-wait-set 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-executors 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-guard-conditions 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-minimal-action-client 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-minimal-action-server 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-minimal-client 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-minimal-publisher 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-minimal-service 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-minimal-subscriber 0.18.1-r1 --> 0.18.2-r1*
* *examples-rclpy-pointcloud-publisher 0.18.1-r1 --> 0.18.2-r1*
* *fastrtps 2.10.5-r1 --> 2.10.6-r1*
* *force-torque-sensor-broadcaster 3.27.0-r1 --> 3.28.0-r1*
* *forward-command-controller 3.27.0-r1 --> 3.28.0-r1*
* *gripper-controllers 3.27.0-r1 --> 3.28.0-r1*
* *hardware-interface 3.29.0-r1 --> 3.30.0-r1*
* *hardware-interface-testing 3.29.0-r1 --> 3.30.0-r1*
* *imu-sensor-broadcaster 3.27.0-r1 --> 3.28.0-r1*
* *joint-limits 3.29.0-r1 --> 3.30.0-r1*
* *joint-state-broadcaster 3.27.0-r1 --> 3.28.0-r1*
* *joint-trajectory-controller 3.27.0-r1 --> 3.28.0-r1*
* *kinematics-interface 1.2.0-r1 --> 1.2.1-r1*
* *kinematics-interface-kdl 1.2.0-r1 --> 1.2.1-r1*
* *laser-filters 2.0.7-r1 --> 2.0.8-r1*
* *launch-ros 0.24.1-r1 --> 0.24.2-r1*
* *launch-testing-examples 0.18.1-r1 --> 0.18.2-r1*
* *launch-testing-ros 0.24.1-r1 --> 0.24.2-r1*
* *leo 2.0.3-r1 --> 2.0.4-r1*
* *leo-description 2.0.3-r1 --> 2.0.4-r1*
* *leo-gz-bringup 1.1.0-r1 --> 1.1.1-r1*
* *leo-gz-worlds 1.1.0-r1 --> 1.1.1-r1*
* *leo-msgs 2.0.3-r1 --> 2.0.4-r1*
* *leo-simulator 1.1.0-r1 --> 1.1.1-r1*
* *leo-teleop 2.0.3-r1 --> 2.0.4-r1*
* *libstatistics-collector 1.5.2-r1 --> 1.5.3-r1*
* *mcap-vendor 0.22.7-r1 --> 0.22.8-r1*
* *novatel-gps-driver 4.1.3-r1 --> 4.2.0-r1*
* *novatel-gps-msgs 4.1.3-r1 --> 4.2.0-r1*
* *octomap-msgs 2.0.0-r4 --> 2.0.1-r1*
* *pid-controller 3.27.0-r1 --> 3.28.0-r1*
* *pose-broadcaster 3.27.0-r1 --> 3.28.0-r1*
* *position-controllers 3.27.0-r1 --> 3.28.0-r1*
* *range-sensor-broadcaster 3.27.0-r1 --> 3.28.0-r1*
* *rcl 6.0.6-r1 --> 6.0.7-r1*
* *rcl-action 6.0.6-r1 --> 6.0.7-r1*
* *rcl-lifecycle 6.0.6-r1 --> 6.0.7-r1*
* *rcl-yaml-param-parser 6.0.6-r1 --> 6.0.7-r1*
* *rclcpp 21.0.7-r1 --> 21.0.8-r1*
* *rclcpp-action 21.0.7-r1 --> 21.0.8-r1*
* *rclcpp-components 21.0.7-r1 --> 21.0.8-r1*
* *rclcpp-lifecycle 21.0.7-r1 --> 21.0.8-r1*
* *rclpy 4.1.6-r1 --> 4.1.7-r1*
* *rmf-charging-schedule 2.2.6-r1 --> 2.2.7-r1*
* *rmf-fleet-adapter 2.2.6-r1 --> 2.2.7-r1*
* *rmf-fleet-adapter-python 2.2.6-r1 --> 2.2.7-r1*
* *rmf-task-ros2 2.2.6-r1 --> 2.2.7-r1*
* *rmf-traffic-ros2 2.2.6-r1 --> 2.2.7-r1*
* *rmf-websocket 2.2.6-r1 --> 2.2.7-r1*
* *robot-calibration 0.8.1-r1 --> 0.9.2-r1*
* *robot-calibration-msgs 0.8.1-r1 --> 0.9.2-r1*
* *ros2-control 3.29.0-r1 --> 3.30.0-r1*
* *ros2-control-test-assets 3.29.0-r1 --> 3.30.0-r1*
* *ros2-controllers 3.27.0-r1 --> 3.28.0-r1*
* *ros2-controllers-test-nodes 3.27.0-r1 --> 3.28.0-r1*
* *ros2action 0.25.7-r1 --> 0.25.8-r1*
* *ros2bag 0.22.7-r1 --> 0.22.8-r1*
* *ros2cli 0.25.7-r1 --> 0.25.8-r1*
* *ros2cli-test-interfaces 0.25.7-r1 --> 0.25.8-r1*
* *ros2component 0.25.7-r1 --> 0.25.8-r1*
* *ros2controlcli 3.29.0-r1 --> 3.30.0-r1*
* *ros2doctor 0.25.7-r1 --> 0.25.8-r1*
* *ros2interface 0.25.7-r1 --> 0.25.8-r1*
* *ros2launch 0.24.1-r1 --> 0.24.2-r1*
* *ros2lifecycle 0.25.7-r1 --> 0.25.8-r1*
* *ros2lifecycle-test-fixtures 0.25.7-r1 --> 0.25.8-r1*
* *ros2multicast 0.25.7-r1 --> 0.25.8-r1*
* *ros2node 0.25.7-r1 --> 0.25.8-r1*
* *ros2param 0.25.7-r1 --> 0.25.8-r1*
* *ros2pkg 0.25.7-r1 --> 0.25.8-r1*
* *ros2run 0.25.7-r1 --> 0.25.8-r1*
* *ros2service 0.25.7-r1 --> 0.25.8-r1*
* *ros2topic 0.25.7-r1 --> 0.25.8-r1*
* *ros2trace 6.3.2-r1 --> 6.3.3-r1*
* *rosbag2 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-compression 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-compression-zstd 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-cpp 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-examples-cpp 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-examples-py 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-interfaces 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-performance-benchmarking 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-performance-benchmarking-msgs 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-py 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-storage 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-storage-default-plugins 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-storage-mcap 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-storage-sqlite3 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-test-common 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-test-msgdefs 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-tests 0.22.7-r1 --> 0.22.8-r1*
* *rosbag2-transport 0.22.7-r1 --> 0.22.8-r1*
* *rqt-controller-manager 3.29.0-r1 --> 3.30.0-r1*
* *rqt-joint-trajectory-controller 3.27.0-r1 --> 3.28.0-r1*
* *rviz-assimp-vendor 12.4.8-r1 --> 12.4.9-r1*
* *rviz-common 12.4.8-r1 --> 12.4.9-r1*
* *rviz-default-plugins 12.4.8-r1 --> 12.4.9-r1*
* *rviz-ogre-vendor 12.4.8-r1 --> 12.4.9-r1*
* *rviz-rendering 12.4.8-r1 --> 12.4.9-r1*
* *rviz-rendering-tests 12.4.8-r1 --> 12.4.9-r1*
* *rviz-visual-testing-framework 12.4.8-r1 --> 12.4.9-r1*
* *rviz2 12.4.8-r1 --> 12.4.9-r1*
* *shared-queues-vendor 0.22.7-r1 --> 0.22.8-r1*
* *simple-grasping 0.5.0-r1*
* *sqlite3-vendor 0.22.7-r1 --> 0.22.8-r1*
* *steering-controllers-library 3.27.0-r1 --> 3.28.0-r1*
* *tracetools 6.3.2-r1 --> 6.3.3-r1*
* *tracetools-launch 6.3.2-r1 --> 6.3.3-r1*
* *tracetools-read 6.3.2-r1 --> 6.3.3-r1*
* *tracetools-test 6.3.2-r1 --> 6.3.3-r1*
* *tracetools-trace 6.3.2-r1 --> 6.3.3-r1*
* *transmission-interface 3.29.0-r1 --> 3.30.0-r1*
* *tricycle-controller 3.27.0-r1 --> 3.28.0-r1*
* *tricycle-steering-controller 3.27.0-r1 --> 3.28.0-r1*
* *ur 2.3.11-r2 --> 2.3.12-r1*
* *ur-calibration 2.3.11-r2 --> 2.3.12-r1*
* *ur-controllers 2.3.11-r2 --> 2.3.12-r1*
* *ur-dashboard-msgs 2.3.11-r2 --> 2.3.12-r1*
* *ur-moveit-config 2.3.11-r2 --> 2.3.12-r1*
* *ur-robot-driver 2.3.11-r2 --> 2.3.12-r1*
* *velocity-controllers 3.27.0-r1 --> 3.28.0-r1*
* *zstd-vendor 0.22.7-r1 --> 0.22.8-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.15.0-r1 --> 4.16.0-r1*
* *admittance-controller 4.15.0-r1 --> 4.16.0-r1*
* *bicycle-steering-controller 4.15.0-r1 --> 4.16.0-r1*
* *controller-interface 4.19.0-r1 --> 4.20.0-r1*
* *controller-manager 4.19.0-r1 --> 4.20.0-r1*
* *controller-manager-msgs 4.19.0-r1 --> 4.20.0-r1*
* *costmap-queue 1.3.2-r1 --> 1.3.3-r1*
* *diff-drive-controller 4.15.0-r1 --> 4.16.0-r1*
* *dwb-core 1.3.2-r1 --> 1.3.3-r1*
* *dwb-critics 1.3.2-r1 --> 1.3.3-r1*
* *dwb-msgs 1.3.2-r1 --> 1.3.3-r1*
* *dwb-plugins 1.3.2-r1 --> 1.3.3-r1*
* *effort-controllers 4.15.0-r1 --> 4.16.0-r1*
* *force-torque-sensor-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *forward-command-controller 4.15.0-r1 --> 4.16.0-r1*
* *gripper-controllers 4.15.0-r1 --> 4.16.0-r1*
* *gz-msgs-vendor 0.0.4-r1 --> 0.0.5-r1*
* *gz-physics-vendor 0.0.4-r1 --> 0.0.5-r1*
* *gz-rendering-vendor 0.0.4-r1 --> 0.0.5-r1*
* *gz-sensors-vendor 0.0.4-r1 --> 0.0.5-r1*
* *gz-sim-vendor 0.0.5-r1 --> 0.0.6-r1*
* *hardware-interface 4.19.0-r1 --> 4.20.0-r1*
* *hardware-interface-testing 4.19.0-r1 --> 4.20.0-r1*
* *imu-sensor-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *joint-limits 4.19.0-r1 --> 4.20.0-r1*
* *joint-state-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *joint-trajectory-controller 4.15.0-r1 --> 4.16.0-r1*
* *kinematics-interface 1.2.0-r1 --> 1.2.1-r1*
* *kinematics-interface-kdl 1.2.0-r1 --> 1.2.1-r1*
* *leo 3.0.3-r1 --> 3.0.4-r1*
* *leo-description 3.0.3-r1 --> 3.0.4-r1*
* *leo-gz-bringup 2.0.0-r1 --> 2.0.1-r1*
* *leo-gz-plugins 2.0.0-r1 --> 2.0.1-r1*
* *leo-gz-worlds 2.0.0-r1 --> 2.0.1-r1*
* *leo-msgs 3.0.3-r1 --> 3.0.4-r1*
* *leo-simulator 2.0.0-r1 --> 2.0.1-r1*
* *leo-teleop 3.0.3-r1 --> 3.0.4-r1*
* *mp2p-icp 1.6.2-r1 --> 1.6.3-r1*
* *nav-2d-msgs 1.3.2-r1 --> 1.3.3-r1*
* *nav-2d-utils 1.3.2-r1 --> 1.3.3-r1*
* *nav2-amcl 1.3.2-r1 --> 1.3.3-r1*
* *nav2-behavior-tree 1.3.2-r1 --> 1.3.3-r1*
* *nav2-behaviors 1.3.2-r1 --> 1.3.3-r1*
* *nav2-bringup 1.3.2-r1 --> 1.3.3-r1*
* *nav2-bt-navigator 1.3.2-r1 --> 1.3.3-r1*
* *nav2-collision-monitor 1.3.2-r1 --> 1.3.3-r1*
* *nav2-common 1.3.2-r1 --> 1.3.3-r1*
* *nav2-constrained-smoother 1.3.2-r1 --> 1.3.3-r1*
* *nav2-controller 1.3.2-r1 --> 1.3.3-r1*
* *nav2-core 1.3.2-r1 --> 1.3.3-r1*
* *nav2-costmap-2d 1.3.2-r1 --> 1.3.3-r1*
* *nav2-dwb-controller 1.3.2-r1 --> 1.3.3-r1*
* *nav2-graceful-controller 1.3.2-r1 --> 1.3.3-r1*
* *nav2-lifecycle-manager 1.3.2-r1 --> 1.3.3-r1*
* *nav2-loopback-sim 1.3.2-r1 --> 1.3.3-r1*
* *nav2-map-server 1.3.2-r1 --> 1.3.3-r1*
* *nav2-mppi-controller 1.3.2-r1 --> 1.3.3-r1*
* *nav2-msgs 1.3.2-r1 --> 1.3.3-r1*
* *nav2-navfn-planner 1.3.2-r1 --> 1.3.3-r1*
* *nav2-planner 1.3.2-r1 --> 1.3.3-r1*
* *nav2-regulated-pure-pursuit-controller 1.3.2-r1 --> 1.3.3-r1*
* *nav2-rotation-shim-controller 1.3.2-r1 --> 1.3.3-r1*
* *nav2-rviz-plugins 1.3.2-r1 --> 1.3.3-r1*
* *nav2-simple-commander 1.3.2-r1 --> 1.3.3-r1*
* *nav2-smac-planner 1.3.2-r1 --> 1.3.3-r1*
* *nav2-smoother 1.3.2-r1 --> 1.3.3-r1*
* *nav2-system-tests 1.3.2-r1 --> 1.3.3-r1*
* *nav2-theta-star-planner 1.3.2-r1 --> 1.3.3-r1*
* *nav2-util 1.3.2-r1 --> 1.3.3-r1*
* *nav2-velocity-smoother 1.3.2-r1 --> 1.3.3-r1*
* *nav2-voxel-grid 1.3.2-r1 --> 1.3.3-r1*
* *nav2-waypoint-follower 1.3.2-r1 --> 1.3.3-r1*
* *navigation2 1.3.2-r1 --> 1.3.3-r1*
* *novatel-gps-driver 4.1.3-r1 --> 4.2.0-r1*
* *novatel-gps-msgs 4.1.3-r1 --> 4.2.0-r1*
* *octomap-msgs 2.0.0-r5 --> 2.0.1-r1*
* *opennav-docking 1.3.2-r1 --> 1.3.3-r1*
* *opennav-docking-bt 1.3.2-r1 --> 1.3.3-r1*
* *opennav-docking-core 1.3.2-r1 --> 1.3.3-r1*
* *parallel-gripper-controller 4.15.0-r1 --> 4.16.0-r1*
* *pcl-conversions 2.6.1-r4 --> 2.6.2-r1*
* *pcl-ros 2.6.1-r4 --> 2.6.2-r1*
* *perception-pcl 2.6.1-r4 --> 2.6.2-r1*
* *pid-controller 4.15.0-r1 --> 4.16.0-r1*
* *pose-broadcaster 4.16.0-r1*
* *position-controllers 4.15.0-r1 --> 4.16.0-r1*
* *range-sensor-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *robot-calibration 0.9.1-r1 --> 0.9.2-r1*
* *robot-calibration-msgs 0.9.1-r1 --> 0.9.2-r1*
* *ros-gz 1.0.6-r1 --> 1.0.7-r1*
* *ros-gz-bridge 1.0.6-r1 --> 1.0.7-r1*
* *ros-gz-image 1.0.6-r1 --> 1.0.7-r1*
* *ros-gz-interfaces 1.0.6-r1 --> 1.0.7-r1*
* *ros-gz-sim 1.0.6-r1 --> 1.0.7-r1*
* *ros-gz-sim-demos 1.0.6-r1 --> 1.0.7-r1*
* *ros2-control 4.19.0-r1 --> 4.20.0-r1*
* *ros2-control-test-assets 4.19.0-r1 --> 4.20.0-r1*
* *ros2-controllers 4.15.0-r1 --> 4.16.0-r1*
* *ros2-controllers-test-nodes 4.15.0-r1 --> 4.16.0-r1*
* *ros2controlcli 4.19.0-r1 --> 4.20.0-r1*
* *rqt-controller-manager 4.19.0-r1 --> 4.20.0-r1*
* *rqt-joint-trajectory-controller 4.15.0-r1 --> 4.16.0-r1*
* *scenario-execution-control 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-gazebo 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-interfaces 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-nav2 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-os 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-py-trees-ros 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-ros 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-rviz 1.2.0-r4 --> 1.2.0-r5*
* *scenario-execution-x11 1.2.0-r4 --> 1.2.0-r5*
* *simple-grasping 0.5.0-r1*
* *steering-controllers-library 4.15.0-r1 --> 4.16.0-r1*
* *test-ros-gz-bridge 1.0.6-r1 --> 1.0.7-r1*
* *transmission-interface 4.19.0-r1 --> 4.20.0-r1*
* *tricycle-controller 4.15.0-r1 --> 4.16.0-r1*
* *tricycle-steering-controller 4.15.0-r1 --> 4.16.0-r1*
* *velocity-controllers 4.15.0-r1 --> 4.16.0-r1*

Noetic Changes:
---------------
* *adi-tmcl 4.0.1-r3 --> 4.0.2-r2*
* *bosch-locator-bridge 1.0.11-r2 --> 1.0.13-r1*
* *costmap-cspace 0.17.1-r1 --> 0.17.2-r1*
* *joystick-interrupt 0.17.1-r1 --> 0.17.2-r1*
* *map-organizer 0.17.1-r1 --> 0.17.2-r1*
* *mp2p-icp 1.6.2-r2 --> 1.6.3-r1*
* *neonavigation 0.17.1-r1 --> 0.17.2-r1*
* *neonavigation-common 0.17.1-r1 --> 0.17.2-r1*
* *neonavigation-launch 0.17.1-r1 --> 0.17.2-r1*
* *obj-to-pointcloud 0.17.1-r1 --> 0.17.2-r1*
* *planner-cspace 0.17.1-r1 --> 0.17.2-r1*
* *safety-limiter 0.17.1-r1 --> 0.17.2-r1*
* *track-odometry 0.17.1-r1 --> 0.17.2-r1*
* *trajectory-tracker 0.17.1-r1 --> 0.17.2-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.15.0-r1 --> 4.16.0-r1*
* *admittance-controller 4.15.0-r1 --> 4.16.0-r1*
* *bicycle-steering-controller 4.15.0-r1 --> 4.16.0-r1*
* *controller-interface 4.19.0-r1 --> 4.20.0-r1*
* *controller-manager 4.19.0-r1 --> 4.20.0-r1*
* *controller-manager-msgs 4.19.0-r1 --> 4.20.0-r1*
* *diff-drive-controller 4.15.0-r1 --> 4.16.0-r1*
* *effort-controllers 4.15.0-r1 --> 4.16.0-r1*
* *force-torque-sensor-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *forward-command-controller 4.15.0-r1 --> 4.16.0-r1*
* *grasping-msgs 0.5.0-r1*
* *gripper-controllers 4.15.0-r1 --> 4.16.0-r1*
* *gz-cmake-vendor 0.2.0-r1 --> 0.2.1-r1*
* *hardware-interface 4.19.0-r1 --> 4.20.0-r1*
* *hardware-interface-testing 4.19.0-r1 --> 4.20.0-r1*
* *imu-sensor-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *joint-limits 4.19.0-r1 --> 4.20.0-r1*
* *joint-state-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *joint-trajectory-controller 4.15.0-r1 --> 4.16.0-r1*
* *kinematics-interface 1.2.0-r1 --> 1.2.1-r1*
* *kinematics-interface-kdl 1.2.0-r1 --> 1.2.1-r1*
* *laser-filters 2.0.7-r2 --> 2.0.8-r1*
* *mp2p-icp 1.6.2-r1 --> 1.6.3-r1*
* *novatel-gps-driver 4.1.3-r1 --> 4.2.0-r1*
* *novatel-gps-msgs 4.1.3-r1 --> 4.2.0-r1*
* *octomap-msgs 2.0.0-r4 --> 2.0.1-r1*
* *parallel-gripper-controller 4.15.0-r1 --> 4.16.0-r1*
* *pid-controller 4.15.0-r1 --> 4.16.0-r1*
* *pose-broadcaster 4.16.0-r1*
* *position-controllers 4.15.0-r1 --> 4.16.0-r1*
* *range-sensor-broadcaster 4.15.0-r1 --> 4.16.0-r1*
* *raspimouse 2.0.0-r1*
* *raspimouse-msgs 2.0.0-r1*
* *rmf-building-sim-gz-plugins 2.4.0-r1 --> 2.4.1-r1*
* *rmf-charger-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-dispenser-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-door-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-fleet-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-ingestor-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-lift-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-obstacle-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-reservation-msgs 3.4.1-r1*
* *rmf-robot-sim-common 2.4.0-r1 --> 2.4.1-r1*
* *rmf-robot-sim-gz-plugins 2.4.0-r1 --> 2.4.1-r1*
* *rmf-scheduler-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-site-map-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-task-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-traffic-msgs 3.4.0-r1 --> 3.4.1-r1*
* *rmf-workcell-msgs 3.4.0-r1 --> 3.4.1-r1*
* *robot-calibration 0.9.1-r1 --> 0.9.2-r1*
* *robot-calibration-msgs 0.9.1-r1 --> 0.9.2-r1*
* *ros2-control 4.19.0-r1 --> 4.20.0-r1*
* *ros2-control-test-assets 4.19.0-r1 --> 4.20.0-r1*
* *ros2-controllers 4.15.0-r1 --> 4.16.0-r1*
* *ros2-controllers-test-nodes 4.15.0-r1 --> 4.16.0-r1*
* *ros2controlcli 4.19.0-r1 --> 4.20.0-r1*
* *rqt-controller-manager 4.19.0-r1 --> 4.20.0-r1*
* *rqt-joint-trajectory-controller 4.15.0-r1 --> 4.16.0-r1*
* *rt-usb-9axisimu-driver 3.0.0-r1*
* *sdformat-vendor 0.2.1-r1 --> 0.2.2-r1*
* *simple-grasping 0.5.0-r1*
* *slg-msgs 3.9.1-r1*
* *steering-controllers-library 4.15.0-r1 --> 4.16.0-r1*
* *transmission-interface 4.19.0-r1 --> 4.20.0-r1*
* *tricycle-controller 4.15.0-r1 --> 4.16.0-r1*
* *tricycle-steering-controller 4.15.0-r1 --> 4.16.0-r1*
* *velocity-controllers 4.15.0-r1 --> 4.16.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-antlr4
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-pexpect
 * [ ] python3-pre-commit
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pyside2
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rich
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

