### PR TITLE
fix: ros2 build on darwin

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -144,7 +144,7 @@ in {
       self.qt5.qtgraphicaleffects
       self.pkg-config
     ];
-    qtWrapperArgs = qtWrapperArgs ++ [
+    qtWrapperArgs = qtWrapperArgs ++ lib.optionals self.stdenv.isLinux [
       # Gazebo is currently broken on Wayland
       # https://gazebosim.org/docs/ionic/troubleshooting/#wayland-issues
       "--set-default QT_QPA_PLATFORM xcb"

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -144,7 +144,7 @@ in {
       self.qt5.qtgraphicaleffects
       self.pkg-config
     ];
-    qtWrapperArgs = qtWrapperArgs ++ [
+    qtWrapperArgs = qtWrapperArgs ++ lib.optionals self.stdenv.isLinux [
       # Gazebo is currently broken on Wayland
       # https://gazebosim.org/docs/ionic/troubleshooting/#wayland-issues
       "--set-default QT_QPA_PLATFORM xcb"


### PR DESCRIPTION
Newer distributions include the `lttng` dependency, which is not available on macOS and Windows platforms. Removing these dependencies automatically disables tracking. Also fixes rviz2 build.

However, ros2 jazzy is still not fully functional on macOS with this commit. Further investigation is required. 