### PR TITLE
rosdistro sync, Fri Nov 29 13:44:25 2024

### DIFF
--- a/distros/humble/adi-3dtof-image-stitching/default.nix
+++ b/distros/humble/adi-3dtof-image-stitching/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, compressed-depth-image-transport, cv-bridge, image-geometry, image-transport, pcl-conversions, pcl-ros, ros2launch, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-adi-3dtof-image-stitching";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/adi_3dtof_image_stitching-release/archive/release/humble/adi_3dtof_image_stitching/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "c161c2da36275c6ca6d2aca4a5fee1e17a353812ca62eff7fcc34040837cebac";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ compressed-depth-image-transport cv-bridge image-geometry image-transport pcl-conversions pcl-ros ros2launch sensor-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The adi_3dtof_image_stitching package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ament-cmake-auto/default.nix
+++ b/distros/humble/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-auto";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "d435be1af9ee2702e35c454b077fc18cfbbb6094e5a15be3f9a7b7a80744d5f1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_auto/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "4c557506ee6c79a6fe944090a2fa9e1656a85abacc4e50bde4ecd1cf82cc3ac0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-core/default.nix
+++ b/distros/humble/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-core";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "e1dc7ca030acbf5789240e5da5c1ac151f531aa76902dead8987a6ab31fe626f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_core/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "ca4074bdb72cfdc53d8b04daa29b195d0445ef6da638b7b38fee5a441f6194db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-definitions/default.nix
+++ b/distros/humble/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-definitions";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "1768af9dab66522b38c40cb8b5de930479d6749db4b52ec7811dd59fde1e2aad";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_definitions/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "328a8f0d2f75fef8e9fa024a22a1ffb6c3bf46343a8d6e4fb4429349bf711d07";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-dependencies/default.nix
+++ b/distros/humble/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-dependencies";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "2ded3649235337226aa2f26486a015a5195b318587a5addd1d615a1ddd168010";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_dependencies/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "07c88006679d8b2c7d6ebd2b65cc64641d17fdb554ae5a0f9b0c3866234bddc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-include-directories/default.nix
+++ b/distros/humble/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-include-directories";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "309780fe9db71104b4c5bddad049502c3b59b50a8b9277c567903f07502e42b7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_include_directories/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "aa89df7b6932cbd14c2870f41b6b88ac840e9049b2187dce0dfdbb5217d18af6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-interfaces/default.nix
+++ b/distros/humble/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-interfaces";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "403ab5ba78c3f15531ccfa4ebdd22a72ed4e2955e1e641a5e524f24e33d88db6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_interfaces/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "68f7787f793e5ffbebe44cdb6edc0af8f5d1912a124f846aeaf11179273408ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-libraries/default.nix
+++ b/distros/humble/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-libraries";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "159235d2a02f9852cab61ea32ac16bf7f126c8b267785151528155fde33ee701";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_libraries/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "dcd6476f98ab8d4888ec30cb26c36fe1f1eec212e15837670a37fb55c49e7f3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-link-flags/default.nix
+++ b/distros/humble/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-link-flags";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "cd1b04d561d1b9644e18a370de3901e15120db0d02c8d64e06dc602cbd912365";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_link_flags/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "1c4e8f7872aa0bfc27a80eed8bfd4b17beebea486cfce2d30479ee60cd20d698";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-export-targets/default.nix
+++ b/distros/humble/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-export-targets";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "f751dded95b0fb809bd41233d89cc0b19aac204cd2cf660813c4ea254a91e806";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_export_targets/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "705c6826baafb3f33c2f1aefc6efb10c4b3560672b537af5a0c5f51f3bd780ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gen-version-h/default.nix
+++ b/distros/humble/ament-cmake-gen-version-h/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-package }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gen-version-h";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "a40c8afbae1dadb2affe881e35cc786f7bf85c788c2cea6f9fdfa92996c8d4fc";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gen_version_h/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "be77a7c6b02a464363288ebc2480ec9c545a15170072a3911ddec4a1a7aafb95";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gmock/default.nix
+++ b/distros/humble/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gmock";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "494f3bfc95ec6ee5f3ec91b16023090af17bda0f143c5438cbd8adc4494baae2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gmock/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "864aee7784bfa47fade7056b3f7b60c2ca975f3161a8a71b5ec8978fb40d9325";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-google-benchmark/default.nix
+++ b/distros/humble/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-google-benchmark";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "dbe284153d0355699731fcf8456ec631a9233a5f7a0a00c12ca80309750d1191";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_google_benchmark/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "37e09512a6c66e7dccac345911b318921bb25434b476ccaa14b5a84ced902c46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-gtest/default.nix
+++ b/distros/humble/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-gtest";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "133d16ea7d5dbf9b563fcee55c4ae585a4971c5802cb59f4fa69c5e15ae33051";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_gtest/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "c6f9375095b6da2ffde821b5a1cbd24a00953479dde3f7362e3d72731856379d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-include-directories/default.nix
+++ b/distros/humble/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-include-directories";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "b30070499487db06c44c6ba6502665153c14bc309ace0ebb5673785ffe3cc17f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_include_directories/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "13f2bb74e6057fe79db316c9ecedee3eac5b06c56b471023941ccf09ea17ce58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-libraries/default.nix
+++ b/distros/humble/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-libraries";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "9f259d51ea16519126a9346e51894fd311d7902f7f77a8655b636d7102441fe4";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_libraries/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "d86aed9f823982093c7a3a33fed9c7c0426eb55b2022858caf254b65f3329e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-nose/default.nix
+++ b/distros/humble/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-nose";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "2058e91a6ca6be919b912c7f99c0fbd05299001001722c775a8d15c069f789c0";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_nose/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "56570f6628062453f89fe3903edb96826690734869e6e86afba283ca978d7dbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pytest/default.nix
+++ b/distros/humble/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pytest";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "af703cfe993ceb3adfdba48ee3fc6a9ad661eac5f1e6e9e80fb5e9c8e394722d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_pytest/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "75816886c3457b1a5997aac7963c95ffefe783b5bb3eff9a7491b47304b58436";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-python/default.nix
+++ b/distros/humble/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-python";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "22dfaafc6abd04638dfc160f705b6cd2861a258335ffeb42c1e787853d9fe12f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_python/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "abcc2be7cb7983705fd526eeff6a17c5973f473bdc588493c1ade259d070f4fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-target-dependencies/default.nix
+++ b/distros/humble/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-target-dependencies";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "92923a98880f7821d64c463b885f6df5182985c016d931834e93c48cadaf7524";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_target_dependencies/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "6b82d091debb69800aeab89d89a2605237d8c7caa8bb075047fc79b25c85a44d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-test/default.nix
+++ b/distros/humble/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-test";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "ef20c8002bed0b34a98277af122254d813a81a67231cbb7a66367aa8197ecd1c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_test/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "cb3ceb5eb10a7115278e5f48ab533413efa95935f824d8b1e286ed526505da50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-vendor-package/default.nix
+++ b/distros/humble/ament-cmake-vendor-package/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, vcstool }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-cmake-test, git, vcstool }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-vendor-package";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "99a5bbb41355ccfbf00a53b22fe5da8741a9046301344864681dfe259b376794";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_vendor_package/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "58baee6062992ea5ccf7ad6c9b3d37396e1f0ff9d85842b46de75e0bad55058c";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-test ];
-  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies vcstool ];
+  propagatedBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git vcstool ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies git vcstool ];
 
   meta = {
     description = "Macros for maintaining a 'vendor' package.";

--- a/distros/humble/ament-cmake-version/default.nix
+++ b/distros/humble/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-version";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "2f22ca79ff00237236189f56f0558490196604fdcab743317db9ee00e3898c58";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake_version/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "db0ff57211d7e15b289645b79db33fa57d971abe31d874a90d6b0f06d39e121f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake/default.nix
+++ b/distros/humble/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-gen-version-h, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake";
-  version = "1.3.10-r1";
+  version = "1.3.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.10-1.tar.gz";
-    name = "1.3.10-1.tar.gz";
-    sha256 = "0dff90d2d2365f726407a6e91851aa5ee0bb9762030c172a99f858d9234c76a9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/humble/ament_cmake/1.3.11-1.tar.gz";
+    name = "1.3.11-1.tar.gz";
+    sha256 = "b5119e0f77144857f2136279c514eadc8b25bff7c6bd2bd3aeb5eaaa8d98f8f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/axis-camera/default.nix
+++ b/distros/humble/axis-camera/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, axis-msgs, camera-info-manager-py, ptz-action-server-msgs, python3Packages, pythonPackages, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-axis-camera";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/axis_camera-release/archive/release/humble/axis_camera/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2e4405c4288ac0cc6fecd3432866a1f6a877536139d575de3471dc2fb3255076";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ axis-msgs camera-info-manager-py ptz-action-server-msgs python3Packages.requests sensor-msgs std-srvs ];
+
+  meta = {
+    description = "ROS 2 driver for fixed and PTZ Axis cameras";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/axis-description/default.nix
+++ b/distros/humble/axis-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-humble-axis-description";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/axis_camera-release/archive/release/humble/axis_description/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "42adb697735b30ea2c3695e09d9aec3f4689fab9c5c61575617fccfa22637bf9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Description package with URDF files for common Axis fixed and PTZ cameras";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/axis-msgs/default.nix
+++ b/distros/humble/axis-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-axis-msgs";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/axis_camera-release/archive/release/humble/axis_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f19d10a439d7d3acf999ad66b94f8dc3e822bd6368fd79033e9af5aa299bd42f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS messages used by the axis_camera package to control Axis PTZ and fixed cameras";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/camera-calibration-parsers/default.nix
+++ b/distros/humble/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration-parsers";
-  version = "3.1.9-r1";
+  version = "3.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.9-1.tar.gz";
-    name = "3.1.9-1.tar.gz";
-    sha256 = "80800aee3b054ae28be1ff504e02f493914fbd34fef742b8fd8c2a5b58ad82b3";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.10-1.tar.gz";
+    name = "3.1.10-1.tar.gz";
+    sha256 = "d0c502969e366139e4f679d3f78a1bfa17d093e7807e47de75f71cf2abb0ec77";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-info-manager-py/default.nix
+++ b/distros/humble/camera-info-manager-py/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, pythonPackages, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-camera-info-manager-py";
+  version = "3.1.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager_py/3.1.10-1.tar.gz";
+    name = "3.1.10-1.tar.gz";
+    sha256 = "a190bbee6fbee1a7f63544fdb3b1ec2e6c8494fdccd149d6de1bf81ff42d37c4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml python3Packages.rospkg rclpy sensor-msgs ];
+
+  meta = {
+    description = "Python interface for camera calibration information.
+
+    This ROS package provides a CameraInfo interface for Python camera
+    drivers similar to the C++ camera_info_manager package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/camera-info-manager/default.nix
+++ b/distros/humble/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager";
-  version = "3.1.9-r1";
+  version = "3.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.9-1.tar.gz";
-    name = "3.1.9-1.tar.gz";
-    sha256 = "68387148b569c7ff0ee9ffa381def0c544372bb834cc4867459b8ea8b2d5204e";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.10-1.tar.gz";
+    name = "3.1.10-1.tar.gz";
+    sha256 = "6a4c4be4287234b62de00dafdef4662775c7f8e14930fd307f2232605b4a60c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-ros/default.nix
+++ b/distros/humble/camera-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-lint-auto, camera-info-manager, cv-bridge, libcamera, rclcpp-components, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-lint-auto, camera-info-manager, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-ros";
-  version = "0.1.0-r2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/humble/camera_ros/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "f59474661a00d39139e02ec3b6e22015f9a43c79d4a9dd6590ca2c973e2efc6d";
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/humble/camera_ros/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "bc9c9c1a2621d948cbff5124232d37625ef60f708de331a194c28ceef40df907";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-lint-auto ];
-  propagatedBuildInputs = [ camera-info-manager cv-bridge libcamera rclcpp-components sensor-msgs ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-pyflakes ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common, clearpath-platform }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "339836294909960602d486ace0b4cf87cd5efcb4c1ea0c7112234063656fd94a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "44c455604cecb4c473f2e319abab592227528437e24062e049ec9d375e94e000";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-control clearpath-description clearpath-generator-common clearpath-platform ];
+  propagatedBuildInputs = [ clearpath-control clearpath-description clearpath-generator-common ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "0.3.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "9fde631240bd6f010b038d8fa8557d4ef3e8c5e01161f8e64485a919e5be3f28";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fc8d0ee1fc51723b020190d286206a3dc9f3f083f9503540eb0bccbf80fb0cab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "dc090659b0ac69032b6cd33b240fec5d2620b2c846e00ffedce1d2990a3a7fe8";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6d4886927dd0a520e9ec528c50daf648ea193eda46c2f31b5635a04e858c32c9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "251e4d875637dc9aa5ada8866bdbcbc02c183e7260936ed71799467bd981e657";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0e9a6efc3adb3436495a3724ad5ab26cba422db852b349f98b9c4c8776b28693";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "ae52e86cd42cadaca9c1528606d2f7cfb7e6e844dee189336786430f0b7bb114";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0dcd6ab86b69fc7116eff59c095ca0805c10a6739e272ce300a95c89d95bec11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "7948cea108150bf9530ced12f95040f1a5677e8f433b6f8209c441996b618b5a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bccc7edf6f8513c9b3c7ecb86305dcf0993b1b81eab1ec8a09cb54b1aadeca42";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "0.3.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1c20de72609fca45d7a58d1c0a19331a08c3aa996d669901991bbb89c1892c38";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "84f7a8ef40830598690c31beea5005bcb3868a7f8a43bdfd957b7cf3a13a9ccd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, clearpath-platform, moveit-setup-srdf-plugins }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "4e150b0ddfef0bf53144274ab6ec1c15d393add61883a55b0a937f2e386a2c11";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1f05495e814499bb82dbec6589daf05acbed116aab4312a251d98cc89072d5f3";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake moveit-setup-srdf-plugins ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ clearpath-config clearpath-control clearpath-description clearpath-manipulators clearpath-platform ];
+  propagatedBuildInputs = [ clearpath-config clearpath-control clearpath-description clearpath-manipulators ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-generator-gz/default.nix
+++ b/distros/humble/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-gz";
-  version = "0.3.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "17c6bfcc0a52d2a0dc76fe64014a771ee6337fb9d614f00a03fcc45f35d221a7";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_generator_gz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a89f99aa0e97771198003d91f53f4f8e2ef23c1cf54c30826515056eaff4a9e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-gz/default.nix
+++ b/distros/humble/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, ign-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-gz";
-  version = "0.3.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "3bcdcd0214a869e03b6c777dc07a690dcdb3b1c2a1a62b7d7b9ce1bd5236234c";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_gz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "42f977a7d297452248b20cab8b1268e74c247a373303f72d5f4d3c77d8da9562";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, kortex-description, robot-state-publisher, robotiq-description, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "08714fd4b4d4f99e4b831bcc0fa8cca3bf9e66c85502089619f626eeeff80e6a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b1af24d52c784d28bca2abe18e885b1e176c827b535dc273d57bdd3299279263";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ kortex-description robot-state-publisher robotiq-description urdf xacro ];
+  propagatedBuildInputs = [ kortex-description robot-state-publisher robotiq-description ur-description urdf xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "88d02df5725b43739ab39256e79e388ca3362b72aa80171807b9e0c55085ce32";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "badf41fadc197d605d76143ed3ac05e52a45a8a4bf8e2c4b9859c5519de0d248";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-motor-msgs/default.nix
+++ b/distros/humble/clearpath-motor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-clearpath-motor-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_motor_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c6480afc3ea8381d7f8a30414138171d95cff58b185a62ab0299ee24f12a01f9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Messages for Clearpath Motor Drivers.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "3de214307d713f2a62549d7f4751703faea3004269388bdf6c4410b6c34c7a1a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f68a2d18de0b7e635bc26bc4ca8c4422ed5a7ac76b9e007652ecc229ff5aa02b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-msgs/default.nix
+++ b/distros/humble/clearpath-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-motor-msgs, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c2dc06865a60ef15490533948cdb77ec5cb2b9eda0bc42fe79580c7c80d2898b";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "455a3135eac58ab2c0d71ad0767a694e1a60ee02ef4af3dce744514ffbe7b984";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-platform-msgs ];
+  propagatedBuildInputs = [ clearpath-motor-msgs clearpath-platform-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-nav2-demos/default.nix
+++ b/distros/humble/clearpath-nav2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, nav2-bringup, slam-toolbox }:
 buildRosPackage {
   pname = "ros-humble-clearpath-nav2-demos";
-  version = "0.2.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "a0d37c58b144c2e461db93f24360b334e3e01b5460e0c59d7f0f82ebaa4dfd32";
+    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/humble/clearpath_nav2_demos/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4b54a4831c34b4a2f5c9844cc4727ef95914786ffb5587796ee999af6dba13ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "cd33c2b665f11a23b20dd3e2db25e4d4c97da351796fb09d6129f83d897e2518";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0036be56906f8563d43a0d8aa897253f5ca13a1814fae55e5e7e4299aaf39481";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-msgs/default.nix
+++ b/distros/humble/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "651b53b16c079dfdb4ff2c4a0406232d8346e4a548970ef0ce8ab10a1c5cda0f";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/humble/clearpath_platform_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "06de50a095e31afa1f38c2d6302ad7f268a097b966be57fb8ae2f23ccaad6693";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "0.3.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "0b8ab42b662ca1cde54bb364df9a3a71fee5f02594933777e5c1e743c93985c0";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "393427500e5140db5c606b8f2a6cb8d2021c6d2360a8796f5e8dc2c26a8d8104";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-simulator/default.nix
+++ b/distros/humble/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-simulator";
-  version = "0.3.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "d3af91b4d468db5890ab459ecabca1661f2b7f0b0b4db7935c74ce46af238d0c";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/humble/clearpath_simulator/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "02615cfa920f02d86f93c18e7bd5df9b76cf4820e61dc8a0f65401cd1eb2294f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "0.3.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "b5727670409dd096cd9420e63d691ee495fd5ce35d78646089acae231310ae73";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "182edcb7ec769c9e36dab764a342f4c5dc8d62b301d2360ce8e36c7a428ae910";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cyclonedds/default.nix
+++ b/distros/humble/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, iceoryx-binding-c, iceoryx-hoofs, iceoryx-posh, openssl }:
 buildRosPackage {
   pname = "ros-humble-cyclonedds";
-  version = "0.10.4-r1";
+  version = "0.10.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/humble/cyclonedds/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "8f71cbd41b932e092f2d8cb172194d2862bf67c713fb449ede297185a9380fc8";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/humble/cyclonedds/0.10.5-2.tar.gz";
+    name = "0.10.5-2.tar.gz";
+    sha256 = "a636f8a862b4ec5a5ce6bc5d567a97d9e8cb16ac5a13aa07b0a7558a07777d29";
   };
 
   buildType = "cmake";

--- a/distros/humble/dual-laser-merger/default.nix
+++ b/distros/humble/dual-laser-merger/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-copyright, ament-cpplint, ament-flake8, ament-lint-auto, ament-lint-common, ament-pep257, ament-xmllint, geometry-msgs, laser-geometry, message-filters, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-dual-laser-merger";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dual_laser_merger-release/archive/release/humble/dual_laser_merger/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "78d9d77ce6bae43d35cb3c4d9f66dad12ee51f2e1c3c8cadecc2838f4dbbcb06";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-copyright ament-cpplint ament-flake8 ament-lint-auto ament-lint-common ament-pep257 ament-xmllint ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry message-filters pcl pcl-conversions pcl-ros rclcpp rclcpp-components tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "merge dual lidar's scans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/examples-rclcpp-async-client/default.nix
+++ b/distros/humble/examples-rclcpp-async-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-async-client";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_async_client/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "7bc2cd95b109347900925742d36cd746eda42f2b5962deef63b025abf96372bc";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_async_client/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "c69291c92f20c83e2910f5f71c4c8167c5fe43778052388d789e21bf582613e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-cbg-executor/default.nix
+++ b/distros/humble/examples-rclcpp-cbg-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-cbg-executor";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_cbg_executor/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "6e7a61f72fdf406995e1360de12a17c7f2cdc404f965164ff0767ac3dc909529";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_cbg_executor/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "cbb57778f3023c7115ce3ecb357f138f857c8a6f7114adf107f0fd226955c34e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-action-client/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-action-client";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_client/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "0e9e3c1a58605a094ded959ce405055bf8954224c1a8395fe9fc87565376ef9e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_client/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "e85b3a973028fd49213173a3caf30b5af36c5ab507f6c16686a614ebad9c8c50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-action-server/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-action-server";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_server/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "ef67f18f41667633b39ff597ead9148b5d9dbbc6ac8aa21588c09b224ed1f60f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_action_server/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "0bc79224bcba55fb5a29b9afd2ea01a2f754820d92869c5d9ff653e41376f57c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-client/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-client";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_client/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "7d92c12f193e97c771b5c6d5cbb5f535a930992c9bb44fded1bd6fc922c33fd7";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_client/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "381687be6521bc3c48cf60b06fb8b8739238cd25a87c5bcec7a5f2967a8c34bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-composition/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-composition/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-composition";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_composition/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "cd6c40c5dfa28026daf8e3cc790f85e68907074bf1e6f85a352371ddfaffbc4f";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_composition/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "7fd0d5cbfb1bf95c2121154025eb3a7ad6e2ea0a2eefa17f68510fcd8eb1600a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-publisher/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-publisher";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_publisher/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "f52bec619741364cb4a0c2a7c030d8fb8b01ba93b0af5531feec5c0e814de937";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_publisher/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "1eafc7863237b7c0edfe6300f9661ef2187fbf8e3bd29f8c0cb29bb3df904b22";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-service/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-service";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_service/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "6ba92c519586bf35be9a6627a4a2dd2ce0b149051cf0b0e11e6b78c1e615de46";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_service/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "7cfd35b58138775bc8103e65137211bf029dbfac23682e7aa59a725ade2b3242";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-subscriber/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-subscriber";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_subscriber/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "018389c190d5b8024f0099b09f3da91c6f6d8dae0dc65c9e7d7b60648ca9bdf8";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_subscriber/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "a9923e40c31ea6bb59cbcab26bab6c6533cf61cf2905a92f9506c6496832a21c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-minimal-timer/default.nix
+++ b/distros/humble/examples-rclcpp-minimal-timer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-minimal-timer";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_timer/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "91a5ee75d0445ca4d038fd73d1e6147638b3d850d27f15812e5ff239d2de4c11";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_minimal_timer/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "1b0d21d7151af7d182eb06e088a3f897481d343f933b72937d87ce60720e1f1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-multithreaded-executor/default.nix
+++ b/distros/humble/examples-rclcpp-multithreaded-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-multithreaded-executor";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_multithreaded_executor/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "ec7e60d9b39938886baf59cbb1611d29495318f93f0e2aa4b3e3ad4c358cda6e";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_multithreaded_executor/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "973add57d8513b26a5c0721122243a05be71dc4b86d6060bf9ed91534c6c5e2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclcpp-wait-set/default.nix
+++ b/distros/humble/examples-rclcpp-wait-set/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclcpp-wait-set";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_wait_set/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "96cd1334aba21f6c9e3c00625ee980d17be123d46dab9af63f8a6e82573a8b80";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclcpp_wait_set/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "175a742406abbe46b6f722032354e6acabed07591d71f4ecc91c81f236e7a64a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-rclpy-executors/default.nix
+++ b/distros/humble/examples-rclpy-executors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-executors";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_executors/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "e3e7d6b8b52fe4b6b38ab4f51f0604cf41c3955cc5fefe9f15d929b089c40472";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_executors/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "09655d1456f031494fffccad343c010c4e614cb3b560e1b8c36951dad5c14ca7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-guard-conditions/default.nix
+++ b/distros/humble/examples-rclpy-guard-conditions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-guard-conditions";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_guard_conditions/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "6d7afecddf113c57fc1dfde2281ecef535dd31d442904e57dfef3cf12ec97302";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_guard_conditions/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "d1f990a7b8137e551cc07f5bc10fef28b2c67912f9a9b9ebc0045132e291096b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-action-client/default.nix
+++ b/distros/humble/examples-rclpy-minimal-action-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-action-client";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_client/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "28a8cfa804509e5d670225b6493542ce1e68b778a60e011b1d0c1fd86f43e5ba";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_client/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "8223312961203abb721a54d757df7025e8fd77f605f6557276865487478ac1b4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-action-server/default.nix
+++ b/distros/humble/examples-rclpy-minimal-action-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-action-server";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_server/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "debe2b6e339881cb974ff26a065709c6e372e1bc5fb24c1075553810165a1703";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_action_server/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "ba74af931c66cfcadcd2450acc09523f075f32617b105894bb30e421d8fbf8b1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-client/default.nix
+++ b/distros/humble/examples-rclpy-minimal-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-client";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_client/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "add427eeca042ff203095f2c51e2142fac92eed036d553cbf2f8187c9820612a";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_client/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "cbc617d41cf86cf77260f0a8c79e69aec92eaf2fb18f2e222a37745821371246";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-publisher/default.nix
+++ b/distros/humble/examples-rclpy-minimal-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-publisher";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_publisher/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "366d1da6c3a2621c9751911b8611a2804da6bd2e62822988c0b208293a3e0d1c";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_publisher/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "d4d598d40fd88155340877c6c1ed533dd90cbc91d689547d050f88ca9e04f838";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-service/default.nix
+++ b/distros/humble/examples-rclpy-minimal-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-service";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_service/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "135d1341e5f6f980f813b3f55c273feb3d46705c9e2e728bef61c073ef9e5a67";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_service/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "69c39822f70f063723a5248a4f5cbcf94ee551060638f2f3c53a0f73b08c9030";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-minimal-subscriber/default.nix
+++ b/distros/humble/examples-rclpy-minimal-subscriber/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-minimal-subscriber";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_subscriber/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "399f00b056cacf54e3b1a63ff7ed26243d263877fd88e3c992607e536337eb68";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_minimal_subscriber/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "4c9d2b90031419c53c9970aaaf7dc4f715dd6d5288b6406f5665d84dc791fdf5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/examples-rclpy-pointcloud-publisher/default.nix
+++ b/distros/humble/examples-rclpy-pointcloud-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, sensor-msgs, sensor-msgs-py, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-examples-rclpy-pointcloud-publisher";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_pointcloud_publisher/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "a38407edd63ed333d688899297917ceb28a8055a5a784191ea61ee330bbb45fb";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/examples_rclpy_pointcloud_publisher/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "f911ca8d80797fdb63062752217c1fe3c80402583596a2fc815e549fccb28e46";
   };
 
   buildType = "ament_python";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ca480317afe7f6db7490635a041b68e4d518993d191db43cc49f4e53b925bc3d";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "b1309746b62ab475b1aaa1039cff9f191268f835e61c66ee5f86e0b3b15b361a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -26,6 +26,8 @@ self: super: {
 
  adaptive-component = self.callPackage ./adaptive-component {};
 
+ adi-3dtof-image-stitching = self.callPackage ./adi-3dtof-image-stitching {};
+
  adi-tmcl = self.callPackage ./adi-tmcl {};
 
  admittance-controller = self.callPackage ./admittance-controller {};
@@ -328,6 +330,12 @@ self: super: {
 
  aws-sdk-cpp-vendor = self.callPackage ./aws-sdk-cpp-vendor {};
 
+ axis-camera = self.callPackage ./axis-camera {};
+
+ axis-description = self.callPackage ./axis-description {};
+
+ axis-msgs = self.callPackage ./axis-msgs {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  bag2-to-image = self.callPackage ./bag2-to-image {};
@@ -377,6 +385,8 @@ self: super: {
  camera-calibration-parsers = self.callPackage ./camera-calibration-parsers {};
 
  camera-info-manager = self.callPackage ./camera-info-manager {};
+
+ camera-info-manager-py = self.callPackage ./camera-info-manager-py {};
 
  camera-ros = self.callPackage ./camera-ros {};
 
@@ -456,13 +466,13 @@ self: super: {
 
  clearpath-mecanum-drive-controller = self.callPackage ./clearpath-mecanum-drive-controller {};
 
+ clearpath-motor-msgs = self.callPackage ./clearpath-motor-msgs {};
+
  clearpath-mounts-description = self.callPackage ./clearpath-mounts-description {};
 
  clearpath-msgs = self.callPackage ./clearpath-msgs {};
 
  clearpath-nav2-demos = self.callPackage ./clearpath-nav2-demos {};
-
- clearpath-platform = self.callPackage ./clearpath-platform {};
 
  clearpath-platform-description = self.callPackage ./clearpath-platform-description {};
 
@@ -681,6 +691,8 @@ self: super: {
  ds-dbw-joystick-demo = self.callPackage ./ds-dbw-joystick-demo {};
 
  ds-dbw-msgs = self.callPackage ./ds-dbw-msgs {};
+
+ dual-laser-merger = self.callPackage ./dual-laser-merger {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -1113,6 +1125,8 @@ self: super: {
  hardware-interface-testing = self.callPackage ./hardware-interface-testing {};
 
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
+
+ hatchbed-common = self.callPackage ./hatchbed-common {};
 
  heaphook = self.callPackage ./heaphook {};
 
@@ -2660,6 +2674,8 @@ self: super: {
 
  rosbag2-tests = self.callPackage ./rosbag2-tests {};
 
+ rosbag2-to-video = self.callPackage ./rosbag2-to-video {};
+
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
 
  rosbridge-library = self.callPackage ./rosbridge-library {};
@@ -3471,6 +3487,8 @@ self: super: {
  yaml-cpp-vendor = self.callPackage ./yaml-cpp-vendor {};
 
  zbar-ros = self.callPackage ./zbar-ros {};
+
+ zed-msgs = self.callPackage ./zed-msgs {};
 
  zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 

--- a/distros/humble/hatchbed-common/default.nix
+++ b/distros/humble/hatchbed-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-hatchbed-common";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hatchbed_common-release/archive/release/humble/hatchbed_common/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "9bd8ff67a8a0e5f94012be0913fdbd08ac017329a47c5acb96a0014b464cc0d6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common Hatchbed C++ utility code for ROS, such registering and handling updates to ros parameters.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/image-common/default.nix
+++ b/distros/humble/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-common";
-  version = "3.1.9-r1";
+  version = "3.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.9-1.tar.gz";
-    name = "3.1.9-1.tar.gz";
-    sha256 = "220959ac9c86065c387d7ca0e3d6c04aef9be478e6f53344d466451925374854";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.10-1.tar.gz";
+    name = "3.1.10-1.tar.gz";
+    sha256 = "b26f7a64988ea47446bf3d7a7c1a6416a07ce7b5d1d09d0d3b1db1f61a4e3301";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport/default.nix
+++ b/distros/humble/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-transport";
-  version = "3.1.9-r1";
+  version = "3.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.9-1.tar.gz";
-    name = "3.1.9-1.tar.gz";
-    sha256 = "a0070dab9e1759df86a54a63c92f3417dd09031cdd352bbf5c9c542243aa65b2";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.10-1.tar.gz";
+    name = "3.1.10-1.tar.gz";
+    sha256 = "d4a3e9ed96cce39307039803d825099ef9d3ec1a57174d3251d9e678dc0c01ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-pytest/default.nix
+++ b/distros/humble/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-pytest";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_pytest/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "ce8bcf37eabd5099f849ff759c81fdcf0a290ec4b2ddc90dcfdfe6cf5e806a73";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_pytest/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "919147f83de65f9e7fc68fddc15d4d5c8a0cfe991ce4dd125a586dc4537da438";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-ros/default.nix
+++ b/distros/humble/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-launch-ros";
-  version = "0.19.7-r2";
+  version = "0.19.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.7-2.tar.gz";
-    name = "0.19.7-2.tar.gz";
-    sha256 = "8002e7deb58708e2f13a9005acf63c80e301a4262ec6bffb019b2fd9cfba3414";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.8-1.tar.gz";
+    name = "0.19.8-1.tar.gz";
+    sha256 = "aba9de0942a38141341385f63b8cf69294d4a85552137deae5a50a48c1404e8c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing-ament-cmake/default.nix
+++ b/distros/humble/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ament-cmake";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing_ament_cmake/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "4dd57952bfc180506352bb05609da86193b08236c4a4053218958192450b9540";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing_ament_cmake/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "c68106e8925f5613116552aa8f623dd1b2b4e9dd0f2082ac142edb23c789afff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-testing-examples/default.nix
+++ b/distros/humble/launch-testing-examples/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2bag, rosbag2-transport, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-cpp, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2bag, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-examples";
-  version = "0.15.2-r1";
+  version = "0.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/launch_testing_examples/0.15.2-1.tar.gz";
-    name = "0.15.2-1.tar.gz";
-    sha256 = "106b547189ed144baa6a536a7a8818072262ed63e2925dcc417e4fb01e216d70";
+    url = "https://github.com/ros2-gbp/examples-release/archive/release/humble/launch_testing_examples/0.15.3-1.tar.gz";
+    name = "0.15.3-1.tar.gz";
+    sha256 = "b5c9e488d6171ef4a8667827ab42c15e3270f13c1ba5ca5f9fbeb40bfcf98b86";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 demo-nodes-cpp launch launch-ros launch-testing launch-testing-ros pythonPackages.pytest rclpy ros2bag rosbag2-transport std-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
+  propagatedBuildInputs = [ demo-nodes-cpp launch launch-ros launch-testing launch-testing-ros pythonPackages.pytest rcl-interfaces rclpy ros2bag std-msgs ];
 
   meta = {
     description = "Examples of simple launch tests";

--- a/distros/humble/launch-testing-ros/default.nix
+++ b/distros/humble/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ros";
-  version = "0.19.7-r2";
+  version = "0.19.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.7-2.tar.gz";
-    name = "0.19.7-2.tar.gz";
-    sha256 = "b33c63555240075cfc935f440349de2fdecbfd4bcac7fa00004615b816574e88";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.8-1.tar.gz";
+    name = "0.19.8-1.tar.gz";
+    sha256 = "3eb7f63b33346b4922143f40285d2560d6c40566c73daffb3ca5aecb9d43b120";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing/default.nix
+++ b/distros/humble/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-testing";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "356e2d4d9abcf30a101bd6ef1e1f988b192f76ae15a04a30aa7c7421dddb980c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a51eede6fa423f8cddcc1918dbaa12c0dccae3a70298f4a7b27d42720def1a21";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-xml/default.nix
+++ b/distros/humble/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-xml";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_xml/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "3ec68c3b0e5aaa4100a9d6cf234d3025c66c51b8e0a0b922e3031e0b9729a2c9";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_xml/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "c235a1cac3088a8847124f8008f4358250d6bd6a7ecec48033029850e49b2d06";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-yaml/default.nix
+++ b/distros/humble/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch-yaml";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_yaml/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "00d0736b6453f30abd6e883135e056b409f9404266efbaf41c68903c88efacd1";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_yaml/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "1306d99f1622574c4ff008e628252e0a1a5f161a55989355d2dbe0e468e1e9db";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch/default.nix
+++ b/distros/humble/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-launch";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "f0ceb9c9f52c259402929369f57cabfa887676b8baf4d9299c99754034e6188b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "95720b36e3ce39bfa169dd0cf61a84d121b427e648a396f54ba301e673d98e16";
   };
 
   buildType = "ament_python";

--- a/distros/humble/libstatistics-collector/default.nix
+++ b/distros/humble/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, performance-test-fixture, rcl, rcpputils, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-libstatistics-collector";
-  version = "1.3.2-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/humble/libstatistics_collector/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "e725e6f3bfaf74e4936377fcd403ef4dbe5e7b3b0e45574009fc6b7be57fe4e9";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/humble/libstatistics_collector/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "9990f978a3100df3527edd61617ebc2dedca627a5e31fcb625d7bd36f7a7657b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/log-view/default.nix
+++ b/distros/humble/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
 buildRosPackage {
   pname = "ros-humble-log-view";
-  version = "0.2.3-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/humble/log_view/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "27cf93d53ee0a2b6933555cd261f12fed7f236b6b0b43187039704957c96d079";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/humble/log_view/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "384287437b37b44ac41b2c0dc545c23f0b3d8cbbd6612abca274c25a3c42d0e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "9f8ccc697a345ec85db7821ef9eee4d0bfadfd2630b990b760ed2e3aa2f25ab7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "9a48a5ed09ac08a7c7da6e7aed983978926f80667934930b495802c3b1386ad2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/osrf-pycommon/default.nix
+++ b/distros/humble/osrf-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-osrf-pycommon";
-  version = "2.0.2-r2";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/humble/osrf_pycommon/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "99b61b77be91e9aa5bee393befcf4c9b5a21f5bed075b7b399880fbeb9d0412d";
+    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/humble/osrf_pycommon/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "7eb7f928ef424bd59d5a691afc7ea4c7fb508022a3df6da8f8700b5503abe54d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics-msgs";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "600934b5250715d9b74df44c67e7fe478bac9600a7cfba0b8822da415a45d926";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "8c35b376a2bf0c58127e9c20feef324d24902d4df7505b8834f1878653b2e948";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics";
-  version = "2.3.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "edeefd7bb10b75730fed43cf05b2d09a848acb696c1f1a5580c3e71e774f8338";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "9af9b7c4cb0a80952956b9893a9b237711166137d92bcb359c9c4beba342cffa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rc-reason-clients/default.nix
+++ b/distros/humble/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-clients";
-  version = "0.4.0-r1";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "d922904dc15eb160b980c61445d01481591dff0cb0bc56a47a5c89e77a7af10f";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_clients/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "e4b27cc833f8046b938c78cb2c4e0ad1b42e23d4ec0e8f10dc5388fc360857db";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rc-reason-msgs/default.nix
+++ b/distros/humble/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rc-reason-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "b85b5f8823febc81456b7cc9de342137f1c0093a0eb1e6fb2ed1a54d151a4a55";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/humble/rc_reason_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "3243e06381e419e21b302c7c47074496a3489962a89887929acf97635eaa1a0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-action/default.nix
+++ b/distros/humble/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-action";
-  version = "16.0.10-r1";
+  version = "16.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.10-1.tar.gz";
-    name = "16.0.10-1.tar.gz";
-    sha256 = "24b21fc234d14886c4fd91d67614cf6cefe3303276bfc31f78bb4589b7b6505f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.11-1.tar.gz";
+    name = "16.0.11-1.tar.gz";
+    sha256 = "bedd54adba7a72de4890513ded7d161003bddd8c2ecdcf30b0ce0d8aa3f3aec8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-components/default.nix
+++ b/distros/humble/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-components";
-  version = "16.0.10-r1";
+  version = "16.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.10-1.tar.gz";
-    name = "16.0.10-1.tar.gz";
-    sha256 = "0ddecd759ae682ff6d79576aeb68254c8bc8a2cd48ec940af54ac58c5616685c";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.11-1.tar.gz";
+    name = "16.0.11-1.tar.gz";
+    sha256 = "62299fb090b35effeb73c2e6572f5d9e30fdd1c34f34b7ada27e81829fbe5ca6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-lifecycle/default.nix
+++ b/distros/humble/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-lifecycle";
-  version = "16.0.10-r1";
+  version = "16.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.10-1.tar.gz";
-    name = "16.0.10-1.tar.gz";
-    sha256 = "c22b5f38c962fa65d78b445ade3f38cf36dbc89530912b332f6a79fba985f809";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.11-1.tar.gz";
+    name = "16.0.11-1.tar.gz";
+    sha256 = "e9383f97647416c3eedacb481e84c43228c1f76b1ca1aff76933bdb99e997871";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp/default.nix
+++ b/distros/humble/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rclcpp";
-  version = "16.0.10-r1";
+  version = "16.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.10-1.tar.gz";
-    name = "16.0.10-1.tar.gz";
-    sha256 = "b42cfb57707511c016512fa95a1910e8c77e378b4660ced3e3ce72eadf3d37e6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.11-1.tar.gz";
+    name = "16.0.11-1.tar.gz";
+    sha256 = "8ecf24a23575fa6e67000b977f7fa0363b98d775740fbd15cffe1f5fef5358de";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclpy/default.nix
+++ b/distros/humble/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclpy";
-  version = "3.3.14-r1";
+  version = "3.3.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.14-1.tar.gz";
-    name = "3.3.14-1.tar.gz";
-    sha256 = "0ba3bee35a4514180f47226c13f0db3ef6708bba3d4b7742860ce27870e01455";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.15-1.tar.gz";
+    name = "3.3.15-1.tar.gz";
+    sha256 = "8be73b988640c972749829398ebcfb7a56ce57867e11751da53d22e1273cf81c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcpputils/default.nix
+++ b/distros/humble/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rcpputils";
-  version = "2.4.3-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.3-1.tar.gz";
-    name = "2.4.3-1.tar.gz";
-    sha256 = "759e9ec41c2b2407f1ef69a629105f280b67c6a7b296c5728dfe485611d793fb";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "54b758ba1de0a95e6a8830b33df232f1e346a923d9604add4f216cda055a92a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-connextdds-common/default.nix
+++ b/distros/humble/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-rmw-connextdds-common";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds_common/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "ef1e11f55370064c80d9921c7a69999c5bcf08f77419da816f1b95d69b054012";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds_common/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "26a2e884e4fc49ae8ad6a612c19efbde00d3394e577788be618acedce3ea0812";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-connextdds/default.nix
+++ b/distros/humble/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-humble-rmw-connextdds";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "94cb333746fe8612d47286c99eb5b1c4b8052fcc01b6b42e43948862b48b7f22";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rmw_connextdds/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "b5d31ab430a6c4e8f967e8009dfc1a171be3a46175d43fb02ab4025f6fa11f2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2bag/default.nix
+++ b/distros/humble/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins }:
 buildRosPackage {
   pname = "ros-humble-ros2bag";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "21d8d58f37a7737b648d4a5262c7d58e46e0ca93b05cb3e9ff379b0109f1c9c3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "ca4aa39499c3a5ec65e11a545f8fe408460e05591da8d5674261a16d5c7290e6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2launch/default.nix
+++ b/distros/humble/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2launch";
-  version = "0.19.7-r2";
+  version = "0.19.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.7-2.tar.gz";
-    name = "0.19.7-2.tar.gz";
-    sha256 = "47c9778af21d89ffe7d5883d08d4967284e4ce1f300e7af0437baafa216208dd";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.8-1.tar.gz";
+    name = "0.19.8-1.tar.gz";
+    sha256 = "0c98668e4e45ddc7df4de62acaafceeb319d737afba017cba9a624a0c9eb7fa2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosbag2-compression-zstd/default.nix
+++ b/distros/humble/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression-zstd";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "c7257e9a8a3a272b59f195b663d5ef3b2f13fdf82d7a0703134dd2700b2d7bb9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "c6592762972eef99145b43fffe21f9fabb10cd573c36b0c6990fbddd2935cfc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-compression/default.nix
+++ b/distros/humble/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "25ba0739c6096353a676f7cd85b84bd5aabc5f90a50e74278591e97a5c465ce9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "915795abcd25d59a62d913f0baf0f61f843348d4b50a195f808e8f10b278ae6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-cpp/default.nix
+++ b/distros/humble/rosbag2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-storage-mcap, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-storage-mcap, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-cpp";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "ed2e0be48de3be357bb4ec0b9262eaf6700f5c34454cbe79859179de105aaf93";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "35de47814b6a08c311df06571b947e99a76d1b5a7b16e4e7b844ede859671e9c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-storage-default-plugins rosbag2-storage-mcap rosbag2-test-common test-msgs ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rmw-implementation-cmake rosbag2-storage-default-plugins rosbag2-storage-mcap rosbag2-test-common std-msgs test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp shared-queues-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/humble/rosbag2-interfaces/default.nix
+++ b/distros/humble/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-interfaces";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "22b5c860a20ecb67e5d0ee284d7853d26779b44e782f12d36d9cb623b5483a13";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "855c9075848dbf29a1a0571b71c6ee0c0cded8302cb63de463c332cba5175d47";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-performance-benchmarking/default.nix
+++ b/distros/humble/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rmw, rosbag2-compression, rosbag2-cpp, rosbag2-storage, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-performance-benchmarking";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "be3bddca149a1ec09ead640edf7826c96d8fb8997d324aed450343d8128f994c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "6ef285173177dc6120edf83d2403c86538475fe5027ea540eee150a66a2172cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-py/default.nix
+++ b/distros/humble/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-py";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "0386fa145a08d78694e1076cd8db905ddd59c89dd5a1b9f3f448d1dae61509e5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "8e8b07943b5acb809bb11da4d132965ed319cd0ed89b703abce46b90abaed8f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-default-plugins/default.nix
+++ b/distros/humble/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-default-plugins";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "37210da06ecf3c489f7f7194fc70a9d317e8c5c6eb0358b18c067d20a19bc231";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "a93153a08e0fc62c75e036a28cd1ede1d904394ebe9e8b1d1f6fe65f3f57d303";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap-testdata/default.nix
+++ b/distros/humble/rosbag2-storage-mcap-testdata/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap-testdata";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "ad008d19a0ccd4c86bd1307efdd90f567a69aecdac8d3358cff50e5f13899bd5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "e57a767ff0f38d0bbaed03e6948f8bbca86f146c5c84aee0e172b2486c5ff4a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-storage-mcap-testdata, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "ab581cc8727103abfcfd51e36e2c7f7b2f927dc2b3a074749fb29938264f210e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "79fba85fd39572239bcacf8285060d843e0cffe9085f2b6f05334f140195bc2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage/default.nix
+++ b/distros/humble/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "2aa2fcf26f95d68c8fcdfd7ea66bfd9ad7b36fda7fa6e831eb706069a5835005";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "f185047a68febcabce66825db530df34af66ee2e9f608052fb6923d1a4fa98c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-test-common/default.nix
+++ b/distros/humble/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-test-common";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "3f81a8ab03276d95d5c6849300db4df22dd349eb6eb147d728c8cf855581c217";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "400a7c0f1886017ac738becb13d93351aa507f5c838de56a89f04d3e9630d9dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-tests/default.nix
+++ b/distros/humble/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-tests";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "781e8bb55de91131ec757c6bf4785fcad2dffe479358cc8a57549a346a52a528";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "93b636c94e6c4c53ea3493b6dcd1ccf06aa5285584f779b6185a1f147b31b92b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-to-video/default.nix
+++ b/distros/humble/rosbag2-to-video/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, cv-bridge, opencv, python3Packages, pythonPackages, rclpy, ros2bag, rosbag2-py, rosidl-runtime-py }:
+buildRosPackage {
+  pname = "ros-humble-rosbag2-to-video";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_to_video-release/archive/release/humble/rosbag2_to_video/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "da54f376dd1f9b46c2be12a58e4dc2820b4c5539b9ef0f14fec8af2f3677f47c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev python3Packages.opencv4 rclpy ros2bag rosbag2-py rosidl-runtime-py ];
+
+  meta = {
+    description = "Command line tool to create a video from a rosbag recording";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/rosbag2-transport/default.nix
+++ b/distros/humble/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-transport";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "6f4a8407b921d24a3b5eff2e8a080d8bfbe74eab760f25449a07a2c1fb57ea50";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "a59dd2de797a200447da7bd764dac152cac1a334c5ffe4688aa53464ada5396a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2/default.nix
+++ b/distros/humble/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "43ced50be2c00e8ca9574e86be2e4ff43d7bb1371c3534b7fa743e0c3db46eca";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "1e6867d7ae1e5c0abf4c084ef9b1376bdeb50108d614a4fdf0285cd4446fef44";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-adapter/default.nix
+++ b/distros/humble/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-humble-rosidl-adapter";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_adapter/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "37b20be0a7df3fb224d2ed4026fe988e45f9f42ad01ffaee4ba8f496546fc9ee";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_adapter/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "bfde9f02adf85b0f3f36d0e3d6e74bd4c92bcca6be82608793fc03753494dd90";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-cli/default.nix
+++ b/distros/humble/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-humble-rosidl-cli";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cli/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "61a1967dc31f9368d063ef29572d271d1032c8f4342b286dafa57f8dda0caa2d";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cli/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "6b24149951d562575c859b6d5cacd5f6d8b2487b00d9f8f4b7faa57c55d524c8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosidl-cmake/default.nix
+++ b/distros/humble/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-humble-rosidl-cmake";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cmake/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "16a7e5ce9c45cc29d9671867899bc7cc0d9897a8a3e81c8a452c66ab1576a4bc";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_cmake/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "9082f81c0921ad4e5b57be0bfcbaa3a5990cd3a76259654874ab44b3dce85422";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-generator-c/default.nix
+++ b/distros/humble/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-interface, test-interface-files }:
 buildRosPackage {
   pname = "ros-humble-rosidl-generator-c";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_c/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "e851b414b03d0ad63e00b280b033373a6b761dc109b2f07c687a75ca9426c1df";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_c/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "d6efc0aacd338c25b57d15e2b1ac0f04ca3baa7153d0066875abe1d0eba76c32";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-generator-cpp/default.nix
+++ b/distros/humble/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, test-interface-files }:
 buildRosPackage {
   pname = "ros-humble-rosidl-generator-cpp";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_cpp/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "cb959063177c70d39a6e7b4235dea51b4ee960522eb720edfc8131d944914204";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_generator_cpp/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "3d440f4ce9df5f2bc9013d5d1103a4d37dc61b7e812609048451abd0be440467";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-parser/default.nix
+++ b/distros/humble/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-humble-rosidl-parser";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_parser/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "0c79cd3d40b54f02dc25f3eca6e0bb3fc2f0bd384eea66b811fd4612f65ba820";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_parser/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "d67f10277e9f01ec9a8fee6c0792adf1db76369fa41ba9e42c6d14040b7320d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-runtime-c/default.nix
+++ b/distros/humble/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-humble-rosidl-runtime-c";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_c/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "3077bcd57eb763c9ab6558b400f61c4b0afcad24411dea161ed4a8fc88f31f66";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_c/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "19f3ee12eeffe0fbd5dd0100dce5441a6cbbc7ef5bd2cb5b5a9e8a142905fd25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-runtime-cpp/default.nix
+++ b/distros/humble/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-runtime-cpp";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_cpp/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "b29d4f051dad094079f8fa63f02bcd5944155fc980bc9c0a7a0ba5234c036a0b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_runtime_cpp/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "b7b732db4a3c7db6d90db3371f3f4b4fc851e630581b890bb02cbdb690e416b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-c/default.nix
+++ b/distros/humble/rosidl-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-c";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_c/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5816fac5efd88677d67125061a7807540e9971ca397af1074b3c9817ac4ab103";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_c/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "92ff0c8e94708edad2ef618ff6046c2f6e8c3652072ec0ae275a3805e54637df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-cpp";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_cpp/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ba1b7e214f768a9e534f10f1f4f1fa24d4789fb13fce4fd8f6475ffcc06f93a8";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/humble/rosidl_typesupport_cpp/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "236ba08dce3fde92406012d18492dd92d35a69ff621e5b328625aefdee46c5b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-interface/default.nix
+++ b/distros/humble/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-interface";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_interface/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "4de29433cbd289372fa62c118e8c05bccdf0d1ab9b750fb365315f2ace1ac94d";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_interface/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "e588b0540a54735ebe7e65bf7ca018f866f0a33851fc9d5fe7d8b6f3b406c762";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/humble/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-introspection-c";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_c/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "29e118363d12fce5690010ba7ad0f7e0335d943c4b3a0f411f74ef58e61e7c6b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_c/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "51327b9dfbeb98c1912032211611c6b3e639cb5c8c13e0d27d3cd5317cc00f29";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/humble/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-humble-rosidl-typesupport-introspection-cpp";
-  version = "3.1.5-r2";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_cpp/3.1.5-2.tar.gz";
-    name = "3.1.5-2.tar.gz";
-    sha256 = "a15c3e97a83895198284e34303915e2a71f79aa24121ed55701eeaf09df42bbe";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/humble/rosidl_typesupport_introspection_cpp/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "7769b807c00e183664971d97c5b5db050468a5e293f5a41cdaf447d3cc2c3a26";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rti-connext-dds-cmake-module/default.nix
+++ b/distros/humble/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-rti-connext-dds-cmake-module";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rti_connext_dds_cmake_module/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "6dac21c0a4cfa62302a0e325626b656786848ebaa728709493775f2fa01bb169";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/humble/rti_connext_dds_cmake_module/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "5eadaf55ea990d3b281289c9241c0ce59d82d48edd9171401414443052f73278";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "9b83f04d7e6549124285b74996f264b766de2de83840b70e43199f3912cf463a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "849492597e7a51d45d1298962b859c19f6b9e87b1642164bb40e0b1cbcd3c46c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "69416abe75da20370a55e02811e9c20621142ad27587ef6644a61f699837f3b7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "edcdcd3073f780be18ee6cedfc1005123c9ff2a5a3d38cf077e6bd49c96e6a1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "dd8a91cfb605df379a415e1711419292aab957fdeb3eff7414867f909a6e9ab1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "97ea0791d7cc2a0f249f7ca21f72ae433a74a7279bbb3b4900c6414c23032e81";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "41f490bf70db85a0cc5f3b40d22fdad08df7579d0c9be479960017182563feee";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "d68f8dc70c630913fd58821ac5f199dfaea4eb3464043ee8fead3ba4c83262bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "51b1fecf7017bd0edee73cc0e42267da22a9df57a2977577034e20afa46ea172";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "b82a1dc1c369ff0061faf7a69eeb334b0ba9e3fc4ca8c9ce863b9017a985357b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "b8f169c7beb9c9e5107d10808a0aa6df7318732438146538eead2c8f99bf5dab";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "c1031615cd28fa53d8b490665e8d5f3606cd03ff0cb76d4c2d2441106211abf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "4a55be8038f642b2f9c4adcadfd3614f9d0391ed99faaea2331cdf2bf1389271";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "43507beb7474222ddb21f22bf752569849a433b230f5cafbb04656fbd6cd79d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.13-r1";
+  version = "11.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.13-1.tar.gz";
-    name = "11.2.13-1.tar.gz";
-    sha256 = "5fd0ecea3e4f279d429936e805c2badf9ab801100eab74f3bb12247b004d2cd5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.14-1.tar.gz";
+    name = "11.2.14-1.tar.gz";
+    sha256 = "d6515ae480c1633eee2b4ea44fb71727cb5001895a5c586473e691cfa4ec87f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/shared-queues-vendor/default.nix
+++ b/distros/humble/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-shared-queues-vendor";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "213fe029acf0e5dbf52e70a4e9ca44b1467d22c07fc6cd39485e7ab6a9fb9d48";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "81a4928710ae888143f4b78ee63c9f76218f52f1eec8a9a682e6bdd6adc19781";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sqlite3-vendor/default.nix
+++ b/distros/humble/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-humble-sqlite3-vendor";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "fca7cae92ea61fc86c2d346a0e7015f16761c2ae7cdb3b52213ff9e749d7acc5";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "6edbfddefab71d09c82c4e6c0385696e41e1c9699c29a08b36587fc97c96aae9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "98bfb03a2b7d6bd8b288728667a5829531c1587cdd42c70715964624ebd99b11";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e3c07c05111fb2f801a9f486919d6ae5990db963252917baa25a22a32a8a03bf";
   };
 
   buildType = "cmake";

--- a/distros/humble/zed-msgs/default.nix
+++ b/distros/humble/zed-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-zed-msgs";
+  version = "4.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/zed-ros2-interfaces-release/archive/release/humble/zed_msgs/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "ffaa216b7cd342b466d7ac7e2569e7d3a276076e544368eb2fcd9e577dadbf1d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto builtin-interfaces rosidl-default-generators ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Contains message and service definitions used by the ZED ROS2 nodes.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/zstd-vendor/default.nix
+++ b/distros/humble/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-vendor";
-  version = "0.15.12-r1";
+  version = "0.15.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.12-1.tar.gz";
-    name = "0.15.12-1.tar.gz";
-    sha256 = "ae0f346bc737684811d160337dce694878ef6b0f69ab57ca1951dae76e4e59fc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.13-1.tar.gz";
+    name = "0.15.13-1.tar.gz";
+    sha256 = "587bcfc92e0c3d3882fc094ed123af83dfc3056a2d0cac044a200aefce228c0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/foxglove-bridge/default.nix
+++ b/distros/iron/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-iron-foxglove-bridge";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "df0d62f7d515810c587de4aa84833047ff49ce8b27e82d4fc10d375599391a8b";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/iron/foxglove_bridge/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "122f09eb1cdbcae84963ad278d2afefd965bae9de286adc96342b95f6e3298fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/openeb-vendor/default.nix
+++ b/distros/iron/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-iron-openeb-vendor";
-  version = "2.0.1-r1";
+  version = "2.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/iron/openeb_vendor/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "be732db57cb7f63d198453b19547de53cb29789a6847580e3f751cbf0370d4ec";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/iron/openeb_vendor/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "3f2bc7c57aace945fe39d1853acdccf51dd9460079fab30d13774ec4aa9ee2b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-assimp-vendor/default.nix
+++ b/distros/iron/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-iron-rviz-assimp-vendor";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "7173cc33850c99f8299d06797d59bfddbf8697a7c58e7bf7c66ec2bbd2cdfec4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_assimp_vendor/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "578565c4a605ffc8cc946a388b74c1f802e2f4932c2883e6077b0a702eb24d8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-common/default.nix
+++ b/distros/iron/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-common";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "a38697ba876e515a8da440f7f4a0524c1b0654c7b33920cee23cfdbd8654dd40";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_common/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "5e9a622dc1eacaf194eaca56d09f67233603be5dd5a2bc195baba94235187c6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-default-plugins/default.nix
+++ b/distros/iron/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz-default-plugins";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "f23438b94b80d0a4e369698a21959e5c461f69c6fd4fc31bb20af73a3c9976b0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_default_plugins/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "966a8a183d907e369f954f7282ba1ed41c34a9172cb09f8883cffb2728140ae3";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-ogre-vendor/default.nix
+++ b/distros/iron/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-iron-rviz-ogre-vendor";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "18d9f32695d2db05c6ea8a2470781b9729da4d0fe7021868d3b5fe557fb6025b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_ogre_vendor/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "6fb462cfc5d75e579126551a58d4c44695cf0c4b76fe8ff0aa72d6b8bc58df84";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering-tests/default.nix
+++ b/distros/iron/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering-tests";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "4443cc7fac699e3f708a3df79203305f1159c1e05a15dbd727c5aeea554c6ff7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering_tests/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "e868fd1e95c084b66cc3670377bef46dc42000abcb1273c774a22c335826f126";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-rendering/default.nix
+++ b/distros/iron/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-iron-rviz-rendering";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "741f0763141c186f59a47453eb226251438d558e5246e74dfb6182409fe74815";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_rendering/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "aae60a1e4b98a812acf870624ab78c1ccef14c63fab4fab91c8cea4d9c8c50b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz-visual-testing-framework/default.nix
+++ b/distros/iron/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-iron-rviz-visual-testing-framework";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "36ec8db6b9c292d9fc377094e620dff2c6b9b773b06d1f34813e25163a2f191a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz_visual_testing_framework/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "a2f618eb9af4ce66c06a24502dd9c55b74a4ab3372777989dba9734437c600fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/iron/rviz2/default.nix
+++ b/distros/iron/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-iron-rviz2";
-  version = "12.4.9-r1";
+  version = "12.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.9-1.tar.gz";
-    name = "12.4.9-1.tar.gz";
-    sha256 = "915b84ad1a23e447f8b6679ca3b7fb25428c81f97c904c9b87804a7e5c19d345";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/iron/rviz2/12.4.10-1.tar.gz";
+    name = "12.4.10-1.tar.gz";
+    sha256 = "82f6be65d7f0c680dd56d968ba1f73f5d0f6d38d5c2b3a6d74459db1894c71bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lanelet2-extension-python/default.nix
+++ b/distros/jazzy/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lanelet2-extension-python";
-  version = "0.6.0-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension_python/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "2d139a423d4a1dbdcd8880055960790d8d8bb7640e3a44dfbf365184ae9eeb82";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension_python/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "3d1c51026183ec312c1c082f6e225fd54f9bf2598889e67f8ab90e088f506324";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lanelet2-extension/default.nix
+++ b/distros/jazzy/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lanelet2-extension";
-  version = "0.6.0-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "e231ddd305846ef9bbd1bc7c837d29619f593357208677607bf5e1aea552fa70";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "e810dfee5461a99f731c6e3998b8538bdf7223c0ccffe76398838ce302f9528b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/axis-camera/default.nix
+++ b/distros/jazzy/axis-camera/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, axis-msgs, camera-info-manager-py, ptz-action-server-msgs, python3Packages, pythonPackages, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-jazzy-axis-camera";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/axis_camera-release/archive/release/jazzy/axis_camera/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "5c37339a5faefbdae76cb671e10207ff715a57e86bfa1ab03af734f546b0b6f1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ axis-msgs camera-info-manager-py ptz-action-server-msgs python3Packages.requests sensor-msgs std-srvs ];
+
+  meta = {
+    description = "ROS 2 driver for fixed and PTZ Axis cameras";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/axis-description/default.nix
+++ b/distros/jazzy/axis-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-jazzy-axis-description";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/axis_camera-release/archive/release/jazzy/axis_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "4dad14440a3217c07c59c75e4b8f0ecd4efeec079f2855ad856fcb7910a217bd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Description package with URDF files for common Axis fixed and PTZ cameras";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/axis-msgs/default.nix
+++ b/distros/jazzy/axis-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-axis-msgs";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/axis_camera-release/archive/release/jazzy/axis_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "f1a32f93d1d532cecc3db1f8516fb13b78cff5abd73ea94014e460495fbc31d0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS messages used by the axis_camera package to control Axis PTZ and fixed cameras";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/boost-sml-vendor/default.nix
+++ b/distros/jazzy/boost-sml-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git }:
+buildRosPackage {
+  pname = "ros-jazzy-boost-sml-vendor";
+  version = "1.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/boost_sml_vendor-release/archive/release/jazzy/boost_sml_vendor/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "75f2dbe565b36b8d9012878e4bf8f318a15ae6e9b42c84cb754a1d599219fe2c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for the Boost SML (State Machine Language)";
+    license = with lib.licenses; [ mit "BSL-1.0" ];
+  };
+}

--- a/distros/jazzy/camera-calibration-parsers/default.nix
+++ b/distros/jazzy/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-camera-calibration-parsers";
-  version = "5.1.4-r1";
+  version = "5.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_calibration_parsers/5.1.4-1.tar.gz";
-    name = "5.1.4-1.tar.gz";
-    sha256 = "fc0d5e537c22163b76095f4eadc15d9563681a4fa73ff0f19fa70b18b37e0b55";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_calibration_parsers/5.1.5-1.tar.gz";
+    name = "5.1.5-1.tar.gz";
+    sha256 = "4bb91c757ab42de1b30104f29b4e2a366b173b94838a16c202a3954a5abe8fd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/camera-info-manager-py/default.nix
+++ b/distros/jazzy/camera-info-manager-py/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, pythonPackages, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-camera-info-manager-py";
+  version = "5.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager_py/5.1.5-1.tar.gz";
+    name = "5.1.5-1.tar.gz";
+    sha256 = "b60c5cb07b54818a8dcca4c0aad36bc38790a1496405990e3f3c54fc85ac7882";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml python3Packages.rospkg rclpy sensor-msgs ];
+
+  meta = {
+    description = "Python interface for camera calibration information.
+
+    This ROS package provides a CameraInfo interface for Python camera
+    drivers similar to the C++ camera_info_manager package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/camera-info-manager/default.nix
+++ b/distros/jazzy/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-info-manager";
-  version = "5.1.4-r1";
+  version = "5.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager/5.1.4-1.tar.gz";
-    name = "5.1.4-1.tar.gz";
-    sha256 = "c115939671bf35bfad93fc27a65deaad1d20df286a075e3ffb566e522a01be72";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager/5.1.5-1.tar.gz";
+    name = "5.1.5-1.tar.gz";
+    sha256 = "11a4db7ac93ea393b21594ef41f2e6c66dc8729c4c1507f168dfc9381f3ebf19";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/camera-ros/default.nix
+++ b/distros/jazzy/camera-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-lint-auto, camera-info-manager, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-camera-ros";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/jazzy/camera_ros/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "3ce4365620a3df535370cb2b073da8f59bf812fff07af0a30d60be2dc3c3ffba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-pyflakes ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "node for libcamera supported cameras (V4L2, Raspberry Pi Camera Modules)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/clearpath-ros2-socketcan-interface/default.nix
+++ b/distros/jazzy/clearpath-ros2-socketcan-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-ros2-socketcan-interface";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/jazzy/clearpath_ros2_socketcan_interface/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "1d0318975014415ceec785045338f0848d17aef8f0a8576736f18ed950a89660";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = "A ROS 2 socketcan interface.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/clips-vendor/default.nix
+++ b/distros/jazzy/clips-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, unzip }:
+buildRosPackage {
+  pname = "ros-jazzy-clips-vendor";
+  version = "6.4.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/clips_vendor-release/archive/release/jazzy/clips_vendor/6.4.3-2.tar.gz";
+    name = "6.4.3-2.tar.gz";
+    sha256 = "0f3fe94af4f4137581c500d5d86dd4d580b7794ce494335c45ae0991d7b4b8b9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-cmake-vendor-package unzip ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Vendor package for the CLIPS rule based production system";
+    license = with lib.licenses; [ "MIT-0" ];
+  };
+}

--- a/distros/jazzy/compressed-depth-image-transport/default.nix
+++ b/distros/jazzy/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-depth-image-transport";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "e11d2efcf92f40794cc992d94f13c4921fdb879f5838539e3621550af9e2f555";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_depth_image_transport/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "081ad674ab44cf0c64e45d1cf74ff697ea546851bbb22756688fd05728c22a30";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/compressed-image-transport/default.nix
+++ b/distros/jazzy/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-compressed-image-transport";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "526df62f674964aadabf7d2e91e908b16ee5e40f5205a8a4899e60399a202329";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/compressed_image_transport/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "fc6ca55dc8d17adfd5d92efd5145a6abc98af7d95973bfcd68c3d1ce8dbc2eaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dual-laser-merger/default.nix
+++ b/distros/jazzy/dual-laser-merger/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-copyright, ament-cpplint, ament-flake8, ament-lint-auto, ament-lint-common, ament-pep257, ament-xmllint, geometry-msgs, laser-geometry, message-filters, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-dual-laser-merger";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dual_laser_merger-release/archive/release/jazzy/dual_laser_merger/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "47c23e35f582afc1328393a619a87afa8bb8e4a79e22bbd56c035ce2fbd9e76f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-copyright ament-cpplint ament-flake8 ament-lint-auto ament-lint-common ament-pep257 ament-xmllint ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry message-filters pcl pcl-conversions pcl-ros rclcpp rclcpp-components tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "merge dual lidar's scans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/etsi-its-cam-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "0fe8b910ba6e8c2cde9a7c865a5fe447cc58ad7334e75a1e00aabe742e7b72af";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "55725e73bb533f74bc6d2652947f134d7f07170660f9a98d8a649a49a5e9dfd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3c42692496f1cab54f94144b7140187ec79d1b6bfc2636bae432ce771f052651";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "c9206660614aebfdaff652a21ee9c9cf23486f6bad50464f2caae561f30d043c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "b27718079bff367fd473bfaeeac0783237f509d7e41cf1c6ec3c358a4fbfd72e";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "fa27e05a2d018612905d190a6c5459b635b41889a1d8a57f068c463e8708049e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c1e570af9b3213acdd9d5f9cbd215ac87f7ecb72caf0e78e87e61cfb8968189d";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "96de3e1c719e3fddaa4d01877e735dae16f0eb7628e52ff2c2f315597d9f12ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "561f02efc037d6b9a6930c489282cc6c41958de51fd8da79f9c24fa4a550d498";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0465ab697eeb48f7df61125dcd01842b49b9be264afc506da36320430db70d03";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "54af8d73631d46feab17ab9bf4b5a7d3daf70c1a887347e938d47ef965a2aa14";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "fe6372b5433e51274fd8bd1e45a35706efa57ea667099d013b0e5aa52f7a1d93";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-coding/default.nix
+++ b/distros/jazzy/etsi-its-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "0f2fda2242b3d536bd152ab37074ad73b054a95b03997fbb55fa25e02c0ec22b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "27956f974d84bb4eba3c5ce45ff7b1aa8801e5fa97ad1d9bab28e2451adb90b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-conversion/default.nix
+++ b/distros/jazzy/etsi-its-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f3ac89bf1c02c7fd98c2e4df12e7372c6146001c675d185005eacc864295ddb9";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "0dd2900bb6a76362a62f72d87a6ec56c6df7fa06eb7a11948a32129a6b74fd0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c42164aa6e73272b6ddaebdb849a0b915289cfd2d805d3b9867036c5f7f951a3";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "b67cc12ede4b94801009a6fc1267aa4bff511ebff454f89ee1cc1b31d22b2af0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "e36929e9cb4404d88b84b7d7eca9fa415baeac9b852cbb3d40e2331498f53263";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ece6d4aea12414a189afb72f8a14aee77e4410ce8c41f6cbeb028eb391b5456c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "44d048250b7cf77cf974e38f4b08182caa18323933eb89cbdabeb8958d3eda39";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a0819124436d6961f369b98c2d39c6985c30921edf12aedebcf1f0e5c5a6e718";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-coding/default.nix
+++ b/distros/jazzy/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "e8a961fb8c679d8f03bf1a6b80b65211791382fc51d13350cb67c7bddae702df";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "be1e05392455d4e056f647e96aeb995b73934f92299632ccb033b220f53a3121";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-conversion/default.nix
+++ b/distros/jazzy/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "bb90a413824184289e7082cee3d238a28d6fc01cbd493de2c5e450712843bdd4";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "8b8bea33ace7fd318bb092b3af740ab787c8be01a05bbec371de86fd437536bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-msgs/default.nix
+++ b/distros/jazzy/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "68417e72a5b9d51a03cac11697d0b2cbe2c6597b06ae699b5665acf3383a0794";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "e393c541ee6050580cf0b8e259a93643370d562c71b11d878726baee38046015";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-messages/default.nix
+++ b/distros/jazzy/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-messages";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c69581afb932f1109f8ba6b2774961fc4a9ce041255461be9585e57cb804dce1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "341d6c733c0df939744c44c208b8b161099914826fd3fec6258c834861fc7b11";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs-utils/default.nix
+++ b/distros/jazzy/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs-utils";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "b1a423ed400ec3ff763e6eb396ae36fe93cb6a6f4da16fa204aa4cb7a631ecab";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "31dff6d4c0e5ebb5ca337f206769b54a2ca3bcbacde99bc13ff129b90ba00ad6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs/default.nix
+++ b/distros/jazzy/etsi-its-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "6ab0be272733eca705120326ab1841c604e3e34dd49288cf489571ef5b3655ca";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "62e0a7045d86187346e043bab5b4b3f54842930e332cecd5614f99c3d0458522";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-primitives-conversion/default.nix
+++ b/distros/jazzy/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-primitives-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "70b187152d351b14bebc590682cf0bd0e3f76866797393a04aec7e3e25fbed29";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "b1cb0200378b1f78c6df56cb1b8a8af6dd6c550f5b1c9e40b517c2bd1bdc56c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-rviz-plugins/default.nix
+++ b/distros/jazzy/etsi-its-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-rviz-plugins";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "64068527e6f225e2b453c382b115727966d6b5cbbc31cdfca13423ccd71e1346";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "838613504224fc68e54b6aa981efd81867d9a9c02bae401b7e231907e5f0ca3a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-vam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-coding";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_coding/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "00002457eb89f66bf1adee51954ee1a606b3f65ef022db29ca65f0f26e9f0f1f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_coding/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "4712cf52f99a21908ece63deced825a94e6bfe28b0c2c4156e06f4444eb7454a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-conversion";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_conversion/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "5f442d8df2399b2dfecff59bc9763775506fa32a46ff629cfac76cfcaf910890";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_conversion/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "226d4924979ad54318c11ad30b84a12878cdb77a5932a0a1165814e110d3d712";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-msgs";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_msgs/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "03a4e68cd4d015c53f3b620abbe02553b5f7ffd10b70157df8100f68aafd65d3";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "162c112ece5fefe652f8e83699664e3bfced773e1def244b7427aa9b2c5d13ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/examples-tf2-py/default.nix
+++ b/distros/jazzy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-examples-tf2-py";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/examples_tf2_py/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "c43d64b6fd22a1ec5e2de9cc5da6b0628ec55fd7412bbd847c5acae42e024f76";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/examples_tf2_py/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "c1e00cb0524457f9c0a296f1dff5f43904e5f4b0f4e77d47312bf62548ee51fe";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/flir-camera-description/default.nix
+++ b/distros/jazzy/flir-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-flir-camera-description";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/flir_camera_description/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "546b4c5cabe3d0bb913741610a5552129bf83446589c540baffceadaf1ce315a";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/flir_camera_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "d10785f074fec20c6bd287a2491da4b21b899b1685ce99f2a425cf0002dc3ca1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/flir-camera-msgs/default.nix
+++ b/distros/jazzy/flir-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-flir-camera-msgs";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/flir_camera_msgs/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "aa2826ee7b8bf637f68ed45ef548a85d2b8ccd9091d0086a7b259ce3e07ca649";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/flir_camera_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "07c64756c37f901888035007cf8be426d241e1be6785da7e983e063d8c2b29bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/foxglove-bridge/default.nix
+++ b/distros/jazzy/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-bridge";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "02bb93f8766363311f2bc8cfcf0290041d38c91339fc7b0522dee91de2f7d022";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "82b0925f903e34dca9bc6d0b1426a2b282434eefdf6903eff8ab7fcf0e7168df";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -230,6 +230,12 @@ self: super: {
 
  aws-sdk-cpp-vendor = self.callPackage ./aws-sdk-cpp-vendor {};
 
+ axis-camera = self.callPackage ./axis-camera {};
+
+ axis-description = self.callPackage ./axis-description {};
+
+ axis-msgs = self.callPackage ./axis-msgs {};
+
  azure-iot-sdk-c = self.callPackage ./azure-iot-sdk-c {};
 
  backward-ros = self.callPackage ./backward-ros {};
@@ -264,6 +270,8 @@ self: super: {
 
  boost-geometry-util = self.callPackage ./boost-geometry-util {};
 
+ boost-sml-vendor = self.callPackage ./boost-sml-vendor {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-aravis2 = self.callPackage ./camera-aravis2 {};
@@ -275,6 +283,10 @@ self: super: {
  camera-calibration-parsers = self.callPackage ./camera-calibration-parsers {};
 
  camera-info-manager = self.callPackage ./camera-info-manager {};
+
+ camera-info-manager-py = self.callPackage ./camera-info-manager-py {};
+
+ camera-ros = self.callPackage ./camera-ros {};
 
  can-msgs = self.callPackage ./can-msgs {};
 
@@ -319,6 +331,10 @@ self: super: {
  class-loader = self.callPackage ./class-loader {};
 
  classic-bags = self.callPackage ./classic-bags {};
+
+ clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
+
+ clips-vendor = self.callPackage ./clips-vendor {};
 
  cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
 
@@ -453,6 +469,8 @@ self: super: {
  ds-dbw-msgs = self.callPackage ./ds-dbw-msgs {};
 
  dual-arm-panda-moveit-config = self.callPackage ./dual-arm-panda-moveit-config {};
+
+ dual-laser-merger = self.callPackage ./dual-laser-merger {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -1520,6 +1538,8 @@ self: super: {
 
  navigation2 = self.callPackage ./navigation2 {};
 
+ neo-nav2-bringup = self.callPackage ./neo-nav2-bringup {};
+
  neo-simulation2 = self.callPackage ./neo-simulation2 {};
 
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
@@ -1800,7 +1820,19 @@ self: super: {
 
  range-sensor-broadcaster = self.callPackage ./range-sensor-broadcaster {};
 
+ raspimouse = self.callPackage ./raspimouse {};
+
  raspimouse-description = self.callPackage ./raspimouse-description {};
+
+ raspimouse-fake = self.callPackage ./raspimouse-fake {};
+
+ raspimouse-gazebo = self.callPackage ./raspimouse-gazebo {};
+
+ raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
+
+ raspimouse-ros2-examples = self.callPackage ./raspimouse-ros2-examples {};
+
+ raspimouse-sim = self.callPackage ./raspimouse-sim {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -2143,6 +2175,8 @@ self: super: {
  rosbag2-test-msgdefs = self.callPackage ./rosbag2-test-msgdefs {};
 
  rosbag2-tests = self.callPackage ./rosbag2-tests {};
+
+ rosbag2-to-video = self.callPackage ./rosbag2-to-video {};
 
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
 
@@ -2833,6 +2867,8 @@ self: super: {
  wiimote-msgs = self.callPackage ./wiimote-msgs {};
 
  xacro = self.callPackage ./xacro {};
+
+ yaets = self.callPackage ./yaets {};
 
  yaml-cpp-vendor = self.callPackage ./yaml-cpp-vendor {};
 

--- a/distros/jazzy/geometry2/default.nix
+++ b/distros/jazzy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-jazzy-geometry2";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/geometry2/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "29480384cb805334d91679849e55d1d5955380f13e65a18958dc9d2134ad2ded";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/geometry2/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "47ca4ff630560f965174b3a26a1dbf79e4ab96ae83efc3dd3ffa4a51c9658f5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-dartsim-vendor/default.nix
+++ b/distros/jazzy/gz-dartsim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp, boost, bullet, eigen, fcl, fmt, libccd, lz4, ode, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-gz-dartsim-vendor";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_dartsim_vendor-release/archive/release/jazzy/gz_dartsim_vendor/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "5e3219669129b41c7d8cf12d180bad58a2c0e7718b690c4a651b444324135486";
+    url = "https://github.com/ros2-gbp/gz_dartsim_vendor-release/archive/release/jazzy/gz_dartsim_vendor/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "d70cac8761441561bbdf57471133fb93aed3847db5a4e19bdac70a241e3fadb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-common/default.nix
+++ b/distros/jazzy/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-common";
-  version = "5.1.4-r1";
+  version = "5.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_common/5.1.4-1.tar.gz";
-    name = "5.1.4-1.tar.gz";
-    sha256 = "304b8fc1eb40b8a0e6a8e81f8f059baa9c1adeec6ca8f460285afcb45f1d53ca";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_common/5.1.5-1.tar.gz";
+    name = "5.1.5-1.tar.gz";
+    sha256 = "e48290e46adcefe898aea159574d6841344447476e9623bef857fcd8debef46c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-transport-plugins/default.nix
+++ b/distros/jazzy/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport-plugins";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "4268455daefc895dd288b548295fd340f30a2da7ddb5197b8eb5351e74b97e2b";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/image_transport_plugins/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "f0fd5aa501598d01d69f671b2367db2c6e7e0f4c922a62e46c4925d0a35a172e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-transport/default.nix
+++ b/distros/jazzy/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport";
-  version = "5.1.4-r1";
+  version = "5.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_transport/5.1.4-1.tar.gz";
-    name = "5.1.4-1.tar.gz";
-    sha256 = "ffd8eb9dbedb94346e11847a8053f969ca537c3d26138c9795578ce7af504e4f";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_transport/5.1.5-1.tar.gz";
+    name = "5.1.5-1.tar.gz";
+    sha256 = "46de2bc5d05d427847e11cf952ce455823d3bff754c78ef7bf1df883e04304b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/interactive-marker-twist-server/default.nix
+++ b/distros/jazzy/interactive-marker-twist-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, interactive-markers, rclcpp, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-interactive-marker-twist-server";
-  version = "2.1.0-r3";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/interactive_marker_twist_server-release/archive/release/jazzy/interactive_marker_twist_server/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "504d092ef4c9d46eda34010f66b73096446a4d8856159d448b3bd622fe3c2061";
+    url = "https://github.com/ros2-gbp/interactive_marker_twist_server-release/archive/release/jazzy/interactive_marker_twist_server/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "8f77efac574eaef8d40d721abc4fe23f19f19a64dc3d30b0524cb85589830e85";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/neo-nav2-bringup/default.nix
+++ b/distros/jazzy/neo-nav2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-common, navigation2, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-jazzy-neo-nav2-bringup";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/neo_nav2_bringup-release/archive/release/jazzy/neo_nav2_bringup/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0f433488ba2dcd2d172340fd4a6397790bef907b9591e35ae8d2b25cbd1134d9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-common navigation2 slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS-2 navigation bringup packages for neobotix robots";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/odom-to-tf-ros2/default.nix
+++ b/distros/jazzy/odom-to-tf-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-odom-to-tf-ros2";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/jazzy/odom_to_tf_ros2/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "f63b5775fb1d2fa1abb2ee9a0aab6bb653d0c55d278af3a760ed450448ccc6bd";
+    url = "https://github.com/ros2-gbp/odom_to_tf_ros2-release/archive/release/jazzy/odom_to_tf_ros2/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "fd5715f6a2cd744133dd3d47eff5508b91966cbe7acab3d2f662854c207c2119";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics-msgs/default.nix
+++ b/distros/jazzy/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics-msgs";
-  version = "2.2.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "69a6a49f6f76e5c4e060f1e539f0540c7d10193b61bc72579ea7cbffe7799ce5";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "0a1c9e867e457231fcf55be3c6a686556ea2e75be4d13ff7c71c9bee1c066243";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics/default.nix
+++ b/distros/jazzy/pal-statistics/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics";
-  version = "2.2.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "a877da7db7199831e9d7db598635dfdbbd696de8329c9e3f1e30ce3cbf1b4ab9";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "5b5feac271fd34a691db5dc404aec09bcf62bffe189e8ee5a57c8a970968c8f6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  buildInputs = [ ament-cmake-auto ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclcpp-lifecycle rclpy ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 
   meta = {
     description = "The pal_statistics package";

--- a/distros/jazzy/raspimouse-fake/default.nix
+++ b/distros/jazzy/raspimouse-fake/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse-fake";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/jazzy/raspimouse_fake/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "454780d94a2b77a1a09d105dba224027b4bb4d5e03b125ee021afecfaaf64a2a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The raspimouse_control package";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/raspimouse-gazebo/default.nix
+++ b/distros/jazzy/raspimouse-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, joint-state-broadcaster, raspimouse-description, raspimouse-fake, robot-state-publisher, ros-gz }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse-gazebo";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/jazzy/raspimouse_gazebo/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "e4db22232036f35e69f6000d8cf889d102c7044e10527cede2d9ef08be87d10b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster raspimouse-description raspimouse-fake robot-state-publisher ros-gz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The raspimouse_gazebo package";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/raspimouse-msgs/default.nix
+++ b/distros/jazzy/raspimouse-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/jazzy/raspimouse_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "63e92f76435200de0036a006af9ed92b667c33d48b2a0bf306c70b52faa69286";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "RaspiMouse messages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/raspimouse-ros2-examples/default.nix
+++ b/distros/jazzy/raspimouse-ros2-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, hls-lfcd-lds-driver, joy-linux, nav2-map-server, opencv, raspimouse, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, rt-usb-9axisimu-driver, sensor-msgs, slam-toolbox, std-msgs, std-srvs, usb-cam, v4l-utils }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse-ros2-examples";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_ros2_examples-release/archive/release/jazzy/raspimouse_ros2_examples/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "482d0b1bf61cbd3323711f3dd91952945279cc3e93a139b3300cb40f6336fff7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs hls-lfcd-lds-driver joy-linux nav2-map-server opencv opencv.cxxdev raspimouse raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle rt-usb-9axisimu-driver sensor-msgs slam-toolbox std-msgs std-srvs usb-cam v4l-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Raspberry Pi Mouse examples";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/raspimouse-sim/default.nix
+++ b/distros/jazzy/raspimouse-sim/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, raspimouse-fake, raspimouse-gazebo }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse-sim";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse_sim-release/archive/release/jazzy/raspimouse_sim/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "8fe1cf996a5cc9c3c639502c0ea42a4095ccbe10e5252fed6a9e7252c74d66f7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ raspimouse-fake raspimouse-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 package suite for Raspberry Pi Mouse Simulator";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/raspimouse/default.nix
+++ b/distros/jazzy/raspimouse/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-jazzy-raspimouse";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/raspimouse2-release/archive/release/jazzy/raspimouse/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "67e73458adc62c205da393669c52032ccb771fbfeb51b125813f27fb9067559e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs lifecycle-msgs nav-msgs raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "RaspiMouse ROS 2 node";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/rc-reason-clients/default.nix
+++ b/distros/jazzy/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rc-reason-clients";
-  version = "0.3.1-r3";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/jazzy/rc_reason_clients/0.3.1-3.tar.gz";
-    name = "0.3.1-3.tar.gz";
-    sha256 = "c0b79fb82c1e7968b55984b019922c2140c51901a5ba299103eabef0cdc516c1";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/jazzy/rc_reason_clients/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "80c12fad6fdbf2a093cc883fb163a279fa491e04f5d7ea73638d29ad4581a68c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rc-reason-msgs/default.nix
+++ b/distros/jazzy/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rc-reason-msgs";
-  version = "0.3.1-r3";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/jazzy/rc_reason_msgs/0.3.1-3.tar.gz";
-    name = "0.3.1-3.tar.gz";
-    sha256 = "1dc2d25cfa0601fe855146ecb193eead3d51d588120721cc953474abaf353439";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/jazzy/rc_reason_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "b25d2e15e38d56f0777bd86bd5712bcc12345e8cb2f9f1d9b0a34e85c27209b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbag2-to-video/default.nix
+++ b/distros/jazzy/rosbag2-to-video/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, cv-bridge, opencv, python3Packages, pythonPackages, rclpy, ros2bag, rosbag2-py, rosidl-runtime-py }:
+buildRosPackage {
+  pname = "ros-jazzy-rosbag2-to-video";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_to_video-release/archive/release/jazzy/rosbag2_to_video/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "fd4b99b656026bfaec09d5f55bd3176b8b972ff5c861886288fba32ed750b7cc";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev python3Packages.opencv4 rclpy ros2bag rosbag2-py rosidl-runtime-py ];
+
+  meta = {
+    description = "Command line tool to create a video from a rosbag recording";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/sdformat-vendor/default.nix
+++ b/distros/jazzy/sdformat-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, pythonPackages, tinyxml-2, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, pythonPackages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-sdformat-vendor";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/jazzy/sdformat_vendor/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "301b8cf6451893147eb9025195cbbf572d7f500b3a7ae900f1013f7b4d9c6847";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/jazzy/sdformat_vendor/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "f242cd3c9aca09edabd8b2f6f6b90db7e47e6124a2944f22dbba2530822f96ef";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint libxml2 python3Packages.psutil pythonPackages.pytest ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-math-vendor gz-tools-vendor gz-utils-vendor pythonPackages.pybind11 tinyxml-2 urdfdom ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: sdformat14 14.5.0
+    description = "Vendor package for: sdformat14 14.6.0
 
     SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications";

--- a/distros/jazzy/spinnaker-camera-driver/default.nix
+++ b/distros/jazzy/spinnaker-camera-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, sensor-msgs, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, curl, dpkg, ffmpeg, flir-camera-msgs, image-transport, libusb1, python3Packages, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-spinnaker-camera-driver";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/spinnaker_camera_driver/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "b292d9711182a43a9acfc0c579a30dd8a2886548afc598630f5ed6c1ee36a626";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/spinnaker_camera_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "0ee07547fd288fd8765ccdc9987cd8983ba2d529874c39289a6c109f8022c8c7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ];
+  buildInputs = [ ament-cmake ament-cmake-ros curl dpkg python3Packages.distro ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ camera-info-manager ffmpeg flir-camera-msgs image-transport libusb1 rclcpp rclcpp-components sensor-msgs std-msgs yaml-cpp ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {
     description = "ROS2 driver for flir spinnaker sdk";

--- a/distros/jazzy/spinnaker-synchronized-camera-driver/default.nix
+++ b/distros/jazzy/spinnaker-synchronized-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-clang-format, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, spinnaker-camera-driver }:
 buildRosPackage {
   pname = "ros-jazzy-spinnaker-synchronized-camera-driver";
-  version = "2.0.20-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/spinnaker_synchronized_camera_driver/2.0.20-1.tar.gz";
-    name = "2.0.20-1.tar.gz";
-    sha256 = "331877e4c655d8eab706c71392c7987ead50a96acdf71c15702a12477ef44f5e";
+    url = "https://github.com/ros2-gbp/flir_camera_driver-release/archive/release/jazzy/spinnaker_synchronized_camera_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "74784b9fcf5a0ab5ffa89676cb75c3370d6c84ebf0f8344e743cf1714a49d175";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-bullet/default.nix
+++ b/distros/jazzy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-bullet";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_bullet/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "5af9d7150b2e0ee17b27c7d4908683665f015daee68b7efe872415f6d3c7b905";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_bullet/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "2338a58a8144fa19f3d3e187d3dc1507fdabf34f3e4d16211bc1ea62fe625f13";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-eigen-kdl/default.nix
+++ b/distros/jazzy/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-eigen-kdl";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen_kdl/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "afc914fd9913612f3b9d387efdb094f45f0cca33a066a344c701ea0c5a2b805a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen_kdl/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "252caf58732b35ad33ada456f818de012962e4a34dc72d015b16320aca5998a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-eigen/default.nix
+++ b/distros/jazzy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-eigen";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "794a9ee00df1830782458328e200cdd1ca5fdefc10d68d0ae2f9f105784c33e1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "e56301ecbfd51ffd24ef47e0b06ddcf91908c0595a65909f8515809af09687be";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-geometry-msgs/default.nix
+++ b/distros/jazzy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-geometry-msgs";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_geometry_msgs/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "9c82ae440e72d240c655be9c89cf5f7473fd3ff0a101921846d3b22b1355d915";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_geometry_msgs/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "88dfbbf219d5c71f4e024f802af544b92aa3b036c29c335c514c41041c8aaa7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-kdl/default.nix
+++ b/distros/jazzy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-kdl";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_kdl/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "9369a51bc91b945df28be3da86346692c772dc4bf088b6ab42340813b08c001a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_kdl/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "12732bc32d8cfdb13aa080c2cd2f1171020a106b06fc558b4d626ae5bf79e4c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-msgs/default.nix
+++ b/distros/jazzy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-msgs";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_msgs/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "0e4eaab4ac2079ce28b953ece2f8710b41908b075fb43af966d1e756596fc9aa";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_msgs/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "6826080a83730d8c1644c9987dfcf5aa010858a4a7d908b1854b11db3e08442e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-py/default.nix
+++ b/distros/jazzy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-py";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_py/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "86732abbaa0ef265aef6d2e93c61cf33f27cbc334de1431a70ca04a2be8f259c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_py/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "32a69d8fba77011c3562284a96247217b55aa170f43644c9564f0063b62e9c91";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-ros-py/default.nix
+++ b/distros/jazzy/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-ros-py";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros_py/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "4534982db48b4232a28ead092a7cd3308b03f5fd793ef668a3f777722ae7adb8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros_py/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "51da36a94a5f2d368fca54cba694ec97a8674a84f1bfefbaca9f448ae5017da4";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tf2-ros/default.nix
+++ b/distros/jazzy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-ros";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "1fffd90661d3d3afb39996715d320175cd04a4911efdd4fc9ec1ec13909bd4c6";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "ff55e03ff943b96b63e9ed39b0716f2ee122acb783cd1c7b1a16aecea90373ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-sensor-msgs/default.nix
+++ b/distros/jazzy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-sensor-msgs";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_sensor_msgs/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "fc83a5cbb08dfbe724c94dc12f6583a8b160303fd8c9ade575afe9bd838dc7fb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_sensor_msgs/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "3c981f71e53e883fa3186e0e4775074fbd30b5479532e82c12cf0ecabfc71cb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-tools/default.nix
+++ b/distros/jazzy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-tools";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_tools/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "14f3bfcdacc310b08be24113df4e5e3b0faadd7788f4c941ad04dc3661fe8140";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_tools/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "4b189241cef46fc822714eb0bdd20da3a3285fa7c5221ab19bc89ce27b1b78db";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tf2/default.nix
+++ b/distros/jazzy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-tf2";
-  version = "0.36.4-r1";
+  version = "0.36.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2/0.36.4-1.tar.gz";
-    name = "0.36.4-1.tar.gz";
-    sha256 = "e202e3985adb591ea8fe78283841997fac26451cce0dcabcbf04eb35dd604b82";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2/0.36.5-1.tar.gz";
+    name = "0.36.5-1.tar.gz";
+    sha256 = "b80eaf12cac9570706e1a9e02ba7c6421247017062c9c06060ba452b14ae168b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/theora-image-transport/default.nix
+++ b/distros/jazzy/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-theora-image-transport";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "10ac13da104018ace175ecd301e199b4fa32676c2dd0b6c3e52bb3a243cbc7c1";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/theora_image_transport/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "dd48ef6845b03d656e190c5bcbee49c581dd04a9be5182bacf9d6fe11098c6e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "9152ac2d225d60f41411efca03829a1a374c220fc964abf652ba61372db645ea";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e165ca2c90145a8da6176c1a90bcc009ca344d9745c80ee6e6955ad509b2be76";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/yaets/default.nix
+++ b/distros/jazzy/yaets/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-jazzy-yaets";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fmrico/yaets-release/archive/release/jazzy/yaets/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "0f14e390cd9d34efc7df693665ad8fce66cf2f8f074ea3dda1d3b0d7a4ef1123";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+
+  meta = {
+    description = "This package provides a execution tracing library.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/zstd-image-transport/default.nix
+++ b/distros/jazzy/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-zstd-image-transport";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "0610c3cf64ca08e8b4a38786bbc405229bbf86b6ee09866e00b966ee4d6fc7f2";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/jazzy/zstd_image_transport/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "74a9e9b39a7d092c4c35dc17fb0ac7a2d09f6a6cbf3226708006ed6c0e4b61ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, resource-retriever, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.7.10-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "4caedcd0aa3c35618a06263289034fe60f68033ee5a09bdc97c90dad9121368d";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "8a6881312f84cbc2d2db1d2cdefe5d92bb62d0cdb7165a7f9ffcf8819c4a9edf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1326,6 +1326,8 @@ self: super: {
 
  hardware-interface = self.callPackage ./hardware-interface {};
 
+ hatchbed-common = self.callPackage ./hatchbed-common {};
+
  hdf5-map-io = self.callPackage ./hdf5-map-io {};
 
  hebi-cpp-api = self.callPackage ./hebi-cpp-api {};

--- a/distros/noetic/hatchbed-common/default.nix
+++ b/distros/noetic/hatchbed-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-hatchbed-common";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hatchbed_common-release/archive/release/noetic/hatchbed_common/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "b9a4793cc77f243166c9eeb3a963b4d3cced9629ad8e7ee26d0b06ef50126f4d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ dynamic-reconfigure roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "Common Hatchbed C++ utility code for ROS, such registering and handling updates to ros parameters.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-clients";
-  version = "0.4.0-r1";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "55b139aec55da97a194d9947e1b2be49de36b8740aa25fec91ac021f2ffbc7d8";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "15a2a445c8fb9612cfb3bb1731293d2c665e0ecd7fae508cb6e270892070df24";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-reason-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "7b58ccd8f06e315d6c40abdb2a67a4672bb77472566d7b88311135bcbe14f8bc";
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "6e7cf26d186f3457cb17edc0a82eaf1ed382993094da1f3fd8290e9b95d6c14e";
   };
 
   buildType = "catkin";

--- a/distros/rolling/camera-calibration-parsers/default.nix
+++ b/distros/rolling/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration-parsers";
-  version = "6.0.1-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/6.0.1-1.tar.gz";
-    name = "6.0.1-1.tar.gz";
-    sha256 = "084f56ca75d2e261fad73e0119fc8391f941ad61bf761c1ba99093245ba78c6a";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_calibration_parsers/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "9d9bd415b4b28a78cd90311f085921ce577e452e254405839876469106b61b49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-info-manager-py/default.nix
+++ b/distros/rolling/camera-info-manager-py/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, pythonPackages, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-camera-info-manager-py";
+  version = "6.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager_py/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "c9ded346b37a9202f3b775078d5c36b3cfc20e37b2d6a8639d39943c83476e65";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml python3Packages.rospkg rclpy sensor-msgs ];
+
+  meta = {
+    description = "Python interface for camera calibration information.
+
+    This ROS package provides a CameraInfo interface for Python camera
+    drivers similar to the C++ camera_info_manager package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/camera-info-manager/default.nix
+++ b/distros/rolling/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-info-manager";
-  version = "6.0.1-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/6.0.1-1.tar.gz";
-    name = "6.0.1-1.tar.gz";
-    sha256 = "ff4b63fbcdae0a784279379c45942da863710a4c0f20b93ae8322e9d24186e0a";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/camera_info_manager/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "6cb930ed299cfd46e167b1c66d57523618119be80e89514f89e5cd8b9863cc95";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-ros/default.nix
+++ b/distros/rolling/camera-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-lint-auto, camera-info-manager, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-camera-ros";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "3a025f828916e078eec49a0f350fcdb838f3493e1f7df564997bd2bf8597eda6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-mypy ament-cmake-pep257 ament-cmake-pyflakes ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge image-view libcamera rclcpp rclcpp-components ros2launch sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "node for libcamera supported cameras (V4L2, Raspberry Pi Camera Modules)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/compressed-depth-image-transport/default.nix
+++ b/distros/rolling/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-compressed-depth-image-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_depth_image_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "9e4d2fbd555c06cd6fc1c6efd36da7d93865625a3da8107330c7a55d3b0f2039";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_depth_image_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "d347513bd4b973dbf6967678bca2d93277e4d0fa197fdc1733aec2ffd668f0b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/compressed-image-transport/default.nix
+++ b/distros/rolling/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-compressed-image-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_image_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "27b2968708d472a0bd8802095a37a26a8ce0e44b2c873c0f5b86a19b5e16da41";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/compressed_image_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "27e9d979223e92a7f0d4fececbc34bdf0446ca27ade0f01208529d41ddb6b62e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dual-laser-merger/default.nix
+++ b/distros/rolling/dual-laser-merger/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-copyright, ament-cpplint, ament-flake8, ament-lint-auto, ament-lint-common, ament-pep257, ament-xmllint, geometry-msgs, laser-geometry, message-filters, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-dual-laser-merger";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dual_laser_merger-release/archive/release/rolling/dual_laser_merger/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "9977ceea8935b25fec91715c2f4337b78ca6f212d8bfa44b275fcc2f722c9a86";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto ];
+  checkInputs = [ ament-copyright ament-cpplint ament-flake8 ament-lint-auto ament-lint-common ament-pep257 ament-xmllint ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry message-filters pcl pcl-conversions pcl-ros rclcpp rclcpp-components tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = "merge dual lidar's scans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch-ros, pythonPackages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "3de9afbb33733789d77d36e8c2eb6f36e574ca2b0bcc3f472a292edd00914fcc";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "c14fff5e568b912c67763ddb184f9ec321c70e37a66685bc2c35eb66d1ea9665";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "d5437e8059cacf4d772d2e672e125016cedefb1a066c0a61273382bff8f939df";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "0beba91d683e3dd7ab21a3c2c5284d0b80a4989cec191552b200bfa818f777cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -268,6 +268,10 @@ self: super: {
 
  camera-info-manager = self.callPackage ./camera-info-manager {};
 
+ camera-info-manager-py = self.callPackage ./camera-info-manager-py {};
+
+ camera-ros = self.callPackage ./camera-ros {};
+
  can-msgs = self.callPackage ./can-msgs {};
 
  canopen = self.callPackage ./canopen {};
@@ -397,6 +401,8 @@ self: super: {
  draco-point-cloud-transport = self.callPackage ./draco-point-cloud-transport {};
 
  dual-arm-panda-moveit-config = self.callPackage ./dual-arm-panda-moveit-config {};
+
+ dual-laser-merger = self.callPackage ./dual-laser-merger {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -752,6 +758,8 @@ self: super: {
 
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
 
+ hatchbed-common = self.callPackage ./hatchbed-common {};
+
  heaphook = self.callPackage ./heaphook {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
@@ -979,6 +987,8 @@ self: super: {
  lifecycle-py = self.callPackage ./lifecycle-py {};
 
  linux-isolate-process = self.callPackage ./linux-isolate-process {};
+
+ log-view = self.callPackage ./log-view {};
 
  logging-demo = self.callPackage ./logging-demo {};
 
@@ -1628,8 +1638,6 @@ self: super: {
 
  rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
 
- rmf-charging-schedule = self.callPackage ./rmf-charging-schedule {};
-
  rmf-cmake-uncrustify = self.callPackage ./rmf-cmake-uncrustify {};
 
  rmf-demos = self.callPackage ./rmf-demos {};
@@ -1665,6 +1673,8 @@ self: super: {
  rmf-obstacle-msgs = self.callPackage ./rmf-obstacle-msgs {};
 
  rmf-reservation-msgs = self.callPackage ./rmf-reservation-msgs {};
+
+ rmf-reservation-node = self.callPackage ./rmf-reservation-node {};
 
  rmf-robot-sim-common = self.callPackage ./rmf-robot-sim-common {};
 
@@ -1885,6 +1895,8 @@ self: super: {
  rosbag2-test-msgdefs = self.callPackage ./rosbag2-test-msgdefs {};
 
  rosbag2-tests = self.callPackage ./rosbag2-tests {};
+
+ rosbag2-to-video = self.callPackage ./rosbag2-to-video {};
 
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
 

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "e7169a5a89f3d9e4fc7b712926c0707f3780051d9af5390363bda5342bd5b884";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "b695fd06ecd41a2f3b5311d26b7ab5c87fb09b36bb0c25cd6879def99819d0ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-dartsim-vendor/default.nix
+++ b/distros/rolling/gz-dartsim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp, boost, bullet, eigen, fcl, fmt, libccd, lz4, octomap, ode, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-gz-dartsim-vendor";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_dartsim_vendor-release/archive/release/rolling/gz_dartsim_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "e9f8feaef787e3c4c6df3f0bece2ccac26e551a20a5a9387ab1f459d7f86436a";
+    url = "https://github.com/ros2-gbp/gz_dartsim_vendor-release/archive/release/rolling/gz_dartsim_vendor/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "50e76ad9f990ca6c81e2b8c015fc8e00c79af5c4fefc549ab6f0d10abbb24ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hatchbed-common/default.nix
+++ b/distros/rolling/hatchbed-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-rolling-hatchbed-common";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hatchbed_common-release/archive/release/rolling/hatchbed_common/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "68fae62c52b1a7b47bcfd3b72c6f316ce2e53113623e5e6e7d788c5a165f2c62";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common Hatchbed C++ utility code for ROS, such registering and handling updates to ros parameters.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/image-common/default.nix
+++ b/distros/rolling/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-common";
-  version = "6.0.1-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/6.0.1-1.tar.gz";
-    name = "6.0.1-1.tar.gz";
-    sha256 = "da6228c2e72fc6443c290f3f2472d11ef52efb2b0e5229794ecb9a68da5ca485";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_common/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "798ad530549b241dff9b99d8853a63208cf6ac703a00543e98379c561863ada5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport-plugins/default.nix
+++ b/distros/rolling/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport, zstd-image-transport }:
 buildRosPackage {
   pname = "ros-rolling-image-transport-plugins";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/image_transport_plugins/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "7b8f0ae03de42b959c08f4385f051f519f81e549624a7aaa02f0416748f5df75";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/image_transport_plugins/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "5dbcbf038e761f27c8738152b5699fa920f7e823d172aba9c0d0c3530016ee1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-transport-py/default.nix
+++ b/distros/rolling/image-transport-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, pybind11-vendor, rclcpp, rpyutils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, image-transport, pybind11-vendor, python3, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport-py";
-  version = "6.0.1-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/6.0.1-1.tar.gz";
-    name = "6.0.1-1.tar.gz";
-    sha256 = "6ae8ca0f3076dd6998857c12960844e84c0ae33c15948faf939e16aefe5cc0d0";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport_py/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "cbb16a56f1e10cb7d9a8100bebe1370a88d0e226087daef0c518e31d99c592f7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-python ament-cmake-ros pybind11-vendor ];
+  buildInputs = [ ament-cmake-python ament-cmake-ros pybind11-vendor python3 ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ image-transport rclcpp rpyutils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-python ament-cmake-ros ];

--- a/distros/rolling/image-transport/default.nix
+++ b/distros/rolling/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-transport";
-  version = "6.0.1-r1";
+  version = "6.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/6.0.1-1.tar.gz";
-    name = "6.0.1-1.tar.gz";
-    sha256 = "ec295c4dd7cb8e444e6e1b8d349d43aa6c086cb70845bf2dc49716126fc70ec7";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/rolling/image_transport/6.0.3-1.tar.gz";
+    name = "6.0.3-1.tar.gz";
+    sha256 = "0151adba99a05d1073eee3834321873b71598dd8762bfc920a292c4b0f62b263";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/log-view/default.nix
+++ b/distros/rolling/log-view/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
+buildRosPackage {
+  pname = "ros-rolling-log-view";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/log_view-release/archive/release/rolling/log_view/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "07fd3c9ab20202f683fdcb19739298badd5835be3e5558e145fc4a9a25422cb9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The log_view package provides a ncurses based terminal GUI for
+    viewing and filtering published ROS log messages.
+
+    This is an alternative to rqt_console and swri_console that doesn't depend
+    on qt and can be run directly in a terminal.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/lttngpy/default.nix
+++ b/distros/rolling/lttngpy/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, lttng-tools, pkg-config, pybind11-vendor, rpyutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, lttng-tools, pkg-config, pybind11-vendor, python3, rpyutils }:
 buildRosPackage {
   pname = "ros-rolling-lttngpy";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/lttngpy/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "882b9167053ab5333e73732a95924950052dc651c9e1092a58ba09fb1bace4d3";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/lttngpy/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "d6b350399d3080390712fabaf5b2a278a1c8e9099728108c41623a26ef9c4d78";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pkg-config pybind11-vendor ];
+  buildInputs = [ ament-cmake pkg-config pybind11-vendor python3 ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ lttng-tools rpyutils ];
   nativeBuildInputs = [ ament-cmake pkg-config ];

--- a/distros/rolling/odri-master-board-sdk/default.nix
+++ b/distros/rolling/odri-master-board-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch2, cmake, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-odri-master-board-sdk";
-  version = "1.0.7-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/odri_master_board_sdk-release/archive/release/rolling/odri_master_board_sdk/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "8a1b95685bb0178a02e1d22172ac35c6819e53ba7073851fef2b66e9c78dd262";
+    url = "https://github.com/ros2-gbp/odri_master_board_sdk-release/archive/release/rolling/odri_master_board_sdk/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "2bd32a62ae5ae7374b6df74c4f68a92cf3de7e8a7fe22958260d90728c30ad46";
   };
 
   buildType = "cmake";

--- a/distros/rolling/pal-statistics-msgs/default.nix
+++ b/distros/rolling/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics-msgs";
-  version = "2.2.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "ba6fb66cba9e921f18f0482533624e5dfb408f135efff963f4d326c72233ef01";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "09538837ee0919ac84b7034d5dc1b071411624de22221cd0d1921fb6443fb0b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-statistics/default.nix
+++ b/distros/rolling/pal-statistics/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics";
-  version = "2.2.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "b3b48535f91157c46c724492800e9a129e7f463058f76d32e3a114ca9db20058";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "903099f8270fb5146f40641f568c9472bb85559615f549a7a0925787c48d19ef";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-auto ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  buildInputs = [ ament-cmake-auto ament-cmake-python ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclcpp-lifecycle rclpy ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 
   meta = {
     description = "The pal_statistics package";

--- a/distros/rolling/point-cloud-transport-py/default.nix
+++ b/distros/rolling/point-cloud-transport-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, rclcpp, rpyutils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python3, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport-py";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "5d51ca3fd459e02d9cc550de20474ce3e03c628da04cc14041025853368adf6d";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport_py/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "0a692401e360e386c48e4e1a29b394be312e10ef88d93939bec22707bd351ce3";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-python ament-cmake-ros ];
+  buildInputs = [ ament-cmake-python ament-cmake-ros python3 ];
   propagatedBuildInputs = [ pluginlib point-cloud-transport pybind11-vendor rclcpp rpyutils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake-python ament-cmake-ros ];
 

--- a/distros/rolling/point-cloud-transport/default.nix
+++ b/distros/rolling/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-point-cloud-transport";
-  version = "5.1.0-r1";
+  version = "5.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "52dd9cd067c81da76204d805d564ccdc78e6863ae88432f47072e1ef2dcb800e";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/rolling/point_cloud_transport/5.1.1-1.tar.gz";
+    name = "5.1.1-1.tar.gz";
+    sha256 = "861ada1e5dc44e14bd4d4a777b74dcbf280e74f717e6dfc78538500f54797707";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rc-reason-clients/default.nix
+++ b/distros/rolling/rc-reason-clients/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rc-reason-clients";
-  version = "0.3.1-r2";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_clients/0.3.1-2.tar.gz";
-    name = "0.3.1-2.tar.gz";
-    sha256 = "b0541df9cc5c54bdbf330ea94c59a6e38c21f88fb5d4ac414168d13c1b640879";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_clients/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "1099aa807d28a88c02bf6acc081d18c8a4a137269bc3443d1f268f2257e14b8e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rc-reason-msgs/default.nix
+++ b/distros/rolling/rc-reason-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rc-reason-msgs";
-  version = "0.3.1-r2";
+  version = "0.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_msgs/0.3.1-2.tar.gz";
-    name = "0.3.1-2.tar.gz";
-    sha256 = "a88689cf7de6eebe1f509fa2e4ce473eec2ca509e3a6c4f164b6fbe9efb85914";
+    url = "https://github.com/ros2-gbp/rc_reason_clients-release/archive/release/rolling/rc_reason_msgs/0.4.0-2.tar.gz";
+    name = "0.4.0-2.tar.gz";
+    sha256 = "2dc6be955fc0026f40983da2250c3745ffa7746387f25f633187886705747004";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "29.1.0-r1";
+  version = "29.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/29.1.0-1.tar.gz";
-    name = "29.1.0-1.tar.gz";
-    sha256 = "c256ed692264be83aff88ef7b55ce51911ab840f9ed750fe5e5afb1e5f1936d8";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/29.2.0-1.tar.gz";
+    name = "29.2.0-1.tar.gz";
+    sha256 = "3191ff11e5a968b361514f17520f84d566bb5b371fa87a54ec6b18e6103efb08";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "29.1.0-r1";
+  version = "29.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/29.1.0-1.tar.gz";
-    name = "29.1.0-1.tar.gz";
-    sha256 = "d8dccf2938fdbc0865537412e74fd62cfce7f8dcece9912b03f670ab4e3e5ee8";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/29.2.0-1.tar.gz";
+    name = "29.2.0-1.tar.gz";
+    sha256 = "d7d2291a9ef3898176c92352910f108928c60bcb2588adfdae3d6aa2a5c140ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "29.1.0-r1";
+  version = "29.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/29.1.0-1.tar.gz";
-    name = "29.1.0-1.tar.gz";
-    sha256 = "6a2404414ea5ab60635541d793aea26ee655ffbfe8148d26dc60797e84d325d6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/29.2.0-1.tar.gz";
+    name = "29.2.0-1.tar.gz";
+    sha256 = "0a696db4151b5a216c81b04540b4cdadce9fc79e3937600af1481057241990c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "29.1.0-r1";
+  version = "29.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/29.1.0-1.tar.gz";
-    name = "29.1.0-1.tar.gz";
-    sha256 = "ba4c8c066cdb13f366b8fa91c1d1b2111b002c57b6e0cf59f465ccd53b56feac";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/29.2.0-1.tar.gz";
+    name = "29.2.0-1.tar.gz";
+    sha256 = "8b49ffe1193dc2f1d65224d596a87a1671c09e140a5fbdd5a7249452a902ca83";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-building-map-tools/default.nix
+++ b/distros/rolling/rmf-building-map-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, gz-fuel-tools-vendor, python3Packages, pythonPackages, rclpy, rmf-building-map-msgs, rmf-site-map-msgs, sqlite, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-building-map-tools";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_building_map_tools/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "537b5d7835d8b949882b746aa6bf245a19720923b61978ee7ebdb365944c5036";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_building_map_tools/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "8cfce9b48803e22350e6c85ce817f58330057b35ebb407a98cebd3ca301471e5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos-assets/default.nix
+++ b/distros/rolling/rmf-demos-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-assets";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_assets/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "9f4f25a8ed8d047fddfc5a5ba461726ee1520d1a193daab4d4174fce48ac9ae8";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_assets/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "970a7d72b48164fb441b5ab51ed70ff1a37aaa776c198e0570f500cf1821dd10";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-demos-bridges/default.nix
+++ b/distros/rolling/rmf-demos-bridges/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rmf-building-map-tools, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-bridges";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_bridges/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "b9645c243252cc9ca318ddfebdbf058643ccc5ce863de0ed2d90be91705dc76a";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_bridges/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "5317cf45a67aa091d71f1d166de932562c7fa5f024b72d67255ed4c359315b65";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-demos-fleet-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-xml, python3Packages, rclpy, rmf-fleet-adapter-python, rmf-fleet-msgs, rmf-task-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-fleet-adapter";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_fleet_adapter/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "665c624f2041f164f677f298a54ca268a2c06b95609080574a0b1ff0ce5117a2";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_fleet_adapter/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "779e43ab9ebdab14095b63eda3da34c2ffc2fc6b843476f6f0c6ec769a4f6c16";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos-gz/default.nix
+++ b/distros/rolling/rmf-demos-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gz-sim-vendor, launch-xml, rmf-building-sim-gz-plugins, rmf-demos, rmf-robot-sim-gz-plugins, ros-gz-bridge, ros2launch, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-gz";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_gz/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "bf17d28ae67d2237e8e4b7e37b56ffe04fa49369034d42943914f8bdd330531c";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_gz/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "a5d77746bf4185ceafdb0d22852b050b9a5f2a5d17437f79fa569fb998bf11cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-demos-maps/default.nix
+++ b/distros/rolling/rmf-demos-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-maps";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_maps/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "0e96f19727e673a32b7050cfba8010671797e3e5bbb262a7b40f45f9744b19d4";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_maps/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "590be9262e020a0947f2d08ed42d93ba25e3d919ad61708a520658fed931a663";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-demos-tasks/default.nix
+++ b/distros/rolling/rmf-demos-tasks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-lift-msgs, rmf-task-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos-tasks";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_tasks/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "0e98222a543b23ad1c8f2bc622ea7df9f5b01d83f73b967384a05bde84193e1c";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos_tasks/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "1cf2271fe15fb762cccd031a4895dfc29f0d51a204c26d369c898515de2c6c9e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-demos/default.nix
+++ b/distros/rolling/rmf-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-building-map-tools, rmf-demos-assets, rmf-demos-fleet-adapter, rmf-demos-maps, rmf-demos-tasks, rmf-fleet-adapter, rmf-task-ros2, rmf-traffic-ros2, rmf-visualization, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-rmf-demos";
-  version = "2.4.0-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "6d9b0244a3550385e669587c78325e201d529e749e18695af8196279c0512828";
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/rolling/rmf_demos/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "55eadc9c51b64eedd35e0b4d1287f6357f7f529ba4f377a5cb5a3b486b4ac7d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter-python/default.nix
+++ b/distros/rolling/rmf-fleet-adapter-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-json-vendor, pybind11-vendor, rclpy, rmf-fleet-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter-python";
-  version = "2.7.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "e4f7712b31cd8d32dc34e00d87761df64e3422e69197c80110036306daed243f";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter_python/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "25052d92e6c37ec762a419e5f3c077ee5f11ed8bb11cefe1c46ab725600edaa7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-fleet-adapter/default.nix
+++ b/distros/rolling/rmf-fleet-adapter/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rclcpp-components, rmf-api-msgs, rmf-battery, rmf-building-map-msgs, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-reservation-msgs, rmf-task, rmf-task-msgs, rmf-task-ros2, rmf-task-sequence, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-fleet-adapter";
-  version = "2.7.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "23b01b35c3dcce03a72c377f6b50aad0c4d63acb66b5104a5f9cf7ad31cb7fcf";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_fleet_adapter/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "997af206b660ddd3e765251b4bff761a56cd3ffe54d8471fa9bdbd20e98fa3b9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen yaml-cpp ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ backward-ros nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
+  propagatedBuildInputs = [ backward-ros nlohmann-json-schema-validator-vendor nlohmann_json rclcpp rclcpp-components rmf-api-msgs rmf-battery rmf-building-map-msgs rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-reservation-msgs rmf-task rmf-task-msgs rmf-task-ros2 rmf-task-sequence rmf-traffic rmf-traffic-ros2 rmf-utils rmf-websocket std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-reservation-node/default.nix
+++ b/distros/rolling/rmf-reservation-node/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rmf-building-map-msgs, rmf-fleet-adapter, rmf-reservation-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-rmf-reservation-node";
+  version = "2.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_reservation_node/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "066c5e6e8f490851cfb2094233ea8ebcd4cbc6e9f43c28f653036fbf762c8fdf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rmf-building-map-msgs rmf-fleet-adapter rmf-reservation-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Node that handles current state of parking spots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/rmf-task-ros2/default.nix
+++ b/distros/rolling/rmf-task-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-api-msgs, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-websocket }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-ros2";
-  version = "2.7.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "2bd75cdd9a36c3fbdd6fd0fab0215c3bf4774a4442325104892f461b260d0c44";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_task_ros2/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "dfcd6a3d3be6d5abbf19393f4c145321b651c33b53f9e98615c847815fb51df4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-task-sequence/default.nix
+++ b/distros/rolling/rmf-task-sequence/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, nlohmann-json-schema-validator-vendor, nlohmann_json, rmf-api-msgs, rmf-task }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task-sequence";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1d1c0d9931cd3f13b96056576dd36354bdce856a4351a243e4b94a956c14227a";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task_sequence/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "f4fad35194487b62a3cbc967b2ec2896ca5323751c5b7370e4725adfaf18c740";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmf-task/default.nix
+++ b/distros/rolling/rmf-task/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, rmf-battery, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, ament-cmake-uncrustify, cmake, eigen, nlohmann_json, rmf-battery, rmf-utils }:
 buildRosPackage {
   pname = "ros-rolling-rmf-task";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "1ae58d2c2f42c11378033d2c730e0a52946df2fd83b0a2ab46afa7d65a944bb1";
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/rolling/rmf_task/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "d87171e7a5a374eb7a88306bf0f30a0c91ddfddf0c0118ddf7ec9db52f8c1edc";
   };
 
   buildType = "cmake";
   buildInputs = [ cmake ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ eigen rmf-battery rmf-utils ];
+  propagatedBuildInputs = [ eigen nlohmann_json rmf-battery rmf-utils ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/rmf-traffic-editor-assets/default.nix
+++ b/distros/rolling/rmf-traffic-editor-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-editor-assets";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_traffic_editor_assets/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "39344f54ae60d408a97cecd71af98a459cf632bc05f37c194b09ea0c8c4be340";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_traffic_editor_assets/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "43c5657fbd4c55af4a5d62f3c849467837e50b061c135ee9e642bb30e2628549";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-traffic-editor-test-maps/default.nix
+++ b/distros/rolling/rmf-traffic-editor-test-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-editor-test-maps";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_traffic_editor_test_maps/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "e60d91858304e9058d798fb8be992d5c4e3524cc888de947c80365bfd950fc17";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_traffic_editor_test_maps/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "921f1701a45c43771fb792b41e4e1b9b99238f9c980936affb22895a1e78b4ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-traffic-editor/default.nix
+++ b/distros/rolling/rmf-traffic-editor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-editor";
-  version = "1.10.0-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_traffic_editor/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "ecb9cd4a026f4e8363ec97fc7cbb4fb3108527ac7ce6ebe1cc2b4fc9ce59a821";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/rolling/rmf_traffic_editor/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "db4b5f052464da9b140301ba70bce9adde01428ef69ae2589e4d2107b6b9ae03";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-traffic-ros2/default.nix
+++ b/distros/rolling/rmf-traffic-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, backward-ros, eigen, nlohmann_json, proj, rclcpp, rmf-building-map-msgs, rmf-fleet-msgs, rmf-reservation-msgs, rmf-site-map-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils, util-linux, yaml-cpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-rmf-traffic-ros2";
-  version = "2.7.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "e69a6dc573ec1083c952b50204704c846405258cfef60b05a1737140bb5237ed";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_traffic_ros2/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "b4e03d14cbeae0aa101c6221c9344eee581b090ef340e025584310b40148e611";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake eigen ];
   checkInputs = [ ament-cmake-catch2 ament-cmake-uncrustify ];
-  propagatedBuildInputs = [ backward-ros nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
+  propagatedBuildInputs = [ backward-ros nlohmann_json proj rclcpp rmf-building-map-msgs rmf-fleet-msgs rmf-reservation-msgs rmf-site-map-msgs rmf-traffic rmf-traffic-msgs rmf-utils util-linux yaml-cpp zlib ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmf-visualization-building-systems/default.nix
+++ b/distros/rolling/rmf-visualization-building-systems/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rmf-building-map-msgs, rmf-door-msgs, rmf-lift-msgs, rmf-visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-building-systems";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_building_systems/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "7ccf2299949f6ffb19584b03443f8b59c307192738fae0cb2be32850180ba76f";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_building_systems/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "6da6bdc07295ade4d9a972ab76ff6650567b5da2c48c183a9f64c2cc62adede3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rmf-visualization-fleet-states/default.nix
+++ b/distros/rolling/rmf-visualization-fleet-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rmf-fleet-msgs, rmf-utils, rmf-visualization-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-fleet-states";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_fleet_states/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "e29fc1bef0e714c27a5af57e53a9dd227e74fe6e7e486ec52a2e198a61975ffe";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_fleet_states/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "490945eb51781de303b3f038ccc779d04c34e6d0d9ca31125fc32cc641918815";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-floorplans/default.nix
+++ b/distros/rolling/rmf-visualization-floorplans/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, opencv, rclcpp, rclcpp-components, rmf-building-map-msgs, rmf-utils, rmf-visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-floorplans";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_floorplans/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "81798ac26c0db891fafa3f2e6916171aec356b673d89d63b8bab9e7d0eef34db";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_floorplans/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "f25bcbb649ce671c5101d2cca3df41d11df9d417a90b96dbe96b7cbf4d5b7ce3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-navgraphs/default.nix
+++ b/distros/rolling/rmf-visualization-navgraphs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, rclcpp-components, rmf-building-map-msgs, rmf-fleet-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-navgraphs";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "50e4abc3039dd13f0a259491d533ea373a25bc2b0e11c17b013335d36158500c";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_navgraphs/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "c505686edcea5a776550eb8ae0cdb73b09fa74a2dc514102d9ede480d02f3c1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-obstacles/default.nix
+++ b/distros/rolling/rmf-visualization-obstacles/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, geometry-msgs, rclcpp, rclcpp-components, rmf-obstacle-msgs, rmf-utils, rmf-visualization-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-obstacles";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_obstacles/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "d78105d1099e866a2f5bc694677abf2cace2e0483d1a4256ee0fd2f1ea9c6338";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_obstacles/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "9f2b4b708316bafdc7dd331713e1f0415159f8d6fd460fb510d088400beb81fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
+++ b/distros/rolling/rmf-visualization-rviz2-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, eigen, pluginlib, qt5, rclcpp, resource-retriever, rmf-door-msgs, rmf-lift-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rviz-common, rviz-default-plugins, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-rviz2-plugins";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "10a376c0d620a88b283f7237bb8b308e27f2e9ced0f04675eab4ed83cae4c239";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_rviz2_plugins/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "0091d33f07c77f3b0f8df3e82d6eea5701e65ebf16cfd83d271ff0886ba0c2e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization-schedule/default.nix
+++ b/distros/rolling/rmf-visualization-schedule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, eigen, geometry-msgs, openssl, rclcpp, rclcpp-components, rmf-traffic, rmf-traffic-msgs, rmf-traffic-ros2, rmf-utils, rmf-visualization-msgs, rosidl-default-generators, visualization-msgs, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization-schedule";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "eb52fb9a0cf97e1ff8d9b3722e25c1bb5507140dc399fe95bfe02403d95d0d74";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization_schedule/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "0738441adf62aa5a1a524d31ecdddec2c577631c0085775ee3644ac7dd387981";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-visualization/default.nix
+++ b/distros/rolling/rmf-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch-xml, rmf-visualization-building-systems, rmf-visualization-fleet-states, rmf-visualization-floorplans, rmf-visualization-navgraphs, rmf-visualization-obstacles, rmf-visualization-rviz2-plugins, rmf-visualization-schedule }:
 buildRosPackage {
   pname = "ros-rolling-rmf-visualization";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "9f67c10bcdeeee176dd94bd3b2fb25fccafb21e6221ec4326ddebae0d86cff64";
+    url = "https://github.com/ros2-gbp/rmf_visualization-release/archive/release/rolling/rmf_visualization/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "708ec6903eb1fdefc17b1d72e552dc1be9c42289c2f68a7b75182790a4091293";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmf-websocket/default.nix
+++ b/distros/rolling/rmf-websocket/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, ament-cmake-uncrustify, boost, eigen, nlohmann-json-schema-validator-vendor, nlohmann_json, rclcpp, rmf-utils, websocketpp }:
 buildRosPackage {
   pname = "ros-rolling-rmf-websocket";
-  version = "2.7.1-r1";
+  version = "2.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "a5282f5bc83c1558c4cc7a71699ed97c79b0cde42ba941801f7e4973906d3c9e";
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/rolling/rmf_websocket/2.9.0-1.tar.gz";
+    name = "2.9.0-1.tar.gz";
+    sha256 = "ed87ec1d567d044926bab3b6f4a7ee7634abc0a9b8a7fd86d2525bf8e6f425be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "3.0.3-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "a172440e806d9bd9878cbdcfa982fa173f4edf4580ec51623fb059972d6cb263";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1e76f174d31b6cdc063d6b7a65ff9cb1b8c750a936eb4a076657081bbdabdcc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.0.3-r1";
+  version = "9.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.0.3-1.tar.gz";
-    name = "9.0.3-1.tar.gz";
-    sha256 = "249373ef588d24e96d1bf084093fb97618b150099abc92c9a2b5be20ddd4ff6b";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.1.0-1.tar.gz";
+    name = "9.1.0-1.tar.gz";
+    sha256 = "008d74539ef99fe484f1c9541215d9584e5c9a3cf16a70b50d66587a54e8ff02";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.0.3-r1";
+  version = "9.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.0.3-1.tar.gz";
-    name = "9.0.3-1.tar.gz";
-    sha256 = "a95b063659558b2edd4b5a1bc2859a0959fe7ac20731ca7500c07640117864c0";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.1.0-1.tar.gz";
+    name = "9.1.0-1.tar.gz";
+    sha256 = "9adac6ac40855472db2eac1924e4cd9a67fb617f12fc49ab742885fe6effb732";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.0.3-r1";
+  version = "9.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.0.3-1.tar.gz";
-    name = "9.0.3-1.tar.gz";
-    sha256 = "f559b7ef21795e99a1a02f27c3fa28aa1216cdd49faeea143c6e128fb70a9453";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.1.0-1.tar.gz";
+    name = "9.1.0-1.tar.gz";
+    sha256 = "842f238e6ea75882c6c64c4301a170ed950fd951fe233be5b7794900871f4010";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2trace/default.nix
+++ b/distros/rolling/ros2trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages, ros2cli, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-ros2trace";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/ros2trace/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "0f38d7916beb7f720a655cc74c35d852bada9792a4c340939e8b15566949303e";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/ros2trace/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "fe44b56d0990035be12dff907a383767ceeec944fa9d9a127bb486719448cba3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-to-video/default.nix
+++ b/distros/rolling/rosbag2-to-video/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2024 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, cv-bridge, opencv, python3Packages, pythonPackages, rclpy, ros2bag, rosbag2-py, rosidl-runtime-py }:
+buildRosPackage {
+  pname = "ros-rolling-rosbag2-to-video";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbag2_to_video-release/archive/release/rolling/rosbag2_to_video/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "859a6e1b42aac4d91c21c51d5c92322dd47726d3c6f344059c21d4618aaa082c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ cv-bridge opencv opencv.cxxdev python3Packages.opencv4 rclpy ros2bag rosbag2-py rosidl-runtime-py ];
+
+  meta = {
+    description = "Command line tool to create a video from a rosbag recording";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/rosidl-adapter/default.nix
+++ b/distros/rolling/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3, python3Packages, rosidl-cli }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-adapter";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "2c2aff9ae0cdeeb7df27d56929ec1eefa02651b83ba719835eb79233134b89c1";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_adapter/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "db6cfd1ef8831996c61742a9aa60cba5c1f415c63068181e39dfc2cd3be05a6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-cli/default.nix
+++ b/distros/rolling/rosidl-cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cli";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "85b9e74708a27351452fca021cfd7e20dffb40100a44771ef317216c89cf991c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cli/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "6ed78473d8230add9d48f17bab2b7437667805124ea48951e26c051de38e00cb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-cmake/default.nix
+++ b/distros/rolling/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-pycommon }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-cmake";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "e6ddc1235c6835390bcfaa3b8fb156af8ec0d788196346149701e3e399a522c4";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_cmake/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "3ce077b919d5c4de8fa38666d3425dee2370825621ac0442a63134f8593db614";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-c/default.nix
+++ b/distros/rolling/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rcutils, rosidl-cli, rosidl-cmake, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-c";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "8700c25be9456eb55f882185c4cd75bcd30c632179de7e67c7b2b18d6d492dc5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_c/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "3a481c80c30b11e1a5b8941a9dd1462eddf9a296683a4eb7bf547883f1ae49aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-cpp/default.nix
+++ b/distros/rolling/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-type-description, rosidl-parser, rosidl-pycommon, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-cpp";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "8658887b6a407138ee15c6c67ffa651af073d5167e1c60d6e094c4a150837669";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_cpp/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "3e01315ef15d11dfa37f9fc8b4ba156fb380fec2903b55d6cba8207698bea6cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-generator-type-description/default.nix
+++ b/distros/rolling/rosidl-generator-type-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-generator-type-description";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "c9c7f36b79a9537727328852f50a5cd713074c09926306354942b75f5ca3c81b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_generator_type_description/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "24169513af2d9f75482736758b65a824c9c627ca3c10b04d87f478f73ebf86f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-parser/default.nix
+++ b/distros/rolling/rosidl-parser/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-parser";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "5f29c5b7b4280fa2575092796cb0788b24aa4738d658ab690694fa21068e63fd";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_parser/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "55f5866972eb2ddcd376bf96bb9738929f3518ef3f07f8159fdc87e68eeb2361";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common pythonPackages.pytest ];
+  checkInputs = [ ament-cmake-mypy ament-cmake-pytest ament-lint-auto ament-lint-common pythonPackages.pytest ];
   propagatedBuildInputs = [ python3Packages.lark rosidl-adapter ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/rosidl-pycommon/default.nix
+++ b/distros/rolling/rosidl-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages, rosidl-parser }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-pycommon";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "c1af45b00bcddfcba3b3c976781df72c7b0146621d52925a46b63b9d9dfe570a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_pycommon/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "840270987c5746421cb285abcbeb997a1318e84ec00f87e9a47a514bea3116c3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosidl-runtime-c/default.nix
+++ b/distros/rolling/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-c";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "359a2dca6b9d1ba490c2b2f3b468199468811a3d74595ba9d827f4947db919b5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_c/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "9e39cbe21aea51381c6b27eeb4783bb49a04e5cad6aa8c7db8a02a14892a365a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-runtime-cpp/default.nix
+++ b/distros/rolling/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-runtime-cpp";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "935e71c3edbede78a17576df33440a601c07b82601a3e09f555d14e1f140063a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_runtime_cpp/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "63d249bf3f30befe952e2ea1a004f96e3bb3e237278c54309dfc3b26a8341847";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-interface/default.nix
+++ b/distros/rolling/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-interface";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "ffe10887f4370d7f36edd3ac9db2c544aa9662212015a78464bc37a832c099d8";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_interface/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "9464b08582612f2e6f7f48e518348363ce2ebeecf07c7b160f095b8d576ab14c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-c";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "8427b28f69b2070b6c88238963370f0d5827005a7a3fcef8ff7b486d5e62d5bb";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_c/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "f7e6dae20d334ee084ad0eb87b62804b57b9312a095ed4b0822106f924580bbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, python3, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-introspection-cpp";
-  version = "4.9.1-r1";
+  version = "4.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.9.1-1.tar.gz";
-    name = "4.9.1-1.tar.gz";
-    sha256 = "759f4fcb95667178efcb8944714dce9c5b0769c53b3f153dc7175f91fff192c1";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/rolling/rosidl_typesupport_introspection_cpp/4.9.2-1.tar.gz";
+    name = "4.9.2-1.tar.gz";
+    sha256 = "4ccd91a52710c46cc529761e3b7a0960937c7fab3759bd9cd30970d8f4073ec5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rttest/default.nix
+++ b/distros/rolling/rttest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rttest";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "705d03b192b3f1d7de736324c84b07a61af0c86b1658a5a33be8c87019a9ddb5";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/rttest/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "84ea4ded0beb065ba162f70f2d8733388f91e10a76b3d4cb74dbad5e4396eb65";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "d089cec5356be993fa7eba6368c28252d5810dc07fc2120ad7b6fb2b538013ad";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "957b42a9c0fa55aa9e72c90120fd533a8ca1b399046775b3c3a37ce87757861f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "fc21eab4a5ad66ef7285d6ac3f0c5a4e0cf262c935ace5e3c5c62bff484c4764";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "cb5baa89af06ab147a99756389f0c9b6deafd07d2eeacceaf5d73a756a3802ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "e7310819312a21a7f9bcdd7ae28b9acc90cbdf464e8c6cb94bf08fc127dcc416";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "7b5c9e7f5eaede8269f951a353e76be1652ea46a2b50372076092a80f28222ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "cf93eaa7a443849b9947fa568f6aa7e6f27bf5aa97dde07b4a86bba00faa1e5c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "24934ad0b59aad00e27f32028d8c989d6b9bffcb837de8720b701157277ba649";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "dd00d04da4a187e68ba5427222500e83d908f3c61c6f198282266d6831241f20";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "e98e6f62bd13c7bdc0066fb6c0068eb32174829528be3aede67bc257eb7f5a4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "8399c2c10aab3bbfc6411bd6617e53275d437cb49a0a4819f5ef0a354d1426b3";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "8a8357767cb45cddb7904f7ad8cf404f264899d6b65db2650e44fc3dadc93a92";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "f3fcc7ac3079af95cae9d5c65bfaf6ad09436018ef8641c66d4c25a4a14a94e8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "80a6d8270ebed3b9730dcdaa0c8a2a0fe92d8084a21f2d02c73848e5bd578566";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.3.2-r1";
+  version = "14.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.3.2-1.tar.gz";
-    name = "14.3.2-1.tar.gz";
-    sha256 = "b69dee9b2b937a7100115bdb6704a30779750531e52ef7ad1705395d6d2499f5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.3.3-1.tar.gz";
+    name = "14.3.3-1.tar.gz";
+    sha256 = "f12f349ab878e5c55964656c4edf638b4c664665247c5faaa4280bf70dd0c233";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sdformat-vendor/default.nix
+++ b/distros/rolling/sdformat-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, pythonPackages, tinyxml-2, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, pythonPackages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-sdformat-vendor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "07e37776297e46c61069cdd1223fbc2909801fbbcf2b0ba6450819cda921d7a1";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.3-2.tar.gz";
+    name = "0.2.3-2.tar.gz";
+    sha256 = "c157c281b1c38b716277e21c8b5dc3737cf932044756e7e97a95744840b704d0";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint libxml2 python3Packages.psutil pythonPackages.pytest ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-math-vendor gz-tools-vendor gz-utils-vendor pythonPackages.pybind11 tinyxml-2 urdfdom ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: sdformat15 15.1.0
+    description = "Vendor package for: sdformat15 15.1.1
 
     SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "e78523a2126036efdadf2bd2bb440da58d5925d7686fb0496265013f42915440";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "22a880714a908639d8b9f2ef8d905a89d76107f25d4cd382bfaac3ebaf17c925";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "ec5dbd764711c7c573feb08dcf1c2ed9b6366a59c28b575e993bedf825c37a4a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "7990e5595ae4e0c78c4ad341715794d472ae23dc9a5d38d026ac2b18e81f29b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "97c0decc930b13f4f32732f8005d4ebe50b38ce9e60a3bb29681d6cd81b7ed77";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "b1d0fcf71e2d8e8d2f01690b6c8369d1aa838e688e411a8f5afa152b964ea4f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "fff31624e03d2f7d6350383b02e13a004d2f3a84faf4ea64c3a744cbd6d68a5e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "4a8f18add9f692258a0d9559421775f9ee9ce0b31b076c4a602a335147b1f82f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "d3771197f8186531286e2670be670b2bb466f12a667b960641ae9276b40fc567";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "5cb12d67574e889ea658ab3d3407c1e8ca003fdbece465ebdd8c0f988c720fb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "8f488ceb27f4aeb29e4db2566d27fd67f71857725866e6eda396a73b8646546b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "18d6fc3a4245700c1c57912d75d1b6a7491c17516859ef0ccf54dc20ff191182";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2024 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rclpy, rpyutils, tf2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python3, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "f8ac16bed0770acacc15b8f7175d98795eba350c20b458ae0c939270f222e577";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "20c2f4dec33e550f5bbf4803c3cde5498d636de7d96099bd9eba0fc05cbf3eb1";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake python3 ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rpyutils tf2 ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "100c40964b051000646eb83db18eeb33ae4f4eb51dffc77f9fa9426c8de3ffd7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "70e338bbbb9e642b341d1e0c79ef5050251b390b8ee10eb0fd9589cfd9eff382";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "4eade65d1eba3dc211cdf9899538ed526351f65e23b62dbc4cb8ffd6d229592b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "e397ceb10cf1389cc39ab1beca536cbbca8393757eaaa8122cf2fd5adeb62ec5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "5377be3895f9e370a00f9287f5c070b25225c7437f9af0a4fa54fb55fb55f259";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "d9a4ac2904d8cb1f0e62f43303134d3fb8f503dd49e228e43377a419946626b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, graphviz, python3Packages, pythonPackages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "a5811a56e8fc17c3755dc1f3192a4ea0e2f1adce74177e84924e17d72567fe6e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "063a6cc2e3de554afbf5afa66a6cff263988324c73e020d068c29e3fb0dceb8a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.39.2-r1";
+  version = "0.39.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.39.2-1.tar.gz";
-    name = "0.39.2-1.tar.gz";
-    sha256 = "2377ddb325c03a6bbdf8a7ff85a37ab4028de80be1de1bec2ec171c39f0f15e7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.39.3-1.tar.gz";
+    name = "0.39.3-1.tar.gz";
+    sha256 = "8f291be56fa9d3e0d5e076041040c97bbfeedeb7fa57a62df3942128f9a86ae2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/theora-image-transport/default.nix
+++ b/distros/rolling/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, libogg, libtheora, opencv, pkg-config, pluginlib, rclcpp, rcutils, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-theora-image-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "8c06b4e354e0a221db58a6450d18248f505f4b5cc0e0f64d1e31b112e9392622";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/theora_image_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "d637d45967164c5f6f90dbfabe0e595c975aa832adb27beef6cedc54d92a80b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tlsf-cpp/default.nix
+++ b/distros/rolling/tlsf-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rmw, rmw-implementation-cmake, std-msgs, tlsf }:
 buildRosPackage {
   pname = "ros-rolling-tlsf-cpp";
-  version = "0.18.1-r1";
+  version = "0.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "256d9067620942128cc32f2abf72dec9b131033a597f80161793bccdca589147";
+    url = "https://github.com/ros2-gbp/realtime_support-release/archive/release/rolling/tlsf_cpp/0.18.2-1.tar.gz";
+    name = "0.18.2-1.tar.gz";
+    sha256 = "4e3ea4a7e4a0c55a2bdd88be55d6b8f940ccb84c0f7405a47cbbe429b45760af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-launch/default.nix
+++ b/distros/rolling/tracetools-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-launch";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_launch/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "fbeb153d8878eb30ce20c6e04217b6ebfc32a26be5fa67c0b32562c4fb411866";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_launch/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "1a02c627f476f80dcabcb6734c07dd30ab6f92e66c9af3bb9a849d91dcd3ad48";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools-read/default.nix
+++ b/distros/rolling/tracetools-read/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, babeltrace, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-read";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_read/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "180f914af9d5149f07bda757569a3ab14852bacbf46dcd717288e7b2631dfee4";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_read/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "4708af397dcbfd885cf22f503d9feba54e7e2a2338fa5c0e95f6af6560bbc73d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools-test/default.nix
+++ b/distros/rolling/tracetools-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-launch, tracetools-read, tracetools-trace }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-test";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_test/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "374081f04102b381367c142ca27f09183a274268ba384d01838f193bf4e6d706";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_test/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "66d251394d182654f3ace1ceb45f4ae9b3172f534f86e771cea8d529777de245";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools-trace/default.nix
+++ b/distros/rolling/tracetools-trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, lttngpy, pythonPackages }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-trace";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_trace/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "7f86d7acd085dacf79d31e48f15c51f7dd9a1af241e4d63793f05ff54c62ff46";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools_trace/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "9187e6ea12b6ba276a914d8ac5c354de93ac0f1f3fa4854d0ff2ec71aabd0d98";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tracetools/default.nix
+++ b/distros/rolling/tracetools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lttng-tools, lttng-ust, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-tracetools";
-  version = "8.4.0-r1";
+  version = "8.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools/8.4.0-1.tar.gz";
-    name = "8.4.0-1.tar.gz";
-    sha256 = "6aebc741cc3714fa157fdf47bdb065402c61c4fff7645e74d0302b52b449c5d4";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/rolling/tracetools/8.4.1-1.tar.gz";
+    name = "8.4.1-1.tar.gz";
+    sha256 = "322f07b854f92c8f6f0f58ce0c4706d75b0f5e9fe4f0c2c9df40d6cbfaefd68e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f4ad26fab1f0ddf4c65f8bd3bc587e11ecf4ea46b6ac28fe3e3015803039b6cb";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b2255a8b76e7e0596ec5f0e4de8c0726dff91125ba8ccbdac17df6e5bf7d6ff3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/zstd-image-transport/default.nix
+++ b/distros/rolling/zstd-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, image-transport, zlib }:
 buildRosPackage {
   pname = "ros-rolling-zstd-image-transport";
-  version = "5.0.0-r1";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/zstd_image_transport/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "7f86c4813d7b64d250814c90f9274e38c5e2c20bd1a837ae456c8cfd4bd606b9";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/rolling/zstd_image_transport/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "540b7bc01ebb0e43f249faa2539ed6a3b1b96691886f9b87c1b095ccdbd6a0c9";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'iron', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 567652324584bd1339384e5ade6ed0ed53501eed.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *adi-3dtof-image-stitching 2.1.0-r1*
* *ament-cmake 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-auto 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-core 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-definitions 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-dependencies 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-include-directories 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-interfaces 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-libraries 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-link-flags 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-export-targets 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-gen-version-h 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-gmock 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-google-benchmark 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-gtest 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-include-directories 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-libraries 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-nose 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-pytest 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-python 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-target-dependencies 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-test 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-vendor-package 1.3.10-r1 --> 1.3.11-r1*
* *ament-cmake-version 1.3.10-r1 --> 1.3.11-r1*
* *axis-camera 2.0.3-r1*
* *axis-description 2.0.3-r1*
* *axis-msgs 2.0.3-r1*
* *camera-calibration-parsers 3.1.9-r1 --> 3.1.10-r1*
* *camera-info-manager 3.1.9-r1 --> 3.1.10-r1*
* *camera-info-manager-py 3.1.10-r1*
* *camera-ros 0.1.0-r2 --> 0.2.0-r1*
* *clearpath-common 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-config 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-config-live 0.3.0-r1 --> 1.0.0-r1*
* *clearpath-control 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-customization 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-description 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-desktop 0.3.0-r1 --> 1.0.0-r1*
* *clearpath-generator-common 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-generator-gz 0.3.0-r1 --> 1.0.0-r1*
* *clearpath-gz 0.3.0-r1 --> 1.0.0-r1*
* *clearpath-manipulators 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-manipulators-description 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-motor-msgs 1.0.1-r1*
* *clearpath-mounts-description 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-msgs 1.0.0-r1 --> 1.0.1-r1*
* *clearpath-nav2-demos 0.2.0-r1 --> 1.0.0-r1*
* *clearpath-platform-description 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-platform-msgs 1.0.0-r1 --> 1.0.1-r1*
* *clearpath-sensors-description 0.3.4-r1 --> 1.0.0-r1*
* *clearpath-simulator 0.3.0-r1 --> 1.0.0-r1*
* *clearpath-viz 0.3.0-r1 --> 1.0.0-r1*
* *cyclonedds 0.10.4-r1 --> 0.10.5-r2*
* *dual-laser-merger 0.1.1-r1*
* *examples-rclcpp-async-client 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-cbg-executor 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-action-client 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-action-server 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-client 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-composition 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-publisher 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-service 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-subscriber 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-minimal-timer 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-multithreaded-executor 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclcpp-wait-set 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-executors 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-guard-conditions 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-minimal-action-client 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-minimal-action-server 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-minimal-client 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-minimal-publisher 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-minimal-service 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-minimal-subscriber 0.15.2-r1 --> 0.15.3-r1*
* *examples-rclpy-pointcloud-publisher 0.15.2-r1 --> 0.15.3-r1*
* *foxglove-bridge 0.8.0-r1 --> 0.8.1-r1*
* *hatchbed-common 0.1.1-r1*
* *image-common 3.1.9-r1 --> 3.1.10-r1*
* *image-transport 3.1.9-r1 --> 3.1.10-r1*
* *launch 1.0.6-r1 --> 1.0.7-r1*
* *launch-pytest 1.0.6-r1 --> 1.0.7-r1*
* *launch-ros 0.19.7-r2 --> 0.19.8-r1*
* *launch-testing 1.0.6-r1 --> 1.0.7-r1*
* *launch-testing-ament-cmake 1.0.6-r1 --> 1.0.7-r1*
* *launch-testing-examples 0.15.2-r1 --> 0.15.3-r1*
* *launch-testing-ros 0.19.7-r2 --> 0.19.8-r1*
* *launch-xml 1.0.6-r1 --> 1.0.7-r1*
* *launch-yaml 1.0.6-r1 --> 1.0.7-r1*
* *libstatistics-collector 1.3.2-r1 --> 1.3.4-r1*
* *log-view 0.2.3-r1 --> 0.2.5-r1*
* *mcap-vendor 0.15.12-r1 --> 0.15.13-r1*
* *osrf-pycommon 2.0.2-r2 --> 2.1.4-r1*
* *pal-statistics 2.3.1-r1 --> 2.5.0-r1*
* *pal-statistics-msgs 2.3.1-r1 --> 2.5.0-r1*
* *rc-reason-clients 0.4.0-r1 --> 0.4.0-r2*
* *rc-reason-msgs 0.4.0-r1 --> 0.4.0-r2*
* *rclcpp 16.0.10-r1 --> 16.0.11-r1*
* *rclcpp-action 16.0.10-r1 --> 16.0.11-r1*
* *rclcpp-components 16.0.10-r1 --> 16.0.11-r1*
* *rclcpp-lifecycle 16.0.10-r1 --> 16.0.11-r1*
* *rclpy 3.3.14-r1 --> 3.3.15-r1*
* *rcpputils 2.4.3-r1 --> 2.4.4-r1*
* *rmw-connextdds 0.11.2-r1 --> 0.11.3-r1*
* *rmw-connextdds-common 0.11.2-r1 --> 0.11.3-r1*
* *ros2bag 0.15.12-r1 --> 0.15.13-r1*
* *ros2launch 0.19.7-r2 --> 0.19.8-r1*
* *rosbag2 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-compression 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-compression-zstd 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-cpp 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-interfaces 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-performance-benchmarking 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-py 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-storage 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-storage-default-plugins 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-storage-mcap 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-storage-mcap-testdata 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-test-common 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-tests 0.15.12-r1 --> 0.15.13-r1*
* *rosbag2-to-video 1.0.1-r1*
* *rosbag2-transport 0.15.12-r1 --> 0.15.13-r1*
* *rosidl-adapter 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-cli 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-cmake 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-generator-c 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-generator-cpp 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-parser 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-runtime-c 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-runtime-cpp 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-typesupport-c 2.0.1-r1 --> 2.0.2-r1*
* *rosidl-typesupport-cpp 2.0.1-r1 --> 2.0.2-r1*
* *rosidl-typesupport-interface 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-typesupport-introspection-c 3.1.5-r2 --> 3.1.6-r1*
* *rosidl-typesupport-introspection-cpp 3.1.5-r2 --> 3.1.6-r1*
* *rti-connext-dds-cmake-module 0.11.2-r1 --> 0.11.3-r1*
* *rviz-assimp-vendor 11.2.13-r1 --> 11.2.14-r1*
* *rviz-common 11.2.13-r1 --> 11.2.14-r1*
* *rviz-default-plugins 11.2.13-r1 --> 11.2.14-r1*
* *rviz-ogre-vendor 11.2.13-r1 --> 11.2.14-r1*
* *rviz-rendering 11.2.13-r1 --> 11.2.14-r1*
* *rviz-rendering-tests 11.2.13-r1 --> 11.2.14-r1*
* *rviz-visual-testing-framework 11.2.13-r1 --> 11.2.14-r1*
* *rviz2 11.2.13-r1 --> 11.2.14-r1*
* *shared-queues-vendor 0.15.12-r1 --> 0.15.13-r1*
* *sqlite3-vendor 0.15.12-r1 --> 0.15.13-r1*
* *ur-client-library 1.4.0-r1 --> 1.5.0-r1*
* *zed-msgs 4.2.2-r1*
* *zstd-vendor 0.15.12-r1 --> 0.15.13-r1*

Iron Changes:
-------------
* *foxglove-bridge 0.8.0-r1 --> 0.8.1-r1*
* *openeb-vendor 2.0.1-r1 --> 2.0.1-r2*
* *rviz-assimp-vendor 12.4.9-r1 --> 12.4.10-r1*
* *rviz-common 12.4.9-r1 --> 12.4.10-r1*
* *rviz-default-plugins 12.4.9-r1 --> 12.4.10-r1*
* *rviz-ogre-vendor 12.4.9-r1 --> 12.4.10-r1*
* *rviz-rendering 12.4.9-r1 --> 12.4.10-r1*
* *rviz-rendering-tests 12.4.9-r1 --> 12.4.10-r1*
* *rviz-visual-testing-framework 12.4.9-r1 --> 12.4.10-r1*
* *rviz2 12.4.9-r1 --> 12.4.10-r1*

Jazzy Changes:
--------------
* *autoware-lanelet2-extension 0.6.0-r1 --> 0.6.2-r1*
* *autoware-lanelet2-extension-python 0.6.0-r1 --> 0.6.2-r1*
* *axis-camera 3.0.0-r1*
* *axis-description 3.0.0-r1*
* *axis-msgs 3.0.0-r1*
* *boost-sml-vendor 1.1.11-r1*
* *camera-calibration-parsers 5.1.4-r1 --> 5.1.5-r1*
* *camera-info-manager 5.1.4-r1 --> 5.1.5-r1*
* *camera-info-manager-py 5.1.5-r1*
* *camera-ros 0.2.0-r1*
* *clearpath-ros2-socketcan-interface 2.0.0-r1*
* *clips-vendor 6.4.3-r2*
* *compressed-depth-image-transport 4.0.2-r1 --> 4.0.3-r1*
* *compressed-image-transport 4.0.2-r1 --> 4.0.3-r1*
* *dual-laser-merger 0.3.1-r1*
* *etsi-its-cam-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cam-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-cpm-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-denm-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-messages 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-msgs 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-msgs-utils 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-primitives-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-rviz-plugins 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-coding 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-conversion 2.3.0-r1 --> 2.4.0-r1*
* *etsi-its-vam-ts-msgs 2.3.0-r1 --> 2.4.0-r1*
* *examples-tf2-py 0.36.4-r1 --> 0.36.5-r1*
* *flir-camera-description 2.0.20-r1 --> 3.0.0-r1*
* *flir-camera-msgs 2.0.20-r1 --> 3.0.0-r1*
* *foxglove-bridge 0.8.0-r1 --> 0.8.1-r1*
* *geometry2 0.36.4-r1 --> 0.36.5-r1*
* *gz-dartsim-vendor 0.0.2-r1 --> 0.0.3-r1*
* *image-common 5.1.4-r1 --> 5.1.5-r1*
* *image-transport 5.1.4-r1 --> 5.1.5-r1*
* *image-transport-plugins 4.0.2-r1 --> 4.0.3-r1*
* *interactive-marker-twist-server 2.1.0-r3 --> 2.1.1-r1*
* *neo-nav2-bringup 1.3.0-r1*
* *odom-to-tf-ros2 1.0.3-r2 --> 1.0.4-r1*
* *pal-statistics 2.2.4-r1 --> 2.5.0-r1*
* *pal-statistics-msgs 2.2.4-r1 --> 2.5.0-r1*
* *raspimouse 2.0.0-r1*
* *raspimouse-fake 3.0.0-r1*
* *raspimouse-gazebo 3.0.0-r1*
* *raspimouse-msgs 2.0.0-r1*
* *raspimouse-ros2-examples 3.0.0-r1*
* *raspimouse-sim 3.0.0-r1*
* *rc-reason-clients 0.3.1-r3 --> 0.4.0-r2*
* *rc-reason-msgs 0.3.1-r3 --> 0.4.0-r2*
* *rosbag2-to-video 1.0.1-r1*
* *sdformat-vendor 0.0.7-r1 --> 0.0.8-r1*
* *spinnaker-camera-driver 2.0.20-r1 --> 3.0.0-r1*
* *spinnaker-synchronized-camera-driver 2.0.20-r1 --> 3.0.0-r1*
* *tf2 0.36.4-r1 --> 0.36.5-r1*
* *tf2-bullet 0.36.4-r1 --> 0.36.5-r1*
* *tf2-eigen 0.36.4-r1 --> 0.36.5-r1*
* *tf2-eigen-kdl 0.36.4-r1 --> 0.36.5-r1*
* *tf2-geometry-msgs 0.36.4-r1 --> 0.36.5-r1*
* *tf2-kdl 0.36.4-r1 --> 0.36.5-r1*
* *tf2-msgs 0.36.4-r1 --> 0.36.5-r1*
* *tf2-py 0.36.4-r1 --> 0.36.5-r1*
* *tf2-ros 0.36.4-r1 --> 0.36.5-r1*
* *tf2-ros-py 0.36.4-r1 --> 0.36.5-r1*
* *tf2-sensor-msgs 0.36.4-r1 --> 0.36.5-r1*
* *tf2-tools 0.36.4-r1 --> 0.36.5-r1*
* *theora-image-transport 4.0.2-r1 --> 4.0.3-r1*
* *ur-client-library 1.4.0-r1 --> 1.5.0-r1*
* *yaets 0.0.2-r1*
* *zstd-image-transport 4.0.2-r1 --> 4.0.3-r1*

Noetic Changes:
---------------
* *foxglove-bridge 0.7.10-r1 --> 0.8.1-r1*
* *hatchbed-common 0.0.2-r1*
* *rc-reason-clients 0.4.0-r1 --> 0.4.0-r2*
* *rc-reason-msgs 0.4.0-r1 --> 0.4.0-r2*

Rolling Changes:
----------------
* *camera-calibration-parsers 6.0.1-r1 --> 6.0.3-r1*
* *camera-info-manager 6.0.1-r1 --> 6.0.3-r1*
* *camera-info-manager-py 6.0.3-r1*
* *camera-ros 0.2.0-r1*
* *compressed-depth-image-transport 5.0.0-r1 --> 5.0.1-r1*
* *compressed-image-transport 5.0.0-r1 --> 5.0.1-r1*
* *dual-laser-merger 0.0.1-r1*
* *examples-tf2-py 0.39.2-r1 --> 0.39.3-r1*
* *foxglove-bridge 0.8.0-r1 --> 0.8.1-r1*
* *geometry2 0.39.2-r1 --> 0.39.3-r1*
* *gz-dartsim-vendor 0.1.1-r1 --> 0.1.2-r1*
* *hatchbed-common 0.1.1-r1*
* *image-common 6.0.1-r1 --> 6.0.3-r1*
* *image-transport 6.0.1-r1 --> 6.0.3-r1*
* *image-transport-plugins 5.0.0-r1 --> 5.0.1-r1*
* *image-transport-py 6.0.1-r1 --> 6.0.3-r1*
* *log-view 0.2.5-r1*
* *lttngpy 8.4.0-r1 --> 8.4.1-r1*
* *odri-master-board-sdk 1.0.7-r1 --> 1.0.7-r2*
* *pal-statistics 2.2.4-r1 --> 2.5.0-r1*
* *pal-statistics-msgs 2.2.4-r1 --> 2.5.0-r1*
* *point-cloud-transport 5.1.0-r1 --> 5.1.1-r1*
* *point-cloud-transport-py 5.1.0-r1 --> 5.1.1-r1*
* *rc-reason-clients 0.3.1-r2 --> 0.4.0-r2*
* *rc-reason-msgs 0.3.1-r2 --> 0.4.0-r2*
* *rclcpp 29.1.0-r1 --> 29.2.0-r1*
* *rclcpp-action 29.1.0-r1 --> 29.2.0-r1*
* *rclcpp-components 29.1.0-r1 --> 29.2.0-r1*
* *rclcpp-lifecycle 29.1.0-r1 --> 29.2.0-r1*
* *rmf-building-map-tools 1.10.0-r1 --> 1.11.0-r1*
* *rmf-demos 2.4.0-r1 --> 2.5.0-r1*
* *rmf-demos-assets 2.4.0-r1 --> 2.5.0-r1*
* *rmf-demos-bridges 2.4.0-r1 --> 2.5.0-r1*
* *rmf-demos-fleet-adapter 2.4.0-r1 --> 2.5.0-r1*
* *rmf-demos-gz 2.4.0-r1 --> 2.5.0-r1*
* *rmf-demos-maps 2.4.0-r1 --> 2.5.0-r1*
* *rmf-demos-tasks 2.4.0-r1 --> 2.5.0-r1*
* *rmf-fleet-adapter 2.7.1-r1 --> 2.9.0-r1*
* *rmf-fleet-adapter-python 2.7.1-r1 --> 2.9.0-r1*
* *rmf-reservation-node 2.9.0-r1*
* *rmf-task 2.6.0-r1 --> 2.7.0-r1*
* *rmf-task-ros2 2.7.1-r1 --> 2.9.0-r1*
* *rmf-task-sequence 2.6.0-r1 --> 2.7.0-r1*
* *rmf-traffic-editor 1.10.0-r1 --> 1.11.0-r1*
* *rmf-traffic-editor-assets 1.10.0-r1 --> 1.11.0-r1*
* *rmf-traffic-editor-test-maps 1.10.0-r1 --> 1.11.0-r1*
* *rmf-traffic-ros2 2.7.1-r1 --> 2.9.0-r1*
* *rmf-visualization 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-building-systems 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-fleet-states 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-floorplans 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-navgraphs 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-obstacles 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-rviz2-plugins 2.4.0-r1 --> 2.4.1-r1*
* *rmf-visualization-schedule 2.4.0-r1 --> 2.4.1-r1*
* *rmf-websocket 2.7.1-r1 --> 2.9.0-r1*
* *rmw-cyclonedds-cpp 3.0.3-r1 --> 3.1.0-r1*
* *rmw-fastrtps-cpp 9.0.3-r1 --> 9.1.0-r1*
* *rmw-fastrtps-dynamic-cpp 9.0.3-r1 --> 9.1.0-r1*
* *rmw-fastrtps-shared-cpp 9.0.3-r1 --> 9.1.0-r1*
* *ros2trace 8.4.0-r1 --> 8.4.1-r1*
* *rosbag2-to-video 1.0.1-r1*
* *rosidl-adapter 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-cli 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-cmake 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-generator-c 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-generator-cpp 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-generator-type-description 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-parser 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-pycommon 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-runtime-c 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-runtime-cpp 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-typesupport-interface 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-typesupport-introspection-c 4.9.1-r1 --> 4.9.2-r1*
* *rosidl-typesupport-introspection-cpp 4.9.1-r1 --> 4.9.2-r1*
* *rttest 0.18.1-r1 --> 0.18.2-r1*
* *rviz-assimp-vendor 14.3.2-r1 --> 14.3.3-r1*
* *rviz-common 14.3.2-r1 --> 14.3.3-r1*
* *rviz-default-plugins 14.3.2-r1 --> 14.3.3-r1*
* *rviz-ogre-vendor 14.3.2-r1 --> 14.3.3-r1*
* *rviz-rendering 14.3.2-r1 --> 14.3.3-r1*
* *rviz-rendering-tests 14.3.2-r1 --> 14.3.3-r1*
* *rviz-visual-testing-framework 14.3.2-r1 --> 14.3.3-r1*
* *rviz2 14.3.2-r1 --> 14.3.3-r1*
* *sdformat-vendor 0.2.2-r1 --> 0.2.3-r2*
* *tf2 0.39.2-r1 --> 0.39.3-r1*
* *tf2-bullet 0.39.2-r1 --> 0.39.3-r1*
* *tf2-eigen 0.39.2-r1 --> 0.39.3-r1*
* *tf2-eigen-kdl 0.39.2-r1 --> 0.39.3-r1*
* *tf2-geometry-msgs 0.39.2-r1 --> 0.39.3-r1*
* *tf2-kdl 0.39.2-r1 --> 0.39.3-r1*
* *tf2-msgs 0.39.2-r1 --> 0.39.3-r1*
* *tf2-py 0.39.2-r1 --> 0.39.3-r1*
* *tf2-ros 0.39.2-r1 --> 0.39.3-r1*
* *tf2-ros-py 0.39.2-r1 --> 0.39.3-r1*
* *tf2-sensor-msgs 0.39.2-r1 --> 0.39.3-r1*
* *tf2-tools 0.39.2-r1 --> 0.39.3-r1*
* *theora-image-transport 5.0.0-r1 --> 5.0.1-r1*
* *tlsf-cpp 0.18.1-r1 --> 0.18.2-r1*
* *tracetools 8.4.0-r1 --> 8.4.1-r1*
* *tracetools-launch 8.4.0-r1 --> 8.4.1-r1*
* *tracetools-read 8.4.0-r1 --> 8.4.1-r1*
* *tracetools-test 8.4.0-r1 --> 8.4.1-r1*
* *tracetools-trace 8.4.0-r1 --> 8.4.1-r1*
* *ur-client-library 1.4.0-r1 --> 1.5.0-r1*
* *zstd-image-transport 5.0.0-r1 --> 5.0.1-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-2.8
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-antlr4
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-flake8-blind-except
 * [ ] python3-flake8-class-newline
 * [ ] python3-flake8-deprecated
 * [ ] python3-icecream
 * [ ] python3-pexpect
 * [ ] python3-pre-commit
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pyside2
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rich
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typing-extensions
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

