### PR TITLE
Build gtsam against Eigen from nixpkgs

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -70,6 +70,14 @@ let
       setupHook = ./gazebo-ros-setup-hook.sh;
     });
 
+    gtsam = rosSuper.gtsam.overrideAttrs ({
+      cmakeFlags ? [], ...
+    }: {
+      # Don't use vendored version of Eigen, which can collide with
+      # Eigen version in dependent packages.
+      cmakeFlags = cmakeFlags ++ [ "-DGTSAM_USE_SYSTEM_EIGEN=ON" ];
+    });
+
     joint-state-publisher-gui = rosSuper.joint-state-publisher-gui.overrideAttrs ({
       nativeBuildInputs ? [], postFixup ? "", ...
     }: {


### PR DESCRIPTION
Without this change, gtsam is built against a vendored copy, which is different version (3.3) than what's in nixpkgs (3.4). Dependent packages using eigen then fail with the following error:

    /nix/store/lic85q2svs3ymv0zkgl727af9khm1x4l-ros-jazzy-gtsam-4.2.0-r4/include/gtsam/base/Vector.h:76:30: error: static assertion failed: Error: GTSAM was built against a different version of Eigen
       76 |     GTSAM_EIGEN_VERSION_MAJOR==EIGEN_MAJOR_VERSION,
          |                              ^
    /nix/store/lic85q2svs3ymv0zkgl727af9khm1x4l-ros-jazzy-gtsam-4.2.0-r4/include/gtsam/base/Vector.h:76:30: note: the comparison reduces to '(3 == 4)'

This is the case for mola_state_estimation (which was recently added to ROS) as well as some unofficial ROS packages I worked with.