### PR TITLE
gz-transport-vendor: add libsodium to buildInputs

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -154,10 +154,14 @@ in {
     '';
   });
 
-  gz-transport-vendor = lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
+  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
     version = "13.4.0";
     hash = "sha256-2Akd3vKr07IdgoJppvUV1nZlHE4RdQfI2R18ihHTDHk=";
-  };
+  }).overrideAttrs({
+    buildInputs ? [], ...
+  }: {
+    buildInputs = buildInputs ++ [ self.libsodium ];
+  });
 
   gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
     version = "2.2.0";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -154,10 +154,14 @@ in {
     '';
   });
 
-  gz-transport-vendor = lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
+  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
     version = "14.0.0";
     hash = "sha256-zoGphy2cpmqJsnyS1LNVm4eGtHCWkAwIblga4RdVj4k=";
-  };
+  }).overrideAttrs({
+    buildInputs ? [], ...
+  }: {
+    buildInputs = buildInputs ++ [ self.libsodium ];
+  });
 
   gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
     version = "3.0.0";


### PR DESCRIPTION
Same as here
https://github.com/lopsided98/nix-ros-overlay/pull/228

but for new gz-transport-vendor