### PR TITLE
rosdistro sync, Fri Feb  7 13:49:49 2025

### DIFF
--- a/distros/humble/backward-ros/default.nix
+++ b/distros/humble/backward-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, elfutils }:
 buildRosPackage {
   pname = "ros-humble-backward-ros";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/backward_ros-release/archive/release/humble/backward_ros/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "8e8e19d24a46673ba94e22f96fa8f6cf8defbc76c64d566d7d4e5d9e352cbbb5";
+    url = "https://github.com/ros2-gbp/backward_ros-release/archive/release/humble/backward_ros/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "1689006a5358b7121e093bfeac5b8e933be4b6029e599cf0bb8013fdc57e75e5";
   };
 
   buildType = "cmake";

--- a/distros/humble/foxglove-bridge/default.nix
+++ b/distros/humble/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-humble-foxglove-bridge";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "fcec428a6bc64d8b6f9a47b1d11208ff4b3e5d8c0f3f6c9053381a6bd62e4da5";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/humble/foxglove_bridge/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "c60096cd2a460bcffd0af086d2fbe9d54eb0b9c724cbf4ee69f36d946b6a0fc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hebi-cpp-api/default.nix
+++ b/distros/humble/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
 buildRosPackage {
   pname = "ros-humble-hebi-cpp-api";
-  version = "3.10.0-r1";
+  version = "3.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/humble/hebi_cpp_api/3.10.0-1.tar.gz";
-    name = "3.10.0-1.tar.gz";
-    sha256 = "a46abd28af27f85d466f74b7a1e173d04b9a8e7a713fdac241629a59f05f3734";
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/humble/hebi_cpp_api/3.10.1-1.tar.gz";
+    name = "3.10.1-1.tar.gz";
+    sha256 = "b881efc78d58146fd66b4c05b938dfc1c77ade6d92db481bb3bdf2400f523e3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/moveit-visual-tools/default.nix
+++ b/distros/humble/moveit-visual-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-moveit-visual-tools";
-  version = "4.1.1-r1";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/humble/moveit_visual_tools/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "66b9c4b7e3bbe9e7cb2684692ca55009e15c49bc5a1ee9be680d448dd8ec98c7";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/humble/moveit_visual_tools/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "09a0c95e65a20ec258d3ff706205e248e01ec0b3b8f5306893157e5b80cde0f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mvsim/default.nix
+++ b/distros/humble/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt-libgui, mrpt-libmaps, mrpt-libposes, mrpt-libros-bridge, mrpt-libtclap, nav-msgs, protobuf, python3, python3Packages, ros-environment, ros2launch, sensor-msgs, stereo-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-humble-mvsim";
-  version = "0.13.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.13.0-1.tar.gz";
-    name = "0.13.0-1.tar.gz";
-    sha256 = "5b734c8032fe0f81882fd688c7276daf6a18bd1a01c1a3a32e8333732159f19e";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/humble/mvsim/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "183c6f112aad20f956672eecda862c7f98d45b4297334b790280b30d4bf05cef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-oem7-driver/default.nix
+++ b/distros/humble/novatel-oem7-driver/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-oem7-driver";
-  version = "20.1.0-r1";
+  version = "20.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_driver/20.1.0-1.tar.gz";
-    name = "20.1.0-1.tar.gz";
-    sha256 = "c6b682f112867a5d80548cd081a9f3e9df2b90d030bf29de2882dc19117eeab5";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_driver/20.6.0-1.tar.gz";
+    name = "20.6.0-1.tar.gz";
+    sha256 = "f32d68d582e8d8a5e54a8aa657abcd714da829c3164a03dbf8512214fa22deaf";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake git ];
   checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros rclpy rosbag2 rosidl-runtime-py ];
   propagatedBuildInputs = [ boost geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = "NovAtel Oem7 ROS Driver";

--- a/distros/humble/novatel-oem7-msgs/default.nix
+++ b/distros/humble/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-oem7-msgs";
-  version = "20.1.0-r1";
+  version = "20.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_msgs/20.1.0-1.tar.gz";
-    name = "20.1.0-1.tar.gz";
-    sha256 = "b5eb7bfdbe11472c51543e4f907a500ef7815746742b736c5be365f30cda5447";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_msgs/20.6.0-1.tar.gz";
+    name = "20.6.0-1.tar.gz";
+    sha256 = "7cb0371afe7fd932009b6fa4ceea0ba50651f67494baa58786aa15cbfaceac2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics-msgs/default.nix
+++ b/distros/humble/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "a6fda15a4111b4a73278bfefbc187d42ef0be3c4a17d40394ce5b98a284afacc";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "f3cc541537239702ad306ce1bf028cbdb269050980eee21771f7ce442f0d77f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pal-statistics/default.nix
+++ b/distros/humble/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-humble-pal-statistics";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "13a4dfff2db2642476325476b4423d04690b9932aec95e1405d3f8d9c70925d1";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/humble/pal_statistics/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "593b21d48977edffb142a7d2cf1993a0db28d23c0939725271f4542f3fb73a74";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realtime-tools/default.nix
+++ b/distros/humble/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-realtime-tools";
-  version = "2.10.0-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.10.0-1.tar.gz";
-    name = "2.10.0-1.tar.gz";
-    sha256 = "0ad0a33e5c9da057b3f1a9b51b7e549b785b5ef7fb7fe71d65c239a49b0f39bc";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "68ad811500425329746cab5c48ee54c8ebd0129b5cea435f52b1702fbf6edd11";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "bf9fb63023ed4124e644e6c8d420e474b58592be16aa5645597b353e4eebc61c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "be021b6d549af60c07c229c0db3179a8ed43d4c364bb0d0ccc153a8accc44c89";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "5a15fb17e420539161ef280e1da39f28ed49bc15543ced400751aaf4195387c4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "7073ad60e8d1942d1ff21f9146428280e94100079b612d4dba6db0ff7ad8aa52";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/backward-ros/default.nix
+++ b/distros/jazzy/backward-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, elfutils }:
 buildRosPackage {
   pname = "ros-jazzy-backward-ros";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/backward_ros-release/archive/release/jazzy/backward_ros/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "206da5433d4bbad33a4b1f77108f22ba949e00cb20edd40d19c9532632cf8a2b";
+    url = "https://github.com/ros2-gbp/backward_ros-release/archive/release/jazzy/backward_ros/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "d704b2567ebe5050e5c1f621e31a4ad1e2560180a89ff9e6ecc041854821327a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "7fda35929f533eec316cc2c1e19fabba9f413a6c0d47a61b03035d5b2ba48eaa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "de93829a3de7f82c38a47c6be27a63d1bde94d79440ebd118f1341376d0ef7ea";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "bc8dccef6276c42f083b535edaa4064e24f8b99733631910eb37b0ccde249887";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6bde5dc11b620aa626edb5245700d7cb1005d445d0731902a8bc9feec9d2bb4e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "4023e4f81833349af1eed60f15deb79e69cf744a551a5bfa2211177f6bfce46d";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "ac6e2b2e0541cb2a16ff649acc81530f8a0cda664b9ef40838e831580e882013";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config-live/default.nix
+++ b/distros/jazzy/clearpath-config-live/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-config-live";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_config_live/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "21095a3f1b19148e3c43f15f6c7d8abb255935b13df9e7fab02ee43791908f07";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-generator-common python3Packages.watchdog rclpy xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "Live URDF Updater from Clearpath Configuration.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c29323976e072d7dbd03562c76450edc65a5e16d523b46cdbcdc05fb1614d8e8";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "79f9532de8635e2912ca2a6325ff0602acb09bf069e5aa3c819e1098d8e98983";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "d683eb0f8cfe2f083ef3babbc1b9f019b6b2123a88ccae1dd2a413ed218157c3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "26955cd652df70c97fe032af93639b175498757ca0aaf10a2d06a7dff9c7ca79";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "9866336ea66fbf247661954cc419f64d5335ebff0d0a24b67ce82bda2975b96e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8a47c7956b779b4859e06903790ddcf97d378837a36d97117738d21452aa23c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "61915b182f4d17e49ce296d3df9e54d6be757c1d5ed87ac3d311962643260fde";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "53e04aaef26ee580bf9575cefe8e31adb8d08d515a7db97ce95b3ca6d88102b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-desktop/default.nix
+++ b/distros/jazzy/clearpath-desktop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-offboard-sensors, clearpath-platform-msgs, clearpath-viz }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-desktop";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_desktop/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "b4ee7748a02bd86d4b44c55c45c8689b0671f7d5e4fa712e84dac52e78d25ae9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-config-live clearpath-offboard-sensors clearpath-platform-msgs clearpath-viz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Packages for working with Clearpath Platforms from a ROS 2 desktop.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "107bf50ef4fd51c9b528eb9dc34e72bef7d7ae96fceb55b69bc047faa74ec680";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1df25d67b6795fd31a860085a0602a9c4986c72375d4b3b8626d83541e3b01eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "bf39f4318c1f9a51d488bde03a6b0c0d2f92371ce5b78607e261935347e4d0e1";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d103ba2a4267ccd815fdac96218e1891fdbf71a5f477f3a297b37ef7b3b5940f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "563167dd6ec2e75ae274c6452a82494a3cdb47cda9d7e3209c0447ec4f135c43";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "a35495adf803b1ea4526a692efd06e460cc0f757642850b40861e55b5f15d29f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-motor-msgs/default.nix
+++ b/distros/jazzy/clearpath-motor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-motor-msgs";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "c716544045f474c90729a1dd440429585cee01ca9302db9d1aa83436e7841ce3";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "cad6631f674c18216a638ffd7e26bfa7da53751fab05ca6c014076755d5f0a89";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "8f30bb1ccdc22c760d00069ab86e29c0df90ecfa221ee9d519d33c3e42b00c34";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "c01a29c24b7584a4599b2cc89b526b1ca80123583b0e1bcca57e918c829c41f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-msgs/default.nix
+++ b/distros/jazzy/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-motor-msgs, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-msgs";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "65c254a446ac57eead5beafcf7cc48f0d54e10b25016df838b65393b3fd9b7b7";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "28dc5f6ad87dd990f7ec1289d25e6b4d87aa2095a018bf41dfee14976e260da6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-nav2-demos/default.nix
+++ b/distros/jazzy/clearpath-nav2-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, nav2-bringup, slam-toolbox }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-nav2-demos";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_nav2_demos-release/archive/release/jazzy/clearpath_nav2_demos/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9a31afcdeb0cc163fcf5f97ef69630ab2d76aa7c34eb95d2d7c4cbecc3d1b87a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-config nav2-bringup slam-toolbox ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Nav2 demos for Clearpath robots";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-offboard-sensors/default.nix
+++ b/distros/jazzy/clearpath-offboard-sensors/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, image-transport, image-transport-plugins, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-offboard-sensors";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_offboard_sensors/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bb46f16d47eafaddeb5d35cc71369c68dc49ffc48420123744b172d636d75240";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ image-transport image-transport-plugins velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Launch files for decompressing and consuming high-bandwidth sensor data on offboard computers";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "b0431be9dbee8eb6bfcfc4ef41894aa60ce3c70b5d6ba44ff2b12e52786b4a9a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3944c4ae0b1792eb42f48eacb53038f01e60c1736fa79bae94d84e52890ce86e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-msgs/default.nix
+++ b/distros/jazzy/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-msgs";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "dd51754682bacd6cb95a26a84185819184805e492392d69f6eef35d528c60bd7";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "558b1c43206371fe28b04f44705a401323450b38adedf41c1130cf64e817f40c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-ros2-socketcan-interface/default.nix
+++ b/distros/jazzy/clearpath-ros2-socketcan-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, iproute2, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-ros2-socketcan-interface";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/jazzy/clearpath_ros2_socketcan_interface/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1d0318975014415ceec785045338f0848d17aef8f0a8576736f18ed950a89660";
+    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/jazzy/clearpath_ros2_socketcan_interface/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "58e54d6f5ab78356fc6cd754c3ff211ca1217f24a5ab1376d37a61521749173d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ can-msgs rclcpp ];
+  propagatedBuildInputs = [ can-msgs iproute2 rclcpp ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "fc1bb76ba100f1b3a2570a6e3e32d2287b00b0062246c7fd10ee24d7448bb2d7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "f4892d06888680d2498695af11117e9f05c2ec260cbe8da2a2384abeec12c10e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-viz/default.nix
+++ b/distros/jazzy/clearpath-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-viz";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/jazzy/clearpath_viz/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "7c938874cb81dafc5241529a0cd4e0005e27ac7f3e5db71b2039ef86f3a1e648";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ clearpath-platform-description joint-state-publisher-gui rqt-robot-monitor rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Visualization launchers for Clearpath Platforms.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/control-toolbox/default.nix
+++ b/distros/jazzy/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-jazzy-control-toolbox";
-  version = "3.5.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "b9017d043a7705a47ef1d5b2fe14c243ad5d983dc7bb40d5ff57f576f0d79fa8";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "3cf2ae908c8b74517930627183524031c69f4e052290bafb035aa09c649ef547";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "b8e41b52961f238aae9a12258ac9e802eb898fc1d3dc8005c7b56433fc27b25d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "31f8dec752b2ae2cee6d84737389e9d274d732ed2077888beb1b03e625a88047";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "8134652f3f1e42250c8b5b90b56028a64f33a19d9fe0e3c2a9c40e470aa4e0d5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "92c0243c2b2f2d42a0932c955382efc50d0b70ba45eb1237e06a53323452d105";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "543047ec70bcfbd8d649c8dcf3dfbf35a9902b78417c6932861543aa048e9f3e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "d270a8534398cd8b5aa22de94530cf464cf4c657326fcaf2ff43f3b642985c1c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ament-cmake-pytest example-interfaces hardware-interface-testing launch launch-testing launch-testing-ros python3Packages.coverage rclpy robot-state-publisher ros2-control-test-assets sensor-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater generate-parameter-library hardware-interface launch launch-ros libstatistics-collector pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
+  propagatedBuildInputs = [ backward-ros controller-interface controller-manager-msgs diagnostic-updater generate-parameter-library hardware-interface launch launch-ros libstatistics-collector pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 
   meta = {

--- a/distros/jazzy/crane-plus-control/default.nix
+++ b/distros/jazzy/crane-plus-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, ros2-controllers, ros2controlcli, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-crane-plus-control";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/jazzy/crane_plus_control/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "235b54c252c5d943d36c7d6c420dfb7f3be07d8b9935a31453174683125b4572";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager crane-plus-description dynamixel-sdk hardware-interface pluginlib rclcpp ros2-controllers ros2controlcli xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CRANE+ V2 control package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/crane-plus-description/default.nix
+++ b/distros/jazzy/crane-plus-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, gz-ros2-control, joint-state-publisher-gui, launch, robot-state-publisher, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-crane-plus-description";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/jazzy/crane_plus_description/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "e6387d89fb7465c5a9b0c77dfcff118e8641de933751f62fd68718e885a5b3ed";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gz-ros2-control joint-state-publisher-gui launch robot-state-publisher rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = "CRANE+ V2 description package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/crane-plus-examples/default.nix
+++ b/distros/jazzy/crane-plus-examples/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, crane-plus-control, crane-plus-description, crane-plus-moveit-config, cv-bridge, geometry-msgs, image-geometry, moveit-ros-planning-interface, opencv, rclcpp, tf2-geometry-msgs, usb-cam }:
+buildRosPackage {
+  pname = "ros-jazzy-crane-plus-examples";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/jazzy/crane_plus_examples/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "2238694940a5a30097b7ff88e78207221bdfdf0c330ab2b76407111d9b752e93";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-moveit-config cv-bridge geometry-msgs image-geometry moveit-ros-planning-interface opencv opencv.cxxdev rclcpp tf2-geometry-msgs usb-cam ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CRANE+ V2 examples package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/crane-plus-gazebo/default.nix
+++ b/distros/jazzy/crane-plus-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, crane-plus-moveit-config, gripper-controllers, robot-state-publisher, ros-gz, ros2-controllers }:
+buildRosPackage {
+  pname = "ros-jazzy-crane-plus-gazebo";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/jazzy/crane_plus_gazebo/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "659a62fb66b4edada3d4c40f14f79cff493170f7b2bd077f2334b6c2fadfd7d0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager crane-plus-description crane-plus-moveit-config gripper-controllers robot-state-publisher ros-gz ros2-controllers ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CRANE+ V2 gazebo simulation package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/crane-plus-moveit-config/default.nix
+++ b/distros/jazzy/crane-plus-moveit-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, crane-plus-description, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-crane-plus-moveit-config";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/jazzy/crane_plus_moveit_config/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "d9531bf60067f7495f36e7892fee04faf7a9c0af46c9cb5c02874232ad204eca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager crane-plus-description joint-state-publisher joint-state-publisher-gui moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "CRANE+ V2 move_group config package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/crane-plus/default.nix
+++ b/distros/jazzy/crane-plus/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, crane-plus-control, crane-plus-description, crane-plus-examples, crane-plus-gazebo, crane-plus-moveit-config }:
+buildRosPackage {
+  pname = "ros-jazzy-crane-plus";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/crane_plus-release/archive/release/jazzy/crane_plus/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "ab160fb1ca4fed021efa105ebcf93c4424de41f701af787cd9ba85f3a0fef971";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ crane-plus-control crane-plus-description crane-plus-examples crane-plus-gazebo crane-plus-moveit-config ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 package suite of CRANE+ V2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "01e6fd28a3cc1448ab5479156d424c74402d778978ca8738ccb79f4274015449";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "161ce33e26e64221e9c4fd0cdac6c09593a98155dbb78e506ae0552c84922c6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "3697d066688ef857a3387d8dde2c3df97cbb5e74d9ce1f5f4b83aa44dce0b929";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "71274028c26d870bac6ab8d3d8ce71f440b763be2702dccd5a94d34c1ea97e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "5ded39a1a56905aa888483878e025c25c4f914a39a9b657a664623ae164470b3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "26d3358f3518404c110724eb5678a49c45a814bff778ed5a8e8dd74d38d80b48";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "6c7ebf5eacab027f9d3e877750b1fdede7d6e5bad1180bf6c99507fd049b8bc2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "253d7b0b593c4a8166bea4ce823ebd333b3b8a22fc2e04607292b852d5c6154a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/foxglove-bridge/default.nix
+++ b/distros/jazzy/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-jazzy-foxglove-bridge";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "4c93261dad4a6d0a5f8f6da51416a0042a0c24d88184b81a208fc762ba7ef6f1";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/jazzy/foxglove_bridge/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "5d68e27c757ddd659dbc17b663ee4f4db33c9ae90ac73bca98bfae18a47f9358";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -342,11 +342,15 @@ self: super: {
 
  clearpath-config = self.callPackage ./clearpath-config {};
 
+ clearpath-config-live = self.callPackage ./clearpath-config-live {};
+
  clearpath-control = self.callPackage ./clearpath-control {};
 
  clearpath-customization = self.callPackage ./clearpath-customization {};
 
  clearpath-description = self.callPackage ./clearpath-description {};
+
+ clearpath-desktop = self.callPackage ./clearpath-desktop {};
 
  clearpath-generator-common = self.callPackage ./clearpath-generator-common {};
 
@@ -360,6 +364,10 @@ self: super: {
 
  clearpath-msgs = self.callPackage ./clearpath-msgs {};
 
+ clearpath-nav2-demos = self.callPackage ./clearpath-nav2-demos {};
+
+ clearpath-offboard-sensors = self.callPackage ./clearpath-offboard-sensors {};
+
  clearpath-platform-description = self.callPackage ./clearpath-platform-description {};
 
  clearpath-platform-msgs = self.callPackage ./clearpath-platform-msgs {};
@@ -367,6 +375,8 @@ self: super: {
  clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
 
  clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
+
+ clearpath-viz = self.callPackage ./clearpath-viz {};
 
  clips-vendor = self.callPackage ./clips-vendor {};
 
@@ -409,6 +419,18 @@ self: super: {
  controller-manager-msgs = self.callPackage ./controller-manager-msgs {};
 
  costmap-queue = self.callPackage ./costmap-queue {};
+
+ crane-plus = self.callPackage ./crane-plus {};
+
+ crane-plus-control = self.callPackage ./crane-plus-control {};
+
+ crane-plus-description = self.callPackage ./crane-plus-description {};
+
+ crane-plus-examples = self.callPackage ./crane-plus-examples {};
+
+ crane-plus-gazebo = self.callPackage ./crane-plus-gazebo {};
+
+ crane-plus-moveit-config = self.callPackage ./crane-plus-moveit-config {};
 
  create3-coverage = self.callPackage ./create3-coverage {};
 

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "03de7be4b34200e1fe05018b7eca24684da599852c6cbc3f3996a657dc2b6c84";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "8c81b5dc43a0b7ff3fbe23e2376dc70e853bea394ab5bd6c8ac62a80eac1c5c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "de6e901593a0d7c6b453a396a379e8b2c04c6d8d7b7e599ccad0c0ed93b65ae4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "ab0f146225b676ae11afbfd38e2aa10203f30f60b9e7c765ed0149be8ee8cb57";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "550719e2d9397b5bec546451ad01fc0c15aaa1348dbbc2f1feabe63455c8b70a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "a4bca1f17bfb51fde42b563e0a3ce5949a9289b681a33b4c6dbdfc38ddce5714";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "3e1049128020df91de4beb288e1b203c1de6448fbc866dd1de8f50554697bfda";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "e99e9879cc20ec1240feefb49879e6821ae39ccbc23d15154c93d6b860fb5dd0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "c5b3ded3c612b4e179fb3fcfe1f1a8190128558fe3fca3ef1ac987920ce778cb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "de1fe9e0abc7b68034d36d33e92439a21f9f918c308a349f2a1b6cf295481125";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "4178e286cb3d4bdde66ed2f72e89796ed5ab39e7490dac7f4f700a07e3d13463";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "199d39dc502d10593ea43e6566bb3992f7c05f654fa1dbe3ef11be8963e3cd68";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "bb3280d0a16c5d4afaf77b0dd85fb2508c3a585bf5f77cf1026b76ccfe2542d7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "c99fe38b630d440c42977cdc236146cb2c4c9bcd876f1c67f73a6ba3f65d7846";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "1400d36dff75eaae27d03227e685adf3fbb21dd23e8842a7ccc0488b4524e212";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "f35466e9526b39135df5ba5bd93a917afa731c4a8b62cd07e5dd423ad62aed89";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "95d88b2eaf3223e7a97adf6eea598415a9051c249a6f983256a647a7b344dfc3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "0341deb6314f9f1a349f2aa4c555ed603f4810e34e2374bad6f1145368bea38d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-visual-tools/default.nix
+++ b/distros/jazzy/moveit-visual-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-visual-tools";
-  version = "4.1.1-r1";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/jazzy/moveit_visual_tools/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "e0bda5e0741780000956d731a217ef14cd0ffb8f299bc3d6a4c320e28357bec9";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/jazzy/moveit_visual_tools/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "253f64ef6be72257c498d61cb1bedffdbe107c9edf2f009b284fd71094c15ad8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mvsim/default.nix
+++ b/distros/jazzy/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt-libgui, mrpt-libmaps, mrpt-libposes, mrpt-libros-bridge, mrpt-libtclap, nav-msgs, protobuf, python3, python3Packages, ros-environment, ros2launch, sensor-msgs, stereo-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-jazzy-mvsim";
-  version = "0.13.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/jazzy/mvsim/0.13.0-1.tar.gz";
-    name = "0.13.0-1.tar.gz";
-    sha256 = "cb0eaeb61644ee9a70bbeb92501fd28afef062fa25cd71f2560d1918dc6eb07a";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/jazzy/mvsim/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "186ae5a91a3e332388daa57d0eb88e4f7e10d2d0d5554d76812277fdb542b4c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics-msgs/default.nix
+++ b/distros/jazzy/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "524ffb2f6021a94792f87038f7d0319d4044a8f1ade6e9c4d3219ebf19d31d0e";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "f1a1b1e7d20a43dcc8c33ae102fcb1b4ee5e49d511a94b5dfb52aa582c45b83a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pal-statistics/default.nix
+++ b/distros/jazzy/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-pal-statistics";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "76dc1d3c9099bfdb15ec695fd8dbc716a67000eadd2c85bcc27a179ae39ec054";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/jazzy/pal_statistics/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "7c5cdd10c9993d69870f16269e5360f106ce7d9000d2026dbcfe6e09f3506745";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "1255a024b3dcde479449e338e997592e550b3c1ec11cebe2a59f0c15e72c07a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "c6d1500c2c97f02816dea981510664a79c78e693c5046a40db692470d952ec11";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "f4766a9a78d5b262b2ddd8c647e14906a419a91e5af6399e97dcfd5ebe94bf60";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "323987e7b25156288c108814540206882353320dad488bb569751f223dd4cfb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9a041ee2af5142f27c7c71fe3dcd002972b2afa711183dd51a34870d72211f62";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "43cfed37ef2b9d97533aed8ae91880b36757ba4b6330ea998181a91cd91feec2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "fadeac8cc445269124d7f40a1cdcd460b3eec514b074e4d71bf001eda394fbbc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "e4cdd4ce9c34aecf1ea6d4c231c67e0d67c74fe9d2719dd5653abd941879c850";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "d08295d03deed9a8cb9d099d796a5b8fbb0d68a20fab27086a13a3e8b1fd573b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "225636f017cd35d500c75394be5ad5112268f7b8fb6271bf5c6cc0637ee00e61";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/realtime-tools/default.nix
+++ b/distros/jazzy/realtime-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realtime-tools";
-  version = "3.1.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "740c144c6ae27c2643263f7289193d1351b3994bb4b96d5e02ef2d2f1fd35508";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "28f52f42a80f060c51577b71371c17eab1c9edd098adcd41af387e3f90dda962";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock lifecycle-msgs rclcpp-lifecycle test-msgs ];
-  propagatedBuildInputs = [ ament-cmake libcap rclcpp rclcpp-action ];
+  propagatedBuildInputs = [ ament-cmake boost libcap rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "61cae302881f274816c3f007bede13614f3bcd87cd71fd28565b6dcad3d6ced9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "d6f39b69f90fc3997510f348884829dd3dd4842ea20acb0188e1563d2730070b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "59013e2c567c00ecf911d3ab27c19e1edf8d6533a6c6a4950826319179d6ca91";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "7006c8377a73a278f99f88ef29a8600f109b9bcc4491c0921291c4709f860ab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "01b679c7d9e45e3ff2cff5acab380e24790487eee82cd25e4a5e8c151993739f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "889d3e00cc550086c3a7afe6fc2e9ce7bd96598787a13f0a05131da699f7808f";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9714be7b70d42c44ba410313b7a9a271d58af701e54546f002d69cf55277fac6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "2582290be92b02e42c9611636017d39bf67940bb13708c4afd4097322247060d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "b82372c4370256525545df04ed107b5a0c52e091a2ed533756db9e04d42d7ddf";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "0d03c8f08cd3799bdc36af356d1d4778c5229df3971f76e849e90c50f756f339";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "bd2dbaa8d563b6da502ef9d35a46d0768c9123acf2b35a22d50c5034ccdb5877";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "66406d26fc8c9b6e61677a565bf38259416997b8d370b0667244afc243b24a1b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "19ab4a39725c70a6dd2634a07e114fc82698b2d41de0da3c81a873077fd4f2a8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "a74be614c697e92f52a5ae5f20d25a5b8694e9c73e6a3422d4132439e81c2e18";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "b60b93c21eaa5419e451ba6bbb75dc2ab2a2ca4e0d18caff404c35ced391b998";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "8d1f1a62294e8a29fa6efadebd12cfdcdabda956aab883f88e0f45052a4e8da9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "b48defd668d16c4e97ed23e0a1a5e4719cc0db0539196f86de3d7c396ff981ff";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "b7051031e3422aa4f0d35cd3505c302d2dc5f0bce2335c5194fefba66925eb4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "738ed89c157b0772b7f3565bb131946afd7f8e414efd0dc6d033e0604ccb9dbd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "2a19e7fc0d6bb337e3fbf1ef77323fd9cad3546631e5e2df533a486e12c2f896";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "f6ed97755fa6656cfa19c442acd9b99fd32c4b2f094991827d81a1811c3e5689";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "07cb25d00a182302e82907fa8d410ab35a23089c31174fe35b0c90e4da210658";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "45a6f22b88f3fa5cc77b08f1e25b59464ddc366bcfaa6ef7e5904b053f9c8852";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "45093d6e109c40af64be97a673aceaa49dda5d645200acad998a591606e2f087";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, resource-retriever, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.8.1-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "8a6881312f84cbc2d2db1d2cdefe5d92bb62d0cdb7165a7f9ffcf8819c4a9edf";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "ebf3a322d2d024560b361ded3a2ff54d3ca68abcc632553d726b2ea7f27606f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/grpc/default.nix
+++ b/distros/noetic/grpc/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, autoconf, catkin, git, libtool, rsync, zlib }:
+{ lib, buildRosPackage, fetchurl, autoconf, catkin, git, libtool, openssl, rsync, zlib }:
 buildRosPackage {
   pname = "ros-noetic-grpc";
-  version = "0.0.15-r3";
+  version = "0.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/CogRobRelease/catkin_grpc-release/archive/release/noetic/grpc/0.0.15-3.tar.gz";
-    name = "0.0.15-3.tar.gz";
-    sha256 = "e009b35d165653c130fa964e86175ed6f6eaf92e05e7dba35254e332f4ae8f15";
+    url = "https://github.com/CogRobRelease/catkin_grpc-release/archive/release/noetic/grpc/0.0.16-1.tar.gz";
+    name = "0.0.16-1.tar.gz";
+    sha256 = "f841902330a8f363535a771617f5ed01bcc188dd2b775ce86b8d01b9ee6f5136";
   };
 
   buildType = "catkin";
-  buildInputs = [ autoconf catkin git libtool zlib ];
-  propagatedBuildInputs = [ rsync ];
+  buildInputs = [ autoconf catkin git libtool ];
+  propagatedBuildInputs = [ openssl rsync zlib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "eef7f9765208a832da78da659fbbc4063155a13ec6e49458d8a8629f78b167cb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "90c17ef59dd9eb185916d5e0879c2183f5895a7407edb2f25c7402485b7faa93";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "fb3d61c5c5440b679a6e852b92cff32f2a79c9f8f17d8908695ef265f4179371";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "aafc1338148ae81551ae2ba83cbdf17bd399d28643008623deb42905f01cec0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-clang-format/default.nix
+++ b/distros/rolling/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-format";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "6f4f00133cf3a5fd8906ea8decb8c3e677bea662a86a7bbda119dee5b6572732";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_format/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "81ac9075b79597594fc8290513f1f56bce599dbbc2f3f7f29bf42e7e9333a837";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-clang-tidy/default.nix
+++ b/distros/rolling/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-clang-tidy";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "077b74c89b48b1a174c3bb5638908556bf9ba4d205dd0bc2a7bd23aeb732b7bd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_clang_tidy/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "db2507813345ae59cbe15d2d7473775ccc432c0d8d6bcfe24a69e1b517141166";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cmake-clang-format/default.nix
+++ b/distros/rolling/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-format";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "1f04c465c0ee05ec4c23e15c8acce81d7790033e96bc2d271d686b2c5a0482a9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_format/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "c9b5fc9f62ac060f3c513f606058d3153b0a60cbeeb8638a654b49fcd90f0fa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-clang-tidy/default.nix
+++ b/distros/rolling/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-clang-tidy";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "f8e62f7b5276edbe222749a9fe3050fa1c51ed68aaf0a6a88c87e2a6dc15e9be";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_clang_tidy/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "323a086c2c8b9bfe353f20f350965284c00f971d5cdcba61a6e1d937356f5a08";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-copyright/default.nix
+++ b/distros/rolling/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-copyright";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "848b259af32b32e6a0c0b2431d734d28e905d498669f0080bbe87a8e4df5346e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_copyright/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "d9bab3a68a49ad43efdc682f1afad284440fb6b6b7d0c7860da90df956a95900";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cppcheck/default.nix
+++ b/distros/rolling/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cppcheck";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "14ce13b46675219caa02bbc5ae78413b58fefbe6068c3f2acf58090522896c04";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cppcheck/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "96e1af761f383798b2181f9f0a708218b8459da233e7b7333589f7eee58d6cb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-cpplint/default.nix
+++ b/distros/rolling/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-cpplint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "fe3c3079a4f78b160e9cd5d8f217ffafae8451d42c04829ac7a47a7efce848e3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_cpplint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "54eed66a2171dc1270b50d056eae0e15442f1bbb5ab81da127a6f174d350e3f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-flake8/default.nix
+++ b/distros/rolling/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-flake8";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "c46bc216f99eeb2f50818ea5b0c8969711ebf3065e8f6e3dfc0e66129d7e7d4f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_flake8/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "77cb4790fccec400ef957cda4895cab5364aed8813791c99a336d07dbbc31c7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-lint-cmake/default.nix
+++ b/distros/rolling/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-lint-cmake";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "48a4bd0aeda2d4d4007060aebe051630c5afc278468bdfddad7fb1b0f2fabcb8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_lint_cmake/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "fc47371a2cb3fcbea5605c3d177d76f090b7dceaf0f4c281d2b45826b07c3ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-mypy/default.nix
+++ b/distros/rolling/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-mypy";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "3aab86c87164a856d5c5368ab2462eddb05eb664af4e867438ed46306730e9d7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_mypy/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "2d233da83ca39f379913f6c3daef4a9e1273846c26662745d86b45ffbc14bbc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pclint/default.nix
+++ b/distros/rolling/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pclint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "6595c02ed3288a0079300b20b8b8491316aab5840cc319f829ccd6b7d27df546";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pclint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "604caadb738d4ae2cb52f8870df1202260d91566510075e2f3fb8e8c91bd38a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pep257/default.nix
+++ b/distros/rolling/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pep257";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "a54fcdf1c5c2972c805c9c197e60484ed9db76b488a3d9d06dc0e2cca5b84c40";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pep257/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "7a6a4953cc435f55547b25de50dbe04d8bdf6364d5790b578fe818ea586118b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pycodestyle/default.nix
+++ b/distros/rolling/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pycodestyle";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "59878312c573c70d19af4183d727647a0985b3a919898c38bf1d1be3c91bfeb9";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pycodestyle/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "e0d76166b90316e4da65d1cd2c4eb9677356ca1a318bc64aeccc5678d650d58a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-pyflakes/default.nix
+++ b/distros/rolling/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-pyflakes";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "288882e6810114d730972510e35f4d2da30696d000e0117407a11305c1d3d3e0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_pyflakes/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "4ae2e68f55ab229944d1ea5f3bbad4a74ade944b6ee2895019cf9f9f99ac9149";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-uncrustify/default.nix
+++ b/distros/rolling/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-uncrustify";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "19da9d01ad9b3eff65df74450a3b78ece9b1a8dbe03d94686351f574a9f7d5f0";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_uncrustify/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "78094288d65fdadd1c34169b99815741fd88ab04da18c3e577e66c1ba4740d64";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-xmllint/default.nix
+++ b/distros/rolling/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-xmllint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "eb525c4616205d7df997d8c93368f1296202b0a90e61b25eaced98b948eeefd4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cmake_xmllint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "cbd9ef3b117c23a1126936b3b3cbeceddc01542c4191ef83b2d65378211b66aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-copyright/default.nix
+++ b/distros/rolling/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-copyright";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "16d93742c0249c810fa634c87376218629997dfc956b21b3aec45be170060edb";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_copyright/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "eaf262adb15499837bbe4c192873afcb2a5d1aa3b7c3b2778537e6e01ec3d1c5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cppcheck/default.nix
+++ b/distros/rolling/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, cppcheck, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cppcheck";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "6a8a009988d33933a087d6dba3f1281c45cc32292cd4edfa4b38c71bf291b950";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cppcheck/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "08573180d2eebb8ad190c36a7c209519c89a966e13380bce349bb7147fd0d3d0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-cpplint/default.nix
+++ b/distros/rolling/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-cpplint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "c9458c357ddeb3294cddfb05970c929f613f9ab342d836cf0b4ae5a84eba339a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_cpplint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "b37c6d2395bd112c3e4ed3e1417420c71761b0de5a854de4e9bee1f5f49d8aba";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-flake8/default.nix
+++ b/distros/rolling/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-flake8";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_flake8/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "981e72a70eeb61e1b1acdda2e7c784a40708312dcb78cc63e7cd52936acbaac8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_flake8/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "80b3c62c6dbec96c55f6f359273177fe2b63fa5cb25942f99d86a0bbd9360d79";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-auto/default.nix
+++ b/distros/rolling/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-auto";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "3e83dd4162ae862154f45fa0f45c1e0454aa4782314cfad6615c7ea260f88881";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_auto/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "2f009bcf509640427c8c6ba5e509b05a6913f276dae24d5f9ecfab9a9090edda";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint-cmake/default.nix
+++ b/distros/rolling/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-cmake";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "34beb1744356c0c5271f541e3a2444c4be989aab785a21b4d8e221f83aa033c8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_cmake/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "3e2f2e168dd8138f1854091e7f018562275480b2f86847e45d5e64e6916078ca";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-lint-common/default.nix
+++ b/distros/rolling/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint-common";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "94efac18c7420fac91d88081eda92165ac9ee3040da98261fa86a68e9ee8947a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint_common/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "9e0987861b5fb56073bf6e92929e6026fd4069d8b2c483c4bc57a00fae3ed977";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-lint/default.nix
+++ b/distros/rolling/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-lint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "53d3d95669eb4ab7404aef780a019ad3140a60d20738a46737eac0ba597b80c2";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_lint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "e9530d3e27c768df4ddaab13bbb86bbd045e5781c716a1f48f64ed1937ecc3ef";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-mypy/default.nix
+++ b/distros/rolling/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-mypy";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "101638f12bc6ab1aee22482d736022fddab41ac842e2071dadf6c4141946bb1c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_mypy/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "6bdaf91aa4333dbaf0b313917c663575b1b5efd07756cf17df7a5ea546566623";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pclint/default.nix
+++ b/distros/rolling/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pclint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "8fc3368d91b4026e85f3df454a61c800e261bcab9c069dda03e949a0d98984b1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pclint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "067f2fb9c20bebcfef344fa728fb98e2b349b5e56a2523d569097ee7e9e36d8a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pep257/default.nix
+++ b/distros/rolling/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pep257";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "358f186e35a28ab0c63d22417e8ef06a64645738002ede9e5e83cbf401125712";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pep257/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "aa7262af6cfa6187e74620120971208ed6df36e3de2c6d70bf235ee28b65651a";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pycodestyle/default.nix
+++ b/distros/rolling/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pycodestyle";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "3c91e47b079c364ea51316913472f6e0e0876732daf842e629997cd96563fd4a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pycodestyle/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "89139f6e40fe5ee687d0b4d0e7508f4d7b73b5e65e725d8f2da4b7cdabaeb5b5";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-pyflakes/default.nix
+++ b/distros/rolling/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-pyflakes";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "384ffdeb5ee75bea48729c60563784ba09515f1bbb2d6a15a5bda089ec76c940";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_pyflakes/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "27df630b66c0cff3872fc40ecfaa1b4c8200a53f05e958773224a79f4a64361c";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-uncrustify/default.nix
+++ b/distros/rolling/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, ament-xmllint, python3Packages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ament-uncrustify";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "bc083cb25d9f4fb9cf158ca20da30322d019eec577cc6414c5f924675e0944bd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_uncrustify/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "95a48b7bb31c099a739ab3f78a8230075cbbf7ef1e969287bb21f1a88b159be3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ament-xmllint/default.nix
+++ b/distros/rolling/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-ament-xmllint";
-  version = "0.19.0-r1";
+  version = "0.19.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.19.0-1.tar.gz";
-    name = "0.19.0-1.tar.gz";
-    sha256 = "104b84c9143d8d96b541728d9559f449c46bf3dfc0e60be991ad3a00d6e1c4e6";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/rolling/ament_xmllint/0.19.1-1.tar.gz";
+    name = "0.19.1-1.tar.gz";
+    sha256 = "824b29cbfafd86c40fc158060e041e8379204a63071a1a4a0504527ac6e4b576";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/backward-ros/default.nix
+++ b/distros/rolling/backward-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, elfutils }:
 buildRosPackage {
   pname = "ros-rolling-backward-ros";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/backward_ros-release/archive/release/rolling/backward_ros/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "c155d8c6746b31d4566a9fa0593bd681f6f237228920416667992cdbc79dc4ab";
+    url = "https://github.com/ros2-gbp/backward_ros-release/archive/release/rolling/backward_ros/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "d64c9498c379032ab0cebb46a894e523ad776448c16fe1168a99e1c6b4c165a9";
   };
 
   buildType = "cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "01488553431ea4033e3825e0bc210f667c683d61d2c1ce160e29b7926b5a8234";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "4b69ab6d5628e1150265d045953158b80a56749a155666afb3b4020d9dbc609b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "3.5.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "61f85656c4dae08acc72595ff4aedc2524ea4cd5405865837983b94ca74ee2e4";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "cc3ed5425d5f4c8d66de6c294b971bbde4130d8a160b36e6c6923fafb1df46bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-interface/default.nix
+++ b/distros/rolling/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-interface";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "9c65ddf297975988896512c75df60da5e55b74c7ac452e0370874a3bdbc2b321";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_interface/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "d8678549620771c7479eeff4693a224edda49c747d8e3b9ad66e7bad86d2e8da";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager-msgs/default.nix
+++ b/distros/rolling/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager-msgs";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "2597ecc2aeeadfc9b35bec49f5b3694cc64d2b40d1f98c329f94ec5ff255352c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager_msgs/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "20d17e219a0a046cd9f7f2fa1e42ef12a76dd8aade338e8b9b421dbbaba57092";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/controller-manager/default.nix
+++ b/distros/rolling/controller-manager/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-controller-manager";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "193f2f4f54102474e50dd5b1cadb6b0bb0bdf46ca7a3d5ee7f99732408918a4d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/controller_manager/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "522e86108d030ec421fea6711bdc1bbc415969a49c165a686a27a84241ce664e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
   checkInputs = [ ament-cmake-gmock ament-cmake-pytest example-interfaces hardware-interface-testing launch launch-testing launch-testing-ros python3Packages.coverage rclpy robot-state-publisher ros2-control-test-assets sensor-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs diagnostic-updater generate-parameter-library hardware-interface launch launch-ros libstatistics-collector pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
+  propagatedBuildInputs = [ backward-ros controller-interface controller-manager-msgs diagnostic-updater generate-parameter-library hardware-interface launch launch-ros libstatistics-collector pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 
   meta = {

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "bfcb4c29b92c25c54df3bc96350a84ab2e74685bd81f11a45742516289e1d3aa";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "2df8ac5355738d28c631522fcbb07461fe6f2f46c82c70bfc0e04fb7dff93024";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "02a981b48331fec7a3054b6eefef0579eecb273437728359db228ce33aad6506";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "2b57713715a63ed54849c90b9c1613c402b78f138f45e8685bc50bb01b752bcc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "29cca74cc790c2e543a9c458366d03143a1e49e2f3fc9547312bfd1c5b71b07e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "f79c90a32f186bd94ff67f8329283d72f3cefbd4dc2fb6aba354c7c423a41e37";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "b96862acf0e1cfe1cf94ac82e9e11d45d47f0d1ab4f9f8d7fcc48d6f4bab1a11";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "a38ae8e65c7e2297a229dc63b12584e972b3cd0b309bb5f6757834a1bb3ebae6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/foxglove-bridge/default.nix
+++ b/distros/rolling/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, asio, nlohmann_json, openssl, rclcpp, rclcpp-components, resource-retriever, ros-environment, rosgraph-msgs, rosx-introspection, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-rolling-foxglove-bridge";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "d7a043358a0f2eab96fdc47466bccd83ec0e2cf9362111a1d89657c8e6e925fa";
+    url = "https://github.com/ros2-gbp/foxglove_bridge-release/archive/release/rolling/foxglove_bridge/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "fb40016e5ca7ef643ae6ac3962a9a141a27b91057760ec20ff5a2392ac47e87a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -2136,8 +2136,6 @@ self: super: {
 
  shape-msgs = self.callPackage ./shape-msgs {};
 
- shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
-
  sick-safetyscanners2 = self.callPackage ./sick-safetyscanners2 {};
 
  sick-safetyscanners2-interfaces = self.callPackage ./sick-safetyscanners2-interfaces {};

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9635c39ebc93d6d9ae99c2cbe242cb3b9b5a89a84292c47b607ecf2de7fc3e61";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "ef8de78bb28f01a12ca9667ffd7b2d0a989d2baf5204cd7f224b37b1e7906cf2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "60e19bef1daae4b2495dbc9d300e685f9b97eeceab7219d3d69e0218cc550750";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "3f177131d0668cd00136a5d1c845242b2ff41f3a5c865c626d9aef9adc3fa518";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-rendering-vendor/default.nix
+++ b/distros/rolling/gz-rendering-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, glew, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-ogre-next-vendor, gz-plugin-vendor, gz-utils-vendor, ogre1_9, util-linux, vulkan-loader, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-rendering-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "2e961313a269e2f4426b6ff55dedc59eeafa262b212d7ccc0614fe47c7fc892d";
+    url = "https://github.com/ros2-gbp/gz_rendering_vendor-release/archive/release/rolling/gz_rendering_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "6dd24462a0292f1c32da599edfc06123021ce79a0b723e3a0e9cafa590d40b6e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
   propagatedBuildInputs = [ freeglut freeimage glew gz-cmake-vendor gz-common-vendor gz-math-vendor gz-ogre-next-vendor gz-plugin-vendor gz-utils-vendor ogre1_9 util-linux vulkan-loader xorg.libXi xorg.libXmu ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-rendering9 9.0.0
+    description = "Vendor package for: gz-rendering9 9.1.0
 
     Gazebo Rendering: Rendering library for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-ros2-control-demos/default.nix
+++ b/distros/rolling/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control-demos";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "77c4a27d7623fb743507cc55f1c186e6862d11a65faa3355718fc089cdd9984c";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "2204c3b6356b9435fe35d014c27a374ac4d9233076b86c4a79569fb003d09644";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-ros2-control/default.nix
+++ b/distros/rolling/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control";
-  version = "2.0.3-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "de5bb1e20af70282f24d109395f07bfb8eecc0129eb464441510e05d8789ca42";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "d4abf5981611dba361d2d17abb83a1beae45131c8a14d494e6a0a62b53c041c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface-testing/default.nix
+++ b/distros/rolling/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface-testing";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "f3a70fc4c613b943df938eb0071bb3c627c2ab6d6045a4106a3ac251c179ef20";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface_testing/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "5c080f9dd2797c506d3f629f627eaaefc6c621af38daaf3075ea3dc36ca4ab19";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hardware-interface/default.nix
+++ b/distros/rolling/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-rolling-hardware-interface";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "b5c0faea86f0dfd99b0b4ab83cc3665b64963fd8fcd4a58c3aff996fd9742477";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/hardware_interface/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "6b535aa45cb326951783e9b0e5d57977788625e18e5d7315f7aa0de08a0193a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "297d255c657f16d51abc286734907e2d2d3608a0c8cae84dcf888460e0800081";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "0a6c8ea764bdaa730a89ebe6fd5e118f970b659af621342d460ad96024fa7de8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-limits/default.nix
+++ b/distros/rolling/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-limits";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "ce0bf53f5629a62276133aae91086c6420c6e90c891bdc5170c5adfd539b2cc8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/joint_limits/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "e3618c34edec2f272f3df272a266f7a83588a49da413d28c306f7abb0658876c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "619024936ce25e459271e64be29a5c94dce6218622de6cbc00bd72055e5b3cc1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "53ec80d6646b7070d04422d29ed3504be97da9371c4a572c090f3a74d918526e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "eaf1d72cd97d99b3cb2ba681f92ce818f3e6cbd376699c0380ab8b1010796df1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "636b1f2fab899900e540ab7240bba69393c3159ca92bbf241e44930464d43fa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/liblz4-vendor/default.nix
+++ b/distros/rolling/liblz4-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, lz4 }:
 buildRosPackage {
   pname = "ros-rolling-liblz4-vendor";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/liblz4_vendor/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "5aa558742c76743be4fcd37aed37627a26637f7a658ea7c1ef923ba3e0fdb996";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/liblz4_vendor/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "9adec699ad4d6c6e258eeaf87d07e26d6e34025abee6e015f4090f11b61f8331";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mcap-vendor/default.nix
+++ b/distros/rolling/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, liblz4-vendor, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-mcap-vendor";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "e96146185d6e0b95d13ba64b5da82fca35176769563e2ec1505368cef900ff1a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/mcap_vendor/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "c59ec9bf44de1b8aa3d21bc2600d1eb3065ae751e07a19b3ea1c3e072044ab0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9bd2270336d73bd4dc656ba7cc23ed4d0609fa57d4fac61e6038f67fb2c94b34";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "e004183eaaf84acebf1adfa9ec31c986c899a2e516daf5061d31f7a350253298";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "7.0.0-r1";
+  version = "7.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.0.0-1.tar.gz";
-    name = "7.0.0-1.tar.gz";
-    sha256 = "32244468dc339761eecb399063202117d5aa2acad0256406a961ab0c677934a6";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.0.1-1.tar.gz";
+    name = "7.0.1-1.tar.gz";
+    sha256 = "7a0e229d9560e5e9c1c674ccdfaf1cb637ec8a2e6d7cb766e34e578ee17e67b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-visual-tools/default.nix
+++ b/distros/rolling/moveit-visual-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-visual-tools";
-  version = "4.1.1-r1";
+  version = "4.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/rolling/moveit_visual_tools/4.1.1-1.tar.gz";
-    name = "4.1.1-1.tar.gz";
-    sha256 = "ffd7a85c354acdb531d176aeebe34636b71c4e333aa2a457729a17ba30775f7f";
+    url = "https://github.com/ros2-gbp/moveit_visual_tools-release/archive/release/rolling/moveit_visual_tools/4.1.2-1.tar.gz";
+    name = "4.1.2-1.tar.gz";
+    sha256 = "4b180d1aa2ff90615b6788152db445114ae4678fc6c96b9e8326b78a40cf5dd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mvsim/default.nix
+++ b/distros/rolling/mvsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, boost, cmake, cppzmq, mrpt-libgui, mrpt-libmaps, mrpt-libposes, mrpt-libros-bridge, mrpt-libtclap, nav-msgs, protobuf, python3, python3Packages, ros-environment, ros2launch, sensor-msgs, stereo-msgs, tf2, tf2-geometry-msgs, unzip, visualization-msgs, wget }:
 buildRosPackage {
   pname = "ros-rolling-mvsim";
-  version = "0.13.0-r1";
+  version = "0.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.13.0-1.tar.gz";
-    name = "0.13.0-1.tar.gz";
-    sha256 = "967ad1d316e738c2884d54e39a23a248b76520b72c9719d3d8afe0eeee706fb1";
+    url = "https://github.com/ros2-gbp/mvsim-release/archive/release/rolling/mvsim/0.13.1-1.tar.gz";
+    name = "0.13.1-1.tar.gz";
+    sha256 = "b09a593f49b0d790d70578a7528504d1355d654d97e605c087fdef77e1c5114e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-statistics-msgs/default.nix
+++ b/distros/rolling/pal-statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics-msgs";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "330a40aba0b132792b7a848e29a7da98e66d0ae3ab08ee637e8aa0c8eade3551";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics_msgs/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "ceb224854de0fa209d72f30f7a39d5250156ecb1a015ac530e4ee8cad98ce7ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pal-statistics/default.nix
+++ b/distros/rolling/pal-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclcpp-lifecycle, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-pal-statistics";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "ff934aa2fb81b1b0f2bbc77deadcb0cda80dbf9cce873cf271cb6b19b3b84049";
+    url = "https://github.com/ros2-gbp/pal_statistics-release/archive/release/rolling/pal_statistics/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "4ef03372916e9d70e3b6a3679bc364fa95bdba343ef4e06d7712937e5bc6bce8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "844e4f4ce73e6146613ff10ca21b61c6c89050948e60d09ff02a434428390bb6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "73264e64006d3825d261b3058e0ffc02bdfae9c0d6f7043ca7a8b493842f7ecf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "42d1888bfd13750405652433a8388743523a8a0d322c58000b7d78d49df06655";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "3de4e87d83a758135d39cd6cd16b4323cbceb3ea399888c4b842fcfd06c4f72d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "83ff97716d0a8fd62b5e30bce92a46646f61fbd9a3d316d155fc1e7eef8fa3f1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "e6ddbabb4cf056f07dd014bd9bcb10d195a0beddc55d4c41499cf3338271dc58";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "f861ec8136199b4b7039004d6196d6a449a674700f6042db111accd72e83c9b6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "e9172d28e9e6df71342ed3242aff5f73cdb9b1d2efbbc054315d78bc4b824bc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "d8df128365ff326c7501752e19f9350f71e6aadc27607c957aa257cdc7cbce46";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "bf9a701975b874ca291fb2bcf07cefe73918f9729ce95488cd3f691c770c92c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "10.0.1-r1";
+  version = "10.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.0.1-1.tar.gz";
-    name = "10.0.1-1.tar.gz";
-    sha256 = "605f995f11f413c28000bc0506abcbbb96c109791e426a571235add8e5705172";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.0.2-1.tar.gz";
+    name = "10.0.2-1.tar.gz";
+    sha256 = "e5ca785441e7c93fa61160f31758fc97a064e4c414ad5284ab7d5160ff0bdcbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "10.0.1-r1";
+  version = "10.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.0.1-1.tar.gz";
-    name = "10.0.1-1.tar.gz";
-    sha256 = "3b2c123091cf66620061c9a09c1415c5f240815a88ff04b6bb1c949406a6efb7";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.0.2-1.tar.gz";
+    name = "10.0.2-1.tar.gz";
+    sha256 = "90aabd2c737bca5a7b803f86484ad6c8b72464e365aba40eb37d5110899dde8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "10.0.1-r1";
+  version = "10.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.0.1-1.tar.gz";
-    name = "10.0.1-1.tar.gz";
-    sha256 = "837e03a8d12877af2807447762232d43246eba030287a955bea3b2152e397915";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.0.2-1.tar.gz";
+    name = "10.0.2-1.tar.gz";
+    sha256 = "5ce2ad9399f6d1f6619abd2f4008dba3a653168bd936db598b87166aed825405";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "10.0.1-r1";
+  version = "10.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.0.1-1.tar.gz";
-    name = "10.0.1-1.tar.gz";
-    sha256 = "59b0a37785224cc45928ce721f732a0b3b28d380e30857dc79f49da9e8e90749";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.0.2-1.tar.gz";
+    name = "10.0.2-1.tar.gz";
+    sha256 = "ee153c741e8df229a34847c6378d131b6895a6de69ab4be257e296dbc862331b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclpy/default.nix
+++ b/distros/rolling/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, lifecycle-msgs, pybind11-vendor, python3, python3Packages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclpy";
-  version = "8.0.0-r1";
+  version = "9.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/8.0.0-1.tar.gz";
-    name = "8.0.0-1.tar.gz";
-    sha256 = "1c582d4b6a6000b38d078d1eaec314e21e6e4a45af4fc65eb1c843e8dd817078";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/rolling/rclpy/9.0.0-1.tar.gz";
+    name = "9.0.0-1.tar.gz";
+    sha256 = "dfd51fad041dbb2691906b59c2f6dd6ef7526e9dfc6e5c594315ba188c35cf09";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcpputils/default.nix
+++ b/distros/rolling/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-rolling-rcpputils";
-  version = "2.13.2-r1";
+  version = "2.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.13.2-1.tar.gz";
-    name = "2.13.2-1.tar.gz";
-    sha256 = "acc7d424a5e4d030952ba2beaf97aa97fdcb09bd5feb92be8ee69b1817f6cd8e";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/rolling/rcpputils/2.13.3-1.tar.gz";
+    name = "2.13.3-1.tar.gz";
+    sha256 = "3159d54c2e68f740fe1b4972a2df7c2103581b9d13fba46ad7f94db5a2d99b73";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcutils/default.nix
+++ b/distros/rolling/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-rcutils";
-  version = "6.9.3-r1";
+  version = "6.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.9.3-1.tar.gz";
-    name = "6.9.3-1.tar.gz";
-    sha256 = "a5f2f183dce24901750b36ab1391bf569f32450448b008e8c39161c0876a7b2d";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/rolling/rcutils/6.9.4-1.tar.gz";
+    name = "6.9.4-1.tar.gz";
+    sha256 = "d827193efb97fb6b90fe4a3e161ed9fbb26e3d49b8cb86641c04f8e96726332d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/realtime-tools/default.nix
+++ b/distros/rolling/realtime-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-realtime-tools";
-  version = "3.1.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "298ada3239a5183973fd36694b012fcfa5864d700571e4899be2b9c96d9fd382";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "5633a1881974fc63544b5fbf26b158806ce6c68a4e1da743ede334b944e4faaf";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock lifecycle-msgs rclcpp-lifecycle test-msgs ];
-  propagatedBuildInputs = [ ament-cmake libcap rclcpp rclcpp-action ];
+  propagatedBuildInputs = [ ament-cmake boost libcap rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rmw-implementation-cmake/default.nix
+++ b/distros/rolling/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation-cmake";
-  version = "7.5.1-r1";
+  version = "7.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.5.1-1.tar.gz";
-    name = "7.5.1-1.tar.gz";
-    sha256 = "ce71ba5f4508dcbc7836fc59d8a8accf94cbc744bf464e6126cb5a75cccd4dca";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.6.0-1.tar.gz";
+    name = "7.6.0-1.tar.gz";
+    sha256 = "f2b1ea7fbd528106df65d2887cc75a9465a0c38f043ef6bb3b480c6f75173f1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw/default.nix
+++ b/distros/rolling/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rmw";
-  version = "7.5.1-r1";
+  version = "7.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.5.1-1.tar.gz";
-    name = "7.5.1-1.tar.gz";
-    sha256 = "8cb553f4c6a35ac942503f3e15c49fffdadb42cef0431a5c6a3f58f23079713c";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.6.0-1.tar.gz";
+    name = "7.6.0-1.tar.gz";
+    sha256 = "104ce4a359557abb68db87f127a0242dd397a8c307db69a0c3b724ee53609d56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-test-assets/default.nix
+++ b/distros/rolling/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control-test-assets";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "04b9240eb3d8bb83a4fc908b2094de061280aff2db1949c9bd2bc90725fd8ba9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control_test_assets/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "175565d75325c2f56d1f9740771de7ad4354a5e343eefc57e0b702d791193df1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control/default.nix
+++ b/distros/rolling/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-rolling-ros2-control";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "d28bd3fdd38de41799f433d11a7df05690aa4b3dc1f481236e6f4af7e1fcbb41";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2_control/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "23b75f37ea8a4585a3f5592874d2227ed36729722af05d472ee5db98652d0348";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "6aa4788d9cc8e0bfea7cd171867d7aa62cb85ea62393c73b094045d1929eb6ac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "f4bae215ee1b9628e55cac73de529b7583a3fec4db08aa494b6dda14072e4f65";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "a83071210c427044759bdeca438649c44fd034fdc69800c19d68441b0e8f71a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "5b2a70a3a85fcfde79eb0d52b92545000756acaec1e0f039fe51993635260be9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2action/default.nix
+++ b/distros/rolling/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2action";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "5fbcb894f6a6613e8abf5dc48bbb48f7abb5dff413f5bf96fe1650923631006f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2action/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "64b9ef2dd4ecfe9b6b83b4fb8262d416bdf2879e413747e611e4becdf401030f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2bag/default.nix
+++ b/distros/rolling/ros2bag/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-rolling-ros2bag";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "a11fd1f4f874a7cbf7b2acd9eb58df2d0e3b5850f2bc02d0a2025f659488114e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/ros2bag/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "48e13493e35cb48bbefbda2af8cf13b1cbb6e206fc81771abd01e6374a143117";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 launch-testing launch-testing-ros python3Packages.pytest rosbag2-storage-default-plugins rosbag2-test-common ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch-testing launch-testing-ros python3Packages.pytest rosbag2-storage-default-plugins rosbag2-test-common ];
   propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml rclpy ros2cli rosbag2-py ];
 
   meta = {

--- a/distros/rolling/ros2cli-test-interfaces/default.nix
+++ b/distros/rolling/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli-test-interfaces";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "ddd675caa04c3a52d7a387ae63240f777ffdfc1f93daa98d81c08e21c7d7c1c7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli_test_interfaces/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "4aac36d9fc546880c0d0a1aca23b28f3d4e5a2a6af5f26b9d9ddec63813773b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2cli/default.nix
+++ b/distros/rolling/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2cli";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "f8eb288bf5512d9cb2af6584692ff9fbe89b323fb2384d6d1ab499671ca0895e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2cli/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "2c23f58a1bf0e1369034516a2e9de0994c7aeb67d7afb647882b0bf8204faab4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2component/default.nix
+++ b/distros/rolling/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2component";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "da953eec18f5a51c9d7df027fb49d4c31a919070165c71c3565c0c688042d85e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2component/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "bce080dcb3f344feaa3c7970f28519c7ee19c5ccd944b993d660478d0ab528ee";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2controlcli/default.nix
+++ b/distros/rolling/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-rolling-ros2controlcli";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "b921653bc3fdd31ef4cf09496bdc2f0a8e6bbec28ca5f9330c51818947cd2d8b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/ros2controlcli/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "c59c90384e8be660beff814f8a3a8ab3d9140d249072eb1b719334771d71cde8";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2doctor/default.nix
+++ b/distros/rolling/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2doctor";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "b332b76d15480eaa42aa6c82514d94abe5265949afa351e9066e6f11952bf74b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2doctor/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "4fe32802d029e80c4b83641bad9082ce9fb79de64c0c49795f36dbcf2f80744f";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2interface/default.nix
+++ b/distros/rolling/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-adapter, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2interface";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "082db41629ea20f280b73e8100730ff7dbb52f27733bff4dd4d948ece7f18c6d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2interface/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "73568a57b71cf344ef542de7c6403dc73ca0777ab5b34f22206bff94ac89d697";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/rolling/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle-test-fixtures";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "f8a4aa9e4534502ee35430ae70d96e903448bfb739706aba3e9623d0c77f7615";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle_test_fixtures/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "af54a41b8fef59c1f65f6fe11c990da8dcb5d00af0cd6037953d2fde3d5264cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2lifecycle/default.nix
+++ b/distros/rolling/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2lifecycle";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "2bdde7293ef11a53d61946490caa11211bce38763c03c1867a955061c8a75a0f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2lifecycle/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "3465f81c7727b677104cc5bccd8226c9bdc66a725995a5a20116b388378497d2";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2multicast/default.nix
+++ b/distros/rolling/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2multicast";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "86da0c15420512f6de1bef862ec6ef586945500649c90ba3ff267fc365b25acf";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2multicast/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "a44c0aeff810bc0f31d978054e7f485f6fcf1821cf889c409afc474a1ce7edcf";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2node/default.nix
+++ b/distros/rolling/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2node";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "ceb079e7fedce6f3ef91d656fcfc2c113c61d929ea09bad4155a8793478e5f90";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2node/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "f07b82953bdf4ea064a81b01ef81e29ec3c47eefa3be55992ea0111bf54c40df";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2param/default.nix
+++ b/distros/rolling/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-rolling-ros2param";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "89a7ecd1adf8cccd46f21a9de301c57bcf025a6f407821ea370fcdc2fb83d941";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2param/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "a0c06890d40e20e63234e585fa7b63790272b00175bc60bd3dd94bcdb42e842d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2pkg/default.nix
+++ b/distros/rolling/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-rolling-ros2pkg";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "92633f9340640bcdcf698c36ac8b17c36c4d827144eb02e8383e485c8d99b952";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2pkg/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "c8e8e730fc78fa13d76ff0b300021d0f06976b212dcbf0f588719468c5e90711";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2run/default.nix
+++ b/distros/rolling/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-rolling-ros2run";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "5fa99ac49d6b00c07b7f61df0588d630e994aca1b2b7f9d3e20bbf5b92af8d3f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2run/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "905f99c4388d10976854385b7fcefa6da3967e4734ddb69f83f64c19596a6b90";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2service/default.nix
+++ b/distros/rolling/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2service";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "82c6e6d8bcdc0d772ec6c266bf4f9cea998e1c92f7b32d21ac5f88e7f9a777a0";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2service/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "5a56434925caabf0931d1452213c0f175c5e05e94ce060abef53caa05092c8a3";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2topic/default.nix
+++ b/distros/rolling/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2topic";
-  version = "0.36.1-r1";
+  version = "0.37.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.36.1-1.tar.gz";
-    name = "0.36.1-1.tar.gz";
-    sha256 = "90bd51423147d38985876c0636c501ff41c06138d4e04144618b0d7eab6edb0e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/rolling/ros2topic/0.37.0-1.tar.gz";
+    name = "0.37.0-1.tar.gz";
+    sha256 = "cab1e685837efdc85f208912b4afb8100f4f74f6d6fd42fb28a5c859a7bb6f60";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rosbag2-compression-zstd/default.nix
+++ b/distros/rolling/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression-zstd";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "c6ea5edd0c298ef3f773cfb4177b016c909148df6a8b8cff3057bfe2a56cc78f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression_zstd/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "ca1f72a2b8ef9394c434f668f3a008f8170a55d3e98cfef746e4db63d6096293";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-compression/default.nix
+++ b/distros/rolling/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-compression";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "8d702ad79a5a396e847344d65c3cfb10f4d41cf852e142f831abe15eb3d6e006";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_compression/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "a2bf4bf8ed9c6574a7f62554fb766b35a52e308ac9f733dde275c02cae7dc826";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-cpp/default.nix
+++ b/distros/rolling/rosbag2-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, std-msgs, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-cpp";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "2d8c12ce4f1ce0fb8441983d9fba3f6fc45562b28a244ceec15c0c90578dc052";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_cpp/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "03a1b6a9fdb6b094d8bae685846d7efae26942338b72029d2441a2cb1bb35128";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs std-msgs test-msgs ];
-  propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp shared-queues-vendor ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rmw-implementation-cmake rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs std-msgs test-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp pluginlib rclcpp rcpputils rcutils rmw rmw-implementation rosbag2-storage rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-cpp rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosbag2-examples-cpp/default.nix
+++ b/distros/rolling/rosbag2-examples-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, example-interfaces, rclcpp, rosbag2-cpp, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-cpp";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "4ad9fac8df5bd4953c7af34aa82204934c0a584c84598f226f13bd939b48889f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_cpp/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "c6587057ab2d896ff16d9d88d6e79150303c0474fdd166958d108d82996c0bc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-examples-py/default.nix
+++ b/distros/rolling/rosbag2-examples-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, example-interfaces, python3Packages, rclpy, rosbag2-py, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, example-interfaces, python3Packages, rclpy, rosbag2-py, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-examples-py";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "7331116b1bf97efb9ed1ed0499553bcf833f9906ed670c81cca2f10ec792ded3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_examples_py/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "a49f63aad9112d42399bb8756de569fe1b97ab064d81036918ea7abff83958cc";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ example-interfaces rclpy rosbag2-py std-msgs ];
 
   meta = {

--- a/distros/rolling/rosbag2-interfaces/default.nix
+++ b/distros/rolling/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-interfaces";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "f5c0dc94c1bde8dae21df0ec4d4bd2c3f4c557f8e8a29ee1f439e9a2727a7f24";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_interfaces/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "441d997652915b40560f6a261a78bfcde44b7de18ea1a10042224f2d15dfb9c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking-msgs";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "e3c2075dd7b3941504184d08f6466c2e336f63ecb52eca5e54f72d259e4d2eb6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking_msgs/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "45eca6a4f641902e40c61010fe28149266378d60611f5a3846912219e89d1b7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-performance-benchmarking/default.nix
+++ b/distros/rolling/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, launch, launch-ros, python3Packages, rclcpp, rmw, ros-testing, ros2bag, ros2launch, rosbag2-compression, rosbag2-cpp, rosbag2-performance-benchmarking-msgs, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-performance-benchmarking";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "99a8e9e33a2e6878689114506e80a37c63dc3c272ff8c06a2fd5894b3da29bb2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_performance_benchmarking/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "214f929c9fb5eb3656e4a3be62562a9133a5579177d047c0822e403d04944a66";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-py/default.nix
+++ b/distros/rolling/rosbag2-py/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python3, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-test-msgdefs, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-py";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "41d9c8c3c61027ec3adbd5aae38d7c41faa581a399fd3b6a1bdbc83088d881a3";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_py/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "f33da489db0fe63eabc0dc82128ea11cdbdf0d598a79693e333cfcc2c375290e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  buildInputs = [ ament-cmake-python ament-cmake-ros python3 ];
   checkInputs = [ ament-lint-auto ament-lint-common python3Packages.pytest rcl-interfaces rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common rosbag2-test-msgdefs rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ pybind11-vendor rclpy rosbag2-compression rosbag2-cpp rosbag2-storage rosbag2-transport rpyutils ];
-  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake-ros ];
 
   meta = {
     description = "Python API for rosbag2";

--- a/distros/rolling/rosbag2-storage-default-plugins/default.nix
+++ b/distros/rolling/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosbag2-storage-mcap, rosbag2-storage-sqlite3 }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-default-plugins";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "2d5a8fb4fb0192195515544117ba21b0dd88634f4ae96a1b79aeb08d5b4ab214";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_default_plugins/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "be183de04720677b098c5044686cf7833ca68209b25a2821163d3b0671bf54af";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-mcap/default.nix
+++ b/distros/rolling/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-cmake-python, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcutils, rosbag2-storage, rosbag2-test-common, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-mcap";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "8d0e6864ea268c14fc28948d9d73472c4f7eae531f4418acf161f0341ae5fa24";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_mcap/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "fa97a1b0dccc797ddf9b94cc175b0d14cf06a5a83af8e7d12564bd7eb5b30ca3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage-sqlite3/default.nix
+++ b/distros/rolling/rosbag2-storage-sqlite3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage-sqlite3";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "2ee0cad7471db19b76bcf2fcc2902701b0a358dfcc64fdaa57c8dbb3bb917bf4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage_sqlite3/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "6abd9bac4f2f4370c875dfa744f07078fa6550fad4a3ead43d6b83dd4a641a9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-storage/default.nix
+++ b/distros/rolling/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcutils, rmw, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-storage";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "e50020d9f38583cadd2b35263c22186a4d08745d043e7de7d576a75351be582d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_storage/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "70e8bb8d4f57039462646e422fd939a50881ce8cc1f8180da7da27810e034dec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-test-common/default.nix
+++ b/distros/rolling/rosbag2-test-common/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-common";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "79068f0f6ee6fcf39e22cab7c13421d01651841acd3022964d85875de7e8c352";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_common/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "9836aa79d151d3b0f72683fa8165be711c8c7dc638fb87b0b39c7cf13ac1470d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ rclcpp rcutils ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
+  propagatedBuildInputs = [ rclcpp rcpputils rcutils test-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "Commonly used test helper classes and fixtures for rosbag2";

--- a/distros/rolling/rosbag2-test-msgdefs/default.nix
+++ b/distros/rolling/rosbag2-test-msgdefs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-test-msgdefs";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "5129ae00eb3f6ade51c3b1b34b3f8fbe4564b302fffb54b1a8a71f6880dd9538";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_test_msgdefs/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "a55d4ea0ccdfc78d19109a285135ad72c73719ed209cfb535993c28e7cac381a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-tests/default.nix
+++ b/distros/rolling/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-transport, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-tests";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "5b7a84aac4b494a46875eb769b8b7b9f6f6f97894c7c98c03c6e547ceb68f66b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_tests/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "6be3f986d91fd29d2a5927832363621d4ab4050af34ae5fb5d516d544414fab8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbag2-transport/default.nix
+++ b/distros/rolling/rosbag2-transport/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-components, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, composition-interfaces, keyboard-handler, rclcpp, rclcpp-components, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2-transport";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "68b2a297752a4d845bf45f1f76899ab15e2c755a443a6fb36e38920e45956576";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2_transport/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "f028990204c35553f8525a80071f9c15ddc7772df099ec8e4b3d0728337adf7c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gmock ament-index-cpp ament-lint-auto ament-lint-common composition-interfaces rmw-implementation-cmake rosbag2-compression-zstd rosbag2-storage-default-plugins rosbag2-test-common test-msgs ];
-  propagatedBuildInputs = [ keyboard-handler rclcpp rclcpp-components rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage shared-queues-vendor yaml-cpp-vendor ];
+  propagatedBuildInputs = [ keyboard-handler rclcpp rclcpp-components rcpputils rcutils rmw rosbag2-compression rosbag2-cpp rosbag2-interfaces rosbag2-storage yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rosbag2/default.nix
+++ b/distros/rolling/rosbag2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-rolling-rosbag2";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "ed157bafc9ffac036c091cee751936bd5b13f378d5802209933686ef5eef05b4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/rosbag2/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "d3875d942cc858b82a0b864e09ec18b5299749b055787e4a9c0b19326d3cf968";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ rosbag2-test-common rosbag2-tests ];
-  propagatedBuildInputs = [ ros2bag rosbag2-compression rosbag2-compression-zstd rosbag2-cpp rosbag2-py rosbag2-storage rosbag2-storage-default-plugins rosbag2-transport shared-queues-vendor ];
+  propagatedBuildInputs = [ ros2bag rosbag2-compression rosbag2-compression-zstd rosbag2-cpp rosbag2-py rosbag2-storage rosbag2-storage-default-plugins rosbag2-transport ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/rosidl-typesupport-c/default.nix
+++ b/distros/rolling/rosidl-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-generator-c, rosidl-pycommon, rosidl-runtime-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-c";
-  version = "3.3.1-r1";
+  version = "3.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_c/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "3c51a6b95754ef2495f1820dbb90dcdf74fc9621bee2172201b6fe7560fe34a8";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_c/3.3.2-1.tar.gz";
+    name = "3.3.2-1.tar.gz";
+    sha256 = "1b343be4c61997c849e15d1368197db22b062c92559c6262797c495a5bec6899";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosidl-typesupport-cpp/default.nix
+++ b/distros/rolling/rosidl-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, performance-test-fixture, python3, rcpputils, rcutils, rosidl-cli, rosidl-generator-c, rosidl-generator-type-description, rosidl-pycommon, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rosidl-typesupport-cpp";
-  version = "3.3.1-r1";
+  version = "3.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_cpp/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "71bf9e0abf58658f7ef0309e918f8905713553c2f8dc322c375b0bd83f933a47";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/rolling/rosidl_typesupport_cpp/3.3.2-1.tar.gz";
+    name = "3.3.2-1.tar.gz";
+    sha256 = "cd93686b8085124fb9338ac9dd9352cdcfa3675e1e853fae4ed340bc6708b1c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-controller-manager/default.nix
+++ b/distros/rolling/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-controller-manager";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "d208011510b0827bb7318c9343455b35dec571b1756c3a90d698a3d52222072a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/rqt_controller_manager/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "c249f45ac1dec5d74ffa56a8a4ddd55135a558ab2fff163a15a437f62b1148ac";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-graph/default.nix
+++ b/distros/rolling/rqt-graph/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, python3Packages, qt-dotgraph, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-graph";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/rolling/rqt_graph/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "38e6508240c527331107fbd86464f314978a6136da0123c8ef6d0c371b81cc4f";
+    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/rolling/rqt_graph/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "ad3ca8dc4224d8660a9474a826c2bf2233213cefa3c4c3f3c19b5f6a113de1f6";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ ament-index-python python-qt-binding qt-dotgraph rqt-gui rqt-gui-py ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding qt-dotgraph rclpy rqt-gui rqt-gui-py ];
 
   meta = {
     description = "rqt_graph provides a GUI plugin for visualizing the ROS

--- a/distros/rolling/rqt-gui-cpp/default.nix
+++ b/distros/rolling/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-cpp";
-  version = "1.8.0-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "a2a9c88aa47ed0653901266f783746bc59b309a485e3f031108a7d42ad208f17";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_cpp/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "92f8d4b27e6b14a0432d9fdfeb4ba25569c07dc7f6211acfe0f92730e94b8039";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-gui-py/default.nix
+++ b/distros/rolling/rqt-gui-py/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui-py";
-  version = "1.8.0-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "3232285f3822cdee254e1ba80da89f30e26055944c47c1f56ec445bdd08275d9";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui_py/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "f52219add467a4c156246e87a74665182fc2d5bf68273f638173b1b7f98737b4";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ qt-gui rqt-gui ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ python-qt-binding qt-gui rclpy rqt-gui ];
 
   meta = {
     description = "rqt_gui_py enables GUI plugins to use the Python client library for ROS.";

--- a/distros/rolling/rqt-gui/default.nix
+++ b/distros/rolling/rqt-gui/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-rqt-gui";
-  version = "1.8.0-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "14f5c41f4352a54060e0fd800412ac04a36c95e100792d8ed6246afe3dbe9587";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_gui/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "33d7f0455d41f522dbf0047f52116f5edc62b334be9972bc734de614892bc208";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding python3Packages.catkin-pkg qt-gui rclpy ];
 
   meta = {

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "1d5dd0efa3851575565a4aaed9544f771fda4148ebd04e35f69e3780f9006085";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "51ead15e7eed763b298059577ba49311440b3c5e98ed6d55181644e593fd6d3d";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-py-common/default.nix
+++ b/distros/rolling/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-common";
-  version = "1.8.0-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "86a3b855d5fcc94c77fa07ff5de6cc2a1f3b523bd390d9428a4decb2542419fc";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt_py_common/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "8875bc6f558a07b9701c299af863d8504e1e0ca189081d934feff1552a71c729";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-py-console/default.nix
+++ b/distros/rolling/rqt-py-console/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-py-console";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/rolling/rqt_py_console/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "cc5282e412b23bdffc6c36217e3aa33dc9b03ef3c9ce97d138ac0de5b271c1e5";
+    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/rolling/rqt_py_console/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "b42871ba906fbd12e40e300a1b3dba1ef28f24746d6328ad94e2c626ac5b671f";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.pytest ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ ament-index-python python-qt-binding qt-gui qt-gui-py-common rclpy rqt-gui rqt-gui-py ];
 
   meta = {

--- a/distros/rolling/rqt-service-caller/default.nix
+++ b/distros/rolling/rqt-service-caller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, python3Packages, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python-qt-binding, python3Packages, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt-service-caller";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/rolling/rqt_service_caller/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "8dbb977604b466313e360ff991681db1219d56d96f4cf72376a03cba554d935e";
+    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/rolling/rqt_service_caller/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "8f706aad7e966e30f43b8c1245f511a0bbfda811a126bd6ded947246fb6c82bd";
   };
 
   buildType = "ament_python";
-  checkInputs = [ python3Packages.pytest ];
-  propagatedBuildInputs = [ rqt-gui rqt-gui-py rqt-py-common ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint python3Packages.pytest ];
+  propagatedBuildInputs = [ ament-index-python python-qt-binding rqt-gui rqt-gui-py rqt-py-common ];
 
   meta = {
     description = "rqt_service_caller provides a GUI plugin for calling arbitrary services.";

--- a/distros/rolling/rqt/default.nix
+++ b/distros/rolling/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-rolling-rqt";
-  version = "1.8.0-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/1.8.0-1.tar.gz";
-    name = "1.8.0-1.tar.gz";
-    sha256 = "cf3b52e677dcaea4c96705b3d1b428a802865a49da56bcfc89083bedf13e57d1";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/rolling/rqt/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "0fd6bafb23c67bee8a073df9974d0490b9792319414e0ce39599a0aba6d5f214";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "fa4d700b31f063843e96f203e822f92c0243c32e680f5e0b0246fb02358aec90";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "a56acf0cac95056941834edd5dbfda1facc9b82c20d8419d56d1a23ed692f146";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "0725ca4e880fdecd674a5c44c893ebe23c0ab7b406d50d10c3d15cd1b275c989";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "b881d1c2664e76d9faa4e9211335bf6abe5b5e105332af6c0da8bdd5041e38b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "f69f10367497ec8e6691624b59f1d4b02c7c794be4a87427bc85623fb35cbe32";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "d67789c951ca9b8661e200a8934523c043dbded66ef5909b6f3c396adfe486b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "1764c5110c46ebf2a2caf31d3fc4a7c9993468e28d9528a76f4208f8aab92110";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "274b5005343f9235f0092f7943c4dab0e3ffb23e7c52e621152311bb241d9667";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "22f5d6136f97d5bdb31ab17d7f74ba2c83573188bcd9679f63d149608f304779";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "b498377136ed6c40982c9a7f652d9c17b98c2eaf4daeec03c3df2d9eca42d478";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "c4707a509a17e9043d2a7d7499f6ca23f496bbed6ffe7188352301d0ee19e046";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "ddea9db88b67a2b3dcbb5bf4617e1c153f3f742b47ded9995d936b8f2856d783";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "410beb38b8af9d485083bf7084d09bf819dbc7a4cff0d88ccda3b4b193302081";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "8b4e2bda4d47cc0f00420ee33e4886e77f052e6f2bb76bc9c204bf0458669236";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.4.1-r1";
+  version = "14.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.1-1.tar.gz";
-    name = "14.4.1-1.tar.gz";
-    sha256 = "41d0aaff907a63f6062ea44970d9e0492202e00046081bda3b2e57973dca3894";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.2-1.tar.gz";
+    name = "14.4.2-1.tar.gz";
+    sha256 = "feb1a5bf610ac10a44678e62272f83a84f5e0360699bec08d8c1362bd15b6c8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sqlite3-vendor/default.nix
+++ b/distros/rolling/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, sqlite }:
 buildRosPackage {
   pname = "ros-rolling-sqlite3-vendor";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "c0dce7569172d30f7d523c123bdd3c7ee4e1fca524ea3fcd1f31bd95ade3598c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/sqlite3_vendor/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "50f72e2369bd0367e7d246b3949e175683d57f727c58ff1846314d403ad4f906";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "80cfe527e391a1c16a79ee35daa3d6ff4f17c2fc5d60129ea739723de2c937a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "aac000d7d6dfd97ed0c766ffae0884fb3a2ed8c9a93d1cd1d65cca9a64dc9f5b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/transmission-interface/default.nix
+++ b/distros/rolling/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-transmission-interface";
-  version = "4.24.0-r1";
+  version = "4.25.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.24.0-1.tar.gz";
-    name = "4.24.0-1.tar.gz";
-    sha256 = "9b531d12767a030ca45827b806a0e40f61219ee285a44df4069b14f8f04c83ad";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/rolling/transmission_interface/4.25.0-1.tar.gz";
+    name = "4.25.0-1.tar.gz";
+    sha256 = "07842183bd9f412303c051a3d9c0b15d28f2ccee0e26d1c8c4bed8ca8d59d3a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "9706e19bc6a577d2a6d92d9bdd88f9b1061256700e9a6015f26a0aaa454fd8cc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "af3ca146f45d56323513ce420e4985f8eac3deb956fffc71e6c6b6fd3b175794";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "d19b1d01fef010faa419539ef16310f510e2818c2a01250c99411110994acae1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "763ec2c198fc78e3fe7c9d4c6c9cf9caa6df67976ef57cd5174826809e95a49e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.19.0-r1";
+  version = "4.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.19.0-1.tar.gz";
-    name = "4.19.0-1.tar.gz";
-    sha256 = "bfc6b97457a99d6ae3390cce573ec429120378260dde18a85649a61c9f0ab05c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.20.0-1.tar.gz";
+    name = "4.20.0-1.tar.gz";
+    sha256 = "8a2b9dbab57252a973aa46e23a1d0b0e000bec8d871c71090a15593e267ea20a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zstd-vendor/default.nix
+++ b/distros/rolling/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, zstd }:
 buildRosPackage {
   pname = "ros-rolling-zstd-vendor";
-  version = "0.29.0-r1";
+  version = "0.31.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.29.0-1.tar.gz";
-    name = "0.29.0-1.tar.gz";
-    sha256 = "b3f842b55d15b7f623fd673eb94337a1ede85b1aea6a4f104d0e2bce93d70dd6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/rolling/zstd_vendor/0.31.0-1.tar.gz";
+    name = "0.31.0-1.tar.gz";
+    sha256 = "102fd54cf8618ad1475c0e44ee68bdba34b0c829bba5ec3f81f93ded0de4ee18";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit f9c218f6e94b59d037bb081ba3cf99e2b567ee49.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *backward-ros 1.0.6-r1 --> 1.0.7-r1*
* *foxglove-bridge 0.8.2-r1 --> 0.8.3-r1*
* *hebi-cpp-api 3.10.0-r1 --> 3.10.1-r1*
* *moveit-visual-tools 4.1.1-r1 --> 4.1.2-r1*
* *mvsim 0.13.0-r1 --> 0.13.1-r1*
* *novatel-oem7-driver 20.1.0-r1 --> 20.6.0-r1*
* *novatel-oem7-msgs 20.1.0-r1 --> 20.6.0-r1*
* *pal-statistics 2.6.0-r1 --> 2.6.1-r1*
* *pal-statistics-msgs 2.6.0-r1 --> 2.6.1-r1*
* *realtime-tools 2.10.0-r1 --> 2.11.0-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.19.0-r1 --> 4.20.0-r1*
* *admittance-controller 4.19.0-r1 --> 4.20.0-r1*
* *backward-ros 1.0.6-r1 --> 1.0.7-r1*
* *bicycle-steering-controller 4.19.0-r1 --> 4.20.0-r1*
* *clearpath-bt-joy 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-common 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-config 2.0.1-r1 --> 2.1.0-r1*
* *clearpath-config-live 2.0.0-r1*
* *clearpath-control 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-customization 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-description 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-desktop 2.0.0-r1*
* *clearpath-generator-common 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-manipulators 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-manipulators-description 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-motor-msgs 2.0.0-r1 --> 2.1.0-r1*
* *clearpath-mounts-description 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-msgs 2.0.0-r1 --> 2.1.0-r1*
* *clearpath-nav2-demos 2.0.0-r1*
* *clearpath-offboard-sensors 2.0.0-r1*
* *clearpath-platform-description 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-platform-msgs 2.0.0-r1 --> 2.1.0-r1*
* *clearpath-ros2-socketcan-interface 2.0.0-r1 --> 2.1.0-r1*
* *clearpath-sensors-description 2.0.3-r1 --> 2.1.0-r1*
* *clearpath-viz 2.0.0-r1*
* *control-toolbox 3.5.0-r1 --> 4.0.0-r1*
* *controller-interface 4.24.0-r1 --> 4.25.0-r1*
* *controller-manager 4.24.0-r1 --> 4.25.0-r1*
* *controller-manager-msgs 4.24.0-r1 --> 4.25.0-r1*
* *crane-plus 3.0.0-r1*
* *crane-plus-control 3.0.0-r1*
* *crane-plus-description 3.0.0-r1*
* *crane-plus-examples 3.0.0-r1*
* *crane-plus-gazebo 3.0.0-r1*
* *crane-plus-moveit-config 3.0.0-r1*
* *diff-drive-controller 4.19.0-r1 --> 4.20.0-r1*
* *effort-controllers 4.19.0-r1 --> 4.20.0-r1*
* *force-torque-sensor-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *forward-command-controller 4.19.0-r1 --> 4.20.0-r1*
* *foxglove-bridge 0.8.2-r1 --> 0.8.3-r1*
* *gpio-controllers 4.19.0-r1 --> 4.20.0-r1*
* *gripper-controllers 4.19.0-r1 --> 4.20.0-r1*
* *hardware-interface 4.24.0-r1 --> 4.25.0-r1*
* *hardware-interface-testing 4.24.0-r1 --> 4.25.0-r1*
* *imu-sensor-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *joint-limits 4.24.0-r1 --> 4.25.0-r1*
* *joint-state-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *joint-trajectory-controller 4.19.0-r1 --> 4.20.0-r1*
* *mecanum-drive-controller 4.19.0-r1 --> 4.20.0-r1*
* *moveit-visual-tools 4.1.1-r1 --> 4.1.2-r1*
* *mvsim 0.13.0-r1 --> 0.13.1-r1*
* *pal-statistics 2.6.0-r1 --> 2.6.1-r1*
* *pal-statistics-msgs 2.6.0-r1 --> 2.6.1-r1*
* *parallel-gripper-controller 4.19.0-r1 --> 4.20.0-r1*
* *pid-controller 4.19.0-r1 --> 4.20.0-r1*
* *pose-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *position-controllers 4.19.0-r1 --> 4.20.0-r1*
* *range-sensor-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *realtime-tools 3.1.0-r1 --> 3.3.0-r1*
* *ros2-control 4.24.0-r1 --> 4.25.0-r1*
* *ros2-control-test-assets 4.24.0-r1 --> 4.25.0-r1*
* *ros2-controllers 4.19.0-r1 --> 4.20.0-r1*
* *ros2-controllers-test-nodes 4.19.0-r1 --> 4.20.0-r1*
* *ros2controlcli 4.24.0-r1 --> 4.25.0-r1*
* *rqt-controller-manager 4.24.0-r1 --> 4.25.0-r1*
* *rqt-joint-trajectory-controller 4.19.0-r1 --> 4.20.0-r1*
* *steering-controllers-library 4.19.0-r1 --> 4.20.0-r1*
* *transmission-interface 4.24.0-r1 --> 4.25.0-r1*
* *tricycle-controller 4.19.0-r1 --> 4.20.0-r1*
* *tricycle-steering-controller 4.19.0-r1 --> 4.20.0-r1*
* *velocity-controllers 4.19.0-r1 --> 4.20.0-r1*

Noetic Changes:
---------------
* *foxglove-bridge 0.8.1-r1 --> 0.8.3-r1*
* *grpc 0.0.15-r3 --> 0.0.16-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.19.0-r1 --> 4.20.0-r1*
* *admittance-controller 4.19.0-r1 --> 4.20.0-r1*
* *ament-clang-format 0.19.0-r1 --> 0.19.1-r1*
* *ament-clang-tidy 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-clang-format 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-clang-tidy 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-copyright 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-cppcheck 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-cpplint 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-flake8 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-lint-cmake 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-mypy 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-pclint 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-pep257 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-pycodestyle 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-pyflakes 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-uncrustify 0.19.0-r1 --> 0.19.1-r1*
* *ament-cmake-xmllint 0.19.0-r1 --> 0.19.1-r1*
* *ament-copyright 0.19.0-r1 --> 0.19.1-r1*
* *ament-cppcheck 0.19.0-r1 --> 0.19.1-r1*
* *ament-cpplint 0.19.0-r1 --> 0.19.1-r1*
* *ament-flake8 0.19.0-r1 --> 0.19.1-r1*
* *ament-lint 0.19.0-r1 --> 0.19.1-r1*
* *ament-lint-auto 0.19.0-r1 --> 0.19.1-r1*
* *ament-lint-cmake 0.19.0-r1 --> 0.19.1-r1*
* *ament-lint-common 0.19.0-r1 --> 0.19.1-r1*
* *ament-mypy 0.19.0-r1 --> 0.19.1-r1*
* *ament-pclint 0.19.0-r1 --> 0.19.1-r1*
* *ament-pep257 0.19.0-r1 --> 0.19.1-r1*
* *ament-pycodestyle 0.19.0-r1 --> 0.19.1-r1*
* *ament-pyflakes 0.19.0-r1 --> 0.19.1-r1*
* *ament-uncrustify 0.19.0-r1 --> 0.19.1-r1*
* *ament-xmllint 0.19.0-r1 --> 0.19.1-r1*
* *backward-ros 1.0.6-r1 --> 1.0.7-r1*
* *bicycle-steering-controller 4.19.0-r1 --> 4.20.0-r1*
* *control-toolbox 3.5.0-r1 --> 4.0.0-r1*
* *controller-interface 4.24.0-r1 --> 4.25.0-r1*
* *controller-manager 4.24.0-r1 --> 4.25.0-r1*
* *controller-manager-msgs 4.24.0-r1 --> 4.25.0-r1*
* *diff-drive-controller 4.19.0-r1 --> 4.20.0-r1*
* *effort-controllers 4.19.0-r1 --> 4.20.0-r1*
* *force-torque-sensor-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *forward-command-controller 4.19.0-r1 --> 4.20.0-r1*
* *foxglove-bridge 0.8.2-r1 --> 0.8.3-r1*
* *gpio-controllers 4.19.0-r1 --> 4.20.0-r1*
* *gripper-controllers 4.19.0-r1 --> 4.20.0-r1*
* *gz-rendering-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-ros2-control 2.0.3-r1 --> 2.0.5-r1*
* *gz-ros2-control-demos 2.0.3-r1 --> 2.0.5-r1*
* *hardware-interface 4.24.0-r1 --> 4.25.0-r1*
* *hardware-interface-testing 4.24.0-r1 --> 4.25.0-r1*
* *imu-sensor-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *joint-limits 4.24.0-r1 --> 4.25.0-r1*
* *joint-state-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *joint-trajectory-controller 4.19.0-r1 --> 4.20.0-r1*
* *liblz4-vendor 0.29.0-r1 --> 0.31.0-r1*
* *mcap-vendor 0.29.0-r1 --> 0.31.0-r1*
* *mecanum-drive-controller 4.19.0-r1 --> 4.20.0-r1*
* *message-filters 7.0.0-r1 --> 7.0.1-r1*
* *moveit-visual-tools 4.1.1-r1 --> 4.1.2-r1*
* *mvsim 0.13.0-r1 --> 0.13.1-r1*
* *pal-statistics 2.6.0-r1 --> 2.6.1-r1*
* *pal-statistics-msgs 2.6.0-r1 --> 2.6.1-r1*
* *parallel-gripper-controller 4.19.0-r1 --> 4.20.0-r1*
* *pid-controller 4.19.0-r1 --> 4.20.0-r1*
* *pose-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *position-controllers 4.19.0-r1 --> 4.20.0-r1*
* *range-sensor-broadcaster 4.19.0-r1 --> 4.20.0-r1*
* *rcl 10.0.1-r1 --> 10.0.2-r1*
* *rcl-action 10.0.1-r1 --> 10.0.2-r1*
* *rcl-lifecycle 10.0.1-r1 --> 10.0.2-r1*
* *rcl-yaml-param-parser 10.0.1-r1 --> 10.0.2-r1*
* *rclpy 8.0.0-r1 --> 9.0.0-r1*
* *rcpputils 2.13.2-r1 --> 2.13.3-r1*
* *rcutils 6.9.3-r1 --> 6.9.4-r1*
* *realtime-tools 3.1.0-r1 --> 4.0.0-r1*
* *rmw 7.5.1-r1 --> 7.6.0-r1*
* *rmw-implementation-cmake 7.5.1-r1 --> 7.6.0-r1*
* *ros2-control 4.24.0-r1 --> 4.25.0-r1*
* *ros2-control-test-assets 4.24.0-r1 --> 4.25.0-r1*
* *ros2-controllers 4.19.0-r1 --> 4.20.0-r1*
* *ros2-controllers-test-nodes 4.19.0-r1 --> 4.20.0-r1*
* *ros2action 0.36.1-r1 --> 0.37.0-r1*
* *ros2bag 0.29.0-r1 --> 0.31.0-r1*
* *ros2cli 0.36.1-r1 --> 0.37.0-r1*
* *ros2cli-test-interfaces 0.36.1-r1 --> 0.37.0-r1*
* *ros2component 0.36.1-r1 --> 0.37.0-r1*
* *ros2controlcli 4.24.0-r1 --> 4.25.0-r1*
* *ros2doctor 0.36.1-r1 --> 0.37.0-r1*
* *ros2interface 0.36.1-r1 --> 0.37.0-r1*
* *ros2lifecycle 0.36.1-r1 --> 0.37.0-r1*
* *ros2lifecycle-test-fixtures 0.36.1-r1 --> 0.37.0-r1*
* *ros2multicast 0.36.1-r1 --> 0.37.0-r1*
* *ros2node 0.36.1-r1 --> 0.37.0-r1*
* *ros2param 0.36.1-r1 --> 0.37.0-r1*
* *ros2pkg 0.36.1-r1 --> 0.37.0-r1*
* *ros2run 0.36.1-r1 --> 0.37.0-r1*
* *ros2service 0.36.1-r1 --> 0.37.0-r1*
* *ros2topic 0.36.1-r1 --> 0.37.0-r1*
* *rosbag2 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-compression 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-compression-zstd 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-cpp 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-examples-cpp 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-examples-py 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-interfaces 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-performance-benchmarking 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-performance-benchmarking-msgs 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-py 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-storage 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-storage-default-plugins 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-storage-mcap 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-storage-sqlite3 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-test-common 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-test-msgdefs 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-tests 0.29.0-r1 --> 0.31.0-r1*
* *rosbag2-transport 0.29.0-r1 --> 0.31.0-r1*
* *rosidl-typesupport-c 3.3.1-r1 --> 3.3.2-r1*
* *rosidl-typesupport-cpp 3.3.1-r1 --> 3.3.2-r1*
* *rqt 1.8.0-r1 --> 1.9.0-r1*
* *rqt-controller-manager 4.24.0-r1 --> 4.25.0-r1*
* *rqt-graph 1.6.1-r1 --> 1.7.0-r1*
* *rqt-gui 1.8.0-r1 --> 1.9.0-r1*
* *rqt-gui-cpp 1.8.0-r1 --> 1.9.0-r1*
* *rqt-gui-py 1.8.0-r1 --> 1.9.0-r1*
* *rqt-joint-trajectory-controller 4.19.0-r1 --> 4.20.0-r1*
* *rqt-py-common 1.8.0-r1 --> 1.9.0-r1*
* *rqt-py-console 1.3.0-r1 --> 1.4.0-r1*
* *rqt-service-caller 1.3.0-r1 --> 1.4.0-r1*
* *rviz-assimp-vendor 14.4.1-r1 --> 14.4.2-r1*
* *rviz-common 14.4.1-r1 --> 14.4.2-r1*
* *rviz-default-plugins 14.4.1-r1 --> 14.4.2-r1*
* *rviz-ogre-vendor 14.4.1-r1 --> 14.4.2-r1*
* *rviz-rendering 14.4.1-r1 --> 14.4.2-r1*
* *rviz-rendering-tests 14.4.1-r1 --> 14.4.2-r1*
* *rviz-visual-testing-framework 14.4.1-r1 --> 14.4.2-r1*
* *rviz2 14.4.1-r1 --> 14.4.2-r1*
* *sqlite3-vendor 0.29.0-r1 --> 0.31.0-r1*
* *steering-controllers-library 4.19.0-r1 --> 4.20.0-r1*
* *transmission-interface 4.24.0-r1 --> 4.25.0-r1*
* *tricycle-controller 4.19.0-r1 --> 4.20.0-r1*
* *tricycle-steering-controller 4.19.0-r1 --> 4.20.0-r1*
* *velocity-controllers 4.19.0-r1 --> 4.20.0-r1*
* *zstd-vendor 0.29.0-r1 --> 0.31.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-torch-geometric-pip
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

