### PR TITLE
rosdistro sync, Fri Nov 22 13:28:00 2024

### DIFF
--- a/distros/humble/adi-tmcl/default.nix
+++ b/distros/humble/adi-tmcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, ros2launch, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-adi-tmcl";
-  version = "2.0.3-r1";
+  version = "2.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/humble/adi_tmcl/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "8f4e4350799d69a168a42781b35f54152b39f41f6c1554fe4910c8bcd4b5cf89";
+    url = "https://github.com/ros2-gbp/adi_tmcl-release/archive/release/humble/adi_tmcl/2.0.3-2.tar.gz";
+    name = "2.0.3-2.tar.gz";
+    sha256 = "111f6f7c1412f268696ca3f2e1595372943a845300ddd33c58b1bdb0ee038300";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension-python/default.nix
+++ b/distros/humble/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension-python";
-  version = "0.6.0-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "c9a4e2b1be48bc5b1b38ea5dca8bca761972167c3bc838e19d655181314229f6";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "d5d618b373c3b008025a8f25eb4a1e11a870d531ce0bd35e48e73e1ad4d5ea56";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension/default.nix
+++ b/distros/humble/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension";
-  version = "0.6.0-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "d5bbdf8444f8b20199521cf9609e5b4c9a01a7964175480161409e7b0842e9a8";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "c5256b2bddde6aa049036a31aa24730c6b381aaa7a3bd5d22da982dce9a83fbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/chomp-motion-planner/default.nix
+++ b/distros/humble/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, rclcpp, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-chomp-motion-planner";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/chomp_motion_planner/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "8f68c53d2e7607917885f0a91b62fbbe76ba559117b5f8743f0ec60c31511cfa";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/chomp_motion_planner/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "96929dd52f5c6e88582f01c7744051e46a1786d8ff89f9ec12b06d2df760788c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-ros2-socketcan-interface/default.nix
+++ b/distros/humble/clearpath-ros2-socketcan-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-ros2-socketcan-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/humble/clearpath_ros2_socketcan_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4da41aa84a5fd27c212cbd158102d6a15c900b5041f8ea32590b3ce2dde12eae";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "A ROS 2 socketcan interface.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/control-msgs/default.nix
+++ b/distros/humble/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-control-msgs";
-  version = "4.6.0-r1";
+  version = "4.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/humble/control_msgs/4.6.0-1.tar.gz";
-    name = "4.6.0-1.tar.gz";
-    sha256 = "31cefb8a441049e3b167b747d8cdbb736fc862e822190466447faff2bf731355";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/humble/control_msgs/4.7.0-1.tar.gz";
+    name = "4.7.0-1.tar.gz";
+    sha256 = "5d7aa7fa17e55da387e15a8a0e768399a529ac21a98ac90908e797832fc0b93f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-coding/default.nix
+++ b/distros/humble/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f2b6db19b03b596d615e08ae7613b4a42227264bfa13eb5c66ad3e79fb47b86f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "39a2b645c966ee54878491957c96e6379fe9696048fc2f86bc49ac2749841706";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "274af750a7aa6b458edde3855723aa71b2524151975ab9b108722c8825709d26";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "eb416977718acce3f8b3e5d63ed54678aa90d8121ecb9e18a359cdac8a7771db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5cde23d7c7f72ebf0c3395609c62b8877abe810b9172383ea3c2fb1b90ba0daf";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "98b6fc1511dc1736b685b217e34d6bd672d9ad5157cfa70d9db10bac60c10f6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-coding/default.nix
+++ b/distros/humble/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "b507b8091b7dcef348c47397a4b986a60dd286427cf9e718113872eb13d1122c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "830c8ce568092648702bb9ddc74295f1e880582074196304025f2cb8ccf669a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "73c6eb131d419c05b46e7ffd108ec668374d3057b9ca1127eaaeb6bd7086310b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "8887b912f028f5aadbf1086fe4ada44c96cf08cc00b37f4398e867d60a7911f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "9f826cefbedd6a8b02ebda2abd968df81bc1b626bce9842c6bb08302fa535a4a";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "910fb99de20cf22c4757074b25150264004f987171064d8e8473e10421285306";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-coding/default.nix
+++ b/distros/humble/etsi-its-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "2c67ef83a4aaa5b22cafe6457664a5b672934d453fa10d29924b26acd7f1fc00";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "5e665ed2538258f09d40adb79c3d06864100df5beceed3066aef941eace73c3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-conversion/default.nix
+++ b/distros/humble/etsi-its-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "711c4be802e65bbc04dd92d3de42d9023c8024d51e187e439ed54c6d9a7b392c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c8c28a9d89c96a016ae2fb9b3eb656a2adf741ed75d2d9363e2de49dc27d1809";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "6f4b4d480b0cd81367b8c0b327b78377e73cc75e8d0f321b36728fb006950839";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "b625b1d5b24d0c98ddcfb9a36929de43313d767477264a1cdd147a3eea44d591";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "284fa2b2bc069ffe8bfb86e970568c9b3a681d6c6b9e969be559442f8e88380f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "85f51781c5789f834422477636ab19801157f435f2472812bd3c9268ab14a819";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "2780b510e0d4a4623a9eaf84b4777f92061059998664cec5b1f921fba638a373";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "66a6fd9c3784969a1de10837b36da32128508501dd8afc09feca4bb186794add";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-coding/default.nix
+++ b/distros/humble/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "37c8463ae0638f609bb8df17be107ef0b708ff7385c6aa047a07e57dfc495127";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "fa7c9809faa038ee1f170e9c00d0f484531decdd55dfcfb6f6c61185054c47ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "80408859720778530e37476968d6a0d411e0091448cc5043ad38520dc4b9a5c2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e7079359c90fcba41ecb22e0ff5b539d895f40940329a2b8ed12b58b4c951ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c60ee187e50454a5c36ef9c915d02e2bf9092a37ab126d46c81e85607864aee8";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "cb3abbaee718fd9c87ef7ef8de0f9c0418c35a6980fbd1a4176ad50886fc2a76";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-messages/default.nix
+++ b/distros/humble/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-messages";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_messages/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "66539d8ef3b2e3f9c39d59902e9f752d5e0a130320075bf7005e2683428cea36";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_messages/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e04ad5da6c6bb356500f2049dabf73cf048b22c6ff439c3d3f82d8cf7b7af469";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs-utils/default.nix
+++ b/distros/humble/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs-utils";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "d83bbbc04cf833009214ac3a7cf42a755ca330a90a7de503594f608735fad61b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "83ade205e3ecd0c2ff755648dc1a7049385584bd1389d048e409af4ee375854a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs/default.nix
+++ b/distros/humble/etsi-its-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "4f0c75ffff42b851bdf802d3aed2f36bac47a4700e0d2b8075a3c488b5f021f1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "72c71a7a96e9758c365f466026b8a94565d3573deaf64937a510358d1eb20e81";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-primitives-conversion/default.nix
+++ b/distros/humble/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-primitives-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "73036e2554d433138f686f06a0462462202ee8b073aa63ddf4d9ea4ed15ef0ac";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "31d619f2848116cb92cc2e0fb13e0bd675cf525b56083cef5874fa2b9ceeb547";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-rviz-plugins/default.nix
+++ b/distros/humble/etsi-its-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-rviz-plugins";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5d41efd2ab6f810cd11116dd0b8775eebbf68c1688c5525cc016a93d12739fa4";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d174e3ae95c1069cedb6ce9b74ee4612d2067d5750d7117df7c8c07acbc765c1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-vam-ts-coding/default.nix
+++ b/distros/humble/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-vam-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "9ff20200bfd29bb0e1dfda02efbf01212ed8bd4b9f2e8a95a224089f3b97e914";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "74e29106f90c6e2abd00a90914a65008caa2ef6aa1d6940ff5c5cf5bcf3cea8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-vam-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "fd865a51376824b85f06366ed92ffd5290bd261ebec80051a6f280a179f2a3a7";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c28a6ff88b96436cfd42f3e8cb725bd44c36d533ac6f76207b452dfefbe6d416";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-vam-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f018a58ff6810359111cee67099914121833f1f3038eaadeaa1028264e4c72b1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "757424d01c0c149f293e18d281365d79654d3b00d5f9883b10181c647fd707b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "544acbb107041b44f9804c6eb45c2a4473330981578ddb7076b2763ee1919896";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "24d196bc904b58f1167268ab1feb16a98b995875b0786d71666ec81ac2e61e88";
   };
 
   buildType = "ament_python";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-humble-fastrtps";
-  version = "2.6.8-r1";
+  version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.8-1.tar.gz";
-    name = "2.6.8-1.tar.gz";
-    sha256 = "7d3109581c9d2293a8ac72ee1f29305dd087397a77bb480f1f79a55c804343ac";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.9-1.tar.gz";
+    name = "2.6.9-1.tar.gz";
+    sha256 = "05cb89165ef4476c59e7f56d645dfe10a4a03924bf22aa3038ede50d174f7dd9";
   };
 
   buildType = "cmake";

