### PR TITLE
[fix] plotjuggler for all distros

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -138,7 +138,7 @@ let
       nativeBuildInputs ? [], ...
     }: {
       dontWrapQtApps = false;
-      nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
+      nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook self.protobuf_21 ];
       postFixup = ''
         wrapQtApp "$out/lib/plotjuggler/plotjuggler"
       '';


### PR DESCRIPTION
Plotjuggler was not compiling on the distros I use (noetic, humble, jazzy) because of protobuf errors. I had to use an older protobuf version to get it working. 
My changes work, but the solution is not so clean, because now plotjuggler uses protobuf and protobuf_21 as nativeBuildInputs. Maybe there is a way to override protobuf only for plotjuggler.