### PR TITLE
[jazzy] zenoh-cpp-vendor WIP

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -281,4 +281,18 @@ in {
       })
     ];
   });
+
+  zenoh-cpp-vendor = (lib.patchAmentVendorGit (lib.patchAmentVendorGit rosSuper.zenoh-cpp-vendor {
+    url = "https://github.com/eclipse-zenoh/zenoh-cpp";
+    rev = "964b64dc8b935a43147287199e7bb12da7b141e6";
+    fetchgitArgs.hash = "sha256-9aAWcTJU3D5R2J9fasQ1aUYXWkcCk3FcmOT340Pc0ko=";
+  }) {
+    url = "https://github.com/eclipse-zenoh/zenoh-c.git";
+    rev = "57d5e4d31d9b38fef34d7bcad3d3e54869c4ce73";
+    fetchgitArgs.hash = "sha256-e8OtpyKp+AEgh6QWD/5aBtbmDV55ocx9DeLakYdikmI=";
+  }).overrideAttrs ({
+     ...
+  }: {
+  });
+
 }


### PR DESCRIPTION
I have tested the somewhat new middleware [rmw_zenoh](https://github.com/ros2/rmw_zenoh) in a local workspace. Now I try to get the corresponding nix packages running. 
When try to build them:
```bash
nix build .\#jazzy.zenoh-cpp-vendor --accept-flake-config
```
Colcon gets invoked, then colcon executes cargo and cargo cannot download stuff because it is sandboxed. According to the [nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#compiling-non-rust-packages-that-include-rust-code) we would have to set the `cargoDeps`. 
I saw that in #501 was also done some work to build rust nodes.