--- a/distros/humble/flir-camera-description/default.nix
+++ b/distros/humble/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-description";
-  version = "2.1.17-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/2.1.17-1.tar.gz";
-    name = "2.1.17-1.tar.gz";
-    sha256 = "097d2c0c9ff222d6422808cfc7c772210653c5827db5c3d806b84ef0ee743dab";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "dcb52d4a7fe640600a5325b603088f129d42ca692419e790f0d108d3ac6a65bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/flir-camera-msgs/default.nix
+++ b/distros/humble/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-flir-camera-msgs";
-  version = "2.1.17-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/2.1.17-1.tar.gz";
-    name = "2.1.17-1.tar.gz";
-    sha256 = "34030e78dc14a7248563fb2be9a0d8b53f1cc0341840245e56e47737f82aee7c";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/flir_camera_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "d39e867a5622d36327fe9a82e6ae3ee18fac468a9d9f7b3fbdbbcaefb8ea66e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/foxglove-compressed-video-transport/default.nix
+++ b/distros/humble/foxglove-compressed-video-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-foxglove-compressed-video-transport";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/humble/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a04b755b1b120b782ef9b79aa2d4266494b891490f08b6d7cd1b0e3a73057b48";
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/humble/foxglove_compressed_video_transport/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9a2d6494b1e0e7672b95482d254ab2452f0defa834311ae943447b7d197d456b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -468,6 +468,8 @@ self: super: {
 
  clearpath-platform-msgs = self.callPackage ./clearpath-platform-msgs {};
 
+ clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
+
  clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
 
  clearpath-simulator = self.callPackage ./clearpath-simulator {};
@@ -1126,7 +1128,11 @@ self: super: {
 
  hri-actions-msgs = self.callPackage ./hri-actions-msgs {};
 
+ hri-face-body-matcher = self.callPackage ./hri-face-body-matcher {};
+
  hri-msgs = self.callPackage ./hri-msgs {};
+
+ hri-privacy-msgs = self.callPackage ./hri-privacy-msgs {};
 
  hri-rviz = self.callPackage ./hri-rviz {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "1b734fac14aa8c124e715cb0ea73105922593ef1a610e25a77fbfc776f4b007f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "10224eddf977159cbb8a06a5e8cb330ada2c79b2dbe2345d060f046aeb88f404";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hri-face-body-matcher/default.nix
+++ b/distros/humble/hri-face-body-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-lint-auto, ament-lint-common, blas, diagnostic-msgs, diagnostic-updater, dlib, hri, hri-msgs, liblapack, lifecycle-msgs, opencv, rcl-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rosgraph-msgs, sqlite }:
+buildRosPackage {
+  pname = "ros-humble-hri-face-body-matcher";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/hri_face_body_matcher-release/archive/release/humble/hri_face_body_matcher/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "f93aa1ae680ec1b15271beeb41eabaac2986b442db02d10609d294c21eb9dff1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common hri-msgs lifecycle-msgs rcl-interfaces rclpy rosgraph-msgs ];
+  propagatedBuildInputs = [ blas diagnostic-msgs diagnostic-updater dlib hri hri-msgs liblapack lifecycle-msgs opencv opencv.cxxdev rclcpp rclcpp-lifecycle sqlite ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The hri_face_body_matcher package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/hri-privacy-msgs/default.nix
+++ b/distros/humble/hri-privacy-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-hri-privacy-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros4hri/hri_privacy_msgs-release/archive/release/humble/hri_privacy_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d86d5b826254110001cc78b9bf57a515aa389455273e31708d26af22f5ce2c88";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "ROS message definitions for declaring privacy-sensitive data flows";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/interactive-marker-twist-server/default.nix
+++ b/distros/humble/interactive-marker-twist-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, interactive-markers, rclcpp, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-interactive-marker-twist-server";
-  version = "2.1.0-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/humble/interactive_marker_twist_server/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "1b9df1af9948af8d471ad8d2e1e0453b9692bef48fd2af714168860433a658f2";
+    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/humble/interactive_marker_twist_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "35b96f93781f185da250e93e39cea35adb28c92c799feb096e4eb530f85caac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-bringup/default.nix
+++ b/distros/humble/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-bringup";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_bringup/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "04aacc5143333843f27b239359069608c57a5b0730e43a876638f855fa7c2406";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_bringup/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "bd791fd55901b77fdd6a21a24e8dc37df67f3495ab16f2448aac2541b1c37dc7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera xacro ];
+  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/leo-fw/default.nix
+++ b/distros/humble/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-leo-fw";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_fw/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f3ae70275dacc8460051e83c2a090cc3298463a2633a89dc4c46178260e7f8b9";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_fw/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "f1bb02044b35653579c3454843051f9dd7acfdf8c1f428855aeebaf8a682c046";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-robot/default.nix
+++ b/distros/humble/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-humble-leo-robot";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_robot/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f604081dc57198b19639494f08893d85f71317d70930b09948750f1414b76888";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/humble/leo_robot/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "37e655e3763f61f1fc4861f2ae0ac755a10770846f96fea2e44201357c6577ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/humble/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-moveit-chomp-optimizer-adapter";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_chomp_optimizer_adapter/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "5b7313307c165ca77f5739c599fe8614a7d29a9d1a1ec5678eb425ec7d2ffe4f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_chomp_optimizer_adapter/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "449e114056301acf785af91077ed08cc4d1e679e7ea3f3d5d2624bd4ed73b926";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-common/default.nix
+++ b/distros/humble/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, backward-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-common";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_common/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "d6dd352ca8ddbb4693858a4ca852cf85ba487a137316d799d36c496545fb549c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_common/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "d5e5ad0e4a5bc0dffd8cd00a5ba30af3a7f8f8efa63a02a6c13ab3cac672e8c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-configs-utils/default.nix
+++ b/distros/humble/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-humble-moveit-configs-utils";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_configs_utils/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "c3e448991b03e40d2d160eeb774ae43fdcd98f97fbc29ae4b0f55ad193d46b36";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_configs_utils/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "cb4e78fe86d4fac36a3ac77ee4a23c29a61ebf28e3a43ea4364fc3a77dc71536";
   };
 
   buildType = "ament_python";

--- a/distros/humble/moveit-core/default.nix
+++ b/distros/humble/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-core";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_core/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "0e71705886c8b62478971767c012cbfc5ce7fc057962823c58eea4ac6ed5bcf9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_core/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "808f68574c75156001224fb7963f8933207915013facc52174db3a55260bd047";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-hybrid-planning/default.nix
+++ b/distros/humble/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-hybrid-planning";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_hybrid_planning/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "a0cc8653f14a128462e6c052fcd091ffe7ea40a56ed85aa0e73c3388486e6541";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_hybrid_planning/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "07d3c2b7cc088ebaf2c2414a9031f33d8d0e969e929adf1ad9d029a9eb3562cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-kinematics/default.nix
+++ b/distros/humble/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-humble-moveit-kinematics";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_kinematics/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "9743cfa3859c4d29d7e573c3ff697b1ec526b300b8bee872fcd409ad7856a63b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_kinematics/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "50144d296ed3b0a0dd8cc8b7798d85934861df5c92c6f8f5e0367d08e2401804";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-planners-chomp/default.nix
+++ b/distros/humble/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-moveit-planners-chomp";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_planners_chomp/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "576e8838d0c6847d80e1904db9ad3bd306cb8165d152198cf636bdfe9cbb915f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_planners_chomp/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "8493a0b53e79e4ae54ae3bd3ffe8c940c3d0d3e1b61057b2e0817ec47612d16e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-planners-ompl/default.nix
+++ b/distros/humble/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-planners-ompl";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_planners_ompl/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "4b48361175ac1eb1a83a0a1278630dbd0f8766cce02a67a939e3eb4ffebec0c3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_planners_ompl/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "8d677ea09bc50bd6b789beffacbb23c7a6b9afa90db6adbda34a36f224db7d19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-planners/default.nix
+++ b/distros/humble/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-humble-moveit-planners";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_planners/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "8f164da760600011b83e195d18534501f8580ff514df200387e69ac7122456ed";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_planners/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "fe9450646acd131e65e981f490d456d40abd4d6662c179d608971cc2078df295";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-plugins/default.nix
+++ b/distros/humble/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-humble-moveit-plugins";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_plugins/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "56e6db623e76ca1b32ddd98997cd0d19424791cb7895ae900eef054de153ff45";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_plugins/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "bd671754d40c112a208b566add067e33968085fcfcb53ecf2651f95b6ac3b833";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/humble/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_ikfast_manipulator_plugin/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "8a8a5220caf887ed1501ebbad8db6e2120b4a0a469854dbdb3641f8877befa1f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_ikfast_manipulator_plugin/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "f3dc35d48a6c00ab117742a2daadeb60ff1af4c2bf0c4bcdf932ab3c8506e86e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/humble/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-moveit-config";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_moveit_config/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "f32c60577356e5b3f662973ae7401b42de16706f269c047785ac821aa7145031";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_moveit_config/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "9e2319bfc665c9989ec968d7957fc19aa5027961dfcd2a4444a1546ce5a9475b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/humble/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-pg70-support";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_pg70_support/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "2fc4a06abcce8847af1241cb7844866df79a8bc813f184eb5d96fdf7e028647a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_pg70_support/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "be1319626fbdc15da393be22e3521bfa6904d1b2efe6f725ddbd6ab0894df09c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-resources-prbt-support/default.nix
+++ b/distros/humble/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-humble-moveit-resources-prbt-support";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_support/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "6671aca6df9cdbe25302ca950b981e0e6a1ce8ec71ab5fe721a4be876a0a8308";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_resources_prbt_support/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "00c049cac281af20b6ceabd629c26a007437b8180ad9eb725ea587991bec96f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-benchmarks/default.nix
+++ b/distros/humble/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-benchmarks";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_benchmarks/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "f964b5819ff5b63b8ae810b14e24bf92396225de0b6556c8096bef23282203d8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_benchmarks/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "7b5e6da071896409a07683540e8492034c5823dd5fd64f2b2a7ae9ae1fbaa9c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-control-interface/default.nix
+++ b/distros/humble/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-control-interface";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_control_interface/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "2ad12ede82ba2bf987c9aea0835ee47c06d84e62e2f34e4e01148ab7d62fa806";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_control_interface/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "5870c087f07a0c27fc5e75200c0f1e73609817f19fa7c15c92dc377cb81f58bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-move-group/default.nix
+++ b/distros/humble/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-move-group";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_move_group/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "cc1dd334b9dc50299f36ae381485e726b1417719e4702a6833a7896bc6bd69f8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_move_group/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "9cb49561cfe69e84a9237c30a56f5160c25b32d4271cd60984a5f0818ef61fe0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/humble/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-occupancy-map-monitor";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_occupancy_map_monitor/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "594f4b7d67a81f254669e89ff519453d6e7a0fa389a02bb0ef1fcb98f486576e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_occupancy_map_monitor/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "5862b6de0f0770ac8534482bb3965535606a8bba05785de06c80f5c34e81d359";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-perception/default.nix
+++ b/distros/humble/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-perception";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_perception/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "08ecb4b44db4e2d39654b7fee0a8495fb6a76d807a2e709f8df07563ca71f6fe";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_perception/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "ef9a3ec6715dfbf476be6f6309cdd7f0af2452651f8b0cd624bf20a8adc41b1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-planning-interface/default.nix
+++ b/distros/humble/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-planning-interface";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_planning_interface/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "b02cf19244cc781e398112a9d4d08e8dd84432d1960fa470bfccede62c5f49f3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_planning_interface/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "3c0da73a382a90381024fbb720d863e493dfae0c2db981bc4c7ae946d90f8745";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-planning/default.nix
+++ b/distros/humble/moveit-ros-planning/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, ros-testing, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, ros-testing, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-planning";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_planning/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "6acbd9248fe92a05afb3a9d7d5b3375bcd71e6e884a39c86148290449d8af275";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_planning/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "6e803912eb9b612087b3d2eacf59ca8e5795473600b767b6447de016bf248e98";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common moveit-configs-utils moveit-resources-panda-moveit-config ros-testing ];
   propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module message-filters moveit-common moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rclcpp rclcpp-action srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/humble/moveit-ros-robot-interaction/default.nix
+++ b/distros/humble/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-robot-interaction";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_robot_interaction/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "533b0967ee511163348feb973d75d360cddaee5723b8f390725abb5e09413523";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_robot_interaction/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "b7d1fcb6a88a1227f50fd390230d677e77b244554ea17349b1702465911e2f2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-visualization/default.nix
+++ b/distros/humble/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-visualization";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_visualization/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "b09635d98e3027d74a4105d95144b9fa34b213f4fff42fe4a1430f64faa14836";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_visualization/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "78f3c260b336a600dad2ab6eb34951767ef70f9ac95e3ba615bffc66edd7c9db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros-warehouse/default.nix
+++ b/distros/humble/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros-warehouse";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_warehouse/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "d7cea46c881d18bc49bade1fbd1af0758ee363693de34036b4fa81c3b91d1379";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros_warehouse/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "0c150fdd5744f69ffdacd205ca8288b8dd93bd98ac63f1c9710508d9daac3662";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-ros/default.nix
+++ b/distros/humble/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-humble-moveit-ros";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "16a157064b7cd3545afbfaa940e6d8a865963c4a09146172f6ad66473d047c0b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_ros/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "f12c25dae0d6e276d91691067975497a95f2657ee3176ad28030de2b7271aade";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-runtime/default.nix
+++ b/distros/humble/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-humble-moveit-runtime";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_runtime/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "2b30848b7ce2c56e194b021e158c470c83221d1eb479061588511a135e474681";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_runtime/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "fb1c37027a48741896c83d7b006e8dfa52bcada6be78f9df84bfa10ad520cda3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-servo/default.nix
+++ b/distros/humble/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-manager, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, pluginlib, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-servo";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_servo/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "83d6233c0b9cbc8eaba4bc6ba63df7b5b9e7b61ac49f9f23ca76f6ce288a2281";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_servo/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "c9d9f05d1089d1e3f4007aa558266a8208acf4af850aa1cd934a1dfffa28c34a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-app-plugins/default.nix
+++ b/distros/humble/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-app-plugins";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_app_plugins/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "06a5b0f77e8b69219e2098deaeb8b732d335efa7b2d62c0a99985d8dee0f6b02";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_app_plugins/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "bfe4f3c5de7bc7c01ff40c11f897cbcbbfac6b00ab96a254ddf19130519b6a9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-assistant/default.nix
+++ b/distros/humble/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-assistant";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_assistant/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "2ab9e159e948492e739154241ce135a390bc1341b0a6a0e29df4210ea382883d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_assistant/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "bf77e7892609bfa7b7689b4c43e0bde9bd7faead2a042cd95a303ff90eec2746";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-controllers/default.nix
+++ b/distros/humble/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-controllers";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_controllers/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "99400240b25f2755e3c4251702e1518b46326326fb56a013dc92ff44063b793c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_controllers/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "6c7d92c8f6289d3b1ceb9f6ae7f1c7158dc14ba434045b3338f6139968a11b7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-core-plugins/default.nix
+++ b/distros/humble/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-core-plugins";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_core_plugins/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "4a1c24d1b90c6d75f216c938cd27202ae41dcb57b26890123c435052329ef48f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_core_plugins/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "82d6cc6ba8612a1a3442b6361cb2eac8d53417c4020ff263114efcd7c9696c7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-framework/default.nix
+++ b/distros/humble/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-framework";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_framework/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "1161dc253ae9148aa06c4a9fc806a91287c6faab88dd5b92cc70b448a7cc0b80";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_framework/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "9b9d20bb89796d111ed21f8ced73acc68f6777a0c602313c38dd58e179826606";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-setup-srdf-plugins/default.nix
+++ b/distros/humble/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-moveit-setup-srdf-plugins";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_srdf_plugins/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "3ebf18f00bbdd53130fce71c4cb33d18153afbd6746cde23f04a3a1e0f1ec8a9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_setup_srdf_plugins/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "b2c3bd7f09a3a0c25fc1c424ec226431d7f7a32b416876e94eb2a921b0d3ebc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-simple-controller-manager/default.nix
+++ b/distros/humble/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-moveit-simple-controller-manager";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_simple_controller_manager/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "3c17d27e89bff5eddf985a03af5b50978211336094df1a1dde7377ec168e78c4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit_simple_controller_manager/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "1bc3e59d971c7fd6acb1ea3f4a98828ec8ad6c645e45c92298222d9363a0f264";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit/default.nix
+++ b/distros/humble/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-humble-moveit";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "6b4548e003deb4fc5e3c8038ca32e7dc780a2220cbde62e62e69ac7e082837ce";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/moveit/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "d82734ea580cb4b3530cc841556ee371f89861a6e23dbd248e219721e75e38be";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/odom-to-tf-ros2/default.nix
+++ b/distros/humble/odom-to-tf-ros2/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-odom-to-tf-ros2";
-  version = "1.0.2-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/humble/odom_to_tf_ros2/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "55fb77df94f443ecdce53466364fd25afd3dc547bce365d831bb0910e5163b92";
+    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/humble/odom_to_tf_ros2/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "0ea655c0462cef5a49c7c2ab27a389aa70ebac529a0c046cabfb302471bceaf8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav-msgs rclcpp tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/humble/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-humble-pilz-industrial-motion-planner-testutils";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/pilz_industrial_motion_planner_testutils/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "af7c7abd92cbb520f2a8385e2de7fb396cd85c85b5ec8f06031f84540fad0501";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/pilz_industrial_motion_planner_testutils/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "a4a817fd690ce761526071727d39db36084203ff5ec6ae2ca82bf74bc34e554b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pilz-industrial-motion-planner/default.nix
+++ b/distros/humble/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, eigen3-cmake-module, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-pilz-industrial-motion-planner";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/pilz_industrial_motion_planner/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "d23b71f7598f15e47cd79aacb738e826dbfef34409bf010e43654e8512202ee8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/humble/pilz_industrial_motion_planner/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "31c2ade84f42006f028b5d91c24261200bd83dfa90f59f3fa6fe12a6e70950fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rc-reason-clients/default.nix
+++ b/distros/humble/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-clients";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "e97e9b874214e57645119ce0f6e83d78a281c21ea09a7d62cf06ec7b4c94963c";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d922904dc15eb160b980c61445d01481591dff0cb0bc56a47a5c89e77a7af10f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rc-reason-msgs/default.nix
+++ b/distros/humble/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-msgs";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "ae2db8d62dfec093c4d27b6ae935054694ba3c8be9d8b85346a2e93e245d9a3c";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b85b5f8823febc81456b7cc9de342137f1c0093a0eb1e6fb2ed1a54d151a4a55";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/spinnaker-camera-driver/default.nix
+++ b/distros/humble/spinnaker-camera-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-camera-driver";
-  version = "2.1.17-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/2.1.17-1.tar.gz";
-    name = "2.1.17-1.tar.gz";
-    sha256 = "4e0db76759dc7e0d0cdc4983456fa22811be36c6f1a44889b60b959e76a1c575";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_camera_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "1e2a9ebb2f56cca40d94620391ea3dccf638893213a556c166d44dc72ba4074f";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ];
+  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {
     description = "ROS2 driver for flir spinnaker sdk";

--- a/distros/humble/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/humble/spinnaker-synchronized-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-humble-spinnaker-synchronized-camera-driver";
-  version = "2.1.17-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_synchronized_camera_driver/2.1.17-1.tar.gz";
-    name = "2.1.17-1.tar.gz";
-    sha256 = "9ce17fcb875381b2155d8d13abf130057752307d001ff4c69d472023a8aa25a0";
+    url = "https://github.com/ros-drivers-gbp/flir_camera_driver-release/archive/release/humble/spinnaker_synchronized_camera_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "b93b5041676a29ba3e55c209dd33c31cbda6a8f5f502364de7c516e1409987a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "d3400eb10f948bc0207b7a2ef49a4a4cc89de1954497e50bfd45146890f0f396";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "0cbab3f45ec6bdc77451d1fc260835f3e3911b4fd3b975485c16c0aba576e175";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "ffb732cd5881aaa3480ac7936d40ab6ba0561cd02a4d23ce39e8a3e21d19e17d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "29c59cba49b8d4819d96e497857f03c81b87cb59cc52d9ca6b0713211758d109";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "52d201357aae661fd262858e0fdfe246b778ee2c929b43d8f414cbed039126b2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "f47e021db720405d326517b83c2cc8ab2660cb2bb1ac6e622f508680563161b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "20c80215ad4cd9644af9baa367772787653291e3dfc3c563ddddc8da743f6d24";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "c0c7edee1dbd2c56ea0877488198c1c62082922c813f6958249729ceae38a000";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "c31510035dfcfc2acc549e9dfdbf36322708fd79a7d15f3eb6549b9e83f43eef";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "656dbe4703d7104ada00fbf48b2c162ed50380366bd23a3bca065fa574aa331a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "cfc6ee7c9f094ee67cb0ac5d6680f476d84923fea0c602f690c6072392b0045a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "fea22e86373060422d8191f529f68b249f7f1e2bfec1b47f19a844aebb17e3d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "93d55036d2fd4d478959f6c05065d6a50ed8ff474d659e7353ce143deb050987";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "2bca273a9a78459687b51b2f69a1c25f13a9299e359ff54e5aef066680d995df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "3a9704e041893827a9f1375fbe5ff975dc1cbf4808d4a105c311cf09ecc4f3fa";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "1385b835d1e602d345547e432fee4493039b7195590e983384619540d0fc40b2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "d2c61936220d48a9242dd9371b53222b71808a937b0f24741914f1f862d9fc35";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "164504767793e8759baac2a1fce4ecb7010f881acb1ad145d3433a3be242af27";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "1e435ecc0ef5d5a9c1ba9dd0a22c4c15431e6305535f274f382b7304cc870593";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "564a61689ac2fb740525a83a141957208af38af9c07ebd35aecb3c4d114fc9dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "e0a8186e1167bdcd8480c2f0f3fa1c15be701d158e8708c10ea8c078d58f13a4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "009d08f0919aa7098a2d38fe4a583fdf87479f9408b451d39f4c8d2457819ffd";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.8-r1";
+  version = "0.25.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.8-1.tar.gz";
-    name = "0.25.8-1.tar.gz";
-    sha256 = "dcdd5372d9437abb1d25f64641c879cbcbdfc2de4f7077369aa876f8cbf76744";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.9-1.tar.gz";
+    name = "0.25.9-1.tar.gz";
+    sha256 = "fda8ecec85d93178f8d0e120a46710640f2f0739daf55be54b83c8ed0ed7cdce";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tracetools-analysis/default.nix
+++ b/distros/humble/tracetools-analysis/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages, tracetools-read }:
 buildRosPackage {
   pname = "ros-humble-tracetools-analysis";
   version = "3.0.0-r4";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
-  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read ];
+  propagatedBuildInputs = [ python3Packages.notebook python3Packages.pandas tracetools-read ];
 
   meta = {
     description = "Tools for analysing trace data.";

--- a/distros/humble/twist-stamper/default.nix
+++ b/distros/humble/twist-stamper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-twist-stamper";
-  version = "0.0.3-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_stamper-release/archive/release/humble/twist_stamper/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "e91fabf0b36836ae94e29706d8e875b62ef1c96ad06dbc31776ead5af2939c4a";
+    url = "https://github.com/ros2-gbp/twist_stamper-release/archive/release/humble/twist_stamper/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "6686cd1b3233765239195167c004979c2f40a918aff85ba7e7cebc98332bea1a";
   };
 
   buildType = "ament_python";

--- a/distros/iron/foxglove-compressed-video-transport/default.nix
+++ b/distros/iron/foxglove-compressed-video-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-iron-foxglove-compressed-video-transport";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/iron/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1c4695663905677d864184d6e2a9bd5302ecbe2c800b8384509e19daccbfc3ff";
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/iron/foxglove_compressed_video_transport/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "1814bed18ac7cca7fbfd000730b00e67e936526a734a6856fc5e0545af94c4cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/tracetools-analysis/default.nix
+++ b/distros/iron/tracetools-analysis/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages, tracetools-read }:
 buildRosPackage {
   pname = "ros-iron-tracetools-analysis";
   version = "3.0.0-r5";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
-  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read ];
+  propagatedBuildInputs = [ python3Packages.notebook python3Packages.pandas tracetools-read ];
 
   meta = {
     description = "Tools for analysing trace data.";

--- a/distros/jazzy/control-msgs/default.nix
+++ b/distros/jazzy/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-control-msgs";
-  version = "5.2.0-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/jazzy/control_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "5206bf027dd7c02026f7876200fa17ba305825414db2fc6b075562f23f506aff";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/jazzy/control_msgs/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "b43b883f65f9ca58bc13976248446dede87758a973a8482ce846ac7a5ac21250";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/foxglove-compressed-video-transport/default.nix
+++ b/distros/jazzy/foxglove-compressed-video-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-compressed-video-transport";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/jazzy/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0b8eaf6b69ab651d57ba1d8a1f5040bedeeb9422105c0af1fd389dcfc86121d9";
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/jazzy/foxglove_compressed_video_transport/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "a9aba56f1c37143c1481f6c49c0a16187c503da2008b1c5dc9c144e290d05f57";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -1800,6 +1800,8 @@ self: super: {
 
  range-sensor-broadcaster = self.callPackage ./range-sensor-broadcaster {};
 
+ raspimouse-description = self.callPackage ./raspimouse-description {};
+
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
  rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
@@ -2289,6 +2291,8 @@ self: super: {
  rt-manipulators-cpp = self.callPackage ./rt-manipulators-cpp {};
 
  rt-manipulators-examples = self.callPackage ./rt-manipulators-examples {};
+
+ rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 
  rtabmap = self.callPackage ./rtabmap {};
 

--- a/distros/jazzy/gz-common-vendor/default.nix
+++ b/distros/jazzy/gz-common-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, ffmpeg, freeimage, gdal, gts, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, tinyxml-2, util-linux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gts, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-jazzy-gz-common-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/jazzy/gz_common_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "397c2eeb384f31b81c91f5543a08a77f9add918976581cbb9a3864c6ddab7358";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/jazzy/gz_common_vendor/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "9f9885463f651f9cdf99dfc5a1c05cc96cee56cb3037221c65f834a66ed556ee";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ assimp ffmpeg freeimage gdal gts gz-cmake-vendor gz-math-vendor gz-utils-vendor tinyxml-2 util-linux ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-common5 5.6.0
+    description = "Vendor package for: gz-common5 5.7.0
 
     Gazebo Common : AV, Graphics, Events, and much more.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-math-vendor/default.nix
+++ b/distros/jazzy/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, eigen, gz-cmake-vendor, gz-utils-vendor, pythonPackages }:
 buildRosPackage {
   pname = "ros-jazzy-gz-math-vendor";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/jazzy/gz_math_vendor/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "36bfe5fe1bd0fe7e64071ab3ecc81be692c58be18fa539381da2388a47effeff";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/jazzy/gz_math_vendor/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "a3ba3848802a33711586c437ba9257c8b0577dd71cea67d010283e5db5209ad1";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
 
   meta = {
-    description = "Vendor package for: gz-math7 7.5.0
+    description = "Vendor package for: gz-math7 7.5.1
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/laser-filters/default.nix
+++ b/distros/jazzy/laser-filters/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, launch-testing-ament-cmake, message-filters, pluginlib, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, tf2, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-laser-filters";
-  version = "2.0.7-r3";
+  version = "2.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/jazzy/laser_filters/2.0.7-3.tar.gz";
-    name = "2.0.7-3.tar.gz";
-    sha256 = "95c5654a17239d40a9754ea47782ebb554f68eb72139593456d6e5b80992e747";
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/jazzy/laser_filters/2.0.8-1.tar.gz";
+    name = "2.0.8-1.tar.gz";
+    sha256 = "b0f1100159fa6a821825c3ecd5b3c708162dc9ddafeffeb7da3636111873db66";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-lifecycle sensor-msgs tf2 tf2-ros ];
+  checkInputs = [ ament-cmake-gtest launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs tf2 tf2-geometry-msgs tf2-kdl tf2-ros ];
 
   meta = {
     description = "Assorted filters designed to operate on 2D planar laser scanners,

--- a/distros/jazzy/leo-bringup/default.nix
+++ b/distros/jazzy/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-leo-bringup";
-  version = "1.4.0-r3";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_bringup/1.4.0-3.tar.gz";
-    name = "1.4.0-3.tar.gz";
-    sha256 = "8aeec7786752d3acad8d6162848bff85ad476a28783e3bf09eb90f873f6895de";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "5cf1cfc9f3a9fbbc03edf5d3dc9bb35533531150a8d66d4233a3d82eccf5c9bd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera xacro ];
+  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/leo-fw/default.nix
+++ b/distros/jazzy/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-leo-fw";
-  version = "1.4.0-r3";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_fw/1.4.0-3.tar.gz";
-    name = "1.4.0-3.tar.gz";
-    sha256 = "76104fd4f3cd84e6937b9906b2fab5c375017c4d12824d2c3c6f86b17847549b";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_fw/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "547c8e4db4c3c7588d18604e67438fff9997f68815527ad2935b81e4211507cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-robot/default.nix
+++ b/distros/jazzy/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-jazzy-leo-robot";
-  version = "1.4.0-r3";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_robot/1.4.0-3.tar.gz";
-    name = "1.4.0-3.tar.gz";
-    sha256 = "1a46f673397e720313eee467ada17671000accced54e2a6da34cc2706197cb3b";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/jazzy/leo_robot/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "0262b2b171c417ff2e1bf144dcfcbff9dc8eda56b5aa4d01101e5ec56b224722";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/odom-to-tf-ros2/default.nix
+++ b/distros/jazzy/odom-to-tf-ros2/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-odom-to-tf-ros2";
-  version = "1.0.2-r4";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/jazzy/odom_to_tf_ros2/1.0.2-4.tar.gz";
-    name = "1.0.2-4.tar.gz";
-    sha256 = "19e092e250e883e65d7b21b942f98eb1191e88151a5cdd79ed1eb1e2e043a194";
+    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/jazzy/odom_to_tf_ros2/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "f63b5775fb1d2fa1abb2ee9a0aab6bb653d0c55d278af3a760ed450448ccc6bd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav-msgs rclcpp tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/plansys2-bringup/default.nix
+++ b/distros/jazzy/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-bringup";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_bringup/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "55ac0ac58ae963fa70a8b3b3b3aa8cd4b19cfe02e132a640c0bfd6ae5e5bf0a0";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_bringup/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "c89e607f29faeca00a75ba7f1f9eb4dd2720afa5962a0e70a6fdf9b530c69056";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-bt-actions/default.nix
+++ b/distros/jazzy/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-bt-actions";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_bt_actions/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "f186fa02a47851e06dd9a6170a38544cf7e5ccae068df120830bb80fcb9ddb8f";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_bt_actions/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "065e478520225e0a837a11e6db256d17d3ea4666df9155f796ae691b8225d2c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-core/default.nix
+++ b/distros/jazzy/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-core";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_core/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "2e324a9646aeaa160e7de709413b0dbac2306689e76f4b6159e0f73b7eb157b8";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_core/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "70cf6642e61762ef66d80ccd0940892babb5aae596274a9e38c92cf66682d0fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-domain-expert/default.nix
+++ b/distros/jazzy/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-domain-expert";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_domain_expert/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "b62d6443d902f78dbd5e7f728c731bfc82a5cf60514ddafff0e95a4104a54505";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_domain_expert/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "75aae5e33becddb89fa7c9f9e068ac06a9fbfb62ac6b8f10e470c30a713ffeb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-executor/default.nix
+++ b/distros/jazzy/plansys2-executor/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp, eigen, eigen3-cmake-module, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, pluginlib, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-executor";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_executor/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "13e032b7e4aa57168985fd29bbde48dbe258ec276bbff2f59ece78780c4da35e";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_executor/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "dd11d8ed5b86a033018d413e77140ff0bdb5f68e1aed9355c39ae09ebd4dbfdf";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake eigen eigen3-cmake-module ];
+  buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert pluginlib popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs std-srvs ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp eigen3-cmake-module lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert pluginlib popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs std-srvs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/jazzy/plansys2-lifecycle-manager/default.nix
+++ b/distros/jazzy/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-lifecycle-manager";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_lifecycle_manager/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "f2910c37e31a78e4db9a3911ea0d0af4d840786459eb4e789bad49de5766de44";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_lifecycle_manager/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "ea60cbec4d965233906603c577b94d81f7a1fa224b6b78d2f151d5ceed054a94";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-msgs/default.nix
+++ b/distros/jazzy/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-msgs";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_msgs/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "4741b202d3ca795bb0879798dc98b1fffebbc5b1e5af0d6f047afecdeb56528d";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_msgs/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "277abf1a716ed1c79aac85fe1d4b3c78f19a1491e21be3e8acc85942886f29f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-pddl-parser/default.nix
+++ b/distros/jazzy/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-pddl-parser";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_pddl_parser/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "2bf32ecf955891cd03bd6688dc15a5308478d039cc0ce76a176fd87ee10be90c";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_pddl_parser/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "3c26d8b2f3a119a0cd8ce3e3187188a8ec2f391f6fe3f6f9fe54b4f125ed694b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-planner/default.nix
+++ b/distros/jazzy/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-planner";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_planner/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "5ae72c37d53c72abf937251f6660215de37ec87af5499d988939a02b34fe5768";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_planner/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "6ab37b714b7f245c7db5731c1f6ceeca04bf8e4f0037c2814dad9c7fb2aa905a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-popf-plan-solver/default.nix
+++ b/distros/jazzy/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-popf-plan-solver";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_popf_plan_solver/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "87655715217bdad708d85fa4eb87d1d433c1d455ab9622da3fa9f9a17aeaf072";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_popf_plan_solver/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "2c614b77dd3bbe249f746899dbcb7a8c950359e075d82e3c9aa9e35aa0f5f21a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-problem-expert/default.nix
+++ b/distros/jazzy/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, qt5, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-problem-expert";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_problem_expert/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "5db5e72fe9d03d579c91f6f7254a4725a7f685d2eca546e329c2aacd3519aa7e";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_problem_expert/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "bbb518c3ef40ee7ec34e55609d38e34441d258cb89add9ee2a6be698a844975c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-support-py/default.nix
+++ b/distros/jazzy/plansys2-support-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-copyright, ament-flake8, ament-pep257, lifecycle-msgs, plansys2-msgs, python-cmake-module, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-support-py";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_support_py/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "8dd2e966f4687a2a0e43cea6c43f5be52606a9f71ddaa5683bc0b60fc1e6cb52";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_support_py/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "d8ef31e518771df4b7330b600a87e836d5652cd30a4c256ae420c593952da1e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-terminal/default.nix
+++ b/distros/jazzy/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-terminal";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_terminal/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "24a71dfe69ec28efed0e1c2acdcad163333c286d45d5802056db142466e4d1a7";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_terminal/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "30674962398b0f531024a3969bf4656bd72b00404c0e2f7f94addc97d1faa08b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-tests/default.nix
+++ b/distros/jazzy/plansys2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-tests";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_tests/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "dce30eb353258420327cf2c0dfd0d82752e4603da1ac91d9e85a2ad7e9aac903";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_tests/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "f986f3179ea9728a9d88f8c21ee24408a8ae5ae51f1c68855b1e7ffef8278db3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/plansys2-tools/default.nix
+++ b/distros/jazzy/plansys2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-problem-expert, qt-gui-cpp, qt5, rclcpp, rclcpp-lifecycle, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-plansys2-tools";
-  version = "2.0.13-r1";
+  version = "2.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_tools/2.0.13-1.tar.gz";
-    name = "2.0.13-1.tar.gz";
-    sha256 = "2cb83387d477649949ca4825928564cfa4bd9c28764c8d0744b542afb0e575df";
+    url = "https://github.com/ros2-gbp/ros2_planning_system-release/archive/release/jazzy/plansys2_tools/2.0.14-1.tar.gz";
+    name = "2.0.14-1.tar.gz";
+    sha256 = "ec05f4f2dca26f5867a48681868c0cb9eeabc99d85b09fae1c5181965c98a642";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/raspimouse-description/default.nix
+++ b/distros/jazzy/raspimouse-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-ros2-control, joint-state-publisher, joint-state-publisher-gui, launch, realsense2-description, robot-state-publisher, rviz2, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_description-release/archive/release/jazzy/raspimouse_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "5a32142c28a77d68c928c6d96eedf2d3c1d3c75e58ad99c701e58a2d8c425f5a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gz-ros2-control joint-state-publisher joint-state-publisher-gui launch realsense2-description robot-state-publisher rviz2 urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The raspimouse_description package";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/rt-usb-9axisimu-driver/default.nix
+++ b/distros/jazzy/rt-usb-9axisimu-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-jazzy-rt-usb-9axisimu-driver";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release/archive/release/jazzy/rt_usb_9axisimu_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "f9bb3853c339647686d53639a638267a379c1c851758db7deef96a873c4a6dcd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The rt_usb_9axisimu_driver package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/tracetools-analysis/default.nix
+++ b/distros/jazzy/tracetools-analysis/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages, tracetools-read }:
 buildRosPackage {
   pname = "ros-jazzy-tracetools-analysis";
   version = "3.0.0-r6";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
-  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read ];
+  propagatedBuildInputs = [ python3Packages.notebook python3Packages.pandas tracetools-read ];
 
   meta = {
     description = "Tools for analysing trace data.";

--- a/distros/jazzy/twist-stamper/default.nix
+++ b/distros/jazzy/twist-stamper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-twist-stamper";
-  version = "0.0.3-r4";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_stamper-release/archive/release/jazzy/twist_stamper/0.0.3-4.tar.gz";
-    name = "0.0.3-4.tar.gz";
-    sha256 = "404bce67baa04e782a49c2b977a728e08f2745f2e94fb648973a5d8621a11a5f";
+    url = "https://github.com/ros2-gbp/twist_stamper-release/archive/release/jazzy/twist_stamper/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "7cf5e6d3348f56839287c9b10398699b682af7be156839229ff08994c0eea507";
   };
 
   buildType = "ament_python";

--- a/distros/noetic/etsi-its-cam-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a5504821c8c15b9814b18659ff52e895c6918f488ac8cc85f1156bdd4f9f0ba4";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "b7c7bc430b515d7cf93583d92f235e60461cae7c11b2b34de7c134957ca48c77";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5c454823378a487133633fd3f84afb2d24943476c0417b1560bb1231e74db217";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "515e7dfb5d49b368bdf70a93d8ef6fe3abc8bf6d325396aa2e97276a44c8e6e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "1c3068d048ded1fbf5fbbb69d8368b9fdea977110b749511b63d9cf3a32f7dd9";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "4a483cdcbe74a25dd30b3547db90343ccea574045c3ef4071c0b7d627b427f3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "71ba94f5ce7580f9705f943fd1988724bc20ca842cb6befb0c6b95dbf43950ae";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "d155ddc656ea3e14af03f7eb7be81dc7d39de4d8763cf7f90a996c0bd05a4476";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "dbd97bfb568d7658814a5ea36fb5b5eb5ec9c65358c9d9be49fe912432910052";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7904db14cbfa96fe70acfe62ba8175d4c4268daf120128f98371e3ab536f9f83";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "001314258fdb802ccac6081e5ba1fb5f85e88feb0b55e5da2238a2f1294ef5ca";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "cf06f450d1db9142a568284dcc72b143267eb2817cea4fc2f191ce182816846b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-coding/default.nix
+++ b/distros/noetic/etsi-its-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "8e8f62fa8e5a625911df8055371ab34924947771fe1bc8d9f814d3c7f6bf17b1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "f8a8ec50bdfbe1a402e4c1d207aba742c288a9244f5462e1d8804b8c2d107d71";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-conversion/default.nix
+++ b/distros/noetic/etsi-its-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-vam-ts-conversion, message-runtime, nodelet, ros-environment, roscpp, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "51752f64a78da75934d3a49cb6020a08872e6e41fc98d409ea41247ce0346246";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "389db95c12ef1b48981d5df7c4f0591861cf43498dceb034f86523a127e2b172";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "90f1926082c1ea1dab82c03ae1121deaee3b465b6a47eb3e258ce22f25e848e6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "df5571c231505b5913aa4f10e590908fda4496ff48441b6e420a9d58ebf313f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a2348b33c79b2703d4609c387cba134045b97ede17f6c96ef666f1e6bc5fb71b";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "9327c8694218195358709c7dd79d9fd41e4dc1b74191867588af92ad92f16605";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "52eb223eb49457bf7f9a2369a8d4227d72cccda5553d1d27cfae54656fc2b506";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "74d1b6ccba5b19630a938d0f991cf4cc45a1830e97350b05d05472680c1c9b69";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-coding/default.nix
+++ b/distros/noetic/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "d48c5c66c2eaa6515eb714c0e81b9f5bc75d217a92def94337cc6f003791ef06";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "4f295ba8b18aaf3d6bdaac7f63bb8aea8b25e107d146472bb04a65cd83bb7371";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-conversion/default.nix
+++ b/distros/noetic/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "85c2a2dce0c70204192139145a677a41f782fca869e8a93f5011f8d79f9f579e";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "2ffc0528b83d756aa5bcd522b669b0978d22ce5fd77300fc63e7fb030aaa86d2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-msgs/default.nix
+++ b/distros/noetic/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5e6db6d932f4d8f7f539f1827cd5b7a0b16818da7c7cab4d5c165926acdf66b9";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "13629e74f47a05f657d4c62d39da0f8b1391b693591cd7a172ca2c5147338805";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-messages/default.nix
+++ b/distros/noetic/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-messages";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "4989a1227c7ffb7366908cd87d8e4c2a5504f9dbfce4722f38e756e548c871c6";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c69c1381ff9dc2a5d4d78d75eecdd0dc2b3ae324c54baaaaac0371eace31dd91";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs-utils/default.nix
+++ b/distros/noetic/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs-utils";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "34599a7524992a65e95cfcd5920f2e835f5e3713ea2b539765d561f45eac0048";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "63e9006b47a2587da354c6442c7fd2b081e16bfab7f671ec0f69a2f17bf3bbb9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs/default.nix
+++ b/distros/noetic/etsi-its-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3ddcd2e803c2a9062791cdf26c6c2439bd44a88a90cbea947eb2eaee103dfa47";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ecc771c76533d663869823baf2d63b78bc26b273cfb667c0415acd949e6f9e01";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-primitives-conversion/default.nix
+++ b/distros/noetic/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-primitives-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "acf42946e002f1accbbbce43bd04870354499d951b1c8d0824a036c6d1aaca89";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "4214065c94913bd468f1520a9234e26f57b626a6648779f6449012d466624ea1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-rviz-plugins/default.nix
+++ b/distros/noetic/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-rviz-plugins";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "d18cb4a3529d61ccaf168d58db48bba7ebed09984f72a293eba2956b23d36caf";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "9b8eee11c4e02d84aaa4c1b3aa2eb93a95c16b7ee94f2fd9c78f0a7b0b50f95b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-vam-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-vam-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "bf0ddfa141197f2752a1d0ddb692ae2914c106e1b850a3e4594cba27208180fd";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "545af4de443b839d530d41535d22df577410cde291ed30ac6160e3f71d4461bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-vam-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a75fb206bc90c0cbf00a2444dcaba126c2957f49281d35b671dc1d05b46aa965";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "7be519135be7373d4b479acaf4b4f5d913e074599deb93c8693eb5520ed5f2f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-vam-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "001cddb83f7d9c7c53112dddadc5633a5907fdee777fe7da644b2f982f45abb1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "007c9db81288fee5476274d901d8b8c9a8823886cdb3d6243ff30548705c6b0d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-noisy-depth-camera/default.nix
+++ b/distros/noetic/gazebo-noisy-depth-camera/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-custom-sensor-preloader, gazebo-dev }:
+buildRosPackage {
+  pname = "ros-noetic-gazebo-noisy-depth-camera";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/gazebo_noisy_depth_camera-release/-/archive/release/noetic/gazebo_noisy_depth_camera/1.0.1-1/archive.tar.gz";
+    name = "archive.tar.gz";
+    sha256 = "47cfc77251c668c19f570660de50af27f1702cb1fbfeefe19ab2f01d0d5b7dee";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ gazebo-custom-sensor-preloader gazebo-dev ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "Gazebo depth camera which supports noise";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1190,6 +1190,8 @@ self: super: {
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
 
+ gazebo-noisy-depth-camera = self.callPackage ./gazebo-noisy-depth-camera {};
+
  gazebo-plugins = self.callPackage ./gazebo-plugins {};
 
  gazebo-ros = self.callPackage ./gazebo-ros {};

--- a/distros/noetic/inorbit-republisher/default.nix
+++ b/distros/noetic/inorbit-republisher/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, roslib, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, roslib, rospy, rospy-message-converter, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-inorbit-republisher";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b420da2301282b41147d5215ba8c3325acb09083f41cae41dcd8c4529c647197";
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "240ef03e220c1b525f047b43d1cfd2d73f10b4ea200bc088358c8597c8fba378";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ geometry-msgs python3Packages.pyyaml python3Packages.rospkg roslib rospy std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.pyyaml python3Packages.rospkg roslib rospy rospy-message-converter std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/nodelet-core/default.nix
+++ b/distros/noetic/nodelet-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, nodelet-topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-nodelet-core";
-  version = "1.11.0-r2";
+  version = "1.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_core/1.11.0-2.tar.gz";
-    name = "1.11.0-2.tar.gz";
-    sha256 = "2725e477c4ff5c59f779b3733ab098542102871877ad247eb8c8d487799155f3";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_core/1.11.1-1.tar.gz";
+    name = "1.11.1-1.tar.gz";
+    sha256 = "95964d68aede1dbcdeefca16aa31a0220e48766e6c79ca6fb5e6d64db4a452f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nodelet-topic-tools/default.nix
+++ b/distros/noetic/nodelet-topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, message-filters, nodelet, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-nodelet-topic-tools";
-  version = "1.11.0-r2";
+  version = "1.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_topic_tools/1.11.0-2.tar.gz";
-    name = "1.11.0-2.tar.gz";
-    sha256 = "0f42086736f35d89d0a0e14cbd2d2d329cd7920936df789ab108b39baf8986c2";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_topic_tools/1.11.1-1.tar.gz";
+    name = "1.11.1-1.tar.gz";
+    sha256 = "c23a96966e2a2c6e587f848765a75267b7e5312ee40b58db75db20009d0ca3bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nodelet/default.nix
+++ b/distros/noetic/nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-nodelet";
-  version = "1.11.0-r2";
+  version = "1.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet/1.11.0-2.tar.gz";
-    name = "1.11.0-2.tar.gz";
-    sha256 = "7f6dd83e8edae17f515f0163f87766c4c08c0a96d845ea72cbee33ca8b5a75ec";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet/1.11.1-1.tar.gz";
+    name = "1.11.1-1.tar.gz";
+    sha256 = "b79c548103a7a267e7b18888e06528cd98d62aaf078eb21a7f6c6f7c21cb62e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-clients";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "abcd730e1b48291c87a729bd9778459b16797f7c13dfa94cb24c92cf24a0b8cf";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "55b139aec55da97a194d9947e1b2be49de36b8740aa25fec91ac021f2ffbc7d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-msgs";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "6050c7ec2bfeb73a3418c532fbb1758c2464db962cd0c4506e4c07567124f700";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7b58ccd8f06e315d6c40abdb2a67a4672bb77472566d7b88311135bcbe14f8bc";
   };
 
   buildType = "catkin";

--- a/distros/rolling/action-tutorials-cpp/default.nix
+++ b/distros/rolling/action-tutorials-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-cpp";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "1574ca6ead7b6ac9053bea30b577722065bd8f8c66842d260ae759e07195f870";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_cpp/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "0af46c1ae327071f7255e79f5e82cf7910f681bbef026c6fbb89b22c5b19f89f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/action-tutorials-py/default.nix
+++ b/distros/rolling/action-tutorials-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-action-tutorials-py";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "420ee4f91dadc4a94cee618a7c8355eb3beb6db2f5689e8d9b80da306ca5d9a7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/action_tutorials_py/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "4aee429ab0db864be65408e4fdef0cc10d37028a83ff26e85544abf9fc12d3df";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ example-interfaces rclpy ];
 
   meta = {

--- a/distros/rolling/actionlib-msgs/default.nix
+++ b/distros/rolling/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-actionlib-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "01e89898a58f3c1197c088de97577ddac02ecc53dbaf7060ef685fac54f6bfd0";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "9bcb116acc12f5864f17616fc2132a9f45c65cfd93c233189f2c1b207f007b94";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "97333955fe0d053c3cecc4748fdaf50c6598983c981ac7483451c4101425b1c9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "6f4f00133cf3a5fd8906ea8decb8c3e677bea662a86a7bbda119dee5b6572732";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ clang python3Packages.pyyaml ];
 
   meta = {

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "2880414adadbdf6013b681dc1dbd2e17f8dc605e643863c225b931a624310f76";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "077b74c89b48b1a174c3bb5638908556bf9ba4d205dd0bc2a7bd23aeb732b7bd";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ clang python3Packages.pyyaml ];
 
   meta = {

--- a/distros/rolling/ament-cmake-auto/default.nix
+++ b/distros/rolling/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-auto";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "fd421b4c1f8702e18803cffad5c04da46b540ab779cc90b13fe371e6b59cfd5f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_auto/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "e0cc9be7699f57ff49cee93b245320211daa3481bccd4315a721a98369656597";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "85735e3246b294127cbb62b01c82c370b478b25e3f6169777e2fbbd92dc718ff";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "1f04c465c0ee05ec4c23e15c8acce81d7790033e96bc2d271d686b2c5a0482a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "80c6be79ef5a8a9af49912062546f71ac1009240970c901c86075757df923d74";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "f8e62f7b5276edbe222749a9fe3050fa1c51ed68aaf0a6a88c87e2a6dc15e9be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "c11ae4012e9f54a8d5c23b990116f81374078eae089e76cb0c070728869cd0a1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "848b259af32b32e6a0c0b2431d734d28e905d498669f0080bbe87a8e4df5346e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-core/default.nix
+++ b/distros/rolling/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-core";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "492bdd9ea1b1887f3e5fe83a968d97e04c2a56f0ff1a76dfba2d3b4e18e08948";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_core/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "83034d79a3e8ddb99a74151b9b4eb487925ed3ae42b8ed58d45af221762fd3e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "be2f533c675e381f542533c43fa624cee8a313e21e793217531e48505cfe09d8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "14ce13b46675219caa02bbc5ae78413b58fefbe6068c3f2acf58090522896c04";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "03f7120b88e85cc171adebe440985da143c48558e3cf7e25306d52b133ac2865";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "fe3c3079a4f78b160e9cd5d8f217ffafae8451d42c04829ac7a47a7efce848e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-definitions/default.nix
+++ b/distros/rolling/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-definitions";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "6bb5ddffb71579866cc842fd90de5b99f4acf80e891a534dd83e714c3db5ce53";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_definitions/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "c30af65f9c3b3bfef1227113e940aab6fea296a001622fd083f9427911a559f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-dependencies";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "9328897f2acc640045ebf56140dac9daa8210c15b001844d97b9160e7e098bbb";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_dependencies/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "dc08a9a71fab22276391b431de4c0b178c46b350198b68653e4b166ab0e6ac6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-include-directories";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "db201c2d10ae809b93a8b11380e33e7d27c6426514eba291e127014517e4ffb7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_include_directories/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "2d4c3d8bc58be1aaad860462b507f9c9fb332a78b2d68981333093b7d684a0f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-interfaces/default.nix
+++ b/distros/rolling/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-interfaces";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "8b59f2bb6018bf7417000d74f8547a02e67a74780fc2e21e8d79f71e6f01e0ca";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_interfaces/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "f27398081f27fc5c9a2cf6f00c401ae07819765c7dcdca064d4b4c59600c4112";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-libraries/default.nix
+++ b/distros/rolling/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-libraries";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "57b5730502640220d844b323387bf313165e048660e4460b2e8a2bdf767b01ee";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_libraries/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "99cf6a2d27c13df2056d1f091228b39a795813b2eead45937a31c8f683190c01";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-link-flags/default.nix
+++ b/distros/rolling/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-link-flags";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "6431ca1bf54827c67f306f201024fd322b916c99fc19918af2b7b5bca03b38b1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_link_flags/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "3066f8cf7b7e0726cf06aa3cd4d16e7b1bb876205770966041247fb3b1b78b91";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-export-targets/default.nix
+++ b/distros/rolling/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-export-targets";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "80e2e591a46ca0560d5b4efad222db63aa345caaf250ca1d69b79df9a4908c34";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_export_targets/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "9bf7fe984cfe00ddecd68def0b4758e4022e5923ad8fad243498fd9dc585faee";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "19078046e1017c52821eab08423d6683ab3a5fa289e316dadc66c3ad70f9f246";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "c46bc216f99eeb2f50818ea5b0c8969711ebf3065e8f6e3dfc0e66129d7e7d4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gen-version-h/default.nix
+++ b/distros/rolling/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gen-version-h";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "7843fda34e52b1c8f1633f707913a8e5b572a2e1db9c983efb6f8f2cab2b8c8a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gen_version_h/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "22ca3c7bfc39d845594c14e9327758bcbbf94570c8cb045f777ea27aeb925f39";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gmock/default.nix
+++ b/distros/rolling/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gmock";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "4a165ec73363fbdad17d56b248169806f0679b3867a66924537c6f599200a2d1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gmock/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "b825daa168a4f51695abb31211366ca2d7e52a697d3064312afd6f8784107667";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-google-benchmark/default.nix
+++ b/distros/rolling/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-google-benchmark";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "b017c805532f3d7fe00d10f973a539e2f9958d5d278066d587550ff8b3c6006b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_google_benchmark/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "98a90c1505a2ef80feb7c9af39cf97ae9dd9b952037fcf2f3dbb104101ca576f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-gtest/default.nix
+++ b/distros/rolling/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-gtest";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "e42ee86e8cdee10880e06536c08530ea7abacfbfc848b43673132041da6a9cad";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_gtest/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "f04af8fe5d1cfc9063a017a6d71f2f8c46dc4695161bfda8dd8baecc3ed87483";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-include-directories/default.nix
+++ b/distros/rolling/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-include-directories";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "ce01b6478e7ea2c3e596917bbb7e07d26b3534a34f49a4ee49aa75cfcb97df5c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_include_directories/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "5faffcc9fbbc3393c3283b1735ece82d2b383711da5d35029f155f39c9fb1d64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-libraries/default.nix
+++ b/distros/rolling/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-libraries";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "5c78cc1f88d7aa15771e37c339d7f58aabbb96ab2153d830faab97c64c7167cc";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_libraries/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "fbda5df4161f50f9e4d8f677d401f9a8c324a8fde46aded22e1a78f0599840f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "33b5b4b3c7e3a7e482d05b90e7ac8a5671605c5be6fd6005d01ad80a16fb0f50";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "48a4bd0aeda2d4d4007060aebe051630c5afc278468bdfddad7fb1b0f2fabcb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "4d23e100e787a69ea2b578249e410244bd5fcdacaed197e441015187f6b40bee";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "3aab86c87164a856d5c5368ab2462eddb05eb664af4e867438ed46306730e9d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "72fa4a27bc3d268fc0364e72b677a3e516fda811c5ce4d8b05275db92b66012b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "6595c02ed3288a0079300b20b8b8491316aab5840cc319f829ccd6b7d27df546";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "deb1495c174724050bcd6ce6c8b156a2f01b7d4130416a3e057ac348cb5bc865";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "a54fcdf1c5c2972c805c9c197e60484ed9db76b488a3d9d06dc0e2cca5b84c40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "55ea219b567b6404a9c3321633e9dfbcad363976a46f825cba000d3ecb634037";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "59878312c573c70d19af4183d727647a0985b3a919898c38bf1d1be3c91bfeb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f9b5f06640adb41e04d54982f7e7cf720858cf94e57cf4602c4857687878b264";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "288882e6810114d730972510e35f4d2da30696d000e0117407a11305c1d3d3e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pytest/default.nix
+++ b/distros/rolling/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pytest";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "5724f584b8b6c5aade6ccf1a0a142b38b342dce7f5a7399e7e1980fe8859e3b1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_pytest/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "98e33ebd73d4e5db2ccd04ad24d562d1a42fa13e17bfada3c3846266fc40e57a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-python/default.nix
+++ b/distros/rolling/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-python";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "8f12c1772b51b2efe7f318ce6bccffe6b0d9721c80fd5e166d4f66932edc4ca5";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_python/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "baa8a8146e2ae63617029cf35d5210ea8b1cdf348ef74353360d48c02c095867";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-ros/default.nix
+++ b/distros/rolling/ament-cmake-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, domain-coordinator }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-ros";
-  version = "0.13.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros/0.13.0-1.tar.gz";
-    name = "0.13.0-1.tar.gz";
-    sha256 = "8410e4c444692029938b1e751260d6412744e76e9e53358e5313802e5087b956";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "1b0b47e774593f2c90ad66ee61950d2a930f4603ce380ae27b95ea707b7385de";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-target-dependencies/default.nix
+++ b/distros/rolling/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-target-dependencies";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "9e0b2e9676cc445af1a08aadfa7731a2b576a3c65cab0ad3ea1b9815f13a34d1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_target_dependencies/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "bc12ed3d5e184e69ed9e86019cd54e12a814bab8a51d6a01e5bf8098ddf51502";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-test/default.nix
+++ b/distros/rolling/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-test";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "95321da9b3ea3cdb45477556377e3465018f3cfa10576b10c25dcb076f10e558";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_test/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "cf9a35f4ed6265643fe2d207cf1d3862a803735f300ac7d91497897b94de7d80";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "1e18b0cfe6d3ef1d315cacca7f663207c3e3e147119da67074d221121f10f4e4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "19da9d01ad9b3eff65df74450a3b78ece9b1a8dbe03d94686351f574a9f7d5f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-vendor-package/default.nix
+++ b/distros/rolling/ament-cmake-vendor-package/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, git, vcstool }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-vendor-package";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "c423112d93d18e34e8250684c592ba908350a0f91d57ca247e80c26bfc36a74a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_vendor_package/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "3b0afe98b520c9e3e50bd3fd66f6775c4424aac20a971c64b80b060e49278d52";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-test ];
-  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
+  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git vcstool ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git vcstool ];
 
   meta = {
     description = "Macros for maintaining a 'vendor' package.";

--- a/distros/rolling/ament-cmake-version/default.nix
+++ b/distros/rolling/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-version";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "19ca652a99813953a9bd22a47520c8e76c7f58322205ada49a628251b802975e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake_version/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "bedf3065873e0aa550a9f11116cdba09fcaab2f495a70cea54f796804eb77d34";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "a13d70ce3cc315d32ecafa8f25e50126ce688e21d51050f515f7f2a39383c53d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "eb525c4616205d7df997d8c93368f1296202b0a90e61b25eaced98b948eeefd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake/default.nix
+++ b/distros/rolling/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "6dabc572fbc4ed1e4ca0a0447ad80e43d6758ead6c71a13bd13175dd0b90d721";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/rolling/ament_cmake/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "28a4d620a214044327f375db0368f618229e1b21d0e97f0febf839f4f1503d98";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "12e4701a77584033012843b65861aca4520c3956e5edc41089b9ff0927f9d735";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "16d93742c0249c810fa634c87376218629997dfc956b21b3aec45be170060edb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, cppcheck, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, cppcheck, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "065bc27fcab3244e76b324f719930a8a71603cc0a812955fb9b64419ca42c7ee";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "6a8a009988d33933a087d6dba3f1281c45cc32292cd4edfa4b38c71bf291b950";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-pycodestyle pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-pycodestyle ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ cppcheck ];
 
   meta = {

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "2a6ba59e28b69ddf7cbbc56d982eea81f741abc9705fa477731589459f5446c3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "c9458c357ddeb3294cddfb05970c929f613f9ab342d836cf0b4ae5a84eba339a";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
 
   meta = {
     description = "The ability to check code against the Google style conventions using

--- a/distros/rolling/ament-index-cpp/default.nix
+++ b/distros/rolling/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-ament-index-cpp";
-  version = "1.10.0-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_cpp/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "bcdc38b2a367f697848fa8d171504aa72ec8e5c5e8608f3ff5eb1ba65fa927ae";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_cpp/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "748d548c1551872bf8bc5e59cbfca39bd1505f4029a52bf705127c7eddcf7bcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-index-python/default.nix
+++ b/distros/rolling/ament-index-python/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-index-python";
-  version = "1.10.0-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_python/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "c5d4adb47eda65e93b7a43a2747cf1eb7abdaa9e23adb503e6d575d3192b96b1";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/rolling/ament_index_python/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "96cfdb67df3607a726ba854b79d1af3d018aa2a02d0fe0a4ed46744d3730fb6d";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
 
   meta = {
     description = "Python API to access the ament resource index.";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "e654328a379459179bcdd9b37f68910575e17f00cc570d677d338acf47527af6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "3e83dd4162ae862154f45fa0f45c1e0454aa4782314cfad6615c7ea260f88881";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "8654b95a99774b5eefa74118a58950c58e67bdeecc6539da4717779b05138626";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "34beb1744356c0c5271f541e3a2444c4be989aab785a21b4d8e221f83aa033c8";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
 
   meta = {
     description = "The ability to lint CMake code using cmakelint and generate xUnit test

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "96b810af1bc6aa62ea9279d14b17a399ce2062751ef892811178da4af711a3f0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "94efac18c7420fac91d88081eda92165ac9ee3040da98261fa86a68e9ee8947a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "966c3a244a1ca0c3cc555953eee48b7c9f2ed7ea1d8d2d05184dc4a678330fb9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "53d3d95669eb4ab7404aef780a019ad3140a60d20738a46737eac0ba597b80c2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-flake8, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "9251597238a0446d5025fc5de35d80d40f6c569891926fdfd6454fddf94a6403";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "101638f12bc6ab1aee22482d736022fddab41ac842e2071dadf6c4141946bb1c";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-flake8 python3Packages.pytest-mock pythonPackages.pytest ];
+  checkInputs = [ ament-flake8 ament-xmllint python3Packages.pytest-mock pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.mypy ];
 
   meta = {

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "5496b88833fb2e05ad8298b979125f6c1bdbaf6e3255e205383566b2c236dbbc";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "8fc3368d91b4026e85f3df454a61c800e261bcab9c069dda03e949a0d98984b1";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
 
   meta = {
     description = "The ability to perform static code analysis on C/C++ code using PC-lint

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "cc88644ef9d452e72ae391f065f5e35c06403c915617055452885208a58b1812";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "358f186e35a28ab0c63d22417e8ef06a64645738002ede9e5e83cbf401125712";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "905591ae0ec8a97e8ef71e2e63a496982ec1e3eecd389616dba01de8ca3ca215";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "3c91e47b079c364ea51316913472f6e0e0876732daf842e629997cd96563fd4a";
   };
 
   buildType = "ament_python";
+  checkInputs = [ ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.pycodestyle ];
 
   meta = {

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-pycodestyle, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "4007ef58b417522e01264850aa2640332e6c457f923147e72b0784053e13b9d0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "384ffdeb5ee75bea48729c60563784ba09515f1bbb2d6a15a5bda089ec76c940";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-pycodestyle pythonPackages.pytest ];
+  checkInputs = [ ament-pycodestyle ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.pyflakes ];
 
   meta = {

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, pythonPackages, uncrustify-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, pythonPackages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "e6a439bbb77ba2108cef1415235d8b3e7a4756ce75639b85115a40a755c622a6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "bc083cb25d9f4fb9cf158ca20da30322d019eec577cc6414c5f924675e0944bd";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-pycodestyle pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-pycodestyle ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ uncrustify-vendor ];
 
   meta = {

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "56057a8a6fee0d470ec14e274f8d7bedf69a6b49154f14c75e35f88cf9ff3584";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "104b84c9143d8d96b541728d9559f449c46bf3dfc0e60be991ad3a00d6e1c4e6";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/autoware-lanelet2-extension-python/default.nix
+++ b/distros/rolling/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lanelet2-extension-python";
-  version = "0.6.0-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension_python/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "9a10677623e6271fbc8b52ac36260f9d179bd5061cf4b9231ad4cc35d276ac4e";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension_python/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "e5a181002a9b70586aa3de90d6b61d722ea7c6c734c334a1bea88071424953c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-lanelet2-extension/default.nix
+++ b/distros/rolling/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lanelet2-extension";
-  version = "0.6.0-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "738fb18deb6a8bd3196b267cb2da29bd1236254de01c860c457835d13f254235";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "c00cdcd19b8a84a78bfc1e2203de0fe7e896199f3cef813806072a1cea1f319f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "f8f26341414d864fd5616a5211cacd20fbdbf60e18d50ad17362775a4d49bfb5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "201f1953d17ec6126e1953caa70a91b10cad2497bf2b42043baf57d9f89d8a15";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/composition/default.nix
+++ b/distros/rolling/composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-composition";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "b04fb32bd1c9dd1260be0b4230ce26aeef7fa1650663d900bad5d7bce7d44fac";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/composition/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "1fba479437409e76db1a699a7cee42df23ade8984ca329ded5c08c18026adbb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-msgs/default.nix
+++ b/distros/rolling/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-control-msgs";
-  version = "5.2.0-r1";
+  version = "5.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/5.2.0-1.tar.gz";
-    name = "5.2.0-1.tar.gz";
-    sha256 = "04b4283bed83ab8fc701a1ac0969401a03053f2f2833737265c0c3b1cc4a13bd";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/5.3.0-1.tar.gz";
+    name = "5.3.0-1.tar.gz";
+    sha256 = "62864e50ab0bebcc8f559144ed960109066cdcd181a1bf098b18a53261734e65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp-native/default.nix
+++ b/distros/rolling/demo-nodes-cpp-native/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rmw-fastrtps-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp-native";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "bc702a8d47ac6a92a8c6c2fd11d3cf62b5ee0572371d7e64209c3fd3e0aeb850";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp_native/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "5fb60310bbf952c237a7baaf8765da904127ee1e8c32401e4f3f971f3ebacacc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-cpp/default.nix
+++ b/distros/rolling/demo-nodes-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, rcl, rcl-interfaces, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-cpp";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "bce1fe906be5021df7a6bafb4b43391bac85983629cb4f6ff2a2b0f4c765fea2";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_cpp/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "a53917758d9f2d96b656eb820b1f972e9ea12c563ed9b31556c87e557808f3c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/demo-nodes-py/default.nix
+++ b/distros/rolling/demo-nodes-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, example-interfaces, pythonPackages, rcl-interfaces, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-demo-nodes-py";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "75d16fc0ea7c92d9cc1446aeba6457d506262dc942eaf2b79f79d46898c85cde";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/demo_nodes_py/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "e80bdf7dba3a32f267524a972af9c00a57eda1d465f3f8c376246bcc11ce51b8";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python example-interfaces rcl-interfaces rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "ec162d2c8f9a0f11978f49d6fa9578c79293619bce44d90d3e5937b26311fc28";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "3166fb42f8740c7d386c0213b78e6be0971a3ab80db1f73a73e310e5455ba5ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/domain-coordinator/default.nix
+++ b/distros/rolling/domain-coordinator/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-domain-coordinator";
-  version = "0.13.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/domain_coordinator/0.13.0-1.tar.gz";
-    name = "0.13.0-1.tar.gz";
-    sha256 = "a6f257ff85eeadf21f67ad824a58d65a5401bf2ead884a34cace7a08fb705266";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/domain_coordinator/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "73631bbb0ee51dc7c94748216590c7bbe2201e532d839cead08fe015b4643edc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
 
   meta = {
     description = "A tool to coordinate unique ROS_DOMAIN_IDs across multiple processes";

--- a/distros/rolling/dummy-map-server/default.nix
+++ b/distros/rolling/dummy-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dummy-map-server";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "e61a6d1aa4b213b44235c86c92f70e72c99c69ff859db73e77cd637efdf68084";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_map_server/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "8775cfc10fefeabfc066e8f1c2243ba1679fad9e24c74530a7d8ca8d378e4481";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-robot-bringup/default.nix
+++ b/distros/rolling/dummy-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, dummy-map-server, dummy-sensors, launch, launch-ros, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-rolling-dummy-robot-bringup";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "41cc8f36e1b877e41f6e3b7112a15c5007b172776499944c77c139e130a73eaa";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_robot_bringup/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "f65e030dea92e8efaf78994dc309dfa90936592f5eb6c26bb70d3f23697db07f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dummy-sensors/default.nix
+++ b/distros/rolling/dummy-sensors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dummy-sensors";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "f368b2ee957d4b555bea01d71f5bb236f4b177a4efe1d107e4c1c1dc93da09b7";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/dummy_sensors/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "a1cd8af8c28a03e3e6072a62a477b8a030e6c933126708a9b895798d3553cbf2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-async-client/default.nix
+++ b/distros/rolling/examples-rclcpp-async-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-async-client";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_async_client/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "96d6ce8c22316eea4d66881518e3cf21e3b9524fde683b004b6b8c924819cb42";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_async_client/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "002196113c9d84509832ed849a3ec8e18556cb7dad025fea72fc3598bdb96de6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-cbg-executor/default.nix
+++ b/distros/rolling/examples-rclcpp-cbg-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-cbg-executor";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_cbg_executor/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "0010ff49039550324a001368fa9b287bb13a943feeb844ced153f623eb531c0d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_cbg_executor/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "9337202cc2e14398bbab72086b5983d6d361309770aef562a2987594481f08ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-action-client/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-action-client";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_client/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "beaf21f915f9ebcb26e0943946dd71a0ffc1874181edc42aa47d6e42e04fa227";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_client/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "b5354d2b17527f1e17ee691bd803e91625d349413fb6239760bb56ed6c515aa0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-action-server/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-action-server";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_server/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "30ddf7b6c40e7e7d790b9375460bab6b37237d707533dd043811cd94f92e50ae";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_action_server/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "6bd651e7a2a165e31d889594e75b924640f5a9d129b997e2182221f6ae54e8ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-client/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-client";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_client/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "c58a7f4da34c2cdff8a2635ebda0233709d6e5c167df9148b9d582a90fe742d7";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_client/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "acd193682783222b6d207451aef4509231d045829c31f47496fbecac3bfd527a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-composition/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-composition";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_composition/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "71d2890d5b11214fce0865d2d1b97f53004b232de2e0fe265b2616068583e5f2";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_composition/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "99005af42e85dc17c5d20258e7418837f0bfbd436a141aa87a1e05e03c1d5e72";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-publisher/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-publisher";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_publisher/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "7a608e9ec2f920cc1ca8529c739f9b38a99c741d6f437b5e3eeb4c811a30e45f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_publisher/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "8d80e91308d330e7ef96edf65f8066c46e39acfb04a5e4cfb99b6c33a1cec861";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-service/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-service";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_service/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "039372ede82ae4b2aa730644ebe0ec4a288bceddbf4da03fe76ed2c460b9c62f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_service/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "3e825fa1c91618fe16055bc5877f8c3ad26292fc2107e8c812754755270ba7f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-subscriber/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-subscriber";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_subscriber/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "7f87d33b48c0708e455cc8a79949da734355ab0f6aefda4e61743fb247bcd65d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_subscriber/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "8785a9ea1ec431c2b293d73ad9218571742c83f0c98b5f7d284b06b9821f25bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-minimal-timer/default.nix
+++ b/distros/rolling/examples-rclcpp-minimal-timer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-minimal-timer";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_timer/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "658fc4018b84e44352ff8b8d1c31128c3de46d42f4bf8e4f26f1f063522b906d";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_minimal_timer/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "3a60d210d11832c36219e5f85acd4f5693ae06ba995124d5eef81654f2af95c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-multithreaded-executor/default.nix
+++ b/distros/rolling/examples-rclcpp-multithreaded-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-multithreaded-executor";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_multithreaded_executor/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "6e1b7c18a91c55abefdf397893a3bd06893dcfcce29c5dafbc943f751f2fa908";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_multithreaded_executor/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "ff0f1873b694e13515c010413a6fb82de2ce6c7c4df48899732ddd5b9882be4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclcpp-wait-set/default.nix
+++ b/distros/rolling/examples-rclcpp-wait-set/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclcpp-wait-set";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_wait_set/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "2a24e0a56fa8b972fefda3139be0cc695c0d790b01a04114e57f57befd2c5c06";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclcpp_wait_set/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "2db41df0bec9aa1ed632856b86c6479af463ed48f81d358de4aea472ea4753f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-rclpy-executors/default.nix
+++ b/distros/rolling/examples-rclpy-executors/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-executors";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_executors/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "1582679df13a2989f394d7be226991ac5e732a204483aeb8fff1ab78582ba0ee";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_executors/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "39e53b51893c0663897541f640e5c22ba1c6a14bbeea0f35d09c568f0238803f";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-guard-conditions/default.nix
+++ b/distros/rolling/examples-rclpy-guard-conditions/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-guard-conditions";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_guard_conditions/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "5fe5f8f15d9482d646910394a9b0eef419067485ae4e95fc24ee26c9c84e40a2";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_guard_conditions/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "39d29c05098e7a226311a439b92c65b5ba91c3ce65fe247bc7922cf12d8e94dc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rclpy ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-minimal-action-client/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-action-client/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-action-client";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_client/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "b4c9d261994f902ebdcafb8cf4066ff4cec04acd4b7cd1188ca5ef8487ac3f64";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_client/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "b54abe57fee10d4f5973f137762b2254cc1ebbfeca97e4243540e87e2f5bdddd";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ action-msgs example-interfaces rclpy ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-minimal-action-server/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-action-server/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-action-server";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_server/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "cdf3506108c1cd0e56129725a8ad3f954274a7030bb3e07fbedd65862c4e8496";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_action_server/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "dbaff690d4564d384d4a92b8e58ad4d180424c4ef92fc11382c513eb7d1e14e4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ example-interfaces rclpy ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-minimal-client/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-client/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-client";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_client/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "2a851ab96001b93e957dc1808592de8f61f99ff16a6a728d7a41694879885256";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_client/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "f5a81f4bf71ead7fcb2fb2fdcddb9d12aab446bd211e2a1aacd41087d2f35e04";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ example-interfaces rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-minimal-publisher/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-publisher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-publisher";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_publisher/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "e65493f6e23e1a20ba324f826933cab15e633939a408591d0d4d3140f3b1c9a1";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_publisher/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "e032a7d28398b902012f27dcd6c0c72b77c0231f75a3f7e2d9644f657150005b";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-minimal-service/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-service/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-service";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_service/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "0ef134596cb5c61b3710a0cf79900d32dc4a98c585d8f73e9464de30b6e09b99";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_service/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "a98676350b38299ca3b16ba1c11d8626daa2b1b50101f27a9b35b5f51fd4ceda";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ example-interfaces rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-minimal-subscriber/default.nix
+++ b/distros/rolling/examples-rclpy-minimal-subscriber/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-minimal-subscriber";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_subscriber/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "e73a3bee43290ade1bc40a374563fee9758dcad60e6ecc9a4becc3fea4281e7e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_minimal_subscriber/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "cbfa9ae641258369aba88895b8745296b6a02ad75fffb2fab4ca1aab7c8a2dc4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/examples-rclpy-pointcloud-publisher/default.nix
+++ b/distros/rolling/examples-rclpy-pointcloud-publisher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-examples-rclpy-pointcloud-publisher";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_pointcloud_publisher/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "76a618ae8b7cfc7dae79e2badc1be9fb72ca90a133e80bb73ac485fe17ad6af1";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/examples_rclpy_pointcloud_publisher/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "edd7ee382409673c4951039276eb641817f0784cc65aa1ee69c1cde45bc4e763";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.numpy rclpy sensor-msgs sensor-msgs-py std-msgs ];
 
   meta = {

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "96b01c499921f64515a4ceaeeec525051908c4ba53498dd279ebbf9096d03dda";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "3de9afbb33733789d77d36e8c2eb6f36e574ca2b0bcc3f472a292edd00914fcc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ geometry-msgs launch-ros rclpy sensor-msgs tf2-ros-py ];
 
   meta = {

--- a/distros/rolling/fastrtps-cmake-module/default.nix
+++ b/distros/rolling/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-fastrtps-cmake-module";
-  version = "3.7.0-r1";
+  version = "3.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/fastrtps_cmake_module/3.7.0-1.tar.gz";
-    name = "3.7.0-1.tar.gz";
-    sha256 = "e881989c2e579bd0b191678bdc2d00733b14b256cd420e9b0a26652c43d8fc8e";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/fastrtps_cmake_module/3.7.1-1.tar.gz";
+    name = "3.7.1-1.tar.gz";
+    sha256 = "b0255717b559645e637a1d4641a75854c8df0a20467b882e66032498fc69aac4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/flir-camera-description/default.nix
+++ b/distros/rolling/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-rolling-flir-camera-description";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/flir_camera_description/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "10a2af5086cc8e845140134e508dc9951c57489e4bc754c96cce2278980455f5";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/flir_camera_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "e74a55fd51e69ad50ca77b8808c54c85be175cca3b4ba1a647453a6e3cb0c1b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/flir-camera-msgs/default.nix
+++ b/distros/rolling/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-flir-camera-msgs";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/flir_camera_msgs/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "7eba028321b846fc3eac114af2889c397967264fb0cf57349c3325f6c2ac1bb1";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/flir_camera_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "bf50281efb92ea0346f08f090ee97b7789d3489bbeed174e5b0e8ede67ab4460";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-compressed-video-transport/default.nix
+++ b/distros/rolling/foxglove-compressed-video-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, foxglove-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-compressed-video-transport";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/rolling/foxglove_compressed_video_transport/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "438fcd1ffd54a2ff58ad9d0c4b46b571066a1fa3f28e10bea54acf6403db2cd2";
+    url = "https://github.com/ros2-gbp/foxglove_compressed_video_transport-release/archive/release/rolling/foxglove_compressed_video_transport/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ae81418cb436fae8c32b570d7a77985fc9b6f749e611c7bfe6a96a36e4152f06";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -118,8 +118,6 @@ self: super: {
 
  ament-download = self.callPackage ./ament-download {};
 
- ament-flake8 = self.callPackage ./ament-flake8 {};
-
  ament-index-cpp = self.callPackage ./ament-index-cpp {};
 
  ament-index-python = self.callPackage ./ament-index-python {};
@@ -894,6 +892,8 @@ self: super: {
 
  laser-proc = self.callPackage ./laser-proc {};
 
+ laser-segmentation = self.callPackage ./laser-segmentation {};
+
  launch = self.callPackage ./launch {};
 
  launch-param-builder = self.callPackage ./launch-param-builder {};
@@ -1591,8 +1591,6 @@ self: super: {
  rclcpp-components = self.callPackage ./rclcpp-components {};
 
  rclcpp-lifecycle = self.callPackage ./rclcpp-lifecycle {};
-
- rclpy = self.callPackage ./rclpy {};
 
  rclpy-message-converter = self.callPackage ./rclpy-message-converter {};
 

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "d1fea5c462733368da81464c184d545f3ac470fc58262c1e130c68721e8b11d7";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "0b553df9d4c07aed09a84189985d7d793bd2fbd537e9b188776777feb00b9ca9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "294634cb3c69bb64dc5515250014abb8488800d5fd21e326052fe911fe81d623";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "e7169a5a89f3d9e4fc7b712926c0707f3780051d9af5390363bda5342bd5b884";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-common-vendor/default.nix
+++ b/distros/rolling/gz-common-vendor/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, spdlog-vendor, tinyxml-2, util-linux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-common-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "94f743708626fdac4d263a846f2f371b25f3db094e8a16a9cd1ba3c128c836be";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "6d0f45e86537e5e695756bf2f9fba8ea2cb904df36126badc93712e85a07e4dd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ assimp ffmpeg freeimage gdal gz-cmake-vendor gz-math-vendor gz-utils-vendor spdlog-vendor tinyxml-2 util-linux ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
     description = "Vendor package for: gz-common6 6.0.0

--- a/distros/rolling/image-tools/default.nix
+++ b/distros/rolling/image-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, opencv, rclcpp, rclcpp-components, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-tools";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "d02e745c91d64301a18a6694ec5c92b0d869507f20736796164cf36afac1c089";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/image_tools/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "f845ee5d7b54b455874bbd413edd79a70cd58169a790f4678d0f8ee73fa1ea69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/intra-process-demo/default.nix
+++ b/distros/rolling/intra-process-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, opencv, rclcpp, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-intra-process-demo";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "0e6c055673a2729e69dd08be2ad01e5a0d71555917abb9977326d8d79ce80d1f";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/intra_process_demo/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "5ad18f424f749ba0a106d5c054484e2818106753f19f19dfa2368181ad3d0317";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/laser-geometry/default.nix
+++ b/distros/rolling/laser-geometry/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, python-cmake-module, python3Packages, rclcpp, rclpy, sensor-msgs, sensor-msgs-py, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, python3Packages, rclcpp, rclpy, sensor-msgs, sensor-msgs-py, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-laser-geometry";
-  version = "2.8.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_geometry-release/archive/release/rolling/laser_geometry/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "83a881ee1bc247deceef0b71a6958c0b68dd572dce8e170938a45d453978edc6";
+    url = "https://github.com/ros2-gbp/laser_geometry-release/archive/release/rolling/laser_geometry/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "2f29e9dfc422c94e65cead43be81a4154b518c4d7527ab65f3f212407fe4bec9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common python-cmake-module ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ eigen eigen3-cmake-module python3Packages.numpy rclcpp rclpy sensor-msgs sensor-msgs-py tf2 ];
-  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 
   meta = {
     description = "This package contains a class for converting from a 2D laser scan as defined by

--- a/distros/rolling/laser-segmentation/default.nix
+++ b/distros/rolling/laser-segmentation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, slg-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-laser-segmentation";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/laser_segmentation-release/archive/release/rolling/laser_segmentation/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "3d531e815b43511d54b60c10c93a698c7cd0e27ad904e348bc0521359969d12c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs slg-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Implementation of algorithms for segmentation of laserscans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.6.1-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "d6a51dcf11d4d9fdb65742bc3cd17db8c6184d3fd128176f7b95ce3748c9a5ca";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "0914582141ad93832c6d14024057a370aca40990aa4efecdd66f5c95a12b9fa4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch ];
   propagatedBuildInputs = [ ament-index-python launch launch-testing osrf-pycommon pythonPackages.pytest ];
 
   meta = {

--- a/distros/rolling/launch-ros/default.nix
+++ b/distros/rolling/launch-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-launch-ros";
-  version = "0.27.3-r1";
+  version = "0.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.27.3-1.tar.gz";
-    name = "0.27.3-1.tar.gz";
-    sha256 = "90929988408491aa7a9a71b8f40c215f8eaf2cd547d3a3622b9c55955414eeca";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_ros/0.28.0-1.tar.gz";
+    name = "0.28.0-1.tar.gz";
+    sha256 = "c536458dac999bf5f2614d18c5356071b6c285524e8743c75888d9d992f3ed3d";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python composition-interfaces launch lifecycle-msgs osrf-pycommon python3Packages.importlib-metadata python3Packages.pyyaml rclpy ];
 
   meta = {

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.6.1-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "5dfcf636cf9245cc6966e32f25edccab15ab36aad883095015c968a0f7ba1296";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "fa6017f5db86efef833c1cf75a1970443380951a45f174e9b1f56fff813ce2e5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-copyright launch-testing python-cmake-module ];
-  propagatedBuildInputs = [ ament-cmake-test launch-testing python-cmake-module ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-test launch-testing python-cmake-module ];
+  checkInputs = [ ament-cmake-copyright launch-testing ];
+  propagatedBuildInputs = [ ament-cmake-test launch-testing ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-test launch-testing ];
 
   meta = {
     description = "A package providing cmake functions for running launch tests from the build.";

--- a/distros/rolling/launch-testing-examples/default.nix
+++ b/distros/rolling/launch-testing-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-examples";
-  version = "0.20.2-r1";
+  version = "0.20.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/launch_testing_examples/0.20.2-1.tar.gz";
-    name = "0.20.2-1.tar.gz";
-    sha256 = "17795ad6e074221c909014f3240062fe97e9a7f91cfc5e2605e8dbf1c835052f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/rolling/launch_testing_examples/0.20.3-1.tar.gz";
+    name = "0.20.3-1.tar.gz";
+    sha256 = "eab84c4566b6832aa1ce0e467fc8db205895ab8a086e4916b175cd54b26b0e48";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-testing-ros/default.nix
+++ b/distros/rolling/launch-testing-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ros";
-  version = "0.27.3-r1";
+  version = "0.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.27.3-1.tar.gz";
-    name = "0.27.3-1.tar.gz";
-    sha256 = "7e2f4180965e431dafd4e580a15ea94a1333c36e17241b3f05b5d7f8851e04a5";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/launch_testing_ros/0.28.0-1.tar.gz";
+    name = "0.28.0-1.tar.gz";
+    sha256 = "7d5a10e86a85400faf4e935fa53bfd6e92b539dec79c5206f30075f4fd0154bb";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest std-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest std-msgs ];
   propagatedBuildInputs = [ ament-index-python launch-ros launch-testing rclpy ];
 
   meta = {

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.6.1-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "45c31b811897befddf8f6e8a1535c72aa9192d5ad3edb07e3c652df1b156251a";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "bfd2db24782f86adf0c2fcb0093bef694516db238960fc13bab9a9e06337a181";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch ];
   propagatedBuildInputs = [ ament-index-python launch launch-xml launch-yaml osrf-pycommon pythonPackages.pytest ];
 
   meta = {

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.6.1-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "d5b55f2660c3bceb70dd0b3c62d6f1ed6c30362bdee07a859734b69528c98d94";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "f95789e712b7e526b1668fde9025e9538eeda116c91204fe56185a7fc416f24a";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ launch ];
 
   meta = {

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.6.1-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "d7e4c5fb96a9a6da423a3fdcfa44081f3167f5533b87b66202017790a343df02";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "55003846805e9cdc21df4fcbe06769dbb165dd808f33376e11fab3529aecab0b";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ launch ];
 
   meta = {

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, ament-xmllint, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.6.1-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "c837b8e52413460184de4b18bdb0277320327e73bc8ec84285ccc30ca6c6dfa8";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "b19fc6ef6dfa9bcc7276607258ee3c602a1418e474fc31ec7cb05c95dbd3a1a0";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python osrf-pycommon python3Packages.importlib-metadata python3Packages.lark python3Packages.pyyaml ];
 
   meta = {

--- a/distros/rolling/leo-bringup/default.nix
+++ b/distros/rolling/leo-bringup/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, image-proc, leo-description, leo-fw, robot-state-publisher, rosapi, rosbridge-server, sensor-msgs, v4l2-camera, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-rolling-leo-bringup";
-  version = "1.4.0-r2";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_bringup/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "9bb01ce6e716ba59a7307f90c7ea65de46031f0f7d5ece597e7586f9fb64e941";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_bringup/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "404718a3237de26df34f32326758b954796bf41961b926046476d4de8056a50c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
-  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera xacro ];
+  propagatedBuildInputs = [ geometry-msgs image-proc leo-description leo-fw robot-state-publisher rosapi rosbridge-server sensor-msgs v4l2-camera web-video-server xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/leo-fw/default.nix
+++ b/distros/rolling/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-python, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-python, ament-lint-auto, geometry-msgs, leo-msgs, nav-msgs, python3Packages, rclcpp, rclcpp-components, rclpy, ros2cli, sensor-msgs, std-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-leo-fw";
-  version = "1.4.0-r2";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_fw/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "959a2f545d13bad125d993ba9859f30f8da031834c655158183803aee12e23db";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_fw/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a1b316719849b1718e7cfb61152650cadf0b378f5609f093b74b102b91e14a80";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/leo-robot/default.nix
+++ b/distros/rolling/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-rolling-leo-robot";
-  version = "1.4.0-r2";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_robot/1.4.0-2.tar.gz";
-    name = "1.4.0-2.tar.gz";
-    sha256 = "bff18bb27931b3cc8dc6921c888a24ac782be8afc2b93bd26353c1f8a143dded";
+    url = "https://github.com/ros2-gbp/leo_robot-release/archive/release/rolling/leo_robot/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "264071429b6e8c3213ee81a015634ab032427a51858484cea9c2364e58aff0af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libcurl-vendor/default.nix
+++ b/distros/rolling/libcurl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, curl, file, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-libcurl-vendor";
-  version = "3.5.1-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/rolling/libcurl_vendor/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "526f3ebf8e3a01b7c722ffaa1dc36d1fc372878ad78cbcd86a49b278d96f07a3";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/rolling/libcurl_vendor/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "4949d4bd960634c5a85f1e20becaad7c437242af32b7b5e4ac35d3a10bc93b01";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libstatistics-collector/default.nix
+++ b/distros/rolling/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-libstatistics-collector";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "6e9b84ec72ba715ecbf0ea2e2a36ab63e2ff0c43230b632ee642af53b1367273";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/rolling/libstatistics_collector/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "8960d5bb1e48e9b6e5966ecff049e29cd3c282d63930768a13e59d297c5e01df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libyaml-vendor/default.nix
+++ b/distros/rolling/libyaml-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, libyaml, performance-test-fixture, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-libyaml-vendor";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "80b017b743822c317cb3b33f81fc291f8067c0d19064ae10cc44e14c11e0f651";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/rolling/libyaml_vendor/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "bab1609badeedfeeecaf5a83e6786665943ed02fdf9e45abacc2ca17c2c95953";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/lifecycle-py/default.nix
+++ b/distros/rolling/lifecycle-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle, lifecycle-msgs, rclpy, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle-py";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "3a9ee20769b7aaefcb8547814630e6e412463b31b080ac85526680d989a1e2e5";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle_py/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "fa8338bcd9986dd195d2f093ea5464f1cb91387a31fcf8fde58823ee6b38b6ba";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-lint-auto ament-lint-common lifecycle ros-testing ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint lifecycle ros-testing ];
   propagatedBuildInputs = [ lifecycle-msgs rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/lifecycle/default.nix
+++ b/distros/rolling/lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle, ros-testing, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-lifecycle";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "9194661b5d1301b44a439debeaad7f30fe34b439fa832f2b05704b75d97e2ddf";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/lifecycle/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "69faa4340a1303b33d8e0a74aae3cd7a64c20da300fdd9b77c4fe4ee8816ad45";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/logging-demo/default.nix
+++ b/distros/rolling/logging-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, rcutils, rmw-implementation-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-logging-demo";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "b4e80a7bfae8aa12c904c1fd24a532fd52c070587b4bda1a98d08d2d8d146331";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/logging_demo/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "8393d703868fa797348137245a8ac9ba8d0e32959c5e1ac402641ec26b9e9e0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "6.0.6-r1";
+  version = "6.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/6.0.6-1.tar.gz";
-    name = "6.0.6-1.tar.gz";
-    sha256 = "ab51cee78249bc10b53ce704674af2edb784d44c6d2c11f390734d97dd56a17d";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/6.0.7-1.tar.gz";
+    name = "6.0.7-1.tar.gz";
+    sha256 = "dd1f4e09d812a2f56461144e15890f401d69aeeba41d36b21cb34ed15d990db2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "6831e832b88037bc65edc66f27cc397af78b329294f25fad61af9cd656840ec2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "ab405c79f69d2bac1aede9e0fa201e4e2d21d3e99a2ea07fbf707b41b8e3fd14";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/odom-to-tf-ros2/default.nix
+++ b/distros/rolling/odom-to-tf-ros2/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-odom-to-tf-ros2";
-  version = "1.0.2-r3";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/rolling/odom_to_tf_ros2/1.0.2-3.tar.gz";
-    name = "1.0.2-3.tar.gz";
-    sha256 = "59957be434e867743cc7b2b7dc259b042f7a79c63eaea0df3a591e8063316c1e";
+    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/rolling/odom_to_tf_ros2/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "a961e0f34468cd629eeb6bdd44543b114db595e7d98cbcafc51a5f3db5525580";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ nav-msgs rclcpp tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclcpp tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/openeb-vendor/default.nix
+++ b/distros/rolling/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-rolling-openeb-vendor";
-  version = "2.0.1-r1";
+  version = "2.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/rolling/openeb_vendor/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "75fe978448de891989837ee100a043fb497c17c37003d0f7e4024d38c561db57";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/rolling/openeb_vendor/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "5e5c299b127b2ef6f1b52933eea6f2086207963e7d9d70000570a5934b9fe459";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/orocos-kdl-vendor/default.nix
+++ b/distros/rolling/orocos-kdl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl }:
 buildRosPackage {
   pname = "ros-rolling-orocos-kdl-vendor";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/rolling/orocos_kdl_vendor/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "aa67dc1c25db3652e298d143679a7c42abf7abdb0c40de0ec1e68409c61c9a95";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/rolling/orocos_kdl_vendor/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "7ff2db5c450888a8f009232f049d4e7e932ff8c0ba999d7a39697ac606504d20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-control/default.nix
+++ b/distros/rolling/pendulum-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pendulum-msgs, rclcpp, rmw-implementation-cmake, ros2run, rttest, tlsf-cpp }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-control";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "f2fed60de2b226a77111fb8d7ff43c99bb13e352923f2abca6ebfbc6cd17fb4e";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_control/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "d169d82d8b00abef6084b730b3e44c13eb2bbcccf43a8d7b9f82b9424e71d344";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pendulum-msgs/default.nix
+++ b/distros/rolling/pendulum-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-pendulum-msgs";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "7334b0b639e4b7785fd1a5e307733d2b71e4019863b720b425f41b6d40b784ef";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/pendulum_msgs/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "868eb516ea61ecfd1537cf6d16bcbb4c5e0c579def00afa9976327d9a35fe04d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pluginlib/default.nix
+++ b/distros/rolling/pluginlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, class-loader, rcpputils, rcutils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-pluginlib";
-  version = "5.5.1-r1";
+  version = "5.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pluginlib-release/archive/release/rolling/pluginlib/5.5.1-1.tar.gz";
-    name = "5.5.1-1.tar.gz";
-    sha256 = "52bc956bd2b856789b0f22b95d609c3104ded8d60c0a36a2f151cfb23c31693e";
+    url = "https://github.com/ros2-gbp/pluginlib-release/archive/release/rolling/pluginlib/5.5.2-1.tar.gz";
+    name = "5.5.2-1.tar.gz";
+    sha256 = "6dcc766fabb1e4a9bc8088aac147a30febf04d96657111f2f0c708aec997b8ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "5.0.4-r1";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/5.0.4-1.tar.gz";
-    name = "5.0.4-1.tar.gz";
-    sha256 = "2eb8cff158a967186cf39cf6f07f3ec2731f7fd0329efdf9e257b147dfc5690b";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "5d51ca3fd459e02d9cc550de20474ce3e03c628da04cc14041025853368adf6d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  buildInputs = [ ament-cmake-python ament-cmake-ros ];
   propagatedBuildInputs = [ pluginlib point-cloud-transport pybind11-vendor rclcpp rpyutils sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros ];
 
   meta = {
     description = "Python API for point_cloud_transport";

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "5.0.4-r1";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/5.0.4-1.tar.gz";
-    name = "5.0.4-1.tar.gz";
-    sha256 = "5105012f4b106584f54a63531cdb74e6cf4515a2eb3bbcdcde75eef5cca6302b";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "52dd9cd067c81da76204d805d564ccdc78e6863ae88432f47072e1ef2dcb800e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/python-orocos-kdl-vendor/default.nix
+++ b/distros/rolling/python-orocos-kdl-vendor/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, pybind11-vendor, python-cmake-module, python3Packages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, orocos-kdl-vendor, pybind11-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-python-orocos-kdl-vendor";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/rolling/python_orocos_kdl_vendor/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "02e5946740a16205338f1caa15758e9ef0c37ea9f63892ed59f18f87d4ec46c5";
+    url = "https://github.com/ros2-gbp/orocos_kdl_vendor-release/archive/release/rolling/python_orocos_kdl_vendor/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "71390c209ba95ff1e4b45941c208ac81a22c0785ea7d85e0c47ed9d96a2d4e8e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ orocos-kdl-vendor pybind11-vendor python3Packages.pykdl ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Wrapper around PyKDL, providing nothing but a dependency on PyKDL on some systems.

--- a/distros/rolling/qt-dotgraph/default.nix
+++ b/distros/rolling/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-qt-dotgraph";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "15a11b11b66808383cc224e5c95962975382efd2f3af7630686c23a5e0186960";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_dotgraph/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "f0471e60f0689ca1804f4cdd7f393ef382dd96a1df967b6b191db3c222435175";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-app/default.nix
+++ b/distros/rolling/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-app";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "d0c354f26b9d9d814006679398d8295d9dfa4faf91e7fb5c197065704484d03a";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_app/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "d982be19e4b7bfdef9749185e88b9eb37452fcf41cec8bb8b95a3aaa3a17b35a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-core/default.nix
+++ b/distros/rolling/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-core";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "968a75709371801501086cd10426e4188a5db1b7a3608bd824e69cbb27d7ff9b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_core/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "79f9113189967231b8a5669e131ab44aa29295c3881136b74fc6c0658feb3a5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-cpp/default.nix
+++ b/distros/rolling/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-cpp";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "c05d833d6486e59977b777c099849805d926fbc07e10aae81a6e3f092a0739e4";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_cpp/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "2e403c83195d6332a10721ba20bff1b14901fa7467a1d919e57b83a386120ceb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui-py-common/default.nix
+++ b/distros/rolling/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui-py-common";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "02151738f7ad38eb44ff89b39b8fcb02b488ebc1334c1418ca6c80a4cbb8e6f1";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui_py_common/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "7ab9920033ca3a6cd13a9c22ea14dfc3a189a8e5c7bf77c9a40eec6414c1020e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/qt-gui/default.nix
+++ b/distros/rolling/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-rolling-qt-gui";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "5f8e8563019529abba1cfa8c7dbc06a29ab277e24e0dbf49c055f0c39c5a60d6";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/rolling/qt_gui/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "c27fac70f820926e1ec8c5021b084e1d32c90f61da92c5007be4c3e8fa3afdfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-cpp/default.nix
+++ b/distros/rolling/quality-of-service-demo-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, launch, launch-ros, launch-testing, rclcpp, rclcpp-components, rcutils, rmw, rmw-implementation-cmake, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-cpp";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "31b36c7e144fb22920431de7927060379f32d79ed89d8180188ce11703b247f9";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_cpp/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "493332b86778b69189e910a8d784308aab5c235d7bddd0bd06d3bf1ed712d547";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/quality-of-service-demo-py/default.nix
+++ b/distros/rolling/quality-of-service-demo-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-quality-of-service-demo-py";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "aef3e084a6a3412255e3c308130c1e78a81bea70da086679e1be9230231a00ee";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/quality_of_service_demo_py/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "d0161a521a9ea08edd5ceff6b20ce0050d83e38cb6f7e1950c2176867dd512a9";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rclpy sensor-msgs std-msgs ];
 
   meta = {

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "10.0.0-r1";
+  version = "10.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.0.0-1.tar.gz";
-    name = "10.0.0-1.tar.gz";
-    sha256 = "563809395c8c30712fb451c42bec14576e7f1b48cc11f261451bbf953d357f2c";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.0.1-1.tar.gz";
+    name = "10.0.1-1.tar.gz";
+    sha256 = "605f995f11f413c28000bc0506abcbbb96c109791e426a571235add8e5705172";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "10.0.0-r1";
+  version = "10.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.0.0-1.tar.gz";
-    name = "10.0.0-1.tar.gz";
-    sha256 = "178096d20a831caa3faf69671d1c72413bfd895ceb7fe9aacb76142cef7b52e9";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.0.1-1.tar.gz";
+    name = "10.0.1-1.tar.gz";
+    sha256 = "3b2c123091cf66620061c9a09c1415c5f240815a88ff04b6bb1c949406a6efb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "10.0.0-r1";
+  version = "10.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.0.0-1.tar.gz";
-    name = "10.0.0-1.tar.gz";
-    sha256 = "eac23a8940bf77fd1bec2d349c7cccc8941bebe6c94bd8f41de334ae75e936e0";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.0.1-1.tar.gz";
+    name = "10.0.1-1.tar.gz";
+    sha256 = "837e03a8d12877af2807447762232d43246eba030287a955bea3b2152e397915";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "10.0.0-r1";
+  version = "10.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.0.0-1.tar.gz";
-    name = "10.0.0-1.tar.gz";
-    sha256 = "a17af3da8416181da3ebd8c1c9ec40b796a4c17ff6082ede99da63b1408a2b65";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.0.1-1.tar.gz";
+    name = "10.0.1-1.tar.gz";
+    sha256 = "59b0a37785224cc45928ce721f732a0b3b28d380e30857dc79f49da9e8e90749";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "29.0.0-r1";
+  version = "29.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/29.0.0-1.tar.gz";
-    name = "29.0.0-1.tar.gz";
-    sha256 = "69858a3d0c0476da9e6c1c2c9d5e289bad18cb15bb1f4ed556c639337e209528";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/29.1.0-1.tar.gz";
+    name = "29.1.0-1.tar.gz";
+    sha256 = "c256ed692264be83aff88ef7b55ce51911ab840f9ed750fe5e5afb1e5f1936d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "29.0.0-r1";
+  version = "29.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/29.0.0-1.tar.gz";
-    name = "29.0.0-1.tar.gz";
-    sha256 = "f42b8b197fc67b482645319d949fa1cc1185f7b8f41a6e3b9ab1335500a7dfe8";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/29.1.0-1.tar.gz";
+    name = "29.1.0-1.tar.gz";
+    sha256 = "d8dccf2938fdbc0865537412e74fd62cfce7f8dcece9912b03f670ab4e3e5ee8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "29.0.0-r1";
+  version = "29.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/29.0.0-1.tar.gz";
-    name = "29.0.0-1.tar.gz";
-    sha256 = "bb0416a97a77cd935d0bcd42d5562960b2792b780bf4e83bb79d65c8761d6746";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/29.1.0-1.tar.gz";
+    name = "29.1.0-1.tar.gz";
+    sha256 = "6a2404414ea5ab60635541d793aea26ee655ffbfe8148d26dc60797e84d325d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "29.0.0-r1";
+  version = "29.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/29.0.0-1.tar.gz";
-    name = "29.0.0-1.tar.gz";
-    sha256 = "3044592ef6eeb756b3fac40d6a74063762d07e4b2f55a835e0de7f260ce3f22d";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/29.1.0-1.tar.gz";
+    name = "29.1.0-1.tar.gz";
+    sha256 = "ba4c8c066cdb13f366b8fa91c1d1b2111b002c57b6e0cf59f465ccd53b56feac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.13.1-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.13.1-1.tar.gz";
-    name = "2.13.1-1.tar.gz";
-    sha256 = "675cd4fb28d2c83531edcac9d22256109268fd9ee3b54fab699ce70022dc0518";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "acc7d424a5e4d030952ba2beaf97aa97fdcb09bd5feb92be8ee69b1817f6cd8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/resource-retriever/default.nix
+++ b/distros/rolling/resource-retriever/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, libcurl-vendor, python-cmake-module, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, libcurl-vendor, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-resource-retriever";
-  version = "3.5.1-r1";
+  version = "3.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/rolling/resource_retriever/3.5.1-1.tar.gz";
-    name = "3.5.1-1.tar.gz";
-    sha256 = "d05202344c16a0f0023d2e758a50d45ced1c320254dc4e2e29a97e4ca1c3a1d2";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/rolling/resource_retriever/3.6.0-1.tar.gz";
+    name = "3.6.0-1.tar.gz";
+    sha256 = "bba32c128145d2dd2d90ae5882d8c64b0bcd8501c28d78cc3ec6a4cb03f48b79";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common python-cmake-module pythonPackages.pytest ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-cpp ament-index-python libcurl-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "ae1288b9088b86c0edf80de97d8091424c58820d644ce0d384d61907b07881ff";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "a172440e806d9bd9878cbdcfa982fa173f4edf4580ec51623fb059972d6cb263";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.0.2-r1";
+  version = "9.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.0.2-1.tar.gz";
-    name = "9.0.2-1.tar.gz";
-    sha256 = "983c0c1b9abcb600e287247de8296f19a979535aa20bd0329730f090f0f77d92";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.0.3-1.tar.gz";
+    name = "9.0.3-1.tar.gz";
+    sha256 = "249373ef588d24e96d1bf084093fb97618b150099abc92c9a2b5be20ddd4ff6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.0.2-r1";
+  version = "9.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.0.2-1.tar.gz";
-    name = "9.0.2-1.tar.gz";
-    sha256 = "152d71bc0312734921c4361bb9839a7d6d72869140eb4a19720ef48b55f94c9b";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.0.3-1.tar.gz";
+    name = "9.0.3-1.tar.gz";
+    sha256 = "a95b063659558b2edd4b5a1bc2859a0959fe7ac20731ca7500c07640117864c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.0.2-r1";
+  version = "9.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.0.2-1.tar.gz";
-    name = "9.0.2-1.tar.gz";
-    sha256 = "2863c6a98fdfb82a495800cfd4508821e5b12d52f6bb8229dbc533052f686d7b";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.0.3-1.tar.gz";
+    name = "9.0.3-1.tar.gz";
+    sha256 = "f559b7ef21795e99a1a02f27c3fa28aa1216cdd49faeea143c6e128fb70a9453";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation/default.nix
+++ b/distros/rolling/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation";
-  version = "3.0.2-r1";
+  version = "3.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/3.0.2-1.tar.gz";
-    name = "3.0.2-1.tar.gz";
-    sha256 = "6eb47b13ac856ddb46eb364212f3dfee55dcc136056b0eb09706489055bf3dd4";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "bbbedb78b897909986349648d85ee9738e46bcbdb422c83ac164bf17e646236e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-testing/default.nix
+++ b/distros/rolling/ros-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-export-dependencies, launch-testing, launch-testing-ament-cmake, launch-testing-ros, ros2test }:
 buildRosPackage {
   pname = "ros-rolling-ros-testing";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/rolling/ros_testing/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "7180407877ffc4597b9d40bc01495beaa075f10ad89b07a481268d50269ad48f";
+    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/rolling/ros_testing/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "6dac482fe12c19911291d3a73f7bd6ad8041a9f9891d7d22b439deb604d3da96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "3adac87911c3c9d747ebc446e5cdfc54843ae6062b3f12484c2f3f78e41bcb5d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "2ee3855cba84dc16809d2d24bacff323d0ac96bcc99acd12fb88d77436dc66ea";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "a98747063428f0d59a21c5ade4ed3061a2909daf34f3bb54044ed9876d4b9392";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "ecc43cb1dea328e6a230c6b77e637b4345ec8ed715e1b27b3dea1a1a26d1b175";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "8e1531834f2eb9946e414e0feaa5ff365d56fa49cb699a51feefccc1e14aa5ab";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "188cb2a9ee2f6f1bf9556cab11a029c86136a75558796ee2cdec1685b2dde8f5";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest-timeout pythonPackages.pytest test-msgs ];
-  propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata python3Packages.packaging python3Packages.psutil python3Packages.setuptools rclpy ];
+  propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata python3Packages.packaging python3Packages.psutil rclpy ];
 
   meta = {
     description = "Framework for ROS 2 command line tools.";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "185a5acdb7d4d8142b1e86a7d4a231afea856408c60c56e22885ccbd38a31580";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "09aea9bf4223ff806e06c787daa53ef9a61b9655f679fdd66040d4ae7cb756ee";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "722300eaa8121f89b4c5b3f20a129516efe0a5e3ab8f1057b4b998b4fbd93d18";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "1ff99bb792d073b44f2702efe4c6c123bf97329197a811dd298fbcc4911ac835";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "2c0965f29c01e5a90debdabb5015f74b32ed65b7b91cf10422f440cef9ee63b0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "6ca4c1205d1bcb96e3ae931773d75c484aa8261150e7a3c0b449ad2eb32ec88c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2launch/default.nix
+++ b/distros/rolling/ros2launch/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2launch";
-  version = "0.27.3-r1";
+  version = "0.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.27.3-1.tar.gz";
-    name = "0.27.3-1.tar.gz";
-    sha256 = "c3c9c140d816550681b6dca8cd3f7b0988b5af3c55f633b7167fd0089e6a1f7a";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/rolling/ros2launch/0.28.0-1.tar.gz";
+    name = "0.28.0-1.tar.gz";
+    sha256 = "22d4fc70cb2b721560a07c6a132493870f648b8dc7a10f3258f9b0b082259797";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ ament-index-python launch launch-ros launch-xml launch-yaml ros2cli ros2pkg ];
 
   meta = {

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "caaa03b56356cdc18cffbbeaf57e8b8e649167da9aea19e53bee4e7001bffc2b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "df715ec31a7808a240acb3ed546cf78c5d0bdce0d38049c1b7e5f71daeac9d56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, pythonPackages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "4fcce8e39869171c525937464d93a3b4445aaf9d442cf1b559ed9d3cc59b8ecc";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "3cd95fe3dd4681480448094f1a281a360ac19f09de5452ca5a4093bad746d0fd";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "587c2f6931b5c06aa5bc763e59567a236985f06f5e80f6452f6a5fa3523603c2";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "c1e3f813d2096d540413e5c41aa1b9cbcae90e688ddc2b4d74bdbd5462395d62";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "8879d2c82732665b05e4a2ed7b95b414e0eed1950df0000d741ad916b02ffe68";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "d8c9cd0b0d601784cf32c6b99121b1a276df0a468a2cf40d03c910dbcbfb66fb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "58ef5cc0f8d3411ce66047f7a01134be4654c5ee603967b19706f33fa4f82567";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "537ff486321f2d49a93820b5b9868505776756d8baca6b8719d2e7400c65826b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "808d5bfb35c22063c78af1c080eb8b813fd3248dbc8363af04d09e195ed97759";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "69f9e950f782d42301074259e3cf1c66230fb04b024ddc8f5fe6991b08ddab0a";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-flake8 ament-pep257 ament-xmllint launch launch-testing launch-testing-ros python3Packages.pytest-timeout pythonPackages.pytest ];
-  propagatedBuildInputs = [ ament-copyright ament-index-python python3Packages.catkin-pkg python3Packages.empy python3Packages.importlib-resources python3Packages.setuptools ros2cli ];
+  propagatedBuildInputs = [ ament-copyright ament-index-python python3Packages.catkin-pkg python3Packages.empy python3Packages.importlib-resources ros2cli ];
 
   meta = {
     description = "The pkg command for ROS 2 command line tools.";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "8b6bd7dd99a9f37feffc9a650bc1de12f863867eda2b97107ff011898601d059";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "12fa0be33f0833ff230689cad7eb99688985bfb42e2e6a61d5b3e36f23d6de85";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "a2d2e117eaa10a9a47fab19cc0aa93a9b3cb2e3cd328333e7b2962df24cf21b4";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "46d0f0bf4281482273866aa5f509cd1b3b77d568cd6d86f8b8d09894fe696485";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2test/default.nix
+++ b/distros/rolling/ros2test/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, domain-coordinator, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, ros2cli }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, domain-coordinator, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2test";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/rolling/ros2test/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "19dbc55cfb71558dbb769659e2998e418f1c3cf002edd9934f40bfe61fd0ac94";
+    url = "https://github.com/ros2-gbp/ros_testing-release/archive/release/rolling/ros2test/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "1315f2f2a2c0a5a43e31f2bfc99c3ebf8f70479062037bcac3ac5375bc009c0e";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ domain-coordinator launch launch-ros launch-testing launch-testing-ros ros2cli ];
 
   meta = {

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, pythonPackages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.35.0-r1";
+  version = "0.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "d9c517167ba56efd7eb377a275f3226d1aa49f52dc623bf0fee7b3ff2f022a29";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.36.0-1.tar.gz";
+    name = "0.36.0-1.tar.gz";
+    sha256 = "35654ac4d96f2afb33de9ea16ca330d13adfe152eb8ed29bc1af9828b73ee35e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "7a0fdd471f05576ccbe284c9ba1a6454d97467584e8589e813379bd7bca4acad";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "2c2aff9ae0cdeeb7df27d56929ec1eefa02651b83ba719835eb79233134b89c1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-mypy ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-cmake-core python3 python3Packages.empy rosidl-cli ];
   nativeBuildInputs = [ ament-cmake-core python3 ];
 

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "05b88fb5e6f153e5ef84f66990404f83aa32cb8a115efacf7f43125610260f4a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "85b9e74708a27351452fca021cfd7e20dffb40100a44771ef317216c89cf991c";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata ];
 
   meta = {

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "d4f29b72d1e221fc2058c4f8c6ab3db953d8188a9c28e056a5621b03dfa9cdfd";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "e6ddc1235c6835390bcfaa3b8fb156af8ec0d788196346149701e3e399a522c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-dynamic-typesupport-fastrtps/default.nix
+++ b/distros/rolling/rosidl-dynamic-typesupport-fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, fastcdr, fastrtps, fastrtps-cmake-module, rcutils, rosidl-dynamic-typesupport }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-dynamic-typesupport-fastrtps";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release/archive/release/rolling/rosidl_dynamic_typesupport_fastrtps/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "9c3c665c037adfbe9d16955549279b7d799ece22b255fc2967220bc20cbe87d1";
+    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release/archive/release/rolling/rosidl_dynamic_typesupport_fastrtps/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "4db40019b639d0e0ef056ae57586ba7398fec3a99ef97535d61feab546da5beb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-dynamic-typesupport/default.nix
+++ b/distros/rolling/rosidl-dynamic-typesupport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rcutils, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-dynamic-typesupport";
-  version = "0.2.0-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/rolling/rosidl_dynamic_typesupport/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "fec9210acc61d5b21f43b9a78ac36634054d30608a37abfcb827145af36cf60e";
+    url = "https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release/archive/release/rolling/rosidl_dynamic_typesupport/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "c314e8f179a8b62e97fa7f36092f35adb2fd4bd32ce83d4d9679660afaf55b96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "f9410474dc332dd66c673f2787e9a9ec3fd2dac2f3e88d42d61a0ff0ef23025f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "8700c25be9456eb55f882185c4cd75bcd30c632179de7e67c7b2b18d6d492dc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "f785fb8df13bb0a43423ab73760ade18f859217b9d3244e7436df3a9f21ed86e";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "8658887b6a407138ee15c6c67ffa651af073d5167e1c60d6e094c4a150837669";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-py/default.nix
+++ b/distros/rolling/rosidl-generator-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-pytest, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-pytest, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-py";
-  version = "0.23.1-r1";
+  version = "0.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.23.1-1.tar.gz";
-    name = "0.23.1-1.tar.gz";
-    sha256 = "8467edc936fca849f5545458e577962068ed62638e12d60f29a105d7c37629f2";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/rolling/rosidl_generator_py/0.24.0-1.tar.gz";
+    name = "0.24.0-1.tar.gz";
+    sha256 = "beca0896b74e9d78040ae368bcaf9dc4592728f07a07143f5408347bd243da89";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-pytest ament-index-python ament-lint-auto ament-lint-common python-cmake-module python3Packages.numpy pythonPackages.pytest rmw rosidl-cmake rosidl-generator-c rosidl-generator-cpp rosidl-parser rosidl-typesupport-c rosidl-typesupport-fastrtps-c rosidl-typesupport-introspection-c rpyutils test-interface-files ];
-  propagatedBuildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-index-python python-cmake-module python3Packages.numpy rmw rosidl-cli rosidl-generator-c rosidl-parser rosidl-pycommon rosidl-runtime-c rosidl-typesupport-c rosidl-typesupport-interface rpyutils ];
-  nativeBuildInputs = [ ament-cmake ament-index-python python-cmake-module rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface ];
+  checkInputs = [ ament-cmake-pytest ament-index-python ament-lint-auto ament-lint-common python3Packages.numpy pythonPackages.pytest rmw rosidl-cmake rosidl-generator-c rosidl-generator-cpp rosidl-parser rosidl-typesupport-c rosidl-typesupport-fastrtps-c rosidl-typesupport-introspection-c rpyutils test-interface-files ];
+  propagatedBuildInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-index-python python3Packages.numpy rmw rosidl-cli rosidl-generator-c rosidl-parser rosidl-pycommon rosidl-runtime-c rosidl-typesupport-c rosidl-typesupport-interface rpyutils ];
+  nativeBuildInputs = [ ament-cmake ament-index-python rosidl-generator-c rosidl-pycommon rosidl-typesupport-c rosidl-typesupport-interface ];
 
   meta = {
     description = "Generate the ROS interfaces in Python.";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "907444f7bfcbdb9bf1382976f345b13a49cfe47ef68467afb9bb9a5c13171950";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "c9c7f36b79a9537727328852f50a5cd713074c09926306354942b75f5ca3c81b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "a92cb4f8b8b8d6f5d816da4276e48966caf3294a048e4299b1640aa87266f4c8";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "5f29c5b7b4280fa2575092796cb0788b24aa4738d658ab690694fa21068e63fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, pythonPackages, rosidl-parser }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "cfe5b27da75bbe57a370bf571ac360eb67884387b274c632ab93be9186b069b8";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "c1af45b00bcddfcba3b3c976781df72c7b0146621d52925a46b63b9d9dfe570a";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rosidl-parser ];
 
   meta = {

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "baf25a789a72e07f65ad971fe145b1c3b52250682451e7326d2df4f7ac686bd0";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "359a2dca6b9d1ba490c2b2f3b468199468811a3d74595ba9d827f4947db919b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "76f49d7da0934cba1d8d684212829372166488d6bb7daba9f88f25e2d134b934";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "935e71c3edbede78a17576df33440a601c07b82601a3e09f555d14e1f140063a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-c";
-  version = "3.7.0-r1";
+  version = "3.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.7.0-1.tar.gz";
-    name = "3.7.0-1.tar.gz";
-    sha256 = "b1b4ba709fffd3ccf5f15c8750bca7482ff169933fd48f032987dfd7b5d63431";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_c/3.7.1-1.tar.gz";
+    name = "3.7.1-1.tar.gz";
+    sha256 = "66b9d0848bc3075292070f63eac748f63c5bd9a4b3eaaf27f400b287472db9ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, fastcdr, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, python3, rcutils, rmw, rosidl-cli, rosidl-generator-c, rosidl-generator-cpp, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-fastrtps-cpp";
-  version = "3.7.0-r1";
+  version = "3.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.7.0-1.tar.gz";
-    name = "3.7.0-1.tar.gz";
-    sha256 = "7604c52c4f79f4ef558c6b0e4f5ef6eabce218a148cf99dff63dcca7978ccc7d";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/rolling/rosidl_typesupport_fastrtps_cpp/3.7.1-1.tar.gz";
+    name = "3.7.1-1.tar.gz";
+    sha256 = "7724a837d4bc2493ebefacdc647c58df502b6b8fe2ed5b8b2f45f104c53c2d1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "38896e867ada1b600f61d423077a098f4004e6aa03c80952714bb69f3887eceb";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "ffe10887f4370d7f36edd3ac9db2c544aa9662212015a78464bc37a832c099d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "68b8f802d6b48b2e566d43df9ce0022c6378a1e40c4c9066b63ca349b51dcad3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "8427b28f69b2070b6c88238963370f0d5827005a7a3fcef8ff7b486d5e62d5bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.9.0-r1";
+  version = "4.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.9.0-1.tar.gz";
-    name = "4.9.0-1.tar.gz";
-    sha256 = "ce65790a796581efcda7a86e3b6dc0ef1467879c2160e33b1f6a87a81c7373aa";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.9.1-1.tar.gz";
+    name = "4.9.1-1.tar.gz";
+    sha256 = "759f4fcb95667178efcb8944714dce9c5b0769c53b3f153dc7175f91fff192c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gui-cpp/default.nix
+++ b/distros/rolling/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-cpp";
-  version = "1.7.3-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "e1f6c7bc09be51c81dff8c43ee12eace38a4afb40dc2f769744a36e45f539f52";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "a2a9c88aa47ed0653901266f783746bc59b309a485e3f031108a7d42ad208f17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gui-py/default.nix
+++ b/distros/rolling/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-py";
-  version = "1.7.3-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "960e74e6f0e90315db092b753078ae60099e3dd06232983eab338406c1a987eb";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "3232285f3822cdee254e1ba80da89f30e26055944c47c1f56ec445bdd08275d9";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-gui/default.nix
+++ b/distros/rolling/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui";
-  version = "1.7.3-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "9e3d2721171d34ff69b8f0a5175f7a2004c54f0ec4e99783d6092495298b806f";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "14f5c41f4352a54060e0fd800412ac04a36c95e100792d8ed6246afe3dbe9587";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-py-common/default.nix
+++ b/distros/rolling/rqt-py-common/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-common";
-  version = "1.7.3-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "9ef4a605b1f5a53c7aa00848c5b5d445f545f8bda43efe5516f3115a12d713fc";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "86a3b855d5fcc94c77fa07ff5de6cc2a1f3b523bd390d9428a4decb2542419fc";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common python-cmake-module rosidl-default-generators rosidl-default-runtime ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common rosidl-default-generators rosidl-default-runtime ];
   propagatedBuildInputs = [ python-qt-binding qt-gui qt5.qtbase rclpy ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "rqt_py_common provides common functionality for rqt plugins written in Python.

--- a/distros/rolling/rqt/default.nix
+++ b/distros/rolling/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, pythonPackages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt";
-  version = "1.7.3-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "30e5db7de47361308ebc9dd6d7b23b4bca1da7f0d69e9d655ca0a1cd0e774fb2";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "cf3b52e677dcaea4c96705b3d1b428a802865a49da56bcfc89083bedf13e57d1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "0826a4756f69a450cfeb240df42d583567dc6897a7b012d75011eeaba04904fa";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "d089cec5356be993fa7eba6368c28252d5810dc07fc2120ad7b6fb2b538013ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "c63331a64d1509c3e4583e9a15c0b105dd3447b325c62a4c10113507e4488c35";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "fc21eab4a5ad66ef7285d6ac3f0c5a4e0cf262c935ace5e3c5c62bff484c4764";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "2bf31d36ca1200dcf41cb7785f0d90821ef889ce59be1980d7620a6aa6273d3f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "e7310819312a21a7f9bcdd7ae28b9acc90cbdf464e8c6cb94bf08fc127dcc416";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "891968deea67c519d693dd3990a331632b07ddad03cfbb9dd32840a4c6c9d685";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "cf93eaa7a443849b9947fa568f6aa7e6f27bf5aa97dde07b4a86bba00faa1e5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "532923ad34f9be2266b7b760c578556d4a7618f0dafc4ede79d445605a07d5bb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "dd00d04da4a187e68ba5427222500e83d908f3c61c6f198282266d6831241f20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "85ce0e76306e753bdee6b9711790a47eb442d80a36d0c55dc683468e909b01c1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "8399c2c10aab3bbfc6411bd6617e53275d437cb49a0a4819f5ef0a354d1426b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "412bf21a6ac3b256832e98c45442cbc91cadfbbe2f2685e8c668cff49ebe443d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "f3fcc7ac3079af95cae9d5c65bfaf6ad09436018ef8641c66d4c25a4a14a94e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.3.1-r1";
+  version = "14.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.3.1-1.tar.gz";
-    name = "14.3.1-1.tar.gz";
-    sha256 = "f7449a56d66b4edeab145269189e665a6ebb313ea2ef3ca86e32f36b7c4b96b3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.3.2-1.tar.gz";
+    name = "14.3.2-1.tar.gz";
+    sha256 = "b69dee9b2b937a7100115bdb6704a30779750531e52ef7ad1705395d6d2499f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "5db142b75199d0f4160f7787878f00d2a0e111461e2ee748734ac9734d202152";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "f1d6c815733200c25dfc98b4cd66a4f41105c4f9f9cbf5a7adab47312c0fd525";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.numpy sensor-msgs std-msgs ];
 
   meta = {

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "008447dc6d1bd38bd68980a53d65264a5cd9a4970bc8787d6d30f435b27b2552";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "1df769ea771638b24643c10f200005c8f173215aad76f47f5f50c104f31e280b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "24aaf00b7d933fc9bbec4b2a141fede4749a9ca69b296384281c2b5699774d0c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "bd36417ffeee4daf36a1fb9bde74dca4ef33b5714c2aff1cce99ca51e4d0289a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/spinnaker-camera-driver/default.nix
+++ b/distros/rolling/spinnaker-camera-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-spinnaker-camera-driver";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/spinnaker_camera_driver/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "c49bef6a289860efea04efb2ed414b736d48f279c99f6a96504fb030d325a6bc";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/spinnaker_camera_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "90e3bab73c38e2436eca373f1ad3beaeb63aa5695cacfd525ed2db2765a12dfa";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ];
+  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {
     description = "ROS2 driver for flir spinnaker sdk";

--- a/distros/rolling/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/rolling/spinnaker-synchronized-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-rolling-spinnaker-synchronized-camera-driver";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/spinnaker_synchronized_camera_driver/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "4c53373b808cf8af848d3f0bfc77e521fe2d5af2b178cf718cf7fdde8ea2ee79";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/rolling/spinnaker_synchronized_camera_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "4e677657f505c0619f7ef200e500f5cb3f8f15e3c903d974fdb7a15d6108f8be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "0185590f25394870e62e3f932fc0c84bf45b08dd1fe968d360151cc2f91f8d44";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "42745e24e1407ab6c6da01173f87074757251f374af96fcfa079ecf4d29aa84e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "4635aa17e1eec326c86f1a21ee0a7a1596ca99e66b346302cf8a5f968d14dec7";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "4b7e0fac32c3f27ab34cdcc1d50339b009d771418c89521d0ea3361e53f5bc4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "ee11ed23c16fd326407f6d659834b53d575ae0f74f828a217b9dabeaae2deb9b";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "b97caa9b4b245bc5c0fe4f233b2f7c0e55bffd1222ba028a300b57be76891dd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/test-interface-files/default.nix
+++ b/distros/rolling/test-interface-files/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-rolling-test-interface-files";
-  version = "0.12.0-r1";
+  version = "0.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/test_interface_files-release/archive/release/rolling/test_interface_files/0.12.0-1.tar.gz";
-    name = "0.12.0-1.tar.gz";
-    sha256 = "75b3b03cb35a832fc6bdfca7c765ac28bc56bda6fd3124952468be79b908a46b";
+    url = "https://github.com/ros2-gbp/test_interface_files-release/archive/release/rolling/test_interface_files/0.13.0-1.tar.gz";
+    name = "0.13.0-1.tar.gz";
+    sha256 = "21966c2f500cae0ba6ffc577417d07a54953523c88855b7ccb2652d7ee607629";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "1bcbb6d3ee0178f1135c6cacad6c62f5fa44447d99bd63c1b03ccb6abef8b8ba";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "e78523a2126036efdadf2bd2bb440da58d5925d7686fb0496265013f42915440";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "4ce140204531d5da1ee928e8fd6da7a3e450728aa1b8e16d84427f9656efe91a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "ec5dbd764711c7c573feb08dcf1c2ed9b6366a59c28b575e993bedf825c37a4a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "a1e88bd3163de5201814fd4676f38022da74663f406a61192ae783a363b7c905";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "97c0decc930b13f4f32732f8005d4ebe50b38ce9e60a3bb29681d6cd81b7ed77";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "ab99633b98d4ce4a4d02c089dc9c888fce742298f52db07fcc4dfaf8f7dbeb1b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "fff31624e03d2f7d6350383b02e13a004d2f3a84faf4ea64c3a744cbd6d68a5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "6ceba6b64316ef8d8a73a5fd5b251256a51ebbf13b84e9fb1859cceb5e2cb2fd";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "d3771197f8186531286e2670be670b2bb466f12a667b960641ae9276b40fc567";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "66e9f60f7e4c74d1d59d3607a34e32e4be4e2e285575d9ec25a1ab9283d2c7d8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "8f488ceb27f4aeb29e4db2566d27fd67f71857725866e6eda396a73b8646546b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "e0308d642c407d83d4bad1659e0291ebb728a7ea66a04fb3e492830c06159210";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "f8ac16bed0770acacc15b8f7175d98795eba350c20b458ae0c939270f222e577";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
+{ lib, buildRosPackage, fetchurl, ament-xmllint, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "062d6c9fbf375cda23bd222d9c9faf3ce9d5e1f3ea2383d1aa8250bb82d2f5e5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "100c40964b051000646eb83db18eeb33ae4f4eb51dffc77f9fa9426c8de3ffd7";
   };
 
   buildType = "ament_python";
-  checkInputs = [ pythonPackages.pytest sensor-msgs ];
+  checkInputs = [ ament-xmllint pythonPackages.pytest sensor-msgs ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy sensor-msgs std-msgs tf2-msgs tf2-py ];
 
   meta = {

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "bba45c2a983c8dc60ecf83b6349cddad0477d98de84c19038e8ca2f05e8e7803";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "4eade65d1eba3dc211cdf9899538ed526351f65e23b62dbc4cb8ffd6d229592b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "e70c4d9e2f1c3094a31922f1a9fd7a2aa18622528137cafa8c50fdfc5b5dabde";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "5377be3895f9e370a00f9287f5c070b25225c7437f9af0a4fa54fb55fb55f259";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "efdb5ca4308124cd29dd630e32e460716a462fe06ad6ae1f4f5f52f4adbc88c8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "a5811a56e8fc17c3755dc1f3192a4ea0e2f1adce74177e84924e17d72567fe6e";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ graphviz python3Packages.pyyaml rclpy tf2-msgs tf2-py tf2-ros-py ];
 
   meta = {

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.39.1-r1";
+  version = "0.39.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.39.1-1.tar.gz";
-    name = "0.39.1-1.tar.gz";
-    sha256 = "f4ec2b31ff588aaa9deb288e332ac7c4fac00a3a1babaa7a649ec613cdbaa290";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.39.2-1.tar.gz";
+    name = "0.39.2-1.tar.gz";
+    sha256 = "2377ddb325c03a6bbdf8a7ff85a37ab4028de80be1de1bec2ec171c39f0f15e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-monitor/default.nix
+++ b/distros/rolling/topic-monitor/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-monitor";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "35c7f0066e1abd00d5a8e08312d60be32d735b9f2ac91c4a7c591181384d5687";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_monitor/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "73627730765b071f1fc4eae85ad993d32687f5612557646eea4ef80ee0c6f2e0";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  checkInputs = [ ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ launch launch-ros rclpy std-msgs ];
 
   meta = {

--- a/distros/rolling/topic-statistics-demo/default.nix
+++ b/distros/rolling/topic-statistics-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils, sensor-msgs, statistics-msgs }:
 buildRosPackage {
   pname = "ros-rolling-topic-statistics-demo";
-  version = "0.35.0-r1";
+  version = "0.35.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.35.0-1.tar.gz";
-    name = "0.35.0-1.tar.gz";
-    sha256 = "657b75061e4207efbcb2bd9f8215d859d8e67d556cf32254e348aba4444c96fc";
+    url = "https://github.com/ros2-gbp/demos-release/archive/release/rolling/topic_statistics_demo/0.35.1-1.tar.gz";
+    name = "0.35.1-1.tar.gz";
+    sha256 = "2ab673476ccdd359ddc0c2b24041d4dde214682090445e1a5243ca2c7666bec8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-analysis/default.nix
+++ b/distros/rolling/tracetools-analysis/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, jupyter, python3Packages, pythonPackages, tracetools-read, tracetools-trace }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages, tracetools-read, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-analysis";
   version = "3.1.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 ament-xmllint pythonPackages.pytest ];
-  propagatedBuildInputs = [ jupyter python3Packages.pandas tracetools-read tracetools-trace ];
+  propagatedBuildInputs = [ python3Packages.notebook python3Packages.pandas tracetools-read tracetools-trace ];
 
   meta = {
     description = "Tools for analysing trace data.";

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "8252f749bdf47f78ad1d0c59f98cce7ff562537c4889e94cb9cc785f7f38bc1d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "bf99a8553b7df0ed28d81fbb4cea73c4d736ee98e9c23c9956cb52abb9837163";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/twist-stamper/default.nix
+++ b/distros/rolling/twist-stamper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-twist-stamper";
-  version = "0.0.3-r3";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/twist_stamper-release/archive/release/rolling/twist_stamper/0.0.3-3.tar.gz";
-    name = "0.0.3-3.tar.gz";
-    sha256 = "a9c400c82132e257720704677912d62bf756da099a4e799c09b991a26bb93e7f";
+    url = "https://github.com/ros2-gbp/twist_stamper-release/archive/release/rolling/twist_stamper/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "8c138365a9525cd28da2ea7cdf0bf80482e8518489d920be00344b67cad0eeb7";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.4.1-r1";
+  version = "5.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.4.1-1.tar.gz";
-    name = "5.4.1-1.tar.gz";
-    sha256 = "3229a7e43858bd27972d93e07ac877776ebe38472a9e526b08405d667ca19df5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.4.2-1.tar.gz";
+    name = "5.4.2-1.tar.gz";
+    sha256 = "611ead7b92f80aee5da900b56d7eebd9d6acc3ef4b4b1e0654ece6c9ffe68966";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 1d3da9e17a997463b135bf876ff4f3908bc99914.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *adi-tmcl 2.0.3-r1 --> 2.0.3-r2*
* *autoware-lanelet2-extension 0.6.0-r1 --> 0.6.2-r1*
* *autoware-lanelet2-extension-python 0.6.0-r1 --> 0.6.2-r1*
* *chomp-motion-planner 2.5.5-r1 --> 2.5.6-r1*
* *clearpath-ros2-socketcan-interface 1.0.0-r1*
* *control-msgs 4.6.0-r1 --> 4.7.0-r1*
* *etsi-its-cam-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-messages 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-msgs-utils 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-primitives-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-rviz-plugins 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *examples-tf2-py 0.25.8-r1 --> 0.25.9-r1*
* *fastrtps 2.6.8-r1 --> 2.6.9-r1*
* *flir-camera-description 2.1.17-r1 --> 3.0.0-r1*
* *flir-camera-msgs 2.1.17-r1 --> 3.0.0-r1*
* *foxglove-compressed-video-transport 1.0.0-r1 --> 1.0.1-r1*
* *geometry2 0.25.8-r1 --> 0.25.9-r1*
* *hri-face-body-matcher 2.1.0-r1*
* *hri-privacy-msgs 1.2.0-r1*
* *interactive-marker-twist-server 2.1.0-r2 --> 2.1.1-r1*
* *leo-bringup 1.4.0-r1 --> 1.5.0-r1*
* *leo-fw 1.4.0-r1 --> 1.5.0-r1*
* *leo-robot 1.4.0-r1 --> 1.5.0-r1*
* *moveit 2.5.5-r1 --> 2.5.6-r1*
* *moveit-chomp-optimizer-adapter 2.5.5-r1 --> 2.5.6-r1*
* *moveit-common 2.5.5-r1 --> 2.5.6-r1*
* *moveit-configs-utils 2.5.5-r1 --> 2.5.6-r1*
* *moveit-core 2.5.5-r1 --> 2.5.6-r1*
* *moveit-hybrid-planning 2.5.5-r1 --> 2.5.6-r1*
* *moveit-kinematics 2.5.5-r1 --> 2.5.6-r1*
* *moveit-planners 2.5.5-r1 --> 2.5.6-r1*
* *moveit-planners-chomp 2.5.5-r1 --> 2.5.6-r1*
* *moveit-planners-ompl 2.5.5-r1 --> 2.5.6-r1*
* *moveit-plugins 2.5.5-r1 --> 2.5.6-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.5.5-r1 --> 2.5.6-r1*
* *moveit-resources-prbt-moveit-config 2.5.5-r1 --> 2.5.6-r1*
* *moveit-resources-prbt-pg70-support 2.5.5-r1 --> 2.5.6-r1*
* *moveit-resources-prbt-support 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-benchmarks 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-control-interface 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-move-group 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-occupancy-map-monitor 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-perception 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-planning 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-planning-interface 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-robot-interaction 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-visualization 2.5.5-r1 --> 2.5.6-r1*
* *moveit-ros-warehouse 2.5.5-r1 --> 2.5.6-r1*
* *moveit-runtime 2.5.5-r1 --> 2.5.6-r1*
* *moveit-servo 2.5.5-r1 --> 2.5.6-r1*
* *moveit-setup-app-plugins 2.5.5-r1 --> 2.5.6-r1*
* *moveit-setup-assistant 2.5.5-r1 --> 2.5.6-r1*
* *moveit-setup-controllers 2.5.5-r1 --> 2.5.6-r1*
* *moveit-setup-core-plugins 2.5.5-r1 --> 2.5.6-r1*
* *moveit-setup-framework 2.5.5-r1 --> 2.5.6-r1*
* *moveit-setup-srdf-plugins 2.5.5-r1 --> 2.5.6-r1*
* *moveit-simple-controller-manager 2.5.5-r1 --> 2.5.6-r1*
* *odom-to-tf-ros2 1.0.2-r1 --> 1.0.4-r1*
* *pilz-industrial-motion-planner 2.5.5-r1 --> 2.5.6-r1*
* *pilz-industrial-motion-planner-testutils 2.5.5-r1 --> 2.5.6-r1*
* *rc-reason-clients 0.3.1-r1 --> 0.4.0-r1*
* *rc-reason-msgs 0.3.1-r1 --> 0.4.0-r1*
* *spinnaker-camera-driver 2.1.17-r1 --> 3.0.0-r1*
* *spinnaker-synchronized-camera-driver 2.1.17-r1 --> 3.0.0-r1*
* *tf2 0.25.8-r1 --> 0.25.9-r1*
* *tf2-bullet 0.25.8-r1 --> 0.25.9-r1*
* *tf2-eigen 0.25.8-r1 --> 0.25.9-r1*
* *tf2-eigen-kdl 0.25.8-r1 --> 0.25.9-r1*
* *tf2-geometry-msgs 0.25.8-r1 --> 0.25.9-r1*
* *tf2-kdl 0.25.8-r1 --> 0.25.9-r1*
* *tf2-msgs 0.25.8-r1 --> 0.25.9-r1*
* *tf2-py 0.25.8-r1 --> 0.25.9-r1*
* *tf2-ros 0.25.8-r1 --> 0.25.9-r1*
* *tf2-ros-py 0.25.8-r1 --> 0.25.9-r1*
* *tf2-sensor-msgs 0.25.8-r1 --> 0.25.9-r1*
* *tf2-tools 0.25.8-r1 --> 0.25.9-r1*
* *twist-stamper 0.0.3-r1 --> 0.0.5-r1*

Iron Changes:
-------------
* *foxglove-compressed-video-transport 1.0.0-r1 --> 1.0.1-r1*

Jazzy Changes:
--------------
* *control-msgs 5.2.0-r1 --> 5.3.0-r1*
* *foxglove-compressed-video-transport 1.0.0-r1 --> 1.0.1-r1*
* *gz-common-vendor 0.0.5-r1 --> 0.0.7-r1*
* *gz-math-vendor 0.0.6-r1 --> 0.0.7-r1*
* *laser-filters 2.0.7-r3 --> 2.0.8-r1*
* *leo-bringup 1.4.0-r3 --> 2.0.0-r1*
* *leo-fw 1.4.0-r3 --> 2.0.0-r1*
* *leo-robot 1.4.0-r3 --> 2.0.0-r1*
* *odom-to-tf-ros2 1.0.2-r4 --> 1.0.3-r2*
* *plansys2-bringup 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-bt-actions 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-core 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-domain-expert 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-executor 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-lifecycle-manager 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-msgs 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-pddl-parser 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-planner 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-popf-plan-solver 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-problem-expert 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-support-py 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-terminal 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-tests 2.0.13-r1 --> 2.0.14-r1*
* *plansys2-tools 2.0.13-r1 --> 2.0.14-r1*
* *raspimouse-description 2.0.0-r1*
* *rt-usb-9axisimu-driver 3.0.0-r1*
* *twist-stamper 0.0.3-r4 --> 0.0.5-r1*

Noetic Changes:
---------------
* *etsi-its-cam-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-messages 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-msgs-utils 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-primitives-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-rviz-plugins 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *gazebo-noisy-depth-camera 1.0.1-r1*
* *inorbit-republisher 0.3.0-r1 --> 0.3.2-r1*
* *nodelet 1.11.0-r2 --> 1.11.1-r1*
* *nodelet-core 1.11.0-r2 --> 1.11.1-r1*
* *nodelet-topic-tools 1.11.0-r2 --> 1.11.1-r1*
* *rc-reason-clients 0.3.1-r1 --> 0.4.0-r1*
* *rc-reason-msgs 0.3.1-r1 --> 0.4.0-r1*

Rolling Changes:
----------------
* *action-tutorials-cpp 0.35.0-r1 --> 0.35.1-r1*
* *action-tutorials-py 0.35.0-r1 --> 0.35.1-r1*
* *actionlib-msgs 5.4.1-r1 --> 5.4.2-r1*
* *ament-clang-format 0.18.1-r1 --> 0.19.0-r1*
* *ament-clang-tidy 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-auto 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-clang-format 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-clang-tidy 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-copyright 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-core 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-cppcheck 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-cpplint 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-export-definitions 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-export-dependencies 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-export-include-directories 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-export-interfaces 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-export-libraries 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-export-link-flags 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-export-targets 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-flake8 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-gen-version-h 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-gmock 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-google-benchmark 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-gtest 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-include-directories 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-libraries 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-lint-cmake 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-mypy 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-pclint 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-pep257 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-pycodestyle 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-pyflakes 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-pytest 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-python 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-ros 0.13.0-r1 --> 0.13.1-r1*
* *ament-cmake-target-dependencies 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-test 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-uncrustify 0.18.1-r1 --> 0.19.0-r1*
* *ament-cmake-vendor-package 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-version 2.7.1-r1 --> 2.7.2-r1*
* *ament-cmake-xmllint 0.18.1-r1 --> 0.19.0-r1*
* *ament-copyright 0.18.1-r1 --> 0.19.0-r1*
* *ament-cppcheck 0.18.1-r1 --> 0.19.0-r1*
* *ament-cpplint 0.18.1-r1 --> 0.19.0-r1*
* *ament-index-cpp 1.10.0-r1 --> 1.10.1-r1*
* *ament-index-python 1.10.0-r1 --> 1.10.1-r1*
* *ament-lint 0.18.1-r1 --> 0.19.0-r1*
* *ament-lint-auto 0.18.1-r1 --> 0.19.0-r1*
* *ament-lint-cmake 0.18.1-r1 --> 0.19.0-r1*
* *ament-lint-common 0.18.1-r1 --> 0.19.0-r1*
* *ament-mypy 0.18.1-r1 --> 0.19.0-r1*
* *ament-pclint 0.18.1-r1 --> 0.19.0-r1*
* *ament-pep257 0.18.1-r1 --> 0.19.0-r1*
* *ament-pycodestyle 0.18.1-r1 --> 0.19.0-r1*
* *ament-pyflakes 0.18.1-r1 --> 0.19.0-r1*
* *ament-uncrustify 0.18.1-r1 --> 0.19.0-r1*
* *ament-xmllint 0.18.1-r1 --> 0.19.0-r1*
* *autoware-lanelet2-extension 0.6.0-r1 --> 0.6.2-r1*
* *autoware-lanelet2-extension-python 0.6.0-r1 --> 0.6.2-r1*
* *common-interfaces 5.4.1-r1 --> 5.4.2-r1*
* *composition 0.35.0-r1 --> 0.35.1-r1*
* *control-msgs 5.2.0-r1 --> 5.3.0-r1*
* *demo-nodes-cpp 0.35.0-r1 --> 0.35.1-r1*
* *demo-nodes-cpp-native 0.35.0-r1 --> 0.35.1-r1*
* *demo-nodes-py 0.35.0-r1 --> 0.35.1-r1*
* *diagnostic-msgs 5.4.1-r1 --> 5.4.2-r1*
* *domain-coordinator 0.13.0-r1 --> 0.13.1-r1*
* *dummy-map-server 0.35.0-r1 --> 0.35.1-r1*
* *dummy-robot-bringup 0.35.0-r1 --> 0.35.1-r1*
* *dummy-sensors 0.35.0-r1 --> 0.35.1-r1*
* *examples-rclcpp-async-client 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-cbg-executor 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-action-client 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-action-server 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-client 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-composition 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-publisher 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-service 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-subscriber 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-minimal-timer 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-multithreaded-executor 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclcpp-wait-set 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-executors 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-guard-conditions 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-minimal-action-client 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-minimal-action-server 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-minimal-client 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-minimal-publisher 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-minimal-service 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-minimal-subscriber 0.20.2-r1 --> 0.20.3-r1*
* *examples-rclpy-pointcloud-publisher 0.20.2-r1 --> 0.20.3-r1*
* *examples-tf2-py 0.39.1-r1 --> 0.39.2-r1*
* *fastrtps-cmake-module 3.7.0-r1 --> 3.7.1-r1*
* *flir-camera-description 2.0.20-r1 --> 3.0.0-r1*
* *flir-camera-msgs 2.0.20-r1 --> 3.0.0-r1*
* *foxglove-compressed-video-transport 1.0.0-r1 --> 1.0.1-r1*
* *geometry-msgs 5.4.1-r1 --> 5.4.2-r1*
* *geometry2 0.39.1-r1 --> 0.39.2-r1*
* *gz-common-vendor 0.2.0-r1 --> 0.2.1-r1*
* *image-tools 0.35.0-r1 --> 0.35.1-r1*
* *intra-process-demo 0.35.0-r1 --> 0.35.1-r1*
* *laser-geometry 2.8.1-r1 --> 2.9.0-r1*
* *laser-segmentation 3.0.2-r1*
* *launch 3.6.1-r1 --> 3.7.0-r1*
* *launch-pytest 3.6.1-r1 --> 3.7.0-r1*
* *launch-ros 0.27.3-r1 --> 0.28.0-r1*
* *launch-testing 3.6.1-r1 --> 3.7.0-r1*
* *launch-testing-ament-cmake 3.6.1-r1 --> 3.7.0-r1*
* *launch-testing-examples 0.20.2-r1 --> 0.20.3-r1*
* *launch-testing-ros 0.27.3-r1 --> 0.28.0-r1*
* *launch-xml 3.6.1-r1 --> 3.7.0-r1*
* *launch-yaml 3.6.1-r1 --> 3.7.0-r1*
* *leo-bringup 1.4.0-r2 --> 2.0.0-r1*
* *leo-fw 1.4.0-r2 --> 2.0.0-r1*
* *leo-robot 1.4.0-r2 --> 2.0.0-r1*
* *libcurl-vendor 3.5.1-r1 --> 3.6.0-r1*
* *libstatistics-collector 2.0.0-r1 --> 2.0.1-r1*
* *libyaml-vendor 1.7.0-r1 --> 1.7.1-r1*
* *lifecycle 0.35.0-r1 --> 0.35.1-r1*
* *lifecycle-py 0.35.0-r1 --> 0.35.1-r1*
* *logging-demo 0.35.0-r1 --> 0.35.1-r1*
* *message-filters 6.0.6-r1 --> 6.0.7-r1*
* *nav-msgs 5.4.1-r1 --> 5.4.2-r1*
* *odom-to-tf-ros2 1.0.2-r3 --> 1.0.4-r1*
* *openeb-vendor 2.0.1-r1 --> 2.0.1-r2*
* *orocos-kdl-vendor 0.6.1-r1 --> 0.7.0-r1*
* *pendulum-control 0.35.0-r1 --> 0.35.1-r1*
* *pendulum-msgs 0.35.0-r1 --> 0.35.1-r1*
* *pluginlib 5.5.1-r1 --> 5.5.2-r1*
* *point-cloud-transport 5.0.4-r1 --> 5.1.0-r1*
* *point-cloud-transport-py 5.0.4-r1 --> 5.1.0-r1*
* *python-orocos-kdl-vendor 0.6.1-r1 --> 0.7.0-r1*
* *qt-dotgraph 2.8.2-r1 --> 2.8.3-r1*
* *qt-gui 2.8.2-r1 --> 2.8.3-r1*
* *qt-gui-app 2.8.2-r1 --> 2.8.3-r1*
* *qt-gui-core 2.8.2-r1 --> 2.8.3-r1*
* *qt-gui-cpp 2.8.2-r1 --> 2.8.3-r1*
* *qt-gui-py-common 2.8.2-r1 --> 2.8.3-r1*
* *quality-of-service-demo-cpp 0.35.0-r1 --> 0.35.1-r1*
* *quality-of-service-demo-py 0.35.0-r1 --> 0.35.1-r1*
* *rcl 10.0.0-r1 --> 10.0.1-r1*
* *rcl-action 10.0.0-r1 --> 10.0.1-r1*
* *rcl-lifecycle 10.0.0-r1 --> 10.0.1-r1*
* *rcl-yaml-param-parser 10.0.0-r1 --> 10.0.1-r1*
* *rclcpp 29.0.0-r1 --> 29.1.0-r1*
* *rclcpp-action 29.0.0-r1 --> 29.1.0-r1*
* *rclcpp-components 29.0.0-r1 --> 29.1.0-r1*
* *rclcpp-lifecycle 29.0.0-r1 --> 29.1.0-r1*
* *rcpputils 2.13.1-r1 --> 2.13.2-r1*
* *resource-retriever 3.5.1-r1 --> 3.6.0-r1*
* *rmw-cyclonedds-cpp 3.0.2-r1 --> 3.0.3-r1*
* *rmw-fastrtps-cpp 9.0.2-r1 --> 9.0.3-r1*
* *rmw-fastrtps-dynamic-cpp 9.0.2-r1 --> 9.0.3-r1*
* *rmw-fastrtps-shared-cpp 9.0.2-r1 --> 9.0.3-r1*
* *rmw-implementation 3.0.2-r1 --> 3.0.3-r1*
* *ros-testing 0.7.0-r1 --> 0.8.0-r1*
* *ros2action 0.35.0-r1 --> 0.36.0-r1*
* *ros2cli 0.35.0-r1 --> 0.36.0-r1*
* *ros2cli-test-interfaces 0.35.0-r1 --> 0.36.0-r1*
* *ros2component 0.35.0-r1 --> 0.36.0-r1*
* *ros2doctor 0.35.0-r1 --> 0.36.0-r1*
* *ros2interface 0.35.0-r1 --> 0.36.0-r1*
* *ros2launch 0.27.3-r1 --> 0.28.0-r1*
* *ros2lifecycle 0.35.0-r1 --> 0.36.0-r1*
* *ros2lifecycle-test-fixtures 0.35.0-r1 --> 0.36.0-r1*
* *ros2multicast 0.35.0-r1 --> 0.36.0-r1*
* *ros2node 0.35.0-r1 --> 0.36.0-r1*
* *ros2param 0.35.0-r1 --> 0.36.0-r1*
* *ros2pkg 0.35.0-r1 --> 0.36.0-r1*
* *ros2run 0.35.0-r1 --> 0.36.0-r1*
* *ros2service 0.35.0-r1 --> 0.36.0-r1*
* *ros2test 0.7.0-r1 --> 0.8.0-r1*
* *ros2topic 0.35.0-r1 --> 0.36.0-r1*
* *rosidl-adapter 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-cli 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-cmake 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-dynamic-typesupport 0.2.0-r1 --> 0.3.0-r1*
* *rosidl-dynamic-typesupport-fastrtps 0.2.0-r1 --> 0.3.0-r1*
* *rosidl-generator-c 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-generator-cpp 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-generator-py 0.23.1-r1 --> 0.24.0-r1*
* *rosidl-generator-type-description 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-parser 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-pycommon 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-runtime-c 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-runtime-cpp 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-typesupport-fastrtps-c 3.7.0-r1 --> 3.7.1-r1*
* *rosidl-typesupport-fastrtps-cpp 3.7.0-r1 --> 3.7.1-r1*
* *rosidl-typesupport-interface 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-typesupport-introspection-c 4.9.0-r1 --> 4.9.1-r1*
* *rosidl-typesupport-introspection-cpp 4.9.0-r1 --> 4.9.1-r1*
* *rqt 1.7.3-r1 --> 1.8.0-r1*
* *rqt-gui 1.7.3-r1 --> 1.8.0-r1*
* *rqt-gui-cpp 1.7.3-r1 --> 1.8.0-r1*
* *rqt-gui-py 1.7.3-r1 --> 1.8.0-r1*
* *rqt-py-common 1.7.3-r1 --> 1.8.0-r1*
* *rviz-assimp-vendor 14.3.1-r1 --> 14.3.2-r1*
* *rviz-common 14.3.1-r1 --> 14.3.2-r1*
* *rviz-default-plugins 14.3.1-r1 --> 14.3.2-r1*
* *rviz-ogre-vendor 14.3.1-r1 --> 14.3.2-r1*
* *rviz-rendering 14.3.1-r1 --> 14.3.2-r1*
* *rviz-rendering-tests 14.3.1-r1 --> 14.3.2-r1*
* *rviz-visual-testing-framework 14.3.1-r1 --> 14.3.2-r1*
* *rviz2 14.3.1-r1 --> 14.3.2-r1*
* *sensor-msgs 5.4.1-r1 --> 5.4.2-r1*
* *sensor-msgs-py 5.4.1-r1 --> 5.4.2-r1*
* *shape-msgs 5.4.1-r1 --> 5.4.2-r1*
* *spinnaker-camera-driver 2.0.20-r1 --> 3.0.0-r1*
* *spinnaker-synchronized-camera-driver 2.0.20-r1 --> 3.0.0-r1*
* *std-msgs 5.4.1-r1 --> 5.4.2-r1*
* *std-srvs 5.4.1-r1 --> 5.4.2-r1*
* *stereo-msgs 5.4.1-r1 --> 5.4.2-r1*
* *test-interface-files 0.12.0-r1 --> 0.13.0-r1*
* *tf2 0.39.1-r1 --> 0.39.2-r1*
* *tf2-bullet 0.39.1-r1 --> 0.39.2-r1*
* *tf2-eigen 0.39.1-r1 --> 0.39.2-r1*
* *tf2-eigen-kdl 0.39.1-r1 --> 0.39.2-r1*
* *tf2-geometry-msgs 0.39.1-r1 --> 0.39.2-r1*
* *tf2-kdl 0.39.1-r1 --> 0.39.2-r1*
* *tf2-msgs 0.39.1-r1 --> 0.39.2-r1*
* *tf2-py 0.39.1-r1 --> 0.39.2-r1*
* *tf2-ros 0.39.1-r1 --> 0.39.2-r1*
* *tf2-ros-py 0.39.1-r1 --> 0.39.2-r1*
* *tf2-sensor-msgs 0.39.1-r1 --> 0.39.2-r1*
* *tf2-tools 0.39.1-r1 --> 0.39.2-r1*
* *topic-monitor 0.35.0-r1 --> 0.35.1-r1*
* *topic-statistics-demo 0.35.0-r1 --> 0.35.1-r1*
* *trajectory-msgs 5.4.1-r1 --> 5.4.2-r1*
* *twist-stamper 0.0.3-r3 --> 0.0.5-r1*
* *visualization-msgs 5.4.1-r1 --> 5.4.2-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-antlr4
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-blind-except
 * [ ] python3-flake8-class-newline
 * [ ] python3-flake8-deprecated
 * [ ] python3-pexpect
 * [ ] python3-pre-commit
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pyside2
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rich
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typing-extensions
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

