### PR TITLE
libfranka: add missing pinocchio dependency

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -58,11 +58,12 @@ in with lib; {
   };
 
   libfranka = rosSuper.libfranka.overrideAttrs ({
-    cmakeFlags ? [], ...
+    cmakeFlags ? [], propagatedBuildInputs ?[], ...
   }: {
     # Uses custom flag to disable tests. Attempts to download GTest without
     # this.
     cmakeFlags = cmakeFlags ++ [ "-DBUILD_TESTS=OFF" ];
+    propagatedBuildInputs = propagatedBuildInputs ++ [ self.pinocchio ];
   });
 
   libphidget22 = patchVendorUrl rosSuper.libphidget22 {


### PR DESCRIPTION
Hi,

libfranka recently added the pinocchio dependency, without declaring it in package.xml, so build fails: https://hydra.iid.ciirc.cvut.cz/build/96125/log/tail

Here is a trivial fix, which build correctly.

PS: ref #536: with a nixpkgs version of eigenpy / hpp-fcl / pinocchio, this would have been easier to build :)