### PR TITLE
rosdistro sync, Fri Jan 10 13:46:51 2025

### DIFF
--- a/distros/humble/automatika-ros-sugar/default.nix
+++ b/distros/humble/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-automatika-ros-sugar";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/humble/automatika_ros_sugar/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "f02018acd4c1e3739b3ddccfe1d193708dbfc978a238606f65ba9af535b94854";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/humble/automatika_ros_sugar/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "06c55119381de2122dfa25122b349bbb678f37a248fc899ef1bbbb210ec8270e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/coal/default.nix
+++ b/distros/humble/coal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-humble-coal";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/coal-release/archive/release/humble/coal/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "13a73d77648b6493b98656b512ddce4ca655dcbce52edaa41d128ca3877c058e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake doxygen git python3Packages.lxml ];
+  propagatedBuildInputs = [ assimp boost eigen eigenpy octomap python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "An extension of the Flexible Collision Library.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -496,6 +496,8 @@ self: super: {
 
  cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
 
+ coal = self.callPackage ./coal {};
+
  cob-actions = self.callPackage ./cob-actions {};
 
  cob-msgs = self.callPackage ./cob-msgs {};
@@ -1604,6 +1606,8 @@ self: super: {
 
  mola-demos = self.callPackage ./mola-demos {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1622,6 +1626,8 @@ self: super: {
 
  mola-launcher = self.callPackage ./mola-launcher {};
 
+ mola-lidar-odometry = self.callPackage ./mola-lidar-odometry {};
+
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
 
  mola-msgs = self.callPackage ./mola-msgs {};
@@ -1629,6 +1635,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.4.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_imu_preintegration/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "98f21b3de9e9eac2f0fa392efb9182d8c8de853bdc6c8816c776c8c55aa434b5";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "6a54abbd1140c6f090a9eda13d54b6829b91ba850620f87fd305ba67f66e95df";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -1,22 +1,22 @@
 
-# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "0.4.1-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "852a01726c9d99c3548a66f797548a86ce0f4867245a0cd3b62088ebc8c7c825";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "018295d2e73de71b20250a602873af2d4ab2a179b162a8a5c9e1f3f42f01b6d5";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-state-estimation-simple mola-test-datasets rosbag2-storage-mcap ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-state-estimation-simple/default.nix
+++ b/distros/humble/mola-state-estimation-simple/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
+buildRosPackage {
+  pname = "ros-humble-mola-state-estimation-simple";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "45f18b1e3b6863e139b7600bb4cb43f41761d7170173b6a8b355b8dbd3bdf371";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "SE(3) pose and twist path data fusion estimator";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-state-estimation-smoother/default.nix
+++ b/distros/humble/mola-state-estimation-smoother/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
+buildRosPackage {
+  pname = "ros-humble-mola-state-estimation-smoother";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "3699732600b5c33e0758dab7a25ff2b2884e827afbca67d76cfffea231fa835c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost cmake gtsam ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "SE(3) pose and twist path data fusion estimator";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/humble/mola-state-estimation/default.nix
+++ b/distros/humble/mola-state-estimation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
+buildRosPackage {
+  pname = "ros-humble-mola-state-estimation";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "9dda0af0eddd6f0f08432efe1db5ba445c65d72afe2586b24adc63b2b7e1766d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ mola-imu-preintegration mola-state-estimation-simple mola-state-estimation-smoother ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Metapackage with all state estimation packages MOLA packages.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/qml-ros2-plugin/default.nix
+++ b/distros/humble/qml-ros2-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, image-transport, qt5, rclcpp, ros-babel-fish, ros-babel-fish-test-msgs, std-srvs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-qml-ros2-plugin";
-  version = "1.0.1-r1";
+  version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qml_ros2_plugin-release/archive/release/humble/qml_ros2_plugin/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6876de963f97807133507394f9fc61a79ef54d481ce1fa7ce6be3bcb84e0bf32";
+    url = "https://github.com/ros2-gbp/qml_ros2_plugin-release/archive/release/humble/qml_ros2_plugin/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "94ee6164c17163d97d718ffd8ec6c1a864987638728e5e8a07f53dd9e419c044";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/automatika-ros-sugar/default.nix
+++ b/distros/jazzy/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-automatika-ros-sugar";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/jazzy/automatika_ros_sugar/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "654aa620d0b96164dc67f56e246a6acb6cd3a5b90b69dd711919ff27e58878a2";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/jazzy/automatika_ros_sugar/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "7c4777d543c982a06d1e20ae0acc554966d0a142d33a760fd958fee86c4a703b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/coal/default.nix
+++ b/distros/jazzy/coal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-jazzy-coal";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/coal-release/archive/release/jazzy/coal/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "1860c4440198270a6c30fe9dcd1bc67676d21d546be0f4bf88f8377dc5fbd0f5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake doxygen git python3Packages.lxml ];
+  propagatedBuildInputs = [ assimp boost eigen eigenpy octomap python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "An extension of the Flexible Collision Library.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -350,6 +350,8 @@ self: super: {
 
  cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
 
+ coal = self.callPackage ./coal {};
+
  color-names = self.callPackage ./color-names {};
 
  color-util = self.callPackage ./color-util {};
@@ -1264,6 +1266,8 @@ self: super: {
 
  mola-demos = self.callPackage ./mola-demos {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1282,6 +1286,8 @@ self: super: {
 
  mola-launcher = self.callPackage ./mola-launcher {};
 
+ mola-lidar-odometry = self.callPackage ./mola-lidar-odometry {};
+
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
 
  mola-msgs = self.callPackage ./mola-msgs {};
@@ -1289,6 +1295,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_imu_preintegration/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2c13bd07ffe2192aafa14cb254eef876c4c3fde972af457c62a63549e0afc3d6";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "35b468c063b82e20bfa6bb033256a02003542a86bf7346e5b688eb1e45d4c6dc";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -1,22 +1,22 @@
 
-# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.4.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "163921dbb83591119a08cbb3d890ccbf31eacab110b81febfa12100a568c10b9";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "df741360130af24201d92f44006d03d1304e6d2331ed181f38dac336fc45bdd0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-state-estimation-simple mola-test-datasets rosbag2-storage-mcap ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-state-estimation-simple/default.nix
+++ b/distros/jazzy/mola-state-estimation-simple/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-state-estimation-simple";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "5784452333358afdc619a8e124261235bce33196aade22937a900061c86f0b55";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "SE(3) pose and twist path data fusion estimator";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/mola-state-estimation-smoother/default.nix
+++ b/distros/jazzy/mola-state-estimation-smoother/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-state-estimation-smoother";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "5495794b8c21549bfad7f773e2a348919438244e6e6ded717c392c5a1b14b79b";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost cmake gtsam ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "SE(3) pose and twist path data fusion estimator";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/jazzy/mola-state-estimation/default.nix
+++ b/distros/jazzy/mola-state-estimation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-state-estimation";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "be57c8214d6b17c03ade909c0de1d33f92ce6c5f935a01000f126b7657ed376e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ mola-imu-preintegration mola-state-estimation-simple mola-state-estimation-smoother ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Metapackage with all state estimation packages MOLA packages.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.4.7-r1";
+  version = "2.4.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.4.7-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.4.8-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "bed4c50815c4c6f4e397e03c822ac902e6e545453737c2fb362f881eafb2058b";
+    sha256 = "4ed556f846a158c2523de278efb6567007dadd665a7fcac96b8fe3e139787801";
   };
 
   buildType = "catkin";

--- a/distros/rolling/automatika-ros-sugar/default.nix
+++ b/distros/rolling/automatika-ros-sugar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, python3Packages, rclcpp, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-automatika-ros-sugar";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/rolling/automatika_ros_sugar/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "37ea3e70f3eb6760c8e5c7f48a18e8d7b7dc43cf29e0f84e90bb4df352a29396";
+    url = "https://github.com/ros2-gbp/automatika_ros_sugar-release/archive/release/rolling/automatika_ros_sugar/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "55090d4bfc8635172a863b819592b8702819a862222aa0fc822b88bc7ffe29d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/coal/default.nix
+++ b/distros/rolling/coal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
+buildRosPackage {
+  pname = "ros-rolling-coal";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/coal-release/archive/release/rolling/coal/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "11ead30545e39a151fe5690dd47aef36eb62bdce510228a994e704ae6242655b";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake doxygen git python3Packages.lxml ];
+  propagatedBuildInputs = [ assimp boost eigen eigenpy octomap python3 python3Packages.numpy ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "An extension of the Flexible Collision Library.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -324,6 +324,8 @@ self: super: {
 
  cmake-generate-parameter-module-example = self.callPackage ./cmake-generate-parameter-module-example {};
 
+ coal = self.callPackage ./coal {};
+
  color-names = self.callPackage ./color-names {};
 
  color-util = self.callPackage ./color-util {};
@@ -1082,6 +1084,8 @@ self: super: {
 
  mola-demos = self.callPackage ./mola-demos {};
 
+ mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
+
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
 
  mola-input-kitti360-dataset = self.callPackage ./mola-input-kitti360-dataset {};
@@ -1100,6 +1104,8 @@ self: super: {
 
  mola-launcher = self.callPackage ./mola-launcher {};
 
+ mola-lidar-odometry = self.callPackage ./mola-lidar-odometry {};
+
  mola-metric-maps = self.callPackage ./mola-metric-maps {};
 
  mola-msgs = self.callPackage ./mola-msgs {};
@@ -1107,6 +1113,12 @@ self: super: {
  mola-pose-list = self.callPackage ./mola-pose-list {};
 
  mola-relocalization = self.callPackage ./mola-relocalization {};
+
+ mola-state-estimation = self.callPackage ./mola-state-estimation {};
+
+ mola-state-estimation-simple = self.callPackage ./mola-state-estimation-simple {};
+
+ mola-state-estimation-smoother = self.callPackage ./mola-state-estimation-smoother {};
 
  mola-test-datasets = self.callPackage ./mola-test-datasets {};
 

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.4.1-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_imu_preintegration/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "c895a80d32c68a8f90577ac46bb6476562077d59f5ef8dc0ba688d713dc9f8d8";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "0fc57b89357a8ca11a07b2a35e16899afc58bbbfa04fa9e715966ed64175eecc";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -1,22 +1,22 @@
 
-# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-navstate-fuse, mola-pose-list, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.4.1-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "60409c8ffeaf555537b061c09dd7cd9075efc3d67613d785bdd25e9cc68e1f9e";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "67108967d07e103aa29386bf28958ede4c96c06316e692f8a8c66be199e8d116";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-navstate-fuse mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-state-estimation-simple mola-test-datasets rosbag2-storage-mcap ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-state-estimation-simple/default.nix
+++ b/distros/rolling/mola-state-estimation-simple/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
+buildRosPackage {
+  pname = "ros-rolling-mola-state-estimation-simple";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "bdfb4133acc9dfc127a2b4e23ad2ce44a17fe5b1afe7962589422e5ab772fd09";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "SE(3) pose and twist path data fusion estimator";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-state-estimation-smoother/default.nix
+++ b/distros/rolling/mola-state-estimation-smoother/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
+buildRosPackage {
+  pname = "ros-rolling-mola-state-estimation-smoother";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "fc31f0ee1d3225e3e60071b38c369083ef62d1f2e79ef34fe13fe343be8e9386";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost cmake gtsam ];
+  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "SE(3) pose and twist path data fusion estimator";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/mola-state-estimation/default.nix
+++ b/distros/rolling/mola-state-estimation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
+buildRosPackage {
+  pname = "ros-rolling-mola-state-estimation";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "332253a816cb16d2173120ddf828a5ab2f2eb14962a4fc252cae5543659b1837";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ mola-imu-preintegration mola-state-estimation-simple mola-state-estimation-smoother ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Metapackage with all state estimation packages MOLA packages.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/nav2-minimal-tb3-sim/default.nix
+++ b/distros/rolling/nav2-minimal-tb3-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-interfaces, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-rolling-nav2-minimal-tb3-sim";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release/archive/release/rolling/nav2_minimal_tb3_sim/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "5952a0f5763f6e78177c4c049f100b14d9f7df194b1a586a0692e640a6f35239";
+    url = "https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release/archive/release/rolling/nav2_minimal_tb3_sim/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "debbcb9be4ac18afb22c85c400a1bf7a6d1ec0c1ed97fc73beb8db52f040383f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nav2-minimal-tb4-description/default.nix
+++ b/distros/rolling/nav2-minimal-tb4-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, joint-state-publisher, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-rolling-nav2-minimal-tb4-description";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release/archive/release/rolling/nav2_minimal_tb4_description/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "19852f698391f72468630da9c7d097b758dc617188c58c453defc62719b0a107";
+    url = "https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release/archive/release/rolling/nav2_minimal_tb4_description/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "f205ef4d43830411455f4206b0b66eb67a6f80c72f98d1dfbd7905d00ff009c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nav2-minimal-tb4-sim/default.nix
+++ b/distros/rolling/nav2-minimal-tb4-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav2-minimal-tb4-description, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-interfaces, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-rolling-nav2-minimal-tb4-sim";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release/archive/release/rolling/nav2_minimal_tb4_sim/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c7669fd936bb8ea379b8e5f24ce153270a44d3cfd4b8c0879d1b0a31225ba106";
+    url = "https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release/archive/release/rolling/nav2_minimal_tb4_sim/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "880809f9ec23b9fe399ae71fa8d9df5dd438f69b72c428fd404363086377e0e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-bag-plugins/default.nix
+++ b/distros/rolling/rqt-bag-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy, rosbag2, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag-plugins";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "cab30d3234c2f61767cc1ba6e915b490f9bc168943598802e3097a18bc973132";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "c0998491171245eb410dd2fe26e4c15dcc075593dbd353b6530c4616c6c3e731";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs python3Packages.pillow python3Packages.pycairo rclpy rosbag2 rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ ament-index-python geometry-msgs python3Packages.pillow python3Packages.pycairo rclpy rosbag2 rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
 
   meta = {
     description = "rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.";

--- a/distros/rolling/rqt-bag/default.nix
+++ b/distros/rolling/rqt-bag/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, python-qt-binding, python3Packages, rclpy, rosbag2-py, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, builtin-interfaces, python-qt-binding, python3Packages, rclpy, rosbag2-py, rosidl-runtime-py, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-bag";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "902669d15ff990e964a22864048f69773938d3514cf91f1d12de2b4d70ec3020";
+    url = "https://github.com/ros2-gbp/rqt_bag-release/archive/release/rolling/rqt_bag/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "3f2b78ef80b3c2c779b8b885a494c2e0f767d44412f480652bfd704ad9ca24d4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright python3Packages.pytest ];
-  propagatedBuildInputs = [ python-qt-binding rclpy rosbag2-py rqt-gui rqt-gui-py ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ ament-index-python builtin-interfaces python-qt-binding python3Packages.pyyaml rclpy rosbag2-py rosidl-runtime-py rqt-gui rqt-gui-py ];
 
   meta = {
     description = "rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.";

--- a/distros/rolling/rqt-console/default.nix
+++ b/distros/rolling/rqt-console/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, python3Packages, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-console";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/rolling/rqt_console/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "df0305c69680cd016164f1b3ef898882c6ef08cbb76a4fb95628a7a1fdf1e6b3";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/rolling/rqt_console/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "74f76aad7d0cbe42d099b916c67b8ecf556ade914aa09d3cc2d03122874519a3";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding rcl-interfaces rclpy rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {

--- a/distros/rolling/rqt-shell/default.nix
+++ b/distros/rolling/rqt-shell/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-shell";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/rolling/rqt_shell/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "81b7a1e15a009104ec8525c454fce9887fad3e670b61d974d89601e2c15122d8";
+    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/rolling/rqt_shell/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "ab2622abda86edf36d8bb80c594276a35b581226360a43c1f1d3f675285813be";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg qt-gui qt-gui-py-common rqt-gui rqt-gui-py ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ python-qt-binding qt-gui qt-gui-py-common rqt-gui rqt-gui-py ];
 
   meta = {
     description = "rqt_shell is a Python GUI plugin providing an interactive shell.";

--- a/distros/rolling/tensorrt-cmake-module/default.nix
+++ b/distros/rolling/tensorrt-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-tensorrt-cmake-module";
-  version = "0.0.3-r3";
+  version = "0.0.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/rolling/tensorrt_cmake_module/0.0.3-3.tar.gz";
-    name = "0.0.3-3.tar.gz";
-    sha256 = "7ae52d858070d972b00656e5eeb263928c35f85447a87e5cb592290530330d65";
+    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/rolling/tensorrt_cmake_module/0.0.4-2.tar.gz";
+    name = "0.0.4-2.tar.gz";
+    sha256 = "85fdf9bf8881e8127a2dac932def3fdc00b085b516dc186d1ca5abbfc77acbb5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/xacro/default.nix
+++ b/distros/rolling/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-xacro";
-  version = "2.0.11-r1";
+  version = "2.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/rolling/xacro/2.0.11-1.tar.gz";
-    name = "2.0.11-1.tar.gz";
-    sha256 = "735c549337cc25a137f0a3634575b796fd8bb7dd9178cf6c9104b683845857f9";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/rolling/xacro/2.0.12-1.tar.gz";
+    name = "2.0.12-1.tar.gz";
+    sha256 = "2af6d5c8e0b645b62dbf7af0ea47676dcd70adf656bf9c9b6311b35bb2b8be81";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 31f07eb092fd7f9ee56f03108aeb0b89e5a89b91.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *automatika-ros-sugar 0.2.4-r1 --> 0.2.5-r1*
* *coal 3.0.0-r1*
* *mola-imu-preintegration 1.4.1-r1 --> 1.6.0-r1*
* *mola-lidar-odometry 0.4.1-r1 --> 0.5.1-r1*
* *mola-state-estimation 1.6.0-r1*
* *mola-state-estimation-simple 1.6.0-r1*
* *mola-state-estimation-smoother 1.6.0-r1*
* *qml-ros2-plugin 1.0.1-r1 --> 1.0.1-r2*

Jazzy Changes:
--------------
* *automatika-ros-sugar 0.2.4-r1 --> 0.2.5-r1*
* *coal 3.0.0-r1*
* *mola-imu-preintegration 1.4.0-r1 --> 1.6.0-r1*
* *mola-lidar-odometry 0.4.0-r1 --> 0.5.1-r1*
* *mola-state-estimation 1.6.0-r1*
* *mola-state-estimation-simple 1.6.0-r1*
* *mola-state-estimation-smoother 1.6.0-r1*

Noetic Changes:
---------------
* *image-transport-codecs 2.4.7-r1 --> 2.4.8-r1*

Rolling Changes:
----------------
* *automatika-ros-sugar 0.2.4-r1 --> 0.2.5-r1*
* *coal 3.0.0-r1*
* *mola-imu-preintegration 1.4.1-r1 --> 1.6.0-r1*
* *mola-lidar-odometry 0.4.1-r1 --> 0.5.1-r1*
* *mola-state-estimation 1.6.0-r1*
* *mola-state-estimation-simple 1.6.0-r1*
* *mola-state-estimation-smoother 1.6.0-r1*
* *nav2-minimal-tb3-sim 1.0.1-r1 --> 1.0.2-r1*
* *nav2-minimal-tb4-description 1.0.1-r1 --> 1.0.2-r1*
* *nav2-minimal-tb4-sim 1.0.1-r1 --> 1.0.2-r1*
* *rqt-bag 2.0.1-r1 --> 2.0.2-r1*
* *rqt-bag-plugins 2.0.1-r1 --> 2.0.2-r1*
* *rqt-console 2.3.0-r1 --> 2.3.1-r1*
* *rqt-shell 1.3.0-r1 --> 1.3.1-r1*
* *tensorrt-cmake-module 0.0.3-r3 --> 0.0.4-r2*
* *xacro 2.0.11-r1 --> 2.0.12-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-antlr4
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-expiringdict
 * [ ] python3-flake8-blind-except
 * [ ] python3-flake8-class-newline
 * [ ] python3-flake8-deprecated
 * [ ] python3-icecream
 * [ ] python3-pexpect
 * [ ] python3-pre-commit
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rich
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typing-extensions
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

