### PR TITLE
rosdistro sync, Fri Jan 17 13:25:13 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "a1f19ccf59dbaafc2967666908fa522143d4be874756e789ba9527a5e84ad864";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "a1b96c780560502fc95afecfcf5064cd5b45e3a4c9463df10f4ff699ea6869a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "04a7837b68a178c0356b0ec9fd41e996dc28a33e6eb38e0aecda7fdcb09ca152";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "2b70847e6ef3268f7449f2eb45a8a59092df0eb075f146ec9405b3da24054b81";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "36c3d525c9877040bd25c5a9389e0bbe014b2ac555ef31228d11539eb3656ca8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "2ecb50c4b2ba6e163ee3fa4c138899361f18ebece0e1101e5c675619e9a83ad0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "44c455604cecb4c473f2e319abab592227528437e24062e049ec9d375e94e000";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6fb2862a197ac95169204b461605586c862f244fc0bfef69993d930545c3bce8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "6d4886927dd0a520e9ec528c50daf648ea193eda46c2f31b5635a04e858c32c9";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0adfe45870e64a8b8a31a96f30a6bb000db31eb95b806b81fa54c350722cd517";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0e9a6efc3adb3436495a3724ad5ab26cba422db852b349f98b9c4c8776b28693";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c9f2230e9f20fc9f21150cacdb0ea6b3b3471aa9266cacf6310a247d3de09011";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0dcd6ab86b69fc7116eff59c095ca0805c10a6739e272ce300a95c89d95bec11";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "663af6bf57d2c9a88cdbb934ba2116a3ad7b7030c11fca72ca4ab99f3c7b6587";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "bccc7edf6f8513c9b3c7ecb86305dcf0993b1b81eab1ec8a09cb54b1aadeca42";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2f09ad8efbad1b2c1611766ca8349dbb76101b69a36492d10ec8691773a5132b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1f05495e814499bb82dbec6589daf05acbed116aab4312a251d98cc89072d5f3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "01f51cff93d0c62eca1388f75e27952d89e07bc014a55915cf4d17607964710c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b1af24d52c784d28bca2abe18e885b1e176c827b535dc273d57bdd3299279263";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "e13476241bd928e2104a86bb6934043c92139ed9072226b3aa8ab4a02a679585";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "badf41fadc197d605d76143ed3ac05e52a45a8a4bf8e2c4b9859c5519de0d248";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d059b890e12fe6c9e72ec2100cb89e5a2fcc30dbca04edcce05a3f100133fb48";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f68a2d18de0b7e635bc26bc4ca8c4422ed5a7ac76b9e007652ecc229ff5aa02b";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6f005d7a20fe0c614d8edef883b608dd5b007485ab2d4b21d49f5b406dc7ef46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0036be56906f8563d43a0d8aa897253f5ca13a1814fae55e5e7e4299aaf39481";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "73279619c40b6ee80a6e73895323e9c645d60a1ef93afc5f90d2a857af23438b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "393427500e5140db5c606b8f2a6cb8d2021c6d2360a8796f5e8dc2c26a8d8104";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a750e1c0bb000bdf6dde8334c67add4e34b9c73827f78b76493d068b38df4857";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/cmake-generate-parameter-module-example/default.nix
+++ b/distros/humble/cmake-generate-parameter-module-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
 buildRosPackage {
   pname = "ros-humble-cmake-generate-parameter-module-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/cmake_generate_parameter_module_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "19b059f3a7b0df4d2b1932796956c949c7445f778c3b0b9ba06a8f6060934f5a";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/cmake_generate_parameter_module_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "743ca663ec845b8c9093a16a80df9fafc5cee53ace64e2de0b36f0a87bbba951";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/control-toolbox/default.nix
+++ b/distros/humble/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-control-toolbox";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "1b3f889bea83401e9e41c13a49e375a0d60bed9c6f0ab6730da7425c9cac6321";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "e2a40158c963a4ea985b859090af717fc4ddf6ecbc10860eb5db8caa14bbd234";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "158c64922a43a9dcacb0f962cc8214cdea566a1f98b1e36fe351305504ca1b4a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "5c77087ac37ac607645b54298ab61a678fda9a255b80d6065ff1aff02ec7b891";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "e5e1488e6e365891d8a420667823b3d8d7b9386a2922076c568232c1c5166312";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "0b9ae9919d782678293c0eeb6e3446de87a8691849dc426c4ef7aeb042e3e11a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "1ead40b7c0f0219e8fc740566d6c3cb5307d03758786a7304a7dece1cc33cc49";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "e5c5dd7b71ad9f60b27053afb033edb482ff5b1bfa8df34eee2d4d836bd2e29f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "3917b0eaab23bb8697ccbbcf2637c083482f4ee061cc323d82577f5879c7e52b";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "fdda5dc878e154c56684499529ebf4a5c1de86d6d4a215e9be29ae95a7d24117";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "ac1a299d7a8a6f11a5018b68db3640d6d01765aa0647f722c6c588fe9986f74a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "159bf864b6ab692801818b4b0c582191e8686ea580c630043cccb7deea1853ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "3fa7bcc35a6a1af7ff08e118983e932007e96de26de1b291547d33b67dc4661c";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "7deec7e0c0209339bb582252592d42ff87bdbe6ee2fc82d986ce825368944cb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.10.4-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.10.4-1.tar.gz";
-    name = "2.10.4-1.tar.gz";
-    sha256 = "8b364b7a578a298cca74b4993816bb01856d12d21693e8e5fca1e2a3517ad38f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "776aab87f82e45266b51fac34a43b62a78aafcf9904f85633bb39068d0e46f7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "885b121bec5f7a79c7f3ffbd2382e48f202eb3b711c567bc9e1ebbe1126982db";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "1639002ffa099f814472cb0685130d9c8492894b03477e24734885502210bece";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "3ad16e18a1746fa39e5b0704292b0e79b8aea1e0ac5d7984938dc3c25032639d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "cecde3935a864772925b7eca91ca99c964cf6af57bd67a2c01b8985e9375ac58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/examples-tf2-py/default.nix
+++ b/distros/humble/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, python3Packages, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-examples-tf2-py";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "e29ae9bf64adc4d7c8ba2be74d3f1b65e924cd15c2fb351dcb609b015370d051";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/examples_tf2_py/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "734326813cd0409774766ec29681bb9044e858b3ba193987e240908fb57f1f29";
   };
 
   buildType = "ament_python";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "8636ed36785bab6baa53f2d3aa90bc1c9d459e320cbd6fd108b1a2e0f101d0ae";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "6868e101e910019883118d950cb80fe93701297adb5d64d87f3eb6127b521f73";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "10ec3998f09c02b314e5c6816eac523d33a39588f7997f34cebf5e32a977e955";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "6fe42a70446755fe204446aec9815097aae89c5bd5e4cc85572dc96a8245d50f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-example-external/default.nix
+++ b/distros/humble/generate-parameter-library-example-external/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library-example, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-humble-generate-parameter-library-example-external";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example_external/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "4a7a7dbbcf71f19a16781503de1ebc1e442bc92dd1d64f3efe89f180a08a6404";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-core generate-parameter-library-example rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-core ];
+
+  meta = {
+    description = "Example usage of a parameter header generated in another package.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/generate-parameter-library-example/default.nix
+++ b/distros/humble/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "90bb73931ee209389927292230da430a762942f590f4c248168a63d39d3a2ef5";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "74263dde0e6fc2398e5fea646920f0f97ea9ee1baf24cc893b2cfc7024e11c53";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-library-py/default.nix
+++ b/distros/humble/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library-py";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "24041124ce6afcc32f07849063bd7d6cc9a45f99210c3adedcaa3284bcb91d63";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library_py/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7c32da7dc5c40c2187e3ea32a4f2e33740702c5b51fa6a214a30ac103fec579f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generate-parameter-library/default.nix
+++ b/distros/humble/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-library";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "c2b1a6967752bbe8d4e00fb7f157400ff289d23b4d49405e7b5c948c34611976";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_library/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0a8735530fc4f6a862189cb2000f94988f6806beb47e9de484e80667e869b1a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generate-parameter-module-example/default.nix
+++ b/distros/humble/generate-parameter-module-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-generate-parameter-module-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "c76b9cbf150fe78b4c0f038d2b168f13ae88be0690edbb3bf0b2c04f38db5827";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/generate_parameter_module_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "29618798ac1d9f76faabc12765ca6ea9496c446e499f476212b0cfadbe61bb43";
   };
 
   buildType = "ament_python";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1064,6 +1064,8 @@ self: super: {
 
  generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
 
+ generate-parameter-library-example-external = self.callPackage ./generate-parameter-library-example-external {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
 
  generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
@@ -2257,6 +2259,8 @@ self: super: {
  py-trees-ros = self.callPackage ./py-trees-ros {};
 
  py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
+
+ py-trees-ros-viewer = self.callPackage ./py-trees-ros-viewer {};
 
  pybind11-json-vendor = self.callPackage ./pybind11-json-vendor {};
 

--- a/distros/humble/geometry2/default.nix
+++ b/distros/humble/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-humble-geometry2";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "ead376c4e82b460000d202a8a43d2ec9bf9a45581d3b5c8292f1f94a5d93967e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/geometry2/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "12f92938791a819a1edf2d29fbfc1fd6f9597203177fc539d1cb77f59ef6c268";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "a3f918c952aec5ed0b78a47f399522c5d6696616b6816203ecfa2458d3e4253d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "014e9906a2c62427c403f3e81648f74cb7b7f56d67e889311df34683997112a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "1e549eba5548ee5b82c69e5924e9728ace65874c95e6cd22cc39662d3b9242b3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "84a2cf202496af4713e4fe3c5af652e07f86586e918203790794dfd974416a20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "a4003edb42e5efd3faa5e04a89ebd435571ebc948c66be5dd46c2a6b19a4c0bd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "83d8657dbc6722b30d51584c860222664d98156b18c36221cb3550e5e79530a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "a8dfda2935b2177d6a123860e3898d4adca000143b0495a7565c67ab6af09f8e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "fb13e7ab0740abca517727e8b30bcdb36c85d8ff3ea96590fff7e123fd18f290";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "b08aeea9df5b3d5d89b4227b81cebcd11496064f4114a856b9c8ece63c17e035";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "8660e06755520508befeffff55bd6fb8edc165396cd5e9e66a2179b92b0b496b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "6a54abbd1140c6f090a9eda13d54b6829b91ba850620f87fd305ba67f66e95df";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "6efb6fa59c906089d6c58777460fa4bba121f00ec933d92c621a310c18dabb31";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "0.5.1-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "018295d2e73de71b20250a602873af2d4ab2a179b162a8a5c9e1f3f42f01b6d5";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "ddda33fb416861aef1ce418cf918f3fb89ef17d8afc21eed4538423184502eaa";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-state-estimation-simple mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-state-estimation-simple/default.nix
+++ b/distros/humble/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-simple";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "45f18b1e3b6863e139b7600bb4cb43f41761d7170173b6a8b355b8dbd3bdf371";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "96fc3f1deaeec519a605c19eaa7a995991637d6495ed3f2da442cb21209392b7";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-smoother/default.nix
+++ b/distros/humble/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-smoother";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "3699732600b5c33e0758dab7a25ff2b2884e827afbca67d76cfffea231fa835c";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "5003fe830a14ebaed7f89a5db4e9303dc8b8ba19e9d22c1076d1e25682d5e1fd";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation/default.nix
+++ b/distros/humble/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "9dda0af0eddd6f0f08432efe1db5ba445c65d72afe2586b24adc63b2b7e1766d";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "5f4ec4b7477fd62552694ab5751585781219af92a83148436737a375b708495b";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Metapackage with all state estimation packages MOLA packages.";
+    description = "Metapackage with all MOLA state estimation packages.";
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/humble/mola-test-datasets/default.nix
+++ b/distros/humble/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-test-datasets";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/humble/mola_test_datasets/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "3a70674ad0d2cac97bfee8df35383e2e5eae9b1859859099c480e91024428e1a";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/humble/mola_test_datasets/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "10ccc02182a092d2ff7a1797f0d4570acf62dc42171896ecd3c1f6be3588479b";
   };
 
   buildType = "ament_cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = "Small SLAM dataset extracts used for demos or unit tests in the rest of MOLA packages";
-    license = with lib.licenses; [ bsdOriginal bsdOriginal "CC-BY-NC-SA-3.0" "CC-BY-3.0" "CC-BY-3.0" ];
+    license = with lib.licenses; [ bsdOriginal bsdOriginal "CC-BY-NC-SA-3.0" "CC-BY-3.0" "CC-BY-3.0" cc-by-nc-sa-40 ];
   };
 }

--- a/distros/humble/parameter-traits/default.nix
+++ b/distros/humble/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-humble-parameter-traits";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "3a59d85b8afaeef45f4349eaaf0dbcc247f375fac615fa150141ad11eb8b192e";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/humble/parameter_traits/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "db4a76d3dab1a6b2729ee9229bc60ec8eae3f1841a2cb44e481211bf6fd09bdf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "c6f38fb36ef745df0c27e8c52ca8a6a84d17e5e82c5624ebebf794e484e9142f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "5520fe0c6b74007e00b53cbf14253d1d6a3e1619a590e1da18bf5ea3ac499ca2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "aaf574419a58a0572c39d6ed3787d51c639c1dbee09ddd91e5876b9d8e63ebb9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "26602d1b23914687e8f9cfaa58d1f04ad4aa71bbab6415284ff66523acdce207";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "5d893f40169a5c13ff555da7023af29f96f45dd16682b82c84472c8316ebc9f0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "cf2f6dff9cde4d8336cb42c1db732d00200a09bb45f94daeea68c8f5a378d7e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/py-trees-js/default.nix
+++ b/distros/humble/py-trees-js/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-humble-py-trees-js";
-  version = "0.6.4-r1";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/humble/py_trees_js/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "1be019e96392b50d374dd207e660b3a1e7fac01b3f8ffeb0d7ca1f192b5a2442";
+    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/humble/py_trees_js/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "01d434af4b96a23e79243215f166b111b85cbb17eef2f320884007576edd425d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/py-trees-ros-interfaces/default.nix
+++ b/distros/humble/py-trees-ros-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-py-trees-ros-interfaces";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/humble/py_trees_ros_interfaces/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "db94fc8dfe11f0b3e7278ff905c5aad38c4c3e27cd291d2facbabd2f9f743667";
+    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/humble/py_trees_ros_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "2261e1c486787720ee9c1ccce8670eb83197d24ae26bcaee17d3330903d6deac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/py-trees-ros-viewer/default.nix
+++ b/distros/humble/py-trees-ros-viewer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, py-trees-js, py-trees-ros-interfaces, python3Packages, qt5, rclpy, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-humble-py-trees-ros-viewer";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_ros_viewer-release/archive/release/humble/py_trees_ros_viewer/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "be2ba95a1177c618a00825b73bb38d44ed03665fae16c8ff7fdcadf8b34b01b7";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools qt5.qttools.dev ];
+  propagatedBuildInputs = [ py-trees-js py-trees-ros-interfaces python3Packages.pyqt5 python3Packages.pyqtwebengine rclpy unique-identifier-msgs ];
+
+  meta = {
+    description = "A Qt-JS application for visualisation of executing/log-replayed behaviour trees in a ROS2 ecosystem.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/py-trees-ros/default.nix
+++ b/distros/humble/py-trees-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros-py, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, std-srvs, tf2-ros-py, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-py-trees-ros";
-  version = "2.2.2-r3";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/humble/py_trees_ros/2.2.2-3.tar.gz";
-    name = "2.2.2-3.tar.gz";
-    sha256 = "7745e47ee315848b56ad107e156360afde34a4ffd61bb7a84b5e0ba0af6875da";
+    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/humble/py_trees_ros/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2f76be433f39fe8a20b307b40605e48bab643d81e847fbad087f49d218783eca";
   };
 
   buildType = "ament_python";
   buildInputs = [ python3Packages.setuptools ];
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs tf2-ros-py unique-identifier-msgs ];
+  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs std-srvs tf2-ros-py unique-identifier-msgs ];
 
   meta = {
     description = "ROS2 extensions and behaviours for py_trees.";

--- a/distros/humble/py-trees/default.nix
+++ b/distros/humble/py-trees/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-py-trees";
-  version = "2.2.3-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/humble/py_trees/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "a88f59a69b53c29904f4f41250cf56eec29fdfc92d712cdec1bf41799671ad5f";
+    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/humble/py_trees/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3049da1100f35a2ba411386964405280659dc277d45f9a79da6827f7387f4832";
   };
 
   buildType = "ament_python";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "d53d159e8984102a934f61b02acef5d7ea840ed87732658ea1a0382027fa6ed6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "a1efc91ed4261b29c1b21d7fb556a063207d4dda6554a6b56e8e81541750e852";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-babel-fish-test-msgs/default.nix
