### PR TITLE
humble.rosidl-generator-py: Fix numpy include path

### DIFF
--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -139,7 +139,7 @@ in with lib; {
     postPatch = postPatch + ''
       substituteInPlace cmake/rosidl_generator_py_generate_interfaces.cmake \
        --replace-fail '"import numpy"' "" \
-       --replace-fail 'numpy.get_include()' "'${python.pkgs.numpy}/${python.sitePackages}/numpy/core/include'"
+       --replace-fail 'numpy.get_include()' "'${python.pkgs.numpy}/${python.sitePackages}/numpy/_core/include'"
     '';
   });
 


### PR DESCRIPTION
This fixes many build failures when building the overlay against nixos-unstable.

In the past NumPy core headers were under `numpy/core/include`, but in recent nixpkgs versions, the location changed to `numpy/_core/include`.

NumPy >= 2.0 also includes `numpy-config` tool. We could use the tool to get the correct path, instead of hardcoding it in the Nix expression, but I'm not sure how it would work with cross-compiling, so I'm leaving the logic as it was.