### PR TITLE
remove `--as-needed` propagated flag from backward-ros

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -35,6 +35,22 @@ rosSelf: rosSuper: with rosSelf.lib; {
     '';
   });
 
+  backward-ros = rosSuper.backward-ros.overrideAttrs ({ postPatch ? "", ... }: {
+
+    # The `--as-needed` flag directs the linker to search all libraries specified
+    # during its invocation to identify which ones contain the symbols required by the binary.
+    #
+    # Due to the nixpkgs binutils wrapper and the reliance to `propagatedBuildInputs`,
+    # the overlay often propagates an excessive number of libraries.
+    #
+    # As a result, the `--as-needed` flag can significantly increase the time the linker
+    # spends searching through these libraries, potentially causing builds to fail to complete.
+
+    postPatch = postPatch + ''
+     sed '/-Wl,--as-needed/d' -i cmake/BackwardConfigAment.cmake
+    '';
+  });
+
   cyclonedds = rosSuper.cyclonedds.overrideAttrs ({
     cmakeFlags ? [], ...
   }: {


### PR DESCRIPTION
Fixes https://github.com/lopsided98/nix-ros-overlay/issues/541

Removing the flag relieves the linker in dependent packages like `ros-moveit-*` with many dependencies, since it would otherwise need to search all propagated libraries for symbols.