+++ b/distros/humble/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-babel-fish-test-msgs";
-  version = "0.9.6-r2";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/humble/ros_babel_fish_test_msgs/0.9.6-2.tar.gz";
-    name = "0.9.6-2.tar.gz";
-    sha256 = "3e5ee3cc56d8e6e83cdec3c54ebe824ae941bbb6a630290afba92ef7439f2f88";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/humble/ros_babel_fish_test_msgs/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "20f7506ff961795f541f9c93686a2c2e4919663082f5af352d06a2fb0dfaad79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros-babel-fish/default.nix
+++ b/distros/humble/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, example-interfaces, geometry-msgs, rclcpp, rclcpp-action, rcpputils, ros-babel-fish-test-msgs, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros-babel-fish";
-  version = "0.9.6-r2";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/humble/ros_babel_fish/0.9.6-2.tar.gz";
-    name = "0.9.6-2.tar.gz";
-    sha256 = "59c4b19988d13c337fe9426401607d52422dc3dbc3216aa7fc270b7194ff8d07";
+    url = "https://github.com/ros2-gbp/ros_babel_fish-release/archive/release/humble/ros_babel_fish/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "898c6849cd09f23682a25db29b2934cba9348ba747de6bc673e8ba015635d40f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "819ffc4dd8159b9cde749c0f852a9feeda2ce9bb260ef818a3f60f8cd41e55b9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "ba59bc6e60349043e53707f814397411f9bf8ccab29c5e5d5fb3d15029669faf";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "5e92e51332c48c067c1199703469432243b19e28cef0b73878842abedbf19f4a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "9249f90ab41c0a781c382c482c5ca75aba76a80ff1c489db9c3754b2a09a5d62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "86934041cc1656e51efbfec7be772a4897a7fea81c46c128902c21fe6d54f0c8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "333c356b4e3d5f42d9bf6b7185fbc2499cfd64ff052d76f59fda5bc3aadc343b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rviz-assimp-vendor/default.nix
+++ b/distros/humble/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-humble-rviz-assimp-vendor";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "da632ee3faca1cf4000eb93fde0b037e4deb86bbf177659d11fcca892b47d0f9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_assimp_vendor/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "be172470c7a9cc0d2157693f684d491374848995eda70431b021af7bf2c44cac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-common/default.nix
+++ b/distros/humble/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, rcpputils, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-common";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "fe68425019f1e59f642e86e7f458c80016dbf6aad3d8b8d193812518bbb0bd3d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_common/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "3d88fe3f79971805166661eeb98946adbcb10611e2edb276c6fc0c3842db0e7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-default-plugins/default.nix
+++ b/distros/humble/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, ignition-math6-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz-default-plugins";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "15fc74f6f961c800d108c746f22f9cb443e30ac138f61b21135b4b37dda03646";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_default_plugins/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "afb5faec4f2684d3dc914e31e453e6296e6bff63156233844172914d73f6679e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-ogre-vendor/default.nix
+++ b/distros/humble/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-humble-rviz-ogre-vendor";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "c05633c8b9006def624b5b9b275ff3ffdc6b527a58ee86cb7bbe9c0c5bbb7bf9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_ogre_vendor/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "acf6f6fe746c0ea0d5a9c0340f46b9ef3a267b5323602e86c4cf17ad921f6241";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering-tests/default.nix
+++ b/distros/humble/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering-tests";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "6e3fc61e2dcae3b6cf299525b93bb7b70c29ebcfd2353fd25d009d71dcd875f1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering_tests/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "5b2daf10dda5a58925aff80fdbda64e2acaf0a3214441a6aaedb0c2ce7493e3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-rendering/default.nix
+++ b/distros/humble/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-humble-rviz-rendering";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "d8ae09408b83278af2025d5086aef53d00f25d0b118aa7cdfedcdd85b96f46d5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_rendering/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "a542cd26c3e778890efdb449ec7bd23eec665d9c39ea8c909f499b30c616a1bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz-visual-testing-framework/default.nix
+++ b/distros/humble/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, qt5, rcutils, rviz-common }:
 buildRosPackage {
   pname = "ros-humble-rviz-visual-testing-framework";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "4c063b6880b086bb6c90b4a70e02fd93f380b7db6451a69b4a943bd79dd48578";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz_visual_testing_framework/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "6d1026e8a412a282c8ad36085a7b0b71890223ae7536dbbd4146207f145572a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rviz2/default.nix
+++ b/distros/humble/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rviz2";
-  version = "11.2.15-r1";
+  version = "11.2.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.15-1.tar.gz";
-    name = "11.2.15-1.tar.gz";
-    sha256 = "5b4e3056b71ae32e2a44c59589655290f42d7fc0757b336223281bc5287822fd";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/humble/rviz2/11.2.16-1.tar.gz";
+    name = "11.2.16-1.tar.gz";
+    sha256 = "b0b87e45fa3f035978805b799dfddd2993dbac57b91cd5131a7970717febe4a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "aecb2e9e26f8be0162c2242af7131085b2d4d42ddb0c9c5bf0de00919fb7e15b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "460f0dfaba903c72479a696b2f146a153e3b60983cdc52d94ad039a8d39e8f55";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface generate-parameter-library geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/tf2-bullet/default.nix
+++ b/distros/humble/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-bullet";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "3a03ef6c4bf7498b405e7a08539c2a6c7f6a16af3ed0d4a1aceb4306bf68956a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_bullet/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "5b4fa32789b2fceddea3ec6d5906c0ba99c71758f11607190c0567ab905711d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen-kdl/default.nix
+++ b/distros/humble/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen-kdl";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "d47a2950a15681a39cec236647f5b1114fe11bcd49195ce71286647c80b976d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen_kdl/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "2be1ba567b614ce96c1e9e9d7970a4c8177549e0c95d3abcd4b1a7729b3ca67d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-eigen/default.nix
+++ b/distros/humble/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-tf2-eigen";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "ddb076b72baa19bc620ce5f7e49d71317eec96431f7f9727ab4f8bae4f1429cd";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_eigen/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "dd6d39b6b2c6c88c8f75c4da913f5d4e8acf78f0880485c8574263f1216f401f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-geometry-msgs/default.nix
+++ b/distros/humble/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-geometry-msgs";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "e5d8a58576958f9594234882d083ecf05a0cffd348a0d2bb3b092303afd5ae3a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_geometry_msgs/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "4dfe317aef71a629c27eef8415f7f4c758d2d1af66b3a06c211b8b42135849f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-kdl/default.nix
+++ b/distros/humble/tf2-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, python-orocos-kdl-vendor, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-kdl";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "bff7d8830d98eb2d33e8ac331ec56f0919cff119fcb2857b67b51ebe4e09594a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_kdl/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "ced1b2255e1e705897cade11901645d21cc91fda2e9a62050ab8f35cdfd787f7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest rclcpp tf2-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs orocos-kdl-vendor tf2 tf2-ros tf2-ros-py ];
+  checkInputs = [ ament-cmake-gtest rclcpp ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs orocos-kdl-vendor python-orocos-kdl-vendor tf2 tf2-ros tf2-ros-py ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/tf2-msgs/default.nix
+++ b/distros/humble/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-tf2-msgs";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "a4f4b68a93727b205f7714eaf8efb8a172c598ea472284494a78ac3fa897202d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_msgs/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "2f1be9902e0e5cfee3d674fe347efe8f034d0a1ae618d7d47b437ac7fdb8304d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-py/default.nix
+++ b/distros/humble/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-humble-tf2-py";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "b80fc4135347f51b1acb2bab64a2bc40599cc076a36f69b73db9b95e365e83e7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_py/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "4ebb0b9d28161601b9bb96bea858f3135300d8edbbb6fb66b335c1aa5ab2cc4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-ros-py/default.nix
+++ b/distros/humble/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, python3Packages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros-py";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "4616730199c7c3b7bcbbf1d83e24a0722aa16ad3593af6df0bfc6bf7bbceb1e3";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros_py/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "7ea18eaf80ac83142156903f8b215e291cbd2230871490f87874829663296075";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2-ros/default.nix
+++ b/distros/humble/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tf2-ros";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "f46615cd580b56ca868d1fa441537a627c4932905139307b686b0c7283c0f5b4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_ros/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "a35057cd74ca61386d5fe46cfe6ad884ab50dd6191ba6b5a135392401653a928";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-sensor-msgs/default.nix
+++ b/distros/humble/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-sensor-msgs";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "7a87de273da23e4e0cdb3a689fbd3ea1bd30b97c916b46944f1d6a74375690a1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_sensor_msgs/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "a9f36757d269d811a219b37d6c97dc325cdee088eb2b01d6c309b5e0f31248ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tf2-tools/default.nix
+++ b/distros/humble/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-humble-tf2-tools";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "079002f423eef248e2bd7e8fa8d6706808878868909410fa44bb736b8f41da6c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2_tools/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "eb9ca1079b04f00d330f6731908660a8a536e38196f2414189c2d444f1de9507";
   };
 
   buildType = "ament_python";

--- a/distros/humble/tf2/default.nix
+++ b/distros/humble/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, console-bridge, console-bridge-vendor, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-humble-tf2";
-  version = "0.25.10-r1";
+  version = "0.25.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.10-1.tar.gz";
-    name = "0.25.10-1.tar.gz";
-    sha256 = "887035772ef881e2b39bd6849ee3c522f25652d20f3139157d6fd67ae9f03f20";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/humble/tf2/0.25.11-1.tar.gz";
+    name = "0.25.11-1.tar.gz";
+    sha256 = "b16c20a88e70536e5307bd7a64b62439ab51174adc56f77eda99543217efb42a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "180b9219c046ecc3f347e1b938b75ecd80abdf83eb19addecb0e6e136a28fe77";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "164edf5ed1da3378bdb44e15ae3bdf714cb95331ac7fe29f8b578ca6f2596d6d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "119e6a7cc7bc39f1665dc364b95a0417a255e4a0ee6e2e0ac10f2f45310a8bfb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "f2222c7a86458a1bec6f2f185f1ca08b06fef024262cf620385e1e37773bbc08";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot4-setup/default.nix
+++ b/distros/humble/turtlebot4-setup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, chrony, curl, networkmanager, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, robot-upstart, simple-term-menu-vendor }:
 buildRosPackage {
   pname = "ros-humble-turtlebot4-setup";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/humble/turtlebot4_setup/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "b04565f3b9f412ef7371ef49e9dad9827f859c827e540449fc3cece027068a75";
+    url = "https://github.com/ros2-gbp/turtlebot4_setup-release/archive/release/humble/turtlebot4_setup/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "0b60e5a227ad22c4ff7cfb2c02e5642b0e4377727aea6682022a549179c10cd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.40.0-r1";
+  version = "2.41.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.40.0-1.tar.gz";
-    name = "2.40.0-1.tar.gz";
-    sha256 = "2774097c262ce3ed6939cb90e51ab55648ab666f0b8e159a502aaabace56349e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.41.0-1.tar.gz";
+    name = "2.41.0-1.tar.gz";
+    sha256 = "724014cac50d39c9bf070f9ef2372dbddcf6ecdd76b9906c2dcf8736303850bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "daef8de4665a17aca3788937ba34182d56858a4a71de598be141af9fb6151d9a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "bf9fb63023ed4124e644e6c8d420e474b58592be16aa5645597b353e4eebc61c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "35cfd408148cc3b2699254dc458b862589778d472d299452f425f4c703a4bfc1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "5a15fb17e420539161ef280e1da39f28ed49bc15543ced400751aaf4195387c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "e0467714c9e6712255a0c9f6736aac99d9e360eb18dc6fc7efdd36c4ae6a7045";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "7fda35929f533eec316cc2c1e19fabba9f413a6c0d47a61b03035d5b2ba48eaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-bt-joy";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "549deb6d6f1847cef6aad758e62c9995dd55775f1eb6d042692b08c31d3df389";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ bluez joy-linux twist-mux ];
+
+  meta = {
+    description = "Clearpath bluetooth joy controller signal quality monitoring node";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-common";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "e8e782bf9a375f79ccce1c2ad8d304be0d12988cd7700ccffef4130adb5ce64b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-control clearpath-description clearpath-generator-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath Common Metapackage";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-config";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c29323976e072d7dbd03562c76450edc65a5e16d523b46cdbcdc05fb1614d8e8";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ python3Packages.pyyaml ];
+
+  meta = {
+    description = "Clearpath Configuration YAML Parser and Writer";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-control";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4996287f7b2e518b0fb6e858be4e2bc3b87d4c5fbcfd4859efbeb7f25f7fe68c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-bt-joy controller-manager diff-drive-controller imu-filter-madgwick interactive-marker-twist-server joint-state-broadcaster joint-trajectory-controller joy-linux robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controllers for Clearpath Robotics platforms";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-customization";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "564133e80d6cb863cb47abd5618c0449447e248dd3998a83ddd20843e210c831";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath customization packages.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a7d2c7f0efc2f08a48e53493b7c5ffd84b9dbdf8576a4e6e516054f4cf40969f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-manipulators-description clearpath-mounts-description clearpath-platform-description clearpath-sensors-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath URDF descriptions metapackage";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-generator-common";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "afa47d95cbafd1221497f278e7a88526b1b164e92a4052e802dbe33d0989d5db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake moveit-setup-srdf-plugins ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-config clearpath-control clearpath-description clearpath-manipulators ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath Common Generator";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-manipulators-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "2f01e6b33e720d857a273b1e1aa9e7bcf34ed3d73b1fd5c8f991e1efee453133";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ robot-state-publisher robotiq-description ur-description urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath manipulator URDF descriptions";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-manipulators";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6ea34e2bd08e919b346a3464349b25ef9402da58b845005bdc48f2b223cb79c7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-manipulators-description gripper-controllers moveit-configs-utils moveit-kinematics moveit-planners moveit-planners-chomp moveit-ros-move-group moveit-ros-warehouse moveit-simple-controller-manager position-controllers tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "MoveIt configuration built around Clearpath Configuration";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-motor-msgs/default.nix
+++ b/distros/jazzy/clearpath-motor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-motor-msgs";
-  version = "1.0.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "111d9e91ceb537d6849053e464c25a9615610b47f5065d0ed2bf8595bc954265";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c716544045f474c90729a1dd440429585cee01ca9302db9d1aa83436e7841ce3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-mounts-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "050c077f52eb0aaa8911e750eab31da4b0cbdfabf97a480e24de74808eddcbf3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath mounts URDF descriptions";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-msgs/default.nix
+++ b/distros/jazzy/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-motor-msgs, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-msgs";
-  version = "1.0.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "60ee18dc5fc69ac566dd02d6bf058405e900034085d0b06f82f4552e599081f6";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "65c254a446ac57eead5beafcf7cc48f0d54e10b25016df838b65393b3fd9b7b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-platform-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "16717f08ca7529bd0879c3c2e6d319acef8f275fba59f5c39dd01818a67d2b8e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath Platform URDF descriptions";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-platform-msgs/default.nix
+++ b/distros/jazzy/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-msgs";
-  version = "1.0.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d269e267e7988e8631b1891e9d1aa01674774d963c3c83482a91cbfada4c4bf4";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "dd51754682bacd6cb95a26a84185819184805e492392d69f6eef35d528c60bd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-sensors-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8b292d2a7006fcd97dc65d21546c73ace7d1d478349b54ce86a77ebdae75cfe5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ axis-description microstrain-inertial-description realsense2-description velodyne-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath sensors URDF descriptions";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/cmake-generate-parameter-module-example/default.nix
+++ b/distros/jazzy/cmake-generate-parameter-module-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-cmake-generate-parameter-module-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/cmake_generate_parameter_module_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "481c03d0a03970e6923366507a1086d3b5a4e1fd4cbe94e8077187fbe1e89bb9";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/cmake_generate_parameter_module_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "d5dfa66bce89faf52d547ef1afcb660dd4fb934215cd9b8f0e3935b4702cb712";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/control-toolbox/default.nix
+++ b/distros/jazzy/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-jazzy-control-toolbox";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "dddde0eb1cc37053a011771a1dbec70dd1aeb3b3b382b37369d05aeffb6d9344";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "b9017d043a7705a47ef1d5b2fe14c243ad5d983dc7bb40d5ff57f576f0d79fa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "4710c4abed721dc869cc9d8385c4db83af3045872d7b013c241cba632924c5ed";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "b8e41b52961f238aae9a12258ac9e802eb898fc1d3dc8005c7b56433fc27b25d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "cec0a0b94713b26bd8f2a83c759943fb3acf767939475d38b2c09e9592c1a115";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "8134652f3f1e42250c8b5b90b56028a64f33a19d9fe0e3c2a9c40e470aa4e0d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "5087a3ef6498bebf4b5a72d0faa80848f59965c4fb516353bba3719668f7e898";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "543047ec70bcfbd8d649c8dcf3dfbf35a9902b78417c6932861543aa048e9f3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-bridge/default.nix
+++ b/distros/jazzy/depthai-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "9cdec1993408fff1e464f122f236812329a813c8bbe6d77c43e694d4bb5b1729";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "3e85a1f3a4b7a4bc355b5467f1e8f19593b95f5ccdf37d450fa6f622aeb07d62";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ament-index-cpp boost camera-info-manager composition-interfaces cv-bridge depthai depthai-ros-msgs ffmpeg-image-transport-msgs image-transport opencv opencv.cxxdev rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros vision-msgs xacro ];
+  propagatedBuildInputs = [ boost camera-info-manager composition-interfaces cv-bridge depthai depthai-ros-msgs ffmpeg-image-transport-msgs image-transport opencv opencv.cxxdev rclcpp robot-state-publisher ros-environment sensor-msgs std-msgs stereo-msgs tf2 tf2-geometry-msgs tf2-ros vision-msgs xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/depthai-descriptions/default.nix
+++ b/distros/jazzy/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "69979c2a3243edf3d8c3444e39d27735fe29da59489b42da8bd7e5cd4ac34077";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "63a48c01a54e4808f2ce720ad7f3ccde35bf51c1c0b462c9df05db4676ee71c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples/default.nix
+++ b/distros/jazzy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "ea9f3a5645181e663b57cb58934bf231326b29823abcc06c51fcae8bf728f9ca";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "7c30c88a1df69793837e2950b068624d546157f97830487aa8917abfee240307";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters/default.nix
+++ b/distros/jazzy/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "1d77c5ebd6b3a10223314d16eb8580dc74a1f24d0221f6c59ba3168be7b213a1";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "839b4dde1b2a03c18b60f04debed4d3b1bf14acaace926fb4faaaf5749af7455";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver/default.nix
+++ b/distros/jazzy/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "b360eb09633fcb87270abcb13466a533635ec1580d1772e148778c34d124ce1d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "d09e30ec6a1bd8b614c233fa897f53a23814eb2390c838696068773bb80539d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-msgs/default.nix
+++ b/distros/jazzy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "99c238adcf26b6f4b2744c52d62169be9d9b05cad788a091eaac6cb21b2d1b4f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "ce85144b6260760cf91277874edbe1ff7d23d84db55902a2e9c590d70e9615cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros/default.nix
+++ b/distros/jazzy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "dc3507163cd462dc101e49530445b58391ea1a418e43cbbd36ed98006f0115c7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "bf609d3be53179c159164b29abe0bfd14b61c98235e83f4622294dc02a658724";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "2e33f69fc6f03113df7cd4074f0933df32cdfde887849323d9393aeb5b5f8268";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "01e6fd28a3cc1448ab5479156d424c74402d778978ca8738ccb79f4274015449";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "ccc3a73731d3b93d2fe35f2d4eb9e7c98e148648171e69d164b73c4e0887fc39";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "3697d066688ef857a3387d8dde2c3df97cbb5e74d9ce1f5f4b83aa44dce0b929";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/examples-tf2-py/default.nix
+++ b/distros/jazzy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch-ros, python3Packages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-examples-tf2-py";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/examples_tf2_py/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "886784af2f04bcb4c8d3697b9642c08317a83ba44735ea79f10ea402e7f982c7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/examples_tf2_py/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "1b0a9bd731ce57af87a000ab55e10a49c9e620fd5246b0f07528de6f11f9090f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "fe00343475adeb46c05172297d588cfc5409a6b8cd64904c39d539c1cb9f91aa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "5ded39a1a56905aa888483878e025c25c4f914a39a9b657a664623ae164470b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "80680e670482820cc0961e7e7f6f7d398cc9c761e42ef97d2c2786b9dfb160df";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "6c7ebf5eacab027f9d3e877750b1fdede7d6e5bad1180bf6c99507fd049b8bc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generate-parameter-library-example-external/default.nix
+++ b/distros/jazzy/generate-parameter-library-example-external/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library-example, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-jazzy-generate-parameter-library-example-external";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library_example_external/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6744f3653bc77d02c463a640bb7efc79e7208cee370267bc3fa803c87de2683a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-core generate-parameter-library-example rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-core ];
+
+  meta = {
+    description = "Example usage of a parameter header generated in another package.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/generate-parameter-library-example/default.nix
+++ b/distros/jazzy/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-jazzy-generate-parameter-library-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "8886c78048fdde62f20c83d9a4e2d2d74803402066aeccdb0a81328e941691c8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "23619c3622e98d25c6d89aa95c07a0f2704434211c348ef2d8f4ea6439e67170";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generate-parameter-library-py/default.nix
+++ b/distros/jazzy/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-generate-parameter-library-py";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library_py/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "8ac5a02682b3635eeffc809d7cea94842fd89f14018e71279a3b3a1d317b3949";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library_py/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "fe4876456f062aff06d95c3e5e0ff8cc37eb0eb580d96c9fa787d8b46aae74d3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/generate-parameter-library/default.nix
+++ b/distros/jazzy/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-jazzy-generate-parameter-library";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "9a2d65abb23b77e42bdf29b63b0d65e182185df82d71de98267755d07c06ced0";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_library/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "604cf725179718bd7ad01232fa82d6d5606aee1f5fd79628ba141df25284adc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generate-parameter-module-example/default.nix
+++ b/distros/jazzy/generate-parameter-module-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-generate-parameter-module-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_module_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "bbbf22f4c592c2c14340d98733b067874801419908fb7a273ad6d194003cd50f";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/generate_parameter_module_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "efce492b86da3093a39c36ab73c0a4a1cb88b2b3f94051ca6f2a84146b031312";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -338,13 +338,37 @@ self: super: {
 
  classic-bags = self.callPackage ./classic-bags {};
 
+ clearpath-bt-joy = self.callPackage ./clearpath-bt-joy {};
+
+ clearpath-common = self.callPackage ./clearpath-common {};
+
+ clearpath-config = self.callPackage ./clearpath-config {};
+
+ clearpath-control = self.callPackage ./clearpath-control {};
+
+ clearpath-customization = self.callPackage ./clearpath-customization {};
+
+ clearpath-description = self.callPackage ./clearpath-description {};
+
+ clearpath-generator-common = self.callPackage ./clearpath-generator-common {};
+
+ clearpath-manipulators = self.callPackage ./clearpath-manipulators {};
+
+ clearpath-manipulators-description = self.callPackage ./clearpath-manipulators-description {};
+
  clearpath-motor-msgs = self.callPackage ./clearpath-motor-msgs {};
 
+ clearpath-mounts-description = self.callPackage ./clearpath-mounts-description {};
+
  clearpath-msgs = self.callPackage ./clearpath-msgs {};
+
+ clearpath-platform-description = self.callPackage ./clearpath-platform-description {};
 
  clearpath-platform-msgs = self.callPackage ./clearpath-platform-msgs {};
 
  clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
+
+ clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
 
  clips-vendor = self.callPackage ./clips-vendor {};
 
@@ -819,6 +843,8 @@ self: super: {
  generate-parameter-library = self.callPackage ./generate-parameter-library {};
 
  generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
+
+ generate-parameter-library-example-external = self.callPackage ./generate-parameter-library-example-external {};
 
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
 
@@ -1818,6 +1844,8 @@ self: super: {
 
  py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
 
+ py-trees-ros-viewer = self.callPackage ./py-trees-ros-viewer {};
+
  pybind11-json-vendor = self.callPackage ./pybind11-json-vendor {};
 
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
@@ -1981,6 +2009,14 @@ self: super: {
  rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
 
  rmf-charging-schedule = self.callPackage ./rmf-charging-schedule {};
+
+ rmf-demos-assets = self.callPackage ./rmf-demos-assets {};
+
+ rmf-demos-bridges = self.callPackage ./rmf-demos-bridges {};
+
+ rmf-demos-fleet-adapter = self.callPackage ./rmf-demos-fleet-adapter {};
+
+ rmf-demos-tasks = self.callPackage ./rmf-demos-tasks {};
 
  rmf-dev = self.callPackage ./rmf-dev {};
 

--- a/distros/jazzy/geometry2/default.nix
+++ b/distros/jazzy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-jazzy-geometry2";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/geometry2/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "9b959060169b41e53d2afc9e4ec5139ed3247e86cf917a41c8f668d322909b92";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/geometry2/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "de4519131a42b9875904c4f08c311b8a2bf454aa581e8f4c15ef1cb19243625c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "981a386be499be076e0e8db2480ca16b2b0e958cf9e23fcf0336fb66fc876396";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "03de7be4b34200e1fe05018b7eca24684da599852c6cbc3f3996a657dc2b6c84";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "92e0f7c085122e1507bfb6334f20fb20fba7a5fcc53ef0b6ee91452b7f6840cd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "de6e901593a0d7c6b453a396a379e8b2c04c6d8d7b7e599ccad0c0ed93b65ae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-ros2-control-demos/default.nix
+++ b/distros/jazzy/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control-demos";
-  version = "1.2.9-r1";
+  version = "1.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "272b6e0a9da7a4c1dbbb2450a163d2a7a5be107ad1ea484f04be8f6f6898f814";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.10-1.tar.gz";
+    name = "1.2.10-1.tar.gz";
+    sha256 = "226eca69bb825a9b4fe09b253eefec112f7c329dc60d6a847fb73a7b20ea7201";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-ros2-control/default.nix
+++ b/distros/jazzy/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control";
-  version = "1.2.9-r1";
+  version = "1.2.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "d7078e55119c0c68ce6808f047399501b4b0ed6a14c5357eacd98813b8e01015";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.10-1.tar.gz";
+    name = "1.2.10-1.tar.gz";
+    sha256 = "cd9593253d6f8b4bf02ca5a9d778f6d61353120e98226fc22422ad43a9331eff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-sim-vendor/default.nix
+++ b/distros/jazzy/gz-sim-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-sim-vendor";
-  version = "0.0.6-r1";
+  version = "0.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "afb6de5715946509dad053d9b2c3e1c7a5f14d9a100a1149b232a29f4a2726c8";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "ac1208a853d31c61c39576ac25b355c09dcdbb0b699406aa91cdff99c3bce7c8";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint python3Packages.pytest xorg.xorgserver ];
   propagatedBuildInputs = [ freeglut freeimage gbenchmark glew gz-cmake-vendor gz-common-vendor gz-fuel-tools-vendor gz-gui-vendor gz-math-vendor gz-msgs-vendor gz-physics-vendor gz-plugin-vendor gz-rendering-vendor gz-sensors-vendor gz-tools-vendor gz-transport-vendor gz-utils-vendor protobuf python3Packages.pybind11 qt5.qtbase qt5.qtdeclarative qt5.qtgraphicaleffects qt5.qtquickcontrols qt5.qtquickcontrols2 sdformat-vendor tinyxml-2 util-linux xorg.libXi xorg.libXmu ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim8 8.7.0
+    description = "Vendor package for: gz-sim8 8.8.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "2d00a8daf8826d8661517774c0691f7b85e37fb553b60e6f9a1cc227258fbda3";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "550719e2d9397b5bec546451ad01fc0c15aaa1348dbbc2f1feabe63455c8b70a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "45e43fcbf2b0e3b51653c9d82abc3dc41388045645604591132a4f819d03ed91";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "3e1049128020df91de4beb288e1b203c1de6448fbc866dd1de8f50554697bfda";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "d866d4f131a7160ce04e77bbd5252ecac1b920a40ad2a92eb4926ac556b3a77b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "c5b3ded3c612b4e179fb3fcfe1f1a8190128558fe3fca3ef1ac987920ce778cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "6c5c0da56f90074e2866e3630908d2fe92b988eb735a3af2e47450e8191b5b35";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "4178e286cb3d4bdde66ed2f72e89796ed5ab39e7490dac7f4f700a07e3d13463";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "1a1944f3cb87594d17a489e0809eb724be9ed1430c621235246f4f6d325b1427";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "bb3280d0a16c5d4afaf77b0dd85fb2508c3a585bf5f77cf1026b76ccfe2542d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "782bff305b5d233c55f133517c7cc5b3fd79570078c6c767ec2c36a21332071f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "1400d36dff75eaae27d03227e685adf3fbb21dd23e8842a7ccc0488b4524e212";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "60e9655d4ddcdba5a467ca7c16fb6727303355582d23ed1ae3713d88e3ec3318";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "95d88b2eaf3223e7a97adf6eea598415a9051c249a6f983256a647a7b344dfc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "35b468c063b82e20bfa6bb033256a02003542a86bf7346e5b688eb1e45d4c6dc";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "3b5fedecbfa56daff78178ba09df8afa602520bd48fcf3d37ff6e78e1772c6c6";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.5.1-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "df741360130af24201d92f44006d03d1304e6d2331ed181f38dac336fc45bdd0";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "895251055cda6de32b7fd3a2b3ec6d13683e33c22b5ce4e4854e443e6e4918bf";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-state-estimation-simple mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/jazzy/mola-state-estimation-simple/default.nix
+++ b/distros/jazzy/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-simple";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "5784452333358afdc619a8e124261235bce33196aade22937a900061c86f0b55";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "6fcebd863d7e79166c5fae43db5ee20090e8c806863cd30c27293307a977e261";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-smoother/default.nix
+++ b/distros/jazzy/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-smoother";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "5495794b8c21549bfad7f773e2a348919438244e6e6ded717c392c5a1b14b79b";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "74188eb19febd68be6998571f63a65d4955d72a709f875b1a5e9350b2a2de3bc";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation/default.nix
+++ b/distros/jazzy/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "be57c8214d6b17c03ade909c0de1d33f92ce6c5f935a01000f126b7657ed376e";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "f1086239aaa9fa0951f60df0f5b1c4daa4e25064ea230a7d292091a735696b89";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Metapackage with all state estimation packages MOLA packages.";
+    description = "Metapackage with all MOLA state estimation packages.";
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/jazzy/mola-test-datasets/default.nix
+++ b/distros/jazzy/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-test-datasets";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/jazzy/mola_test_datasets/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "f579f19b94919bebb27712cc0f3e47a95a1aec3cbfd3eeb3634d54ab10d228b3";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/jazzy/mola_test_datasets/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7be5677f90a49924b05b9a53cc1ec30ac7c0efcc85674dd9db2b9b9c5474efc2";
   };
 
   buildType = "ament_cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = "Small SLAM dataset extracts used for demos or unit tests in the rest of MOLA packages";
-    license = with lib.licenses; [ bsdOriginal bsdOriginal "CC-BY-NC-SA-3.0" "CC-BY-3.0" "CC-BY-3.0" ];
+    license = with lib.licenses; [ bsdOriginal bsdOriginal "CC-BY-NC-SA-3.0" "CC-BY-3.0" "CC-BY-3.0" cc-by-nc-sa-40 ];
   };
 }

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "ef3364bf2fb40d6db00770db12391dcf70c967b7c89fe388c1687e456565c164";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "1255a024b3dcde479449e338e997592e550b3c1ec11cebe2a59f0c15e72c07a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parameter-traits/default.nix
+++ b/distros/jazzy/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-jazzy-parameter-traits";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/parameter_traits/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "c8303a0010e40d7e043fa3e748d47b4402e348a9b5c8e03a452619a7b1587114";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/jazzy/parameter_traits/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c49620e85d75ef780a1d7301e446e2ffd62f65d2391db49f22c15ad48f5ce735";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "987616714fff22e1ad91c77969fa583c07b0eb82c4e26143d474770758bbab0a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "f4766a9a78d5b262b2ddd8c647e14906a419a91e5af6399e97dcfd5ebe94bf60";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "97fdca4dd50a9fde113a7f5668931d339b1d0d58079ec30d23b264605371584c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "9a041ee2af5142f27c7c71fe3dcd002972b2afa711183dd51a34870d72211f62";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "e357aa461b5e1e063150bb41fba5e71be309b6873641fce4691a9dc0609f6814";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "fadeac8cc445269124d7f40a1cdcd460b3eec514b074e4d71bf001eda394fbbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/py-trees-js/default.nix
+++ b/distros/jazzy/py-trees-js/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-jazzy-py-trees-js";
-  version = "0.6.4-r1";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/jazzy/py_trees_js/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "900b749558a777ecabb533e83b65257dd1cecae4f6d26aa9996e46951e76f0e3";
+    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/jazzy/py_trees_js/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "c0558b493a09287eee0d95d45e37cf94317979604ae81342719a196a8279cb2a";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/py-trees-ros-interfaces/default.nix
+++ b/distros/jazzy/py-trees-ros-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-py-trees-ros-interfaces";
-  version = "2.1.0-r4";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/jazzy/py_trees_ros_interfaces/2.1.0-4.tar.gz";
-    name = "2.1.0-4.tar.gz";
-    sha256 = "76e03f6cbb5c8eecfc7ca560321cd533e51e4f01fca9f2ab223df4eb2d247eb2";
+    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/jazzy/py_trees_ros_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a61d8c3a10c1caf07fb2e50db04077ad9501777e5e31cfa0170c2e6678c5244e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/py-trees-ros-viewer/default.nix
+++ b/distros/jazzy/py-trees-ros-viewer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, py-trees-js, py-trees-ros-interfaces, python3Packages, qt5, rclpy, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-py-trees-ros-viewer";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_ros_viewer-release/archive/release/jazzy/py_trees_ros_viewer/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "9fd2dca64ee4a414346eb84c55e1094c4879531a7e0b27e3d52d6feec9d1459f";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools qt5.qttools.dev ];
+  propagatedBuildInputs = [ py-trees-js py-trees-ros-interfaces python3Packages.pyqt5 python3Packages.pyqtwebengine rclpy unique-identifier-msgs ];
+
+  meta = {
+    description = "A Qt-JS application for visualisation of executing/log-replayed behaviour trees in a ROS2 ecosystem.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/py-trees-ros/default.nix
+++ b/distros/jazzy/py-trees-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros-py, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, std-srvs, tf2-ros-py, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-py-trees-ros";
-  version = "2.2.2-r4";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/jazzy/py_trees_ros/2.2.2-4.tar.gz";
-    name = "2.2.2-4.tar.gz";
-    sha256 = "740f46c8f914a52b1343e9479b738e2e3481228051f060d928b6f2ecd3cd6ee5";
+    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/jazzy/py_trees_ros/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "8ddc1f63ac42acde2d724534010ae958737c3a9aab86bf4127d404375f3ec339";
   };
 
   buildType = "ament_python";
   buildInputs = [ python3Packages.setuptools ];
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs tf2-ros-py unique-identifier-msgs ];
+  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs std-srvs tf2-ros-py unique-identifier-msgs ];
 
   meta = {
     description = "ROS2 extensions and behaviours for py_trees.";

--- a/distros/jazzy/py-trees/default.nix
+++ b/distros/jazzy/py-trees/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-py-trees";
-  version = "2.2.1-r4";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/jazzy/py_trees/2.2.1-4.tar.gz";
-    name = "2.2.1-4.tar.gz";
-    sha256 = "e69d9b74b50d465fd589ff803c6bbe463bf9c45f014ec1847b41e5849044be88";
+    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/jazzy/py_trees/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "0773f907a5691d8a854849dfe5a2ca0776802268017b2faaae9dd75c56b56ca3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "fcfea365b716cad601dad3ec5d548cd1b62ad373fbaacc5ad0e0812ec7d45201";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "d08295d03deed9a8cb9d099d796a5b8fbb0d68a20fab27086a13a3e8b1fd573b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmf-building-map-tools/default.nix
+++ b/distros/jazzy/rmf-building-map-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, gz-fuel-tools-vendor, python3Packages, rclpy, rmf-building-map-msgs, rmf-site-map-msgs, sqlite, std-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rmf-building-map-tools";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_building_map_tools/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "2c83a541aaf78bb74be457b59c996ddc8df409094d4db6601522d081fb265633";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_building_map_tools/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "996cbd982c7f576b32ab2656d69eb89ddb71baefc2ac35a36d1524e55021ff4f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rmf-demos-assets/default.nix
+++ b/distros/jazzy/rmf-demos-assets/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-jazzy-rmf-demos-assets";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/jazzy/rmf_demos_assets/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "0563367e5f03103564d5355cb624062fa59eeeed808673e22ca2c5373bc4f7f1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Models and other media used for RMF demos";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/rmf-demos-bridges/default.nix
+++ b/distros/jazzy/rmf-demos-bridges/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, rmf-building-map-tools, rmf-fleet-msgs, rmf-site-map-msgs, rmf-traffic-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-rmf-demos-bridges";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/jazzy/rmf_demos_bridges/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a27b36c3b8b858aaba23f4fdebbbc20cc400aec184e1127e7749232eb4a6f38e";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ python3Packages.flask-socketio python3Packages.paho-mqtt python3Packages.pyproj python3Packages.pyyaml rmf-building-map-tools rmf-fleet-msgs rmf-site-map-msgs rmf-traffic-msgs ];
+
+  meta = {
+    description = "Nodes for bridging between different communication stacks";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/rmf-demos-fleet-adapter/default.nix
+++ b/distros/jazzy/rmf-demos-fleet-adapter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-xml, python3Packages, rclpy, rmf-fleet-adapter-python, rmf-fleet-msgs, rmf-task-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-rmf-demos-fleet-adapter";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/jazzy/rmf_demos_fleet_adapter/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "1788f6d10bb3e5fa88e8b58eaa8a00ade49244845ae195ae5ac49f621a37431e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
+  propagatedBuildInputs = [ launch-xml python3Packages.fastapi python3Packages.flask-socketio python3Packages.numpy python3Packages.pydantic python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.uvicorn rclpy rmf-fleet-adapter-python rmf-fleet-msgs rmf-task-msgs ];
+
+  meta = {
+    description = "Fleet adapters for interfacing with RMF Demos robots with a fleet manager via REST API";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/rmf-demos-tasks/default.nix
+++ b/distros/jazzy/rmf-demos-tasks/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, rmf-dispenser-msgs, rmf-fleet-msgs, rmf-lift-msgs, rmf-task-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-rmf-demos-tasks";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_demos-release/archive/release/jazzy/rmf_demos_tasks/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e31f9e978c32d8b58c837900cfdd953ea0a79047ba0b5deae22225412e71472c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ];
+  propagatedBuildInputs = [ rmf-dispenser-msgs rmf-fleet-msgs rmf-lift-msgs rmf-task-msgs ];
+
+  meta = {
+    description = "A package containing scripts for demos";
+    license = with lib.licenses; [ "Apache-Licence-2.0" ];
+  };
+}

--- a/distros/jazzy/rmf-traffic-editor-assets/default.nix
+++ b/distros/jazzy/rmf-traffic-editor-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-rmf-traffic-editor-assets";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_traffic_editor_assets/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "002a18ae0adcf1385dc4c77af8a8832951be0ad20e4eef308728d3768301aaba";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_traffic_editor_assets/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "7f3c6e1fd6bdab25a1df7c8e7cad3ab1edf133595070597474b6fb3276966c7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmf-traffic-editor-test-maps/default.nix
+++ b/distros/jazzy/rmf-traffic-editor-test-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-jazzy-rmf-traffic-editor-test-maps";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_traffic_editor_test_maps/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "604fabefd6fd0eeb4ce5df4978e9e128db393d9a5b229931cee7dd1f4d66d90b";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_traffic_editor_test_maps/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "40de2254c4c238d371636e81c6e17597909de24053f5af8af64e2398634e7204";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmf-traffic-editor/default.nix
+++ b/distros/jazzy/rmf-traffic-editor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-uncrustify, ament-index-cpp, ceres-solver, eigen, glog, proj, qt5, rmf-utils, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rmf-traffic-editor";
-  version = "1.9.1-r1";
+  version = "1.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_traffic_editor/1.9.1-1.tar.gz";
-    name = "1.9.1-1.tar.gz";
-    sha256 = "945c6e0c7a3d8c7b21b36e3bf33f129b64092e8e3f867c53aac36e3145cc1ba4";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/jazzy/rmf_traffic_editor/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "ad36d53c238e2625b5188a3443d9266858bce5f1ddfd9958befc62321096b36d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "a793231f3a959274ac68ce5d839b785a93d71758de431bb933ceb28550419ef0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "61cae302881f274816c3f007bede13614f3bcd87cd71fd28565b6dcad3d6ced9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "d3e35760e6091312ce59dfef21a8f3595ffaf3b37f5910870cbf3bd7049aab44";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "59013e2c567c00ecf911d3ab27c19e1edf8d6533a6c6a4950826319179d6ca91";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "2aaa1ceb93c3ef4ebf93ca92aa2030f845b8cd9d3c0fec761d1476d2d1ebd374";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "01b679c7d9e45e3ff2cff5acab380e24790487eee82cd25e4a5e8c151993739f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "db4ce77b3c3d3c9365ed698cd4f2edb82d3c9c2509766bb503ff4bcea6afa56d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "9714be7b70d42c44ba410313b7a9a271d58af701e54546f002d69cf55277fac6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "6627766afaae072a1e5462925522b60a8b03a49f741d1015368f7de5db18dd20";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "b82372c4370256525545df04ed107b5a0c52e091a2ed533756db9e04d42d7ddf";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "7fc2dcfef10bfd3d1d94efbd81f75fd1ef1e428b1ff644b8d4b6211c49db0ad7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "bd2dbaa8d563b6da502ef9d35a46d0768c9123acf2b35a22d50c5034ccdb5877";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "6b90a95984305926512da5923efed9b96a145ef70f8d2196e0fd31c5ec2520dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "19ab4a39725c70a6dd2634a07e114fc82698b2d41de0da3c81a873077fd4f2a8";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rviz-assimp-vendor/default.nix
+++ b/distros/jazzy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-assimp-vendor";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "8915cb7dbdc97a7d7813a9f27fb5443fdf2cee5767d997e7f6d949d909ae59b4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_assimp_vendor/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "a743c44664d36570f1511e1dd9747b38d926a5de660a6f0ff8e36f75dbae3a32";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-common/default.nix
+++ b/distros/jazzy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-common";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "bb13cad981627b525f9205ea93d5ba6439d27a5816122ef24d06f5c317ddc92a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_common/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "2c766cc10ca8676f0ade67f2fab1deff4ca5d09d1681fde19e29fcf6500cf426";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-default-plugins/default.nix
+++ b/distros/jazzy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-default-plugins";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "87effd5644decb4bda4b2611daab1b25a1ca6ca7f9b4607bf339105eb51fd739";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_default_plugins/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "f7ca098c5cca64076f66918c0ee993044b5eeb5b2635a149b4abdc9ba6188cd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-ogre-vendor/default.nix
+++ b/distros/jazzy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-ogre-vendor";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "d59e6d35dd9c7b0e2402163926bb8768937e162c79e7198a281f8d1de1aaa160";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_ogre_vendor/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "7f1f67762b0615f42b949899224ef0a149d665dacf900ec7c3bdab18dc3f7250";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering-tests/default.nix
+++ b/distros/jazzy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering-tests";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "1b8eecee5df569fe960bbf8f217d6afa84a2843bf0a4d24ada78f001344c56f9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering_tests/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "ef5b67a6a4338e18fc6355abcbb0b363898f029dc5e1878d3e05e6d8e53c2bab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-rendering/default.nix
+++ b/distros/jazzy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, ament-index-cpp, ament-lint-auto, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-rendering";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "797a1bc68a39d595d66fa61c90bf93ffdee0384f74620dc0016befddd3907908";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_rendering/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "146b6142212ecd32c4eddecca55c4177f0384cebe74c788e89d4e16f8a55e3d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz-visual-testing-framework/default.nix
+++ b/distros/jazzy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-rviz-visual-testing-framework";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "eff9c9c2476cb025565e9f74ec85f495bc26e06c194643c08b82534ada469ede";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz_visual_testing_framework/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "026b271a12a7f05a99f760ef368f27d724c0eda980264960207a0c6bd38e48b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rviz2/default.nix
+++ b/distros/jazzy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rviz2";
-  version = "14.1.6-r1";
+  version = "14.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.6-1.tar.gz";
-    name = "14.1.6-1.tar.gz";
-    sha256 = "0fb6c20cf2aa621561116f7f591a088dc82cca817eb777e5e878ac3a2a170528";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/jazzy/rviz2/14.1.7-1.tar.gz";
+    name = "14.1.7-1.tar.gz";
+    sha256 = "d4ace166129f3fee529fe8191145ca8ef6514b6fc4d22a3085720f906a241db1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "4a1e1f14bb015ecb86361d7ee154a0f45c7f398e425318a09bae95d01237f250";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "b60b93c21eaa5419e451ba6bbb75dc2ab2a2ca4e0d18caff404c35ced391b998";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface generate-parameter-library geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/tensorrt-cmake-module/default.nix
+++ b/distros/jazzy/tensorrt-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-jazzy-tensorrt-cmake-module";
-  version = "0.0.3-r4";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/jazzy/tensorrt_cmake_module/0.0.3-4.tar.gz";
-    name = "0.0.3-4.tar.gz";
-    sha256 = "456bd190acc6509fc67bea982d24d58b6ae7a2000d00e01827873c63e14beee6";
+    url = "https://github.com/ros2-gbp/tensorrt_cmake_module-release/archive/release/jazzy/tensorrt_cmake_module/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "7e23083054fac16c406d13fd6565edad159e58a4fdd48b84d75ed345e6fc5c0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-bullet/default.nix
+++ b/distros/jazzy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-bullet";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_bullet/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "8d8a70eac302264775ce35dbcb120a9544c29288fa4f216940185817d8e253f6";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_bullet/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "c396fc31f06fc507f372875b6babff625cd8eb21589a50ebf0f0d2a1e4ce2bcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-eigen-kdl/default.nix
+++ b/distros/jazzy/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-eigen-kdl";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen_kdl/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "b7af486179d990360ed80156722707d94432daf9f8f264957b30268f41c7b701";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen_kdl/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "63fcaadb005f87b9340878f4fc8896bca4450cc31c525663de0a0917a5782a31";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-eigen/default.nix
+++ b/distros/jazzy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-eigen";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "b50eaeca0f40f1b899992b6de347c7b57bb0a2baa10e9aac6449518c8ef04986";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_eigen/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "e345591310ddf2c06911ab744925d1499c7b9ccd8d4928ac7c4942cb0239febf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-geometry-msgs/default.nix
+++ b/distros/jazzy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python-cmake-module, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-geometry-msgs";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_geometry_msgs/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "1b97f6e1f7033ff5c4a0376a6d78fc66f589f76390f58dad070846c76f84d0bb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_geometry_msgs/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "5915168b313d671c11b7b3e672df77b8ff4877dc2d9c26f272b2c11f337504b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-kdl/default.nix
+++ b/distros/jazzy/tf2-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, python-orocos-kdl-vendor, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-kdl";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_kdl/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "0735f5f558c146d86929d032b2db7b075a07281f39349e1e7a99879c311cee5d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_kdl/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "b7019be1f94bd3fd87def0a853a6164c5a209b6bdb54e3f1b796afda371ca445";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest rclcpp tf2-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs orocos-kdl-vendor tf2 tf2-ros tf2-ros-py ];
+  checkInputs = [ ament-cmake-gtest rclcpp ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs orocos-kdl-vendor python-orocos-kdl-vendor tf2 tf2-ros tf2-ros-py ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/tf2-msgs/default.nix
+++ b/distros/jazzy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-msgs";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_msgs/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "49d78ccab8860fbd3176d31f364d729d675f60910b34aaef7c6ffd140c72feee";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_msgs/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "af4302d2932db3c5c5c2ad0bfe4ef79c32ce427fbdcaaf5dce0e1253745953fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-py/default.nix
+++ b/distros/jazzy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-py";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_py/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "1b6ce789d75510c8c9b1db0ca6f39e2aa32a2ad2bf343b76d0d47a4e0a2c85ee";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_py/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "bb22c07ff4baec76a658db41231af5bc5c7ca2a03a5fdc8ab04a9a0bf7fca2da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-ros-py/default.nix
+++ b/distros/jazzy/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, geometry-msgs, python3Packages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-ros-py";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros_py/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "09792b2c03a9c7a2f975959b76ed0c7e58fe6329ddb081c19743182ce0f6865d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros_py/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "b75bcf8a926f6d0342166306c989ed491585a9647796b74830b2845f143b05bd";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tf2-ros/default.nix
+++ b/distros/jazzy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-ros";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "cb9533f5009a6eabffd293e26fbe508505bf8c36338fdcc0e2e6f55fba824b8b";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_ros/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "f416e0a3691c0433551a3e51c71fd34917a30b0d80c1c122f4c71b0f0aabd391";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-sensor-msgs/default.nix
+++ b/distros/jazzy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python-cmake-module, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-sensor-msgs";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_sensor_msgs/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "55019cdef2f6160ddd047d02cbe38f0039b9c87e589c4c93a942626690f56e66";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_sensor_msgs/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "fdb906e4c0894196f427c0176cf8e3abb62baa8262dffd1566fcb1a9d8febfe0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tf2-tools/default.nix
+++ b/distros/jazzy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-jazzy-tf2-tools";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_tools/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "a3b15fe1e1d7e9a56fb9670dc6e5c399df7a0f70166b06c880e8efc6c6666b68";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2_tools/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "4fd812279e3d694dcd0f1ba093c2cf09a974dc3c056da8f795f3bf5b60407947";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/tf2/default.nix
+++ b/distros/jazzy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-tf2";
-  version = "0.36.7-r1";
+  version = "0.36.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2/0.36.7-1.tar.gz";
-    name = "0.36.7-1.tar.gz";
-    sha256 = "cc126f67f68cbd47d61f6202951c60f505b43193e912ef244e0c089043e461a0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/jazzy/tf2/0.36.8-1.tar.gz";
+    name = "0.36.8-1.tar.gz";
+    sha256 = "106034fbf5ebdf20049eb350b4b13e150bb6bbdec8e949a7308af3657ecaea00";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "128f012637b7d15d3c6d825215bf4bd734515c2fb131c6a9d695be3533121c6b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "b48defd668d16c4e97ed23e0a1a5e4719cc0db0539196f86de3d7c396ff981ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "06288bb4eb1a5bb7d4e8e78dd49c4b131077525187aaa26343a474a6edb2c998";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "738ed89c157b0772b7f3565bb131946afd7f8e414efd0dc6d033e0604ccb9dbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "c98247901f8a9fdb8d99ba1a6e8cd9c7cc8170226d0fe55be5a77ff2ee6793c6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "f6ed97755fa6656cfa19c442acd9b99fd32c4b2f094991827d81a1811c3e5689";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.18.0-r1";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.18.0-1.tar.gz";
-    name = "4.18.0-1.tar.gz";
-    sha256 = "8778ebfa83641fd2eed2958a81994117e1aa25636835ad1985a25eed6b3bdfdf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "45a6f22b88f3fa5cc77b08f1e25b59464ddc366bcfaa6ef7e5904b053f9c8852";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, urdf, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "31795287bde34cf83c3cc545ada39a37cc5d6a90732b7de0f6f0fe48e4ae6a91";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "78cc0af1a6e6de332de2bc2be3329ab7cfaf15d80f47787a9c53a780efbb835a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "416e6316dffe63238a4a2785fcf5371a4b17a20e5a18d9d3dec6685ca198073a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "02476c046a8ffdca7a9d348930855d97d455015c9ade2a63348089405194e6bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "ee60cb545bdead5d25ef829312a224674fbb98f488588e1369f504d501149a52";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "77bc4ea47dda255c73f734ebac1fd6a6b13dc693b59897fcb3bf153bbb76f71d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, depthai-ros-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "e7154fe8009230f9dd31a0cbf321b9298db6e8bbbe1139708f1c2494eccb2f9a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "18956974c105d7c122989e77d17a5d66aae82f8be8f797f72a9ba0fb19bfda86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "62a0c36f2b59c6111aff1fbb3e96f6ae9754d96ff9e26f60f9b762a3db1ad811";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "f3b533e3fb8bec43a3893fb5ab936684ea44134cc5f4bcfb943f2946b1b83e40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "c67a343d4aa0326c1a3211d2225c6c95104c78057eb38e9a3ea8cebf91756aa8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "e10daf20a6ec350657502b1e58e5b6cbad828e3d7febffb6c71a2baeb2ab75e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.10.3-r1";
+  version = "2.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.10.3-1.tar.gz";
-    name = "2.10.3-1.tar.gz";
-    sha256 = "041c7cd29bdbcf72537281898cbeec9b8452116806625bcdf65e282c525fda33";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.10.5-1.tar.gz";
+    name = "2.10.5-1.tar.gz";
+    sha256 = "61d429625bc2801e83962f7cd62efc774507bf668ad434f94902b78b45850396";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "dd7b9a32482cc57fc12fcb542f9bd0fd3d3507bec28352109b1231efbd3de376";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "eef7f9765208a832da78da659fbbc4063155a13ec6e49458d8a8629f78b167cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "2d5e3927e420867de0f6468ca24e45c5cd3d141a24f5e94a8eb5198bec22b9a5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "fb3d61c5c5440b679a6e852b92cff32f2a79c9f8f17d8908695ef265f4179371";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "5961088fd6a721f752ccbbf9c4266c539dff6b62884a9e7c7a2e2572577449cc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "01488553431ea4033e3825e0bc210f667c683d61d2c1ce160e29b7926b5a8234";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/cmake-generate-parameter-module-example/default.nix
+++ b/distros/rolling/cmake-generate-parameter-module-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-lint-auto, ament-lint-common, generate-parameter-library, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-cmake-generate-parameter-module-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/cmake_generate_parameter_module_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "92e1a1432b70e3f5fdc737ef5d116d348331fba711145079f54dba8f99912015";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/cmake_generate_parameter_module_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6660bbb9ab1467cf837c80a5944ac68318a2204f0f01495ff5683010294ac9e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "21ac1943fc387a56304f0e2729d8cd8e1abf8de2c045007c4b085b00b39e421e";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "61f85656c4dae08acc72595ff4aedc2524ea4cd5405865837983b94ca74ee2e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "09ab53f163747748bcbac85d6082f1499a96a59f608e057232314aba56e419fc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "9c65ddf297975988896512c75df60da5e55b74c7ac452e0370874a3bdbc2b321";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "4fb9985b933dec1b2088f402395ba8d1640f623408ed8fee1f860a1b93a6c572";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "2597ecc2aeeadfc9b35bec49f5b3694cc64d2b40d1f98c329f94ec5ff255352c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "d33828dede122f53609b8406fed2486fce57ed79ba537b01b5087fc6d1cb031c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "193f2f4f54102474e50dd5b1cadb6b0bb0bdf46ca7a3d5ee7f99732408918a4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "76fe638d58fd7cb9b35408af4aecaa6d620f0b20489562495631dac9d85a8e51";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "bfcb4c29b92c25c54df3bc96350a84ab2e74685bd81f11a45742516289e1d3aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "7809878d1f317ba6c5592dc16e61613c1212b4657eb9abb90ea362e09e002b73";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "02a981b48331fec7a3054b6eefef0579eecb273437728359db228ce33aad6506";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/examples-tf2-py/default.nix
+++ b/distros/rolling/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch-ros, python3Packages, rclpy, sensor-msgs, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-examples-tf2-py";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "d26704321b40261106a8eaf78853d840113d1b95f2d181991c46f58e710f9988";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/examples_tf2_py/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "053758c1f77e0875eb2590178ba20c9c13e25d0e634234ca92d70f13f21cf2f5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "b0dc16190c28b53419a76272fe093554db90fa013bbcb216bd75865424f890de";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "29cca74cc790c2e543a9c458366d03143a1e49e2f3fc9547312bfd1c5b71b07e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "d9bf2bfe630f200bb7f235215ee18e8b01a7e293d28ac2286faac4ca743dc3cb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "b96862acf0e1cfe1cf94ac82e9e11d45d47f0d1ab4f9f8d7fcc48d6f4bab1a11";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-library-example-external/default.nix
+++ b/distros/rolling/generate-parameter-library-example-external/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library-example, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-rolling-generate-parameter-library-example-external";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example_external/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "30ddada3584d23262ecd828e268cdcc0664961d417fa21b3bb92cbd941dda7b3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-core generate-parameter-library-example rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-core ];
+
+  meta = {
+    description = "Example usage of a parameter header generated in another package.";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/generate-parameter-library-example/default.nix
+++ b/distros/rolling/generate-parameter-library-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, generate-parameter-library, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "61a70c85a4f797b2ec23ee3970ef5e6686620f2c3555b94773c5df0c10542c67";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "41b8255b09a257358bf7b4646488b9d1142e25c2ea586357aa8368b738484c4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-library-py/default.nix
+++ b/distros/rolling/generate-parameter-library-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library-py";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "a3a0d521e35671d8b946fe748cec7551baa52347b366c312d7e4d602d86d96a8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library_py/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3c2b57a052a21a574c565a221ea812d466835bbd6e31db308df29eceeb68a2d3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generate-parameter-library/default.nix
+++ b/distros/rolling/generate-parameter-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, fmt, generate-parameter-library-py, parameter-traits, rclcpp, rclcpp-lifecycle, rclpy, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-library";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "602c378a96259e7f7f994a43f44005edc4554aeeda502943fc51e6b8b9cc8ef0";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_library/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6ec097ac6f18f9e5d3529885190007cf7cacb3e55f79cdd22b8942179367c357";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generate-parameter-module-example/default.nix
+++ b/distros/rolling/generate-parameter-module-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, generate-parameter-library, generate-parameter-library-py, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-generate-parameter-module-example";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "d5134f618173573120e681ed89f0bcf8151b5dead2c75f884fbc25e9507773d8";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/generate_parameter_module_example/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "48d35f0e5295c1dd54442c4fc19686e634592c60894717c6ba22ea62c6b341d3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -672,6 +672,8 @@ self: super: {
 
  generate-parameter-library-example = self.callPackage ./generate-parameter-library-example {};
 
+ generate-parameter-library-example-external = self.callPackage ./generate-parameter-library-example-external {};
+
  generate-parameter-library-py = self.callPackage ./generate-parameter-library-py {};
 
  generate-parameter-module-example = self.callPackage ./generate-parameter-module-example {};
@@ -1513,6 +1515,8 @@ self: super: {
  py-trees-ros = self.callPackage ./py-trees-ros {};
 
  py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
+
+ py-trees-ros-viewer = self.callPackage ./py-trees-ros-viewer {};
 
  pybind11-json-vendor = self.callPackage ./pybind11-json-vendor {};
 

--- a/distros/rolling/geometry2/default.nix
+++ b/distros/rolling/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-rolling-geometry2";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "84b892dcc1d8f59026a37b66aed7512ba7e85a6b623bb860a9718f208534b416";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/geometry2/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "0e39fd2ff2d26b4f371ebff3284c0bdbce1c68fe8d90c6bfa78d8750ba98b5cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "d4088287765c776fcf4f6e831491e1a2c7f87bdcb4243f42c14c049bca9a18d7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "9635c39ebc93d6d9ae99c2cbe242cb3b9b5a89a84292c47b607ecf2de7fc3e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "2c89616f90c539535a18a78d8110305a39295fdeae671c24cf24f5b9f9422503";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "60e19bef1daae4b2495dbc9d300e685f9b97eeceab7219d3d69e0218cc550750";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-msgs-vendor/default.nix
+++ b/distros/rolling/gz-msgs-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-msgs-vendor";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "0283dc1b05719ef3240abfd097eee3507689b7cdc3f55550cf3ec56d6a2b43d7";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/rolling/gz_msgs_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "d688da1bdc79e8121817a87743357191bd4c9f504cfb6d8d569f1238e4caab8e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-math-vendor gz-tools-vendor protobuf python3 python3Packages.protobuf tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-msgs11 11.0.1
+    description = "Vendor package for: gz-msgs11 11.0.2
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "1a959125a358f54b3a87bc5d3f1e596e821111610c0b02d57ee484d40ceeb2b5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "f3a70fc4c613b943df938eb0071bb3c627c2ab6d6045a4106a3ac251c179ef20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "aafdd2b85f4384ce8af5c5a1d6a2df413e6f585630117e8a64ae9b08418b12f5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "b5c0faea86f0dfd99b0b4ab83cc3665b64963fd8fcd4a58c3aff996fd9742477";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "b630abc095f35f6fe54faab0c9f3315443179de2544ea676629058558f09dd65";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "297d255c657f16d51abc286734907e2d2d3608a0c8cae84dcf888460e0800081";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "57ab217f56dca1128366d3975af6b39c2020276f966f23512a36fc7cd381ea6a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "ce0bf53f5629a62276133aae91086c6420c6e90c891bdc5170c5adfd539b2cc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "2b296810a1e9385348cf2b0d83203e22349997337a2e13fcb277af8d6eadd47b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "619024936ce25e459271e64be29a5c94dce6218622de6cbc00bd72055e5b3cc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "8f607c853a74557165d6a843f44907899f978ed3a9920ed47733bc432b289924";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "eaf1d72cd97d99b3cb2ba681f92ce818f3e6cbd376699c0380ab8b1010796df1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "5299d0ed02065ad583296bd0c88fcf1f9cffe869835245af5a137f826a01715a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "9bd2270336d73bd4dc656ba7cc23ed4d0609fa57d4fac61e6038f67fb2c94b34";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "0fc57b89357a8ca11a07b2a35e16899afc58bbbfa04fa9e715966ed64175eecc";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "3e565a9ba77fee22cc905298a9266efe216120abedf4a0239a34fdbe3354546d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.5.1-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "67108967d07e103aa29386bf28958ede4c96c06316e692f8a8c66be199e8d116";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "922bfe0990f730033878f81a0dfb0e99c86f1cebc2fd9620ee7633d0faf4f67b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gtest ament-cmake-xmllint cmake ros-environment ];
-  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-state-estimation-simple mola-test-datasets rosbag2-storage-mcap ];
-  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake mola-metric-maps mola-test-datasets rosbag2-storage-mcap ];
+  propagatedBuildInputs = [ mola-common mola-input-kitti-dataset mola-input-kitti360-dataset mola-input-mulran-dataset mola-input-paris-luco-dataset mola-input-rawlog mola-input-rosbag2 mola-kernel mola-launcher mola-pose-list mola-state-estimation-simple mola-viz mp2p-icp mrpt-libmaps mrpt-libtclap ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/rolling/mola-state-estimation-simple/default.nix
+++ b/distros/rolling/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-simple";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "bdfb4133acc9dfc127a2b4e23ad2ce44a17fe5b1afe7962589422e5ab772fd09";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "7b673a15d03ffc9e9635b50d38d2ab9ce427b496385f0b3ca561523b8266f7f2";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-smoother/default.nix
+++ b/distros/rolling/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-smoother";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "fc31f0ee1d3225e3e60071b38c369083ef62d1f2e79ef34fe13fe343be8e9386";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "8dd737cc9c26001c01cf877b53434065373af3f7da50a29d47ac3dc92d96c2fd";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation/default.nix
+++ b/distros/rolling/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "332253a816cb16d2173120ddf828a5ab2f2eb14962a4fc252cae5543659b1837";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "257b5025fd2d7ffc9cd7cbebcf9b9a60dd4827214a95946f91d1d65386dc544a";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "Metapackage with all state estimation packages MOLA packages.";
+    description = "Metapackage with all MOLA state estimation packages.";
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/rolling/mola-test-datasets/default.nix
+++ b/distros/rolling/mola-test-datasets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-test-datasets";
-  version = "0.3.4-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/rolling/mola_test_datasets/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "2e2044b83233520878a5193dfe086f367764f2a09633ed308a02d5845236c043";
+    url = "https://github.com/ros2-gbp/mola_test_datasets-release/archive/release/rolling/mola_test_datasets/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "f69ee565bb978869cb5a84cbec16e8463c441497bfc29995956122615f1f396a";
   };
 
   buildType = "ament_cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = "Small SLAM dataset extracts used for demos or unit tests in the rest of MOLA packages";
-    license = with lib.licenses; [ bsdOriginal bsdOriginal "CC-BY-NC-SA-3.0" "CC-BY-3.0" "CC-BY-3.0" ];
+    license = with lib.licenses; [ bsdOriginal bsdOriginal "CC-BY-NC-SA-3.0" "CC-BY-3.0" "CC-BY-3.0" cc-by-nc-sa-40 ];
   };
 }

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "a7bf01a5c5cda0be2fefd35860cf0003adddd08a06d2081b0c3fc8457d74caa8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "844e4f4ce73e6146613ff10ca21b61c6c89050948e60d09ff02a434428390bb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parameter-traits/default.nix
+++ b/distros/rolling/parameter-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, fmt, rclcpp, rsl, tcb-span, tl-expected }:
 buildRosPackage {
   pname = "ros-rolling-parameter-traits";
-  version = "0.3.9-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.3.9-1.tar.gz";
-    name = "0.3.9-1.tar.gz";
-    sha256 = "7c285c844f52e79f218fae586625880fb191d7cc103cbf4b74c6909f2c418c76";
+    url = "https://github.com/ros2-gbp/generate_parameter_library-release/archive/release/rolling/parameter_traits/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "18294d85f1b279590387e2426a81cac16170d6ba579272c233beddf4ec382bf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "939b3cc5c0063e548eb1742807b1f3d74befd3ac99db803444569d78ed12fc25";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "42d1888bfd13750405652433a8388743523a8a0d322c58000b7d78d49df06655";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "6e18fce6b27eef701ee38b8108683ff10a78a7016a65980e27eeaa705231a0e9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "83ff97716d0a8fd62b5e30bce92a46646f61fbd9a3d316d155fc1e7eef8fa3f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "7eaf0e0bb5e028b6dbfa46e48026a0c5a3032296f72d45ae8aa0ea1b5cab503b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "f861ec8136199b4b7039004d6196d6a449a674700f6042db111accd72e83c9b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/py-trees-js/default.nix
+++ b/distros/rolling/py-trees-js/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, qt5 }:
 buildRosPackage {
   pname = "ros-rolling-py-trees-js";
-  version = "0.6.4-r3";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/rolling/py_trees_js/0.6.4-3.tar.gz";
-    name = "0.6.4-3.tar.gz";
-    sha256 = "7e341e7e703d352aca8ee6f4dd470001970bf9b63bb9f57e1f714108d18ea969";
+    url = "https://github.com/ros2-gbp/py_trees_js-release/archive/release/rolling/py_trees_js/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "19d5603480063c6f5ed764ce849e870069985284df69a53891ac20b084ccd369";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/py-trees-ros-interfaces/default.nix
+++ b/distros/rolling/py-trees-ros-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-py-trees-ros-interfaces";
-  version = "2.1.0-r3";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/rolling/py_trees_ros_interfaces/2.1.0-3.tar.gz";
-    name = "2.1.0-3.tar.gz";
-    sha256 = "9eeb7ffb85e06e4eb9bdf673d4711a82155b284f1c56ac52d5b516db92e1c841";
+    url = "https://github.com/ros2-gbp/py_trees_ros_interfaces-release/archive/release/rolling/py_trees_ros_interfaces/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "7d2c929337457213a93c71f5a44cab5add4b5c6cca9733531e1a53d7746804ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/py-trees-ros-viewer/default.nix
+++ b/distros/rolling/py-trees-ros-viewer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, py-trees-js, py-trees-ros-interfaces, python3Packages, qt5, rclpy, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-py-trees-ros-viewer";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/py_trees_ros_viewer-release/archive/release/rolling/py_trees_ros_viewer/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "80a472e5e769658d767b9f15675c19225fa9360d48df550eb62fc85997e06a11";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools qt5.qttools.dev ];
+  propagatedBuildInputs = [ py-trees-js py-trees-ros-interfaces python3Packages.pyqt5 python3Packages.pyqtwebengine rclpy unique-identifier-msgs ];
+
+  meta = {
+    description = "A Qt-JS application for visualisation of executing/log-replayed behaviour trees in a ROS2 ecosystem.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/rolling/py-trees-ros/default.nix
+++ b/distros/rolling/py-trees-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros-py, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, std-srvs, tf2-ros-py, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-py-trees-ros";
-  version = "2.2.2-r3";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/rolling/py_trees_ros/2.2.2-3.tar.gz";
-    name = "2.2.2-3.tar.gz";
-    sha256 = "3c6fa3434c8d89a0eec1df8cee79dfac735452c9d3154975eb216bd1a4993577";
+    url = "https://github.com/ros2-gbp/py_trees_ros-release/archive/release/rolling/py_trees_ros/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "80db5c9eab62e6059da308aa07a9c0880b7c04eb761c9232a72800896f9d1b60";
   };
 
   buildType = "ament_python";
   buildInputs = [ python3Packages.setuptools ];
   checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs tf2-ros-py unique-identifier-msgs ];
+  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs std-srvs tf2-ros-py unique-identifier-msgs ];
 
   meta = {
     description = "ROS2 extensions and behaviours for py_trees.";

--- a/distros/rolling/py-trees/default.nix
+++ b/distros/rolling/py-trees/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-py-trees";
-  version = "2.2.1-r3";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/rolling/py_trees/2.2.1-3.tar.gz";
-    name = "2.2.1-3.tar.gz";
-    sha256 = "affde676de0d48ba2297ee848e1da7fe5e1d2ebc035a65090520ce0623ceebcc";
+    url = "https://github.com/ros2-gbp/py_trees-release/archive/release/rolling/py_trees/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ae7d506ca96f6ad92228811306c83ffc123ddee297bface74bdfaf6b54b17793";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "31c226ad5574919febe394e9685751064edd28568ca27eca73bab7e01054738c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "d8df128365ff326c7501752e19f9350f71e6aadc27607c957aa257cdc7cbce46";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "5222c6f651573146023143bcbb974f9af6a62df6dbddb083407397fd29d30a76";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "bd215a4c174b81fabe7030c2dbc2e444cb709f3db5108766908b80b7d4c5b974";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "aec11e8ad23043f293e797b4c4c20681a4510396e751f1cdb94ed284ca9db541";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "827303b9ba5b53005dcabd89c2cea522b0d72e52e134d3d6af25ca1c0ff9a0f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "84f99359aac59b2667e248ef4b25297c71103aea8d0b6f32c2b213a567e1766c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "55a8d67302c88958e66e9ae95118057404fc7c85811376cd99d10df4d897c47f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "b70c3c5cc52a55d8bbcb72c403c53efa1ad58337e5bd46bfc28dd45000099e52";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "3b74dc3ffee14aca7aad4bf33d380fb0788172813ffbcc6752513257a40c72be";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ gz-sim-vendor image-transport-plugins robot-state-publisher ros-gz-bridge ros-gz-image ros-gz-sim rqt-image-view rqt-plot rqt-topic rviz2 sdformat-urdf xacro ];
+  propagatedBuildInputs = [ gz-sim-vendor image-transport-plugins robot-state-publisher ros-gz-bridge ros-gz-image ros-gz-sim rqt-image-view rqt-plot rqt-topic rviz-imu-plugin rviz2 sdformat-urdf tf2-ros xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "d72f1bea018f10ff7bfecf25ca5ccefe88faae32441edd0cd5f6f5d01dcd9723";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "03295293a4b753095736bf9825ce5c11009ea712d397e8a18d6d9492b0ad1c77";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-python pkg-config ];
   checkInputs = [ ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ ament-index-python gflags gz-math-vendor gz-msgs-vendor gz-sim-vendor gz-transport-vendor launch launch-ros rclcpp rclcpp-components std-msgs ];
+  propagatedBuildInputs = [ ament-index-python gflags gz-math-vendor gz-msgs-vendor gz-sim-vendor gz-transport-vendor launch launch-ros rclcpp rclcpp-components rcpputils std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "74c7b5a4c5f5f1ead7a74ec1f275360b4bf137388f287634dc2eafea6d726b00";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "77c0a318bb6a0cbf96360ca3f29de036af62b2e0d1aea7dff26a7f7cef15f247";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "2ca5748ece9f746a10fbb8c2c8ad604c40bf6706389637493f3e336b6f1a3361";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "04b9240eb3d8bb83a4fc908b2094de061280aff2db1949c9bd2bc90725fd8ba9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "5f7534c700cc3ca73d07a6ad3ecf04a7410cda82d041f11d8dd98d2abf791b79";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "d28bd3fdd38de41799f433d11a7df05690aa4b3dc1f481236e6f4af7e1fcbb41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "87a1bda78e6b66ee06e01a694655c5ff3fad6b58ddc826741b4e966ecaeacd52";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "6aa4788d9cc8e0bfea7cd171867d7aa62cb85ea62393c73b094045d1929eb6ac";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "784ee4a348ca6680e57351167945453cef8d3ef43a9771625b6f18ac2ab7be89";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "a83071210c427044759bdeca438649c44fd034fdc69800c19d68441b0e8f71a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "435d1dbf36db986c015e37ef1881b5b9e7f662d38c3fd1a7197b30635141f47c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "b921653bc3fdd31ef4cf09496bdc2f0a8e6bbec28ca5f9330c51818947cd2d8b";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "11fc11e11e6a124ea8fb7e6e84eb04146cd865c71e864aa94b823dab41b05e3e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "d208011510b0827bb7318c9343455b35dec571b1756c3a90d698a3d52222072a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "bc8215279502eed8d545847f3694d12669083334a918d7e0d8a7b37fd6c70fe8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "1d5dd0efa3851575565a4aaed9544f771fda4148ebd04e35f69e3780f9006085";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "50c08b76b539398006becc22be051952c6df57f6dced8f274c4a037d1a9a9551";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "fa4d700b31f063843e96f203e822f92c0243c32e680f5e0b0246fb02358aec90";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "ad00f45b079485c6526e19ec9b3558aba77b1278667c0d4f84b8b4be2b366457";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "0725ca4e880fdecd674a5c44c893ebe23c0ab7b406d50d10c3d15cd1b275c989";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "4f5838eb5206d511ed20ec4ed19480eb017131fb6962ea13a289b3d66b344461";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "f69f10367497ec8e6691624b59f1d4b02c7c794be4a87427bc85623fb35cbe32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "5610736c68e6da84d920c3ad45bf4ea1dc81154a3cd9791e33b529d3bd88549f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "1764c5110c46ebf2a2caf31d3fc4a7c9993468e28d9528a76f4208f8aab92110";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "8260e86afab595aea0a48bb45c11c7e9d96986db4f928c74bf19ca892ba61ff0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "22f5d6136f97d5bdb31ab17d7f74ba2c83573188bcd9679f63d149608f304779";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "d5f2f1329e06feccb21609204cd50c205d5b49d0c22f8c95d88fd43f3c76f578";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "c4707a509a17e9043d2a7d7499f6ca23f496bbed6ffe7188352301d0ee19e046";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "8c039d0e9ea548d11da48fd68a98d63959a9436b61b8229a89547381571d83f6";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "410beb38b8af9d485083bf7084d09bf819dbc7a4cff0d88ccda3b4b193302081";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.4.0-r1";
+  version = "14.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.0-1.tar.gz";
-    name = "14.4.0-1.tar.gz";
-    sha256 = "47e1c8f6c7792405f014ded0ee17b1bf812b9929c67d43378279d9fe9ec959fc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.1-1.tar.gz";
+    name = "14.4.1-1.tar.gz";
+    sha256 = "41d0aaff907a63f6062ea44970d9e0492202e00046081bda3b2e57973dca3894";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "c8a75f0cb5147296b84307a1a25c61277e0020d9c26ed96978e62a02e5786d81";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "80cfe527e391a1c16a79ee35daa3d6ff4f17c2fc5d60129ea739723de2c937a9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface generate-parameter-library geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/test-ros-gz-bridge/default.nix
+++ b/distros/rolling/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-rolling-test-ros-gz-bridge";
-  version = "2.1.2-r1";
+  version = "2.1.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "03796d848554a6731ac5a5dfe62f99167029a4d8aa99a98a37f6cc1a09de9129";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.3-2.tar.gz";
+    name = "2.1.3-2.tar.gz";
+    sha256 = "c22f34fb62708470beb43cf61910fc1d85ed0c7d6f3808a74202602d069db00f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-bullet/default.nix
+++ b/distros/rolling/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-bullet";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "d020dd15033b34ade91dcd79f9247b1b33ddc39717105089f2abf535807eab99";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_bullet/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "d7d2bb304dc59e20eb97cbfd95a7de54977087da700d6e76bf8bf5d1a5708748";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen-kdl/default.nix
+++ b/distros/rolling/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, orocos-kdl-vendor, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen-kdl";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "a982bf4550e2b04797830912bed1f87e89996dac35a79fd9fa37247c3cb3981f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen_kdl/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "43d7c748b1ee7af44d800db808a67d00230e18f30977651c0840e103827c3a59";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-eigen/default.nix
+++ b/distros/rolling/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-tf2-eigen";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "ea4a1dfece48982c681d5f9374a2e9d9ba834ce3b7eeb1e4bdb6a48b965e02ec";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_eigen/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "cd84a4fd741d069b7d0008eac827c75a16f2fa22d7d8fd9576885a36547e3791";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-geometry-msgs/default.nix
+++ b/distros/rolling/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, orocos-kdl-vendor, python3Packages, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-geometry-msgs";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "97afaf2511fa400a7cdab78fd90f07f62181991eff97b32df552ee87f997cd5a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_geometry_msgs/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "2fdf76ac45f576fd3544099d52860c155095fdaff4170fd2467d95d696286f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-kdl/default.nix
+++ b/distros/rolling/tf2-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, rclcpp, tf2, tf2-msgs, tf2-ros, tf2-ros-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl-vendor, python-orocos-kdl-vendor, rclcpp, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-kdl";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "7d7a08fb85a1ab751dcea3b6fccf7c1727199384b140fb7bea0122413b65d6cb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_kdl/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "58fe4d8826a3628f7fbccc4f94b74b0e137bb50697b0cdb4a246ad3560f859d4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gtest rclcpp tf2-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs orocos-kdl-vendor tf2 tf2-ros tf2-ros-py ];
+  checkInputs = [ ament-cmake-gtest rclcpp ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs orocos-kdl-vendor python-orocos-kdl-vendor tf2 tf2-ros tf2-ros-py ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/tf2-msgs/default.nix
+++ b/distros/rolling/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-tf2-msgs";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "254c96621bdcc98fb9b17ba67c111f0ec02b7cd044c27c7ab9c7be987c3492ed";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_msgs/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "9af5f645a94d98b416629bea36c045462b6fdde0753048ed92824ee5cab5c25d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-py/default.nix
+++ b/distros/rolling/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python3, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-rolling-tf2-py";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "aad8c5f641f3a4a37652a17e1e0f3c31b1d705098294dc8af06f2ced7f2d8555";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_py/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "890127fbe7cb281c36b07bc97788c9bff360cca3846891e258d4820d8d9d1394";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-ros-py/default.nix
+++ b/distros/rolling/tf2-ros-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, builtin-interfaces, geometry-msgs, python3Packages, rclpy, sensor-msgs, std-msgs, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros-py";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "05f2650b2acb79c61de8cfe510940c5b4e7f5dbaa383cf50034cf234bb914734";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros_py/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "756e75784e0ccc61cde502d8a792e268d8eeb2b0e73c57ce5977fbefd005fb7e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2-ros/default.nix
+++ b/distros/rolling/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, message-filters, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rosgraph-msgs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tf2-ros";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "fca31772ddb4947a2d39a15d3f1c6c26a4c4526700031360fd122647bc15fd15";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_ros/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "7f5efd151bd5ce9dddfa4adb518492461cde03ad18e665514c23cdd9ce08458c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-sensor-msgs/default.nix
+++ b/distros/rolling/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, python3Packages, rclcpp, sensor-msgs, sensor-msgs-py, std-msgs, tf2, tf2-ros, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-sensor-msgs";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "14a5bd6ac9c185ab8fa96ac9a3ed6f8ad47a7053bb8cb595044225eac2aecf25";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_sensor_msgs/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "c42356afc132fa9c607570bc89fc3700b59ba7dd6db01e5a65e4c4c16d68396d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tf2-tools/default.nix
+++ b/distros/rolling/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, graphviz, python3Packages, rclpy, tf2-msgs, tf2-py, tf2-ros-py }:
 buildRosPackage {
   pname = "ros-rolling-tf2-tools";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "6aba5911e65166d408e26d0a12577e1a553f67ddc49950e1257ac7fc4aff2d1e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2_tools/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "78caa975a8bd718deb4694de630fac05e7e822be319fd0413b76872302af851e";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/tf2/default.nix
+++ b/distros/rolling/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, builtin-interfaces, geometry-msgs, rcutils, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-tf2";
-  version = "0.40.0-r1";
+  version = "0.40.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.40.0-1.tar.gz";
-    name = "0.40.0-1.tar.gz";
-    sha256 = "aa03555f223ef36d319e06a0ce3cbb7be81d69d35543fb0351fedb834cd3357f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/rolling/tf2/0.40.1-1.tar.gz";
+    name = "0.40.1-1.tar.gz";
+    sha256 = "5d344992e3dbe1e8e2cd2454b50d03829397d02b55fdc75da2d3d094217159b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.23.0-r1";
+  version = "4.24.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.23.0-1.tar.gz";
-    name = "4.23.0-1.tar.gz";
-    sha256 = "d40d2f5d1cee6403929d5c1b567466afc05fd603a24738e67275c44bcc749b11";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.24.0-1.tar.gz";
+    name = "4.24.0-1.tar.gz";
+    sha256 = "9b531d12767a030ca45827b806a0e40f61219ee285a44df4069b14f8f04c83ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "440bdb0c32733970142f1d404bc5faad572dc54b83a091dcad724afb731f4432";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "9706e19bc6a577d2a6d92d9bdd88f9b1061256700e9a6015f26a0aaa454fd8cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "a585faa49e05ab57d7bde7205967c8c3ae8dd58a284d7c018862ef09060952f8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "d19b1d01fef010faa419539ef16310f510e2818c2a01250c99411110994acae1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.18.0-r2";
+  version = "4.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.18.0-2.tar.gz";
-    name = "4.18.0-2.tar.gz";
-    sha256 = "2fc322adb7a34f0853a7da43896e45af068f18b91227a7a969d28a662d966f70";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.19.0-1.tar.gz";
+    name = "4.19.0-1.tar.gz";
+    sha256 = "bfc6b97457a99d6ae3390cce573ec429120378260dde18a85649a61c9f0ab05c";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 503be406769b14b7907c52000d41a3e6a3531f08.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.40.0-r1 --> 2.41.0-r1*
* *admittance-controller 2.40.0-r1 --> 2.41.0-r1*
* *bicycle-steering-controller 2.40.0-r1 --> 2.41.0-r1*
* *clearpath-common 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-config 1.0.0-r1 --> 1.1.0-r1*
* *clearpath-control 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-customization 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-description 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-generator-common 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-manipulators 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-manipulators-description 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-mounts-description 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-platform-description 1.0.0-r1 --> 1.1.1-r1*
* *clearpath-sensors-description 1.0.0-r1 --> 1.1.1-r1*
* *cmake-generate-parameter-module-example 0.3.9-r1 --> 0.4.0-r1*
* *control-toolbox 3.4.0-r1 --> 3.5.0-r1*
* *depthai-bridge 2.10.4-r1 --> 2.10.5-r1*
* *depthai-descriptions 2.10.4-r1 --> 2.10.5-r1*
* *depthai-examples 2.10.4-r1 --> 2.10.5-r1*
* *depthai-filters 2.10.4-r1 --> 2.10.5-r1*
* *depthai-ros 2.10.4-r1 --> 2.10.5-r1*
* *depthai-ros-driver 2.10.4-r1 --> 2.10.5-r1*
* *depthai-ros-msgs 2.10.4-r1 --> 2.10.5-r1*
* *diff-drive-controller 2.40.0-r1 --> 2.41.0-r1*
* *effort-controllers 2.40.0-r1 --> 2.41.0-r1*
* *examples-tf2-py 0.25.10-r1 --> 0.25.11-r1*
* *force-torque-sensor-broadcaster 2.40.0-r1 --> 2.41.0-r1*
* *forward-command-controller 2.40.0-r1 --> 2.41.0-r1*
* *generate-parameter-library 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-library-example 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-library-example-external 0.4.0-r1*
* *generate-parameter-library-py 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-module-example 0.3.9-r1 --> 0.4.0-r1*
* *geometry2 0.25.10-r1 --> 0.25.11-r1*
* *gpio-controllers 2.40.0-r1 --> 2.41.0-r1*
* *gripper-controllers 2.40.0-r1 --> 2.41.0-r1*
* *imu-sensor-broadcaster 2.40.0-r1 --> 2.41.0-r1*
* *joint-state-broadcaster 2.40.0-r1 --> 2.41.0-r1*
* *joint-trajectory-controller 2.40.0-r1 --> 2.41.0-r1*
* *mola-imu-preintegration 1.6.0-r1 --> 1.6.1-r1*
* *mola-lidar-odometry 0.5.1-r1 --> 0.5.4-r1*
* *mola-state-estimation 1.6.0-r1 --> 1.6.1-r1*
* *mola-state-estimation-simple 1.6.0-r1 --> 1.6.1-r1*
* *mola-state-estimation-smoother 1.6.0-r1 --> 1.6.1-r1*
* *mola-test-datasets 0.3.4-r1 --> 0.4.0-r1*
* *parameter-traits 0.3.9-r1 --> 0.4.0-r1*
* *pid-controller 2.40.0-r1 --> 2.41.0-r1*
* *pose-broadcaster 2.40.0-r1 --> 2.41.0-r1*
* *position-controllers 2.40.0-r1 --> 2.41.0-r1*
* *py-trees 2.2.3-r1 --> 2.3.0-r1*
* *py-trees-js 0.6.4-r1 --> 0.6.6-r1*
* *py-trees-ros 2.2.2-r3 --> 2.3.0-r1*
* *py-trees-ros-interfaces 2.1.0-r1 --> 2.1.1-r1*
* *py-trees-ros-viewer 0.2.5-r1*
* *range-sensor-broadcaster 2.40.0-r1 --> 2.41.0-r1*
* *ros-babel-fish 0.9.6-r2 --> 0.9.4-r1*
* *ros-babel-fish-test-msgs 0.9.6-r2 --> 0.9.4-r1*
* *ros2-controllers 2.40.0-r1 --> 2.41.0-r1*
* *ros2-controllers-test-nodes 2.40.0-r1 --> 2.41.0-r1*
* *rqt-joint-trajectory-controller 2.40.0-r1 --> 2.41.0-r1*
* *rviz-assimp-vendor 11.2.15-r1 --> 11.2.16-r1*
* *rviz-common 11.2.15-r1 --> 11.2.16-r1*
* *rviz-default-plugins 11.2.15-r1 --> 11.2.16-r1*
* *rviz-ogre-vendor 11.2.15-r1 --> 11.2.16-r1*
* *rviz-rendering 11.2.15-r1 --> 11.2.16-r1*
* *rviz-rendering-tests 11.2.15-r1 --> 11.2.16-r1*
* *rviz-visual-testing-framework 11.2.15-r1 --> 11.2.16-r1*
* *rviz2 11.2.15-r1 --> 11.2.16-r1*
* *steering-controllers-library 2.40.0-r1 --> 2.41.0-r1*
* *tf2 0.25.10-r1 --> 0.25.11-r1*
* *tf2-bullet 0.25.10-r1 --> 0.25.11-r1*
* *tf2-eigen 0.25.10-r1 --> 0.25.11-r1*
* *tf2-eigen-kdl 0.25.10-r1 --> 0.25.11-r1*
* *tf2-geometry-msgs 0.25.10-r1 --> 0.25.11-r1*
* *tf2-kdl 0.25.10-r1 --> 0.25.11-r1*
* *tf2-msgs 0.25.10-r1 --> 0.25.11-r1*
* *tf2-py 0.25.10-r1 --> 0.25.11-r1*
* *tf2-ros 0.25.10-r1 --> 0.25.11-r1*
* *tf2-ros-py 0.25.10-r1 --> 0.25.11-r1*
* *tf2-sensor-msgs 0.25.10-r1 --> 0.25.11-r1*
* *tf2-tools 0.25.10-r1 --> 0.25.11-r1*
* *tricycle-controller 2.40.0-r1 --> 2.41.0-r1*
* *tricycle-steering-controller 2.40.0-r1 --> 2.41.0-r1*
* *turtlebot4-setup 1.0.4-r1 --> 1.0.5-r1*
* *velocity-controllers 2.40.0-r1 --> 2.41.0-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.18.0-r1 --> 4.19.0-r1*
* *admittance-controller 4.18.0-r1 --> 4.19.0-r1*
* *bicycle-steering-controller 4.18.0-r1 --> 4.19.0-r1*
* *clearpath-bt-joy 2.0.0-r1*
* *clearpath-common 2.0.0-r1*
* *clearpath-config 2.0.1-r1*
* *clearpath-control 2.0.0-r1*
* *clearpath-customization 2.0.0-r1*
* *clearpath-description 2.0.0-r1*
* *clearpath-generator-common 2.0.0-r1*
* *clearpath-manipulators 2.0.0-r1*
* *clearpath-manipulators-description 2.0.0-r1*
* *clearpath-motor-msgs 1.0.1-r1 --> 2.0.0-r1*
* *clearpath-mounts-description 2.0.0-r1*
* *clearpath-msgs 1.0.1-r1 --> 2.0.0-r1*
* *clearpath-platform-description 2.0.0-r1*
* *clearpath-platform-msgs 1.0.1-r1 --> 2.0.0-r1*
* *clearpath-sensors-description 2.0.0-r1*
* *cmake-generate-parameter-module-example 0.3.9-r1 --> 0.4.0-r1*
* *control-toolbox 3.4.0-r1 --> 3.5.0-r1*
* *controller-interface 4.23.0-r1 --> 4.24.0-r1*
* *controller-manager 4.23.0-r1 --> 4.24.0-r1*
* *controller-manager-msgs 4.23.0-r1 --> 4.24.0-r1*
* *depthai-bridge 2.10.3-r1 --> 2.10.5-r1*
* *depthai-descriptions 2.10.3-r1 --> 2.10.5-r1*
* *depthai-examples 2.10.3-r1 --> 2.10.5-r1*
* *depthai-filters 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros-driver 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros-msgs 2.10.3-r1 --> 2.10.5-r1*
* *diff-drive-controller 4.18.0-r1 --> 4.19.0-r1*
* *effort-controllers 4.18.0-r1 --> 4.19.0-r1*
* *examples-tf2-py 0.36.7-r1 --> 0.36.8-r1*
* *force-torque-sensor-broadcaster 4.18.0-r1 --> 4.19.0-r1*
* *forward-command-controller 4.18.0-r1 --> 4.19.0-r1*
* *generate-parameter-library 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-library-example 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-library-example-external 0.4.0-r1*
* *generate-parameter-library-py 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-module-example 0.3.9-r1 --> 0.4.0-r1*
* *geometry2 0.36.7-r1 --> 0.36.8-r1*
* *gpio-controllers 4.18.0-r1 --> 4.19.0-r1*
* *gripper-controllers 4.18.0-r1 --> 4.19.0-r1*
* *gz-ros2-control 1.2.9-r1 --> 1.2.10-r1*
* *gz-ros2-control-demos 1.2.9-r1 --> 1.2.10-r1*
* *gz-sim-vendor 0.0.6-r1 --> 0.0.7-r1*
* *hardware-interface 4.23.0-r1 --> 4.24.0-r1*
* *hardware-interface-testing 4.23.0-r1 --> 4.24.0-r1*
* *imu-sensor-broadcaster 4.18.0-r1 --> 4.19.0-r1*
* *joint-limits 4.23.0-r1 --> 4.24.0-r1*
* *joint-state-broadcaster 4.18.0-r1 --> 4.19.0-r1*
* *joint-trajectory-controller 4.18.0-r1 --> 4.19.0-r1*
* *mecanum-drive-controller 4.18.0-r1 --> 4.19.0-r1*
* *mola-imu-preintegration 1.6.0-r1 --> 1.6.1-r1*
* *mola-lidar-odometry 0.5.1-r1 --> 0.5.4-r1*
* *mola-state-estimation 1.6.0-r1 --> 1.6.1-r1*
* *mola-state-estimation-simple 1.6.0-r1 --> 1.6.1-r1*
* *mola-state-estimation-smoother 1.6.0-r1 --> 1.6.1-r1*
* *mola-test-datasets 0.3.4-r1 --> 0.4.0-r1*
* *parallel-gripper-controller 4.18.0-r1 --> 4.19.0-r1*
* *parameter-traits 0.3.9-r1 --> 0.4.0-r1*
* *pid-controller 4.18.0-r1 --> 4.19.0-r1*
* *pose-broadcaster 4.18.0-r1 --> 4.19.0-r1*
* *position-controllers 4.18.0-r1 --> 4.19.0-r1*
* *py-trees 2.2.1-r4 --> 2.3.0-r1*
* *py-trees-js 0.6.4-r1 --> 0.6.6-r1*
* *py-trees-ros 2.2.2-r4 --> 2.3.0-r1*
* *py-trees-ros-interfaces 2.1.0-r4 --> 2.1.1-r1*
* *py-trees-ros-viewer 0.2.5-r1*
* *range-sensor-broadcaster 4.18.0-r1 --> 4.19.0-r1*
* *rmf-building-map-tools 1.9.1-r1 --> 1.9.2-r1*
* *rmf-demos-assets 2.3.0-r1*
* *rmf-demos-bridges 2.3.0-r1*
* *rmf-demos-fleet-adapter 2.3.0-r1*
* *rmf-demos-tasks 2.3.0-r1*
* *rmf-traffic-editor 1.9.1-r1 --> 1.9.2-r1*
* *rmf-traffic-editor-assets 1.9.1-r1 --> 1.9.2-r1*
* *rmf-traffic-editor-test-maps 1.9.1-r1 --> 1.9.2-r1*
* *ros2-control 4.23.0-r1 --> 4.24.0-r1*
* *ros2-control-test-assets 4.23.0-r1 --> 4.24.0-r1*
* *ros2-controllers 4.18.0-r1 --> 4.19.0-r1*
* *ros2-controllers-test-nodes 4.18.0-r1 --> 4.19.0-r1*
* *ros2controlcli 4.23.0-r1 --> 4.24.0-r1*
* *rqt-controller-manager 4.23.0-r1 --> 4.24.0-r1*
* *rqt-joint-trajectory-controller 4.18.0-r1 --> 4.19.0-r1*
* *rviz-assimp-vendor 14.1.6-r1 --> 14.1.7-r1*
* *rviz-common 14.1.6-r1 --> 14.1.7-r1*
* *rviz-default-plugins 14.1.6-r1 --> 14.1.7-r1*
* *rviz-ogre-vendor 14.1.6-r1 --> 14.1.7-r1*
* *rviz-rendering 14.1.6-r1 --> 14.1.7-r1*
* *rviz-rendering-tests 14.1.6-r1 --> 14.1.7-r1*
* *rviz-visual-testing-framework 14.1.6-r1 --> 14.1.7-r1*
* *rviz2 14.1.6-r1 --> 14.1.7-r1*
* *steering-controllers-library 4.18.0-r1 --> 4.19.0-r1*
* *tensorrt-cmake-module 0.0.3-r4 --> 0.0.4-r1*
* *tf2 0.36.7-r1 --> 0.36.8-r1*
* *tf2-bullet 0.36.7-r1 --> 0.36.8-r1*
* *tf2-eigen 0.36.7-r1 --> 0.36.8-r1*
* *tf2-eigen-kdl 0.36.7-r1 --> 0.36.8-r1*
* *tf2-geometry-msgs 0.36.7-r1 --> 0.36.8-r1*
* *tf2-kdl 0.36.7-r1 --> 0.36.8-r1*
* *tf2-msgs 0.36.7-r1 --> 0.36.8-r1*
* *tf2-py 0.36.7-r1 --> 0.36.8-r1*
* *tf2-ros 0.36.7-r1 --> 0.36.8-r1*
* *tf2-ros-py 0.36.7-r1 --> 0.36.8-r1*
* *tf2-sensor-msgs 0.36.7-r1 --> 0.36.8-r1*
* *tf2-tools 0.36.7-r1 --> 0.36.8-r1*
* *transmission-interface 4.23.0-r1 --> 4.24.0-r1*
* *tricycle-controller 4.18.0-r1 --> 4.19.0-r1*
* *tricycle-steering-controller 4.18.0-r1 --> 4.19.0-r1*
* *velocity-controllers 4.18.0-r1 --> 4.19.0-r1*

Noetic Changes:
---------------
* *depthai-bridge 2.10.3-r1 --> 2.10.5-r1*
* *depthai-descriptions 2.10.3-r1 --> 2.10.5-r1*
* *depthai-examples 2.10.3-r1 --> 2.10.5-r1*
* *depthai-filters 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros-driver 2.10.3-r1 --> 2.10.5-r1*
* *depthai-ros-msgs 2.10.3-r1 --> 2.10.5-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.18.0-r2 --> 4.19.0-r1*
* *admittance-controller 4.18.0-r2 --> 4.19.0-r1*
* *bicycle-steering-controller 4.18.0-r2 --> 4.19.0-r1*
* *cmake-generate-parameter-module-example 0.3.9-r1 --> 0.4.0-r1*
* *control-toolbox 3.4.0-r1 --> 3.5.0-r1*
* *controller-interface 4.23.0-r1 --> 4.24.0-r1*
* *controller-manager 4.23.0-r1 --> 4.24.0-r1*
* *controller-manager-msgs 4.23.0-r1 --> 4.24.0-r1*
* *diff-drive-controller 4.18.0-r2 --> 4.19.0-r1*
* *effort-controllers 4.18.0-r2 --> 4.19.0-r1*
* *examples-tf2-py 0.40.0-r1 --> 0.40.1-r1*
* *force-torque-sensor-broadcaster 4.18.0-r2 --> 4.19.0-r1*
* *forward-command-controller 4.18.0-r2 --> 4.19.0-r1*
* *generate-parameter-library 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-library-example 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-library-example-external 0.4.0-r1*
* *generate-parameter-library-py 0.3.9-r1 --> 0.4.0-r1*
* *generate-parameter-module-example 0.3.9-r1 --> 0.4.0-r1*
* *geometry2 0.40.0-r1 --> 0.40.1-r1*
* *gpio-controllers 4.18.0-r2 --> 4.19.0-r1*
* *gripper-controllers 4.18.0-r2 --> 4.19.0-r1*
* *gz-msgs-vendor 0.2.1-r1 --> 0.2.2-r1*
* *hardware-interface 4.23.0-r1 --> 4.24.0-r1*
* *hardware-interface-testing 4.23.0-r1 --> 4.24.0-r1*
* *imu-sensor-broadcaster 4.18.0-r2 --> 4.19.0-r1*
* *joint-limits 4.23.0-r1 --> 4.24.0-r1*
* *joint-state-broadcaster 4.18.0-r2 --> 4.19.0-r1*
* *joint-trajectory-controller 4.18.0-r2 --> 4.19.0-r1*
* *mecanum-drive-controller 4.18.0-r2 --> 4.19.0-r1*
* *mola-imu-preintegration 1.6.0-r1 --> 1.6.1-r1*
* *mola-lidar-odometry 0.5.1-r1 --> 0.5.4-r1*
* *mola-state-estimation 1.6.0-r1 --> 1.6.1-r1*
* *mola-state-estimation-simple 1.6.0-r1 --> 1.6.1-r1*
* *mola-state-estimation-smoother 1.6.0-r1 --> 1.6.1-r1*
* *mola-test-datasets 0.3.4-r1 --> 0.4.0-r1*
* *parallel-gripper-controller 4.18.0-r2 --> 4.19.0-r1*
* *parameter-traits 0.3.9-r1 --> 0.4.0-r1*
* *pid-controller 4.18.0-r2 --> 4.19.0-r1*
* *pose-broadcaster 4.18.0-r2 --> 4.19.0-r1*
* *position-controllers 4.18.0-r2 --> 4.19.0-r1*
* *py-trees 2.2.1-r3 --> 2.3.0-r1*
* *py-trees-js 0.6.4-r3 --> 0.6.6-r1*
* *py-trees-ros 2.2.2-r3 --> 2.3.0-r1*
* *py-trees-ros-interfaces 2.1.0-r3 --> 2.1.1-r1*
* *py-trees-ros-viewer 0.2.5-r1*
* *range-sensor-broadcaster 4.18.0-r2 --> 4.19.0-r1*
* *ros-gz 2.1.2-r1 --> 2.1.3-r2*
* *ros-gz-bridge 2.1.2-r1 --> 2.1.3-r2*
* *ros-gz-image 2.1.2-r1 --> 2.1.3-r2*
* *ros-gz-interfaces 2.1.2-r1 --> 2.1.3-r2*
* *ros-gz-sim 2.1.2-r1 --> 2.1.3-r2*
* *ros-gz-sim-demos 2.1.2-r1 --> 2.1.3-r2*
* *ros2-control 4.23.0-r1 --> 4.24.0-r1*
* *ros2-control-test-assets 4.23.0-r1 --> 4.24.0-r1*
* *ros2-controllers 4.18.0-r2 --> 4.19.0-r1*
* *ros2-controllers-test-nodes 4.18.0-r2 --> 4.19.0-r1*
* *ros2controlcli 4.23.0-r1 --> 4.24.0-r1*
* *rqt-controller-manager 4.23.0-r1 --> 4.24.0-r1*
* *rqt-joint-trajectory-controller 4.18.0-r2 --> 4.19.0-r1*
* *rviz-assimp-vendor 14.4.0-r1 --> 14.4.1-r1*
* *rviz-common 14.4.0-r1 --> 14.4.1-r1*
* *rviz-default-plugins 14.4.0-r1 --> 14.4.1-r1*
* *rviz-ogre-vendor 14.4.0-r1 --> 14.4.1-r1*
* *rviz-rendering 14.4.0-r1 --> 14.4.1-r1*
* *rviz-rendering-tests 14.4.0-r1 --> 14.4.1-r1*
* *rviz-visual-testing-framework 14.4.0-r1 --> 14.4.1-r1*
* *rviz2 14.4.0-r1 --> 14.4.1-r1*
* *steering-controllers-library 4.18.0-r2 --> 4.19.0-r1*
* *test-ros-gz-bridge 2.1.2-r1 --> 2.1.3-r2*
* *tf2 0.40.0-r1 --> 0.40.1-r1*
* *tf2-bullet 0.40.0-r1 --> 0.40.1-r1*
* *tf2-eigen 0.40.0-r1 --> 0.40.1-r1*
* *tf2-eigen-kdl 0.40.0-r1 --> 0.40.1-r1*
* *tf2-geometry-msgs 0.40.0-r1 --> 0.40.1-r1*
* *tf2-kdl 0.40.0-r1 --> 0.40.1-r1*
* *tf2-msgs 0.40.0-r1 --> 0.40.1-r1*
* *tf2-py 0.40.0-r1 --> 0.40.1-r1*
* *tf2-ros 0.40.0-r1 --> 0.40.1-r1*
* *tf2-ros-py 0.40.0-r1 --> 0.40.1-r1*
* *tf2-sensor-msgs 0.40.0-r1 --> 0.40.1-r1*
* *tf2-tools 0.40.0-r1 --> 0.40.1-r1*
* *transmission-interface 4.23.0-r1 --> 4.24.0-r1*
* *tricycle-controller 4.18.0-r2 --> 4.19.0-r1*
* *tricycle-steering-controller 4.18.0-r2 --> 4.19.0-r1*
* *velocity-controllers 4.18.0-r2 --> 4.19.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-antlr4
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-expiringdict
 * [ ] python3-flake8-blind-except
 * [ ] python3-flake8-class-newline
 * [ ] python3-flake8-deprecated
 * [ ] python3-icecream
 * [ ] python3-pexpect
 * [ ] python3-pre-commit
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rich
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] python3-typing-extensions
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

