### PR TITLE
Replace python3Packages.nose with a dummy package

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -7,6 +7,12 @@ let
 
       # ROS is not compatible with empy 4
       empy = pyFinal.empy_3;
+
+      # Nose was removed from nixpkgs due to being deprecated and
+      # unmaintained, but catkin depends on it for running tests.
+      # Since we disable tests for most packages, we can "fix" catkin
+      # evaluation by substituting a dummy package for nose.
+      nose = self.runCommand "nose-placeholder" {} "mkdir $out";
     });
   };
 


### PR DESCRIPTION
`python3Packages.nose` was removed from nixpkgs due to being deprecated and unmaintained, but catkin depends on it for running tests. Since we disable tests for most packages, we can "fix" catkin evaluation by substituting a dummy package for nose.

I tried making this substituting only for catkin like this:

    catkin = rosSelf.callPackage ./catkin {
      python3Packages = rosSelf.python3Packages // {
        nose = self.runCommand "nose-placeholder" {} "mkdir $out";
      };
    }

but it was not sufficient and catkin build failed in configurePhase due to:

    FileNotFoundError: [Errno 2] No such file or directory:
    '/build/catkin-release-release-noetic-catkin-0.8.10-1/build/devel/env.sh'

Fixes #525