### PR TITLE
rosdistro sync, Fri Feb 21 13:18:38 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "a1b96c780560502fc95afecfcf5064cd5b45e3a4c9463df10f4ff699ea6869a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "67d5e815663ad338f5fa0a4aa69406289c902454798dd177b536c8b98629972f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "2b70847e6ef3268f7449f2eb45a8a59092df0eb075f146ec9405b3da24054b81";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "de0cd3605e72b6ae95a698b387d5648d5ec20d066bbeaf9352f0cb5f75c20196";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/apriltag/default.nix
+++ b/distros/humble/apriltag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-apriltag";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/humble/apriltag/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "a63342ef70102af9b5f11e8cb1f0829d18778fdbfcf9bf70f13449555ff62bae";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/humble/apriltag/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "0c04eafb8eafacc5fb6560362e04c345a825b1ae0a37cbeaef7ccce227670ef7";
   };
 
   buildType = "cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "2ecb50c4b2ba6e163ee3fa4c138899361f18ebece0e1101e5c675619e9a83ad0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "53361991d490fe03e552526e65f2aef853863d831867d6801114b3bff9d2e779";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-calibration-parsers/default.nix
+++ b/distros/humble/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-camera-calibration-parsers";
-  version = "3.1.10-r1";
+  version = "3.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.10-1.tar.gz";
-    name = "3.1.10-1.tar.gz";
-    sha256 = "d0c502969e366139e4f679d3f78a1bfa17d093e7807e47de75f71cf2abb0ec77";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_calibration_parsers/3.1.11-1.tar.gz";
+    name = "3.1.11-1.tar.gz";
+    sha256 = "f7b0db0cd12a9c692e257dca053de17a999ee663c435d5eb3f9cc95d81b2071a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/camera-info-manager-py/default.nix
+++ b/distros/humble/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager-py";
-  version = "3.1.10-r1";
+  version = "3.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager_py/3.1.10-1.tar.gz";
-    name = "3.1.10-1.tar.gz";
-    sha256 = "a190bbee6fbee1a7f63544fdb3b1ec2e6c8494fdccd149d6de1bf81ff42d37c4";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager_py/3.1.11-1.tar.gz";
+    name = "3.1.11-1.tar.gz";
+    sha256 = "9ffa4120151547fd1ba6a2ae453b1da31706f899d5446a5da341447b8560a34d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/camera-info-manager/default.nix
+++ b/distros/humble/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-camera-info-manager";
-  version = "3.1.10-r1";
+  version = "3.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.10-1.tar.gz";
-    name = "3.1.10-1.tar.gz";
-    sha256 = "6a4c4be4287234b62de00dafdef4662775c7f8e14930fd307f2232605b4a60c3";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/camera_info_manager/3.1.11-1.tar.gz";
+    name = "3.1.11-1.tar.gz";
+    sha256 = "6f1d07a6e5d6fc6d1dd596430b9474f5eb23aa46ee3e461dac6a595f533c70b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/coal/default.nix
+++ b/distros/humble/coal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, cmake, doxygen, eigen, eigenpy, git, octomap, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-coal";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/coal-release/archive/release/humble/coal/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "13a73d77648b6493b98656b512ddce4ca655dcbce52edaa41d128ca3877c058e";
+    url = "https://github.com/ros2-gbp/coal-release/archive/release/humble/coal/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "61b0c04de02eacd6e6b770cd901fee43f1a4dfac895b33aafbc9c2c5a8571928";
   };
 
   buildType = "cmake";

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "5c77087ac37ac607645b54298ab61a678fda9a255b80d6065ff1aff02ec7b891";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "9f5f87ec8d320d2d49371efed68fb36f9606d809dd58a157b12f638b5b1023a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "0b9ae9919d782678293c0eeb6e3446de87a8691849dc426c4ef7aeb042e3e11a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "9d475fb6b85da920f33ec3454e3f2a6a78447903792d3019eddd42950adb7e17";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "e5c5dd7b71ad9f60b27053afb033edb482ff5b1bfa8df34eee2d4d836bd2e29f";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "89c4e3059ce3cb985390e4c36d2d5bb8c01581b960c7e37840656fb65d099560";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "fdda5dc878e154c56684499529ebf4a5c1de86d6d4a215e9be29ae95a7d24117";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "43a933b932456d432cd92ad7b995d06083a6ea76da1d97b630d76f98a25d1ad9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "159bf864b6ab692801818b4b0c582191e8686ea580c630043cccb7deea1853ea";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "117a8c85982a6275b295aae41b9b6dfbecf9802be7a6c3f19625704acc600dbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "7deec7e0c0209339bb582252592d42ff87bdbe6ee2fc82d986ce825368944cb8";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "d319a27bf39c19ff0fb0c8a7edfe3a1e452520ce0dcc47e93532833d26e86259";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "776aab87f82e45266b51fac34a43b62a78aafcf9904f85633bb39068d0e46f7d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "9eefdc02c02ad0ed11712f699467f52d051c1f79a720b290aeb9d20c84895e94";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "1639002ffa099f814472cb0685130d9c8492894b03477e24734885502210bece";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "25f476e613c2dfc2ab5ac1c0525f6a421ccca06f8a5219a69d6e7ba238e41832";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-hardware-interface/default.nix
+++ b/distros/humble/dynamixel-hardware-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
+buildRosPackage {
+  pname = "ros-humble-dynamixel-hardware-interface";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "26a3d690bbc0b6899fdcb5a1991ddd80b40773158d5d3b6f871f3816ce0f91d0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-interfaces dynamixel-sdk hardware-interface pluginlib rclcpp realtime-tools std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 package providing a hardware interface for controlling Dynamixel motors via the ROS 2 control framework.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/dynamixel-interfaces/default.nix
+++ b/distros/humble/dynamixel-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-dynamixel-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/humble/dynamixel_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ae34f8bbe347f3463f8f32d927f8503db44d3a272f4c6862a1767c55257d8d8c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "dynamixel_interfaces contains base messages and service useful for controlling Dynamixel.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/humble/dynamixel-sdk-custom-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-sdk-custom-interfaces";
-  version = "3.7.60-r1";
+  version = "3.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_custom_interfaces/3.7.60-1.tar.gz";
-    name = "3.7.60-1.tar.gz";
-    sha256 = "75841255d97010335e1c6aaccabef9d292338b6613c6c53c20331c69e1d19e10";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_custom_interfaces/3.8.1-1.tar.gz";
+    name = "3.8.1-1.tar.gz";
+    sha256 = "93757af672881b8dd2c968a48181df64720b1b3aaf7a1e8ed778a1e6d71ebbf5";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "ROS2 custom interface examples using ROBOTIS DYNAMIXEL SDK";
+    description = "ROS 2 custom interface examples using ROBOTIS DYNAMIXEL SDK";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/dynamixel-sdk-examples/default.nix
+++ b/distros/humble/dynamixel-sdk-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-sdk-examples";
-  version = "3.7.60-r1";
+  version = "3.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_examples/3.7.60-1.tar.gz";
-    name = "3.7.60-1.tar.gz";
-    sha256 = "54c84822e2cd61baec5a091f5e9acd5fbf2014c6878d1903418f3cf74cdebf2a";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_examples/3.8.1-1.tar.gz";
+    name = "3.8.1-1.tar.gz";
+    sha256 = "4a871d63aa6406318a490b8170b7a8b18ccb817435745bc710afde280f3c8173";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ROS2 examples using ROBOTIS DYNAMIXEL SDK";
+    description = "ROS 2 examples using ROBOTIS DYNAMIXEL SDK";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/dynamixel-sdk/default.nix
+++ b/distros/humble/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-sdk";
-  version = "3.7.60-r1";
+  version = "3.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk/3.7.60-1.tar.gz";
-    name = "3.7.60-1.tar.gz";
-    sha256 = "78df24af4c32789fe1fe7a1ee5f6cf5222de7eae7d110d2404ede8b728bf9537";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk/3.8.1-1.tar.gz";
+    name = "3.8.1-1.tar.gz";
+    sha256 = "42ad9fde7a326163d440452d731f2bbbd2041410e81bf2fb692df984ecf1c97e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "cecde3935a864772925b7eca91ca99c964cf6af57bd67a2c01b8985e9375ac58";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "033f73774fc6b82122a50989f4982e29ccd0baf27cbbdd6a0e49ba17c71b81dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/eigenpy/default.nix
+++ b/distros/humble/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-eigenpy";
-  version = "3.8.2-r1";
+  version = "3.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/3.8.2-1.tar.gz";
-    name = "3.8.2-1.tar.gz";
-    sha256 = "20ff4457a6139281b8e86460a10051121d27eb7672b2c45f09138d4fc6a462ef";
+    url = "https://github.com/ros2-gbp/eigenpy-release/archive/release/humble/eigenpy/3.10.3-1.tar.gz";
+    name = "3.10.3-1.tar.gz";
+    sha256 = "825f0982db7511e876a8f4caa4889b458e99899cf0d6da4b8748cff63e1383dd";
   };
 
   buildType = "cmake";

--- a/distros/humble/etsi-its-cam-coding/default.nix
+++ b/distros/humble/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a012813ffbb227752f330f48937a15aba636c3008af6055de52cfb51f4866e4d";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "dfd85b75ec0b2f232fa328f602259fd387f4d9500304f5a4a81bf968c35065cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1cb8d0077cc7e114d8853b1b1700c78ceae6c312297c237e9d9b3fa2661031d2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "24266e5a37f280d6621f4390e8fbc9fc59074591f90b8ab654baff4f2df3f81e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9460727d29fe5e65ab72a8d03f1553be87d902e01ef215120723f49298969e7c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "71a384889775797d43cecb1958624743ee561ed01852ae7d636b806a8067d193";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-coding/default.nix
+++ b/distros/humble/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9ccb63ecc322d495a4a0861fbc51596a8046c7ee863c0ca253f247719fbd2edb";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "20efa20356edae3a354e53b2eda52d32d0ceab5a1fd52c626492914cda06c1e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "7472e6f5fa0014d4c71476a26ffcaef6ca14c7b09dfcf2ccd72a7d18422587a8";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7e28d7878f2269542ee84f46d0710b9b0ce48fc92d9f99e6b8e1da6ac0c7d862";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9fd844a59df805237744c3a072d982e0126898bbc979d80b34fecc2b2c5a8936";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c32babf904a93dc5751a304864d3bf8c1e174ba26794b66cd770b0fb684665a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-coding/default.nix
+++ b/distros/humble/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-denm-ts-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2c5bd01671d47331cc1346c7d630318a0c1a81da87dd12f366fa3635eecf0b0b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "970f11af6519bcd75d653db57428e9e209fd2c87cb110e19e4005dc68d548db8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-denm-ts-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-conversion/default.nix
+++ b/distros/humble/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-denm-ts-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9eceb04a246c603549fee59f4bac087d5edcb5d2b6af36e5e3a7f8405df51b64";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "882531b49d15647e85b3cec4c6dada788cfde8edaf598a9274c7abbadda34f04";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-denm-ts-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6587d26fda208b64e7229c0d6e784defaf1025c4eaba61e5f7e3d4e8ebff62a7";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "321abb58e061629abf00a53e2e3063cdd544eb9daa138f9dce11cd4c7b020885";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "c5f7811e99c72e929250e4dc75f41b6091c22960ef15860f5cddf9814223d63a";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a44e5abbcef59743556a72923a9143c8c1920415ee696a3a896c747a3d70c27f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-cpm-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "62ee08b839bcacd86c58c478741e6be604d8ec6bbfddcac76f8761ba258e8882";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_cpm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "43db3084de0fadc96e7a54b925901389d892bf28cc3d477c17efb44039ea37ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-coding/default.nix
+++ b/distros/humble/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bc5c018c2955f934c048fddffac8a5d7609216b6f762dfd44ac862b67645a27b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8ba200a71fe88a83d72b1af8187b0f563a429462d78c69cd72ae8e7092c61eb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "774c9b1eb34ae64a84d836809094a214cbf7af8994a05bd0c8b205090e5f5e3f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ec501653d35628c03dae5c4539f7f990704d3ab9aa62f8ab51338a3162d09883";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-denm-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9cd3dec3a371471d16624a349118d7447a2747a765392d1c297e8e3570d55340";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c556c50663f60585ce33fef3b9bc863214f86f4d8ee9e04d24e4c5fdef085350";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-denm-ts-coding/default.nix
+++ b/distros/humble/etsi-its-denm-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-ts-coding";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ea3b0310aa21b3adbf8a56f9162bdb6c0e44a768b05e49dd1e62c872b9d7ad90";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS DENMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-denm-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-ts-coding, etsi-its-denm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-ts-conversion";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "4fae50c8d0e519718c1b91827eed6f2258e573993aaa55ccc1d8bd0543e4c953";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-ts-coding etsi-its-denm-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-denm-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-denm-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-etsi-its-denm-ts-msgs";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_denm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "de8950be195e429bce763d7f5743163b808f51c792e6ab8964aa5c4de62b85cc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS DENM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/etsi-its-mapem-ts-coding/default.nix
+++ b/distros/humble/etsi-its-mapem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-mapem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_mapem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "c6f6c01591df4877c17b9004ae8b0a5afc784a406304a74b90aed3e5be1b7ee1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_mapem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "62cbbbb121baa9b60c04883bd50e7fc6e5c3fadbd81c31ecf23d694f3455e954";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-mapem-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-mapem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-mapem-ts-coding, etsi-its-mapem-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-mapem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_mapem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6628fdff1ff799c3ab33fcb3b1d679a11ae41f008b58c45295988152ecb43c59";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_mapem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0bc829f9cd485fbe9dc2a5804b2586fdfab92f6af88dc4c37f0ca25809a5deb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-mapem-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-mapem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-mapem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_mapem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "616ffad565c9a5b497698ae8e1340cabc9339605fea42f264769c8598b6dfea4";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_mapem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "320b6a6a25c6de5d460aad04e13b18b7611a48e4b0ee476a3fa5219a2cc2df60";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-messages/default.nix
+++ b/distros/humble/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-messages";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_messages/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "c081aa42f9f8396fe66c9349f32170ef8e9ce0b853d1f33b5f1db2bed7f46f0a";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_messages/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "d07768d3c67af0a520ca365a29d11c10f3550f8be51869dcc75faca551c1b986";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs-utils/default.nix
+++ b/distros/humble/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs-utils";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8b2f5e5737eef2ad619ecb2950a1624976b1d0d843c4aa3cc58c15c35acfd37f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs_utils/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "6e69fe5cfdd720dc0f5294c7f3f9859f4650efda8a59e289135507362347cbb2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-msgs/default.nix
+++ b/distros/humble/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-denm-ts-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "682c58fe3c9dfc23ebd33740bc56b2665de6ca405fb60e5d7f409fb54c44d1ae";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e641bac964abde1da06fe6f6f2c43c594f12fd6a6833b5f4bb434ce38ebcc02f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-denm-ts-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-primitives-conversion/default.nix
+++ b/distros/humble/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-primitives-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8d0ecca9ea37671c66a5d5f948cf21339747ea35fbe63ae278e3008c4966ecf2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_primitives_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "26c8e2efbfe11c5c32b06bbee244f9ece2b7aabe6b3737155ea02889b1704320";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-rviz-plugins/default.nix
+++ b/distros/humble/etsi-its-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-msgs-utils, etsi-its-spatem-ts-msgs, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-rviz-plugins";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "85e495ad072dbf81ff384128296b27b3361ae5ab06ace9f1a0fd0580e77ef9ac";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_rviz_plugins/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e94d7bd19602765174fa3fc006ff5a98fedec5b5f0ce73acc743493f14a1b11e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-msgs-utils etsi-its-spatem-ts-msgs pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/etsi-its-spatem-ts-coding/default.nix
+++ b/distros/humble/etsi-its-spatem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-spatem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_spatem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "9c2442e3f5ac32d681ba2a8d489193a350e413555a82721a9a43e74a32898930";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_spatem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ea0d4db26bd271c1c0dff265c33b599f1a8bb5bd4f8dc5a1d0cc9ddd16193ac7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-spatem-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-spatem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-spatem-ts-coding, etsi-its-spatem-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-spatem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_spatem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "25fdbad8d18de400b013437d645b0546050ea1b50c491c46b85c8c033a96796c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_spatem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e22050466289badc1f644cccba1fa6ab1584b8254bcd1f3d5e23c0bd85485fef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-spatem-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-spatem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-spatem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_spatem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8a70dccb91bc9f8c85215496e72fe871253eb46b42ffa046ac15189f99712382";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_spatem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "9d1ca8d46ce2433a81b8a096d20b5bb4548c2fbd08f4760a4532a62f85e61b3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-vam-ts-coding/default.nix
+++ b/distros/humble/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-vam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5cf37bf49ee6153f040382933c3927ada61edc4245fb20ff5bcdd30a31aa1652";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e62f6c2bd03d5601f5bd48f52ca6509833364a0dde5c107bbdad03b242dad375";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/humble/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-vam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "23ceaf12f0de9a01e9c63fb35467045f6c36c6633006ceb4c332c158ff74d316";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ffb62c3c30d7cbcd10fcf1b59302c55e368a00d9dbf97fbe52547b7a863f7fd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/humble/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-etsi-its-vam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f7f7bd9c0fbed1247edc48b17ee446e36bb5c7e6831379b1aff3cab86d4955e9";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/humble/etsi_its_vam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "64bb80ca3ce8d526a0b315c001c769938946685218d6a01b1e14cacf5c958c1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "6868e101e910019883118d950cb80fe93701297adb5d64d87f3eb6127b521f73";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "b447c2250bdca6dd6616baccecf0da6a093d9368328a9dbd61e104530eae97db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "6fe42a70446755fe204446aec9815097aae89c5bd5e4cc85572dc96a8245d50f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "8ff32f363c5f28db9aada3d2dd138bfd938466f3ed6a41ef604462914d373f8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -280,8 +280,6 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
- automatika-ros-sugar = self.callPackage ./automatika-ros-sugar {};
-
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -722,6 +720,10 @@ self: super: {
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
+ dynamixel-hardware-interface = self.callPackage ./dynamixel-hardware-interface {};
+
+ dynamixel-interfaces = self.callPackage ./dynamixel-interfaces {};
+
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
  dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
@@ -847,6 +849,12 @@ self: super: {
  etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
 
  etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-denm-ts-coding = self.callPackage ./etsi-its-denm-ts-coding {};
+
+ etsi-its-denm-ts-conversion = self.callPackage ./etsi-its-denm-ts-conversion {};
+
+ etsi-its-denm-ts-msgs = self.callPackage ./etsi-its-denm-ts-msgs {};
 
  etsi-its-mapem-ts-coding = self.callPackage ./etsi-its-mapem-ts-coding {};
 
@@ -3538,9 +3546,13 @@ self: super: {
 
  webots-ros2-control = self.callPackage ./webots-ros2-control {};
 
+ webots-ros2-crazyflie = self.callPackage ./webots-ros2-crazyflie {};
+
  webots-ros2-driver = self.callPackage ./webots-ros2-driver {};
 
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
+
+ webots-ros2-husarion = self.callPackage ./webots-ros2-husarion {};
 
  webots-ros2-importer = self.callPackage ./webots-ros2-importer {};
 

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "014e9906a2c62427c403f3e81648f74cb7b7f56d67e889311df34683997112a9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "29e813af7ecdab9e30559bc4b154a078508988e2ce99852db7a4afaaa9dada92";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "84a2cf202496af4713e4fe3c5af652e07f86586e918203790794dfd974416a20";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "6264afea72db38e74c9fa1d2756ee25618172d9e896cad9935250aec6e7e52a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gz-ros2-control-tests/default.nix
+++ b/distros/humble/gz-ros2-control-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, geometry-msgs, hardware-interface, ign-ros2-control, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rclcpp, rclcpp-action, robot-state-publisher, ros-ign-gazebo, ros2controlcli, ros2launch, xacro }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control-tests";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "66e8940b65310dd7504b81c6229a3ffabb205aaf4de9f0454fa62f6b7067bc8e";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "c03ebfd589eb2e6d0a4cee3ca0975862ddb1a1c6df2ea940c7f5a9d089284c54";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ign-ros2-control-demos/default.nix
+++ b/distros/humble/ign-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-ign-gazebo, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control-demos";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "35eb164b5c87727c2894be76c1438458a4619b8970aab2099907015193c5b37c";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "fe383495be64effd982f4298af675700e610444f6740d4f978aae49b4a600f33";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-common/default.nix
+++ b/distros/humble/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-humble-image-common";
-  version = "3.1.10-r1";
+  version = "3.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.10-1.tar.gz";
-    name = "3.1.10-1.tar.gz";
-    sha256 = "b26f7a64988ea47446bf3d7a7c1a6416a07ce7b5d1d09d0d3b1db1f61a4e3301";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_common/3.1.11-1.tar.gz";
+    name = "3.1.11-1.tar.gz";
+    sha256 = "36b0e8e5e76bf17368767403d89e43c0d441b152443c9ab86361794f624e20db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/image-transport/default.nix
+++ b/distros/humble/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-image-transport";
-  version = "3.1.10-r1";
+  version = "3.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.10-1.tar.gz";
-    name = "3.1.10-1.tar.gz";
-    sha256 = "d4a3e9ed96cce39307039803d825099ef9d3ec1a57174d3251d9e678dc0c01ca";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/humble/image_transport/3.1.11-1.tar.gz";
+    name = "3.1.11-1.tar.gz";
+    sha256 = "8b0cd423a32080f97b69ac140c03051cefb908f38a3b92ef08e9399cfd71b7ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "83d8657dbc6722b30d51584c860222664d98156b18c36221cb3550e5e79530a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "f2781dd52d38ad16401237f417fb3abfc2fa650986362cc5f833fa80f9f26ad7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "fb13e7ab0740abca517727e8b30bcdb36c85d8ff3ea96590fff7e123fd18f290";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "f87f8957358eabcdf79e5d099721e4cee49104147b17928b09f717f5c20e92a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "8660e06755520508befeffff55bd6fb8edc165396cd5e9e66a2179b92b0b496b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "6a2aff4fc2cf48e92772b584be90dadd9f07aa0c96c43b552d7554f1686b72b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "6f42714eef24e6c67d4ed83eb38d8d4d45dc5c9cb65ed6c0be91026cc6e0034f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "bde66d80ba3b09f33a8345edc55dcc93e1585bcc14b5c703504f0d1c3b0757b5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "41cd672a4465b4ca6dc2b39206548d6750982a9af95f2c4d0635b38d6ac63f1d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "704fbc2ba49faba0496001fd54206f3c58a8c9046fb8e466daa45f5f643ad8eb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ros-environment ];
   checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-cmake ];
-  propagatedBuildInputs = [ geometry-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ geometry-msgs mola-common mola-kernel mola-msgs mrpt-libmaps mrpt-libros-bridge mrpt-nav-interfaces nav-msgs rclcpp sensor-msgs tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "ee2031fd729dae998d28921c25a6fc62b57df053d68b8cbb88dd10b6552707a2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "8bebc6da2315bbff1d53215f8996cf5c3819c06e374b737b368d27cefed7dc96";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a5c5c6a0bc2dd491470747eaf6362407207f3c28d1bcf2a91cfd74b1b9bedf79";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "21c448a4f2bfc5a2053ee56b2b713a438200bffbf76a00d32f702e80b997c018";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "9d96a1e07a70675e5afad423206f1bf7e2d54f7c4efb912961c57b561b5d3227";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "d06f01bcf5bb3a69d1c95b5d5f062395adf0285314c37a55bfdec263a2c590e3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "267f40430a5a9aa7925d07b132d1819f3fff53b84be083995a1eb89e6427d469";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "5356ca1d2a6d3c0681676f37ddacd2a553d063f498d6a179942c197636ee62bf";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "d11bd209bdfa7d711fd5e873a616ef52621af52042d673d1599b53e3568d8f5f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "1294fc96ac60a2475ef35aa357ba59ba70aa59fdc0ce8badbe4fc73d796f63d3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "367d50f90535c1ea0a844c8c1efb42c9e7a02404e32484f14fee31efe0f72ece";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "5ed912baf67ec567bccc1c7a07c8ad019c606d69ccd7884f1ec7f0d3e2d7753d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "84a33713bc31e184e6e4bbeddb4b032b17e1969ac93f8cf492af42ee3e8bb3a3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "f90e49a8a72128a44fe3d9f7e733671564877afee63c8464574f3d0f00713ac9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "65862bb9749e5bed1c8af4591ab9cb4733411e548ba24ce696d4ae3785e904ad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "ea734da85a9bd9197e6cc09e6f6a13e757d4f0678904b7de91315bebaac0e3dc";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1ad38721e85c8bca9834884a3ac59132a70821690788b459e8c75df7250ae290";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "7f8ba1af6177fe5995b6a1b1e6dfa57a155cf7e5ecf39e41b854dc26ec55a5ad";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "5f6f73e9e3d88c00a6fd1dd7c8a5018054a527e45126c39f27c8500860396969";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "797e7394d90a11cae9e3b0d47df98354f58064f818e8ecabb2de718dbf803f6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1451e0dbb9e32741e06bae0e3a34fdecc88d1dbf3b9e73705f707867997dcb5d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "3050303d57fc70566281da3f308e6303a58da5bfc63d947673389efa130f8b25";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a78e26ebce7778146ec45890e57858a01e95ea0b499df5b1d71957340368b325";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "58e32028ee538fa321aa24781d1248cce8876a4e52437b015c639491a05a4c3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "2e57fb0fa2e4a4ade6d7bf51a2429ad7677445cdc4f31067096436758f672f83";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "3c83d74d0aa0cc12014d8d828d2e3cfde65844c51229c92237182b8b3c3b014e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1393bc3191a16ede3ee814fb8d7a6c19b5558f7b9e98767e420186aade4e1551";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "250a02463838113bfb74ff0e0482a12a6f2a743a466559bd54801a18c5f2ae16";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "0669967dfcb69b329a17246c59c753082f99f804949fac2036a592d71367b5f3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "84d11214a535652ddd67a87502e48b62ecb76ba57535f1d27ccb37b7ec2dbb4e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "3c6ff1915fd3acf83f5990eb54a8b98ad3c94c49c7dd03de751d4b32de5740af";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "32fcb9aea8cfdc1f388363972a7cbde396933d104eb3accbb02e3f13ee767650";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "e87d115bba38af7cbfe760d7c392785777a76ec1b31e5c9815d853fe956e5a68";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "baf4b896912c6432866d50206dbc03e518d46c92c0221f0951dc76673bb2cf10";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a8b06aed7ae4f622eeab375e1f7e05b9a756c5252a8605bac6b04a0109858e25";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "8b31bd7e1d2df14e563fbd706fddcea81963b103fbdac3c372eb6828650884ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "5520fe0c6b74007e00b53cbf14253d1d6a3e1619a590e1da18bf5ea3ac499ca2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "be71f88a2be92493167a75458d2dce0b32bea7e2f63097dbfc385cc15c1a65c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pinocchio/default.nix
+++ b/distros/humble/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-humble-pinocchio";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "8c3e288e08f5d904af0503d63eafe3f2bb786403e1ac4f57530389f6000ea81e";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "ce62bb3501debe54a747785519d90cce9beb8bb9ef9985ec04de13b8d03f76ca";
   };
 
   buildType = "cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "26602d1b23914687e8f9cfaa58d1f04ad4aa71bbab6415284ff66523acdce207";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "62dc074344c66403a0e37e7f9aa4b4a48df7bd98f87db65d17ee9adbac6d0cf6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "cf2f6dff9cde4d8336cb42c1db732d00200a09bb45f94daeea68c8f5a378d7e8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "b89ffc60549770efa2197abc4e1fe6d12f02aae481b085901dd3f37f2bd21e85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "a1efc91ed4261b29c1b21d7fb556a063207d4dda6554a6b56e8e81541750e852";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "9ad3132f85d692bad0df939eddafb2d557f658fd1dd8d850289f14254f6fa6e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "ba59bc6e60349043e53707f814397411f9bf8ccab29c5e5d5fb3d15029669faf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "d81b200dbf9e7c89bb7f53a9e8f9484cea19fa3114dddfef570c963673d484f3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "9249f90ab41c0a781c382c482c5ca75aba76a80ff1c489db9c3754b2a09a5d62";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "a94a0effc5851f362b60c4f4f805994beb75deb46143e11c814dcd0fb67e5ec0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "333c356b4e3d5f42d9bf6b7185fbc2499cfd64ff052d76f59fda5bc3aadc343b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "43cf8b17cb389846310830d466f29622b5f6bd1c79962060e590b33f165c9796";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rtabmap-conversions/default.nix
+++ b/distros/humble/rtabmap-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-geometry, laser-geometry, pcl-conversions, rclcpp, rclcpp-components, ros-environment, rtabmap, rtabmap-msgs, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-conversions";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_conversions/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "82c728dd72b7b85f14a7f8a50c45fc871a040f3748cca2be947ce04132ba1cb4";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_conversions/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "d06566c8bef106301355f5b6c523ed34f97e7ac28f960cb64ad32f8d0e3d20f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-demos/default.nix
+++ b/distros/humble/rtabmap-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-demos";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_demos/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "12fd568cc6e41dee376d3081fa96cc5075ea60c2d5b7bc15c38e5c3a89409e9a";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_demos/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "81e0324b06735f84a156a9505d2a5b4df27e63b1746ad904bfb061e36d2ba89b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-examples/default.nix
+++ b/distros/humble/rtabmap-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, imu-filter-madgwick, realsense2-camera, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz, tf2-ros, velodyne }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-examples";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_examples/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "ad2c9ab8e18afa20c5352577d8a1bda2ead2f6e5350c4df5dafa995ac73ad685";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_examples/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "bb3c34df2f6570ed139a4283dc746f6a54e5c1ee9e3cca9f9bb1c0c20f44c280";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-launch/default.nix
+++ b/distros/humble/rtabmap-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-msgs, rtabmap-odom, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-launch";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_launch/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "f791eeb7bb102d68abef994ab6d641e5d5842c1347d66107f3f765b8cb2e9d6f";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_launch/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "4568385053486809adbc2a03a56b0169504687b6c0fe7ffdd08720c2c1808028";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-msgs/default.nix
+++ b/distros/humble/rtabmap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-msgs";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_msgs/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "a46ebe1e643acb2dd9034c2f65445866f67d2ab5f530c3d51f52a9d19e579adf";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_msgs/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "345186b6e2898aa2230e2f050e68d7dc25be31fdc999ae5acd0ca0e69402885c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-odom/default.nix
+++ b/distros/humble/rtabmap-odom/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, image-geometry, laser-geometry, message-filters, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-odom";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_odom/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "009801f0b6738e59abb8c525ed7bc763cbe5bf5285b0d25eb5478827cb3058c0";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_odom/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "e7ff3f983c836f32c9217fe5b044bd85624e2ec33b13036b7ff606b4532618c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-python/default.nix
+++ b/distros/humble/rtabmap-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-python";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_python/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "0f8f48e1e87fa50d146285f279059d1a95054d1fa49d218ee98735eec1e0f783";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_python/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "9c2eb0a1cf37b05274ccefd8c580b1f468bd15e3de177ba3be80745081db2515";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rtabmap-ros/default.nix
+++ b/distros/humble/rtabmap-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rtabmap-conversions, rtabmap-demos, rtabmap-examples, rtabmap-launch, rtabmap-msgs, rtabmap-odom, rtabmap-python, rtabmap-rviz-plugins, rtabmap-slam, rtabmap-sync, rtabmap-util, rtabmap-viz }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-ros";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "7aea9da783fced34a6032046f3d8db1cf7378624966c5d34739156cfc22c5163";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_ros/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "b54aaa2e7596d8bd5ac97bc73c625dc8723779f22e63b3da6d5f29345fb8c8c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-rviz-plugins/default.nix
+++ b/distros/humble/rtabmap-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, pcl-conversions, pluginlib, rclcpp, rtabmap-conversions, rtabmap-msgs, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-rviz-plugins";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_rviz_plugins/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "5747fb1ebeec7cbbe8c0953fdf839c5ba6410760bfcdf85c0c2d1c9c3ce812e5";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_rviz_plugins/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "e9aecfffadf361a3446768fa0fa8b8c1dc39ec2aa308136365e7725f86e83e1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-slam/default.nix
+++ b/distros/humble/rtabmap-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, nav2-msgs, rclcpp, rclcpp-components, rtabmap-msgs, rtabmap-sync, rtabmap-util, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-slam";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_slam/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "655d6cc888951e38f7f3d68c56da8c4e2ceba028fa41b29fbedea9ab8af8643a";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_slam/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "23ec9a9b937203fa38afc857baeb0a2b618a32cc1fceb486699883342ecef03f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-sync/default.nix
+++ b/distros/humble/rtabmap-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, diagnostic-updater, image-transport, message-filters, nav-msgs, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-sync";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_sync/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "eeff82031dc9d93fd16fdf922f366e0421d66c0c20c4de5efce008002bf656fe";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_sync/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "5640cb68505532727a79610f14040fa88641c7572d5493e47daaf105dc234f95";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-util/default.nix
+++ b/distros/humble/rtabmap-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, grid-map-ros, image-transport, laser-geometry, message-filters, nav-msgs, octomap-msgs, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, rtabmap-conversions, rtabmap-msgs, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-util";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_util/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "6433772b6cb875b27a9757db8d284901732ed6deb549191ebd61f0eb7f264f0f";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_util/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "f4d5afa4f247faa690d19e46b5f6350f6be269de02c04b00f3d725a5bfdf2eb8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rtabmap-viz/default.nix
+++ b/distros/humble/rtabmap-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, cv-bridge, geometry-msgs, nav-msgs, rclcpp, rtabmap-msgs, rtabmap-sync, std-msgs, std-srvs, tf2 }:
 buildRosPackage {
   pname = "ros-humble-rtabmap-viz";
-  version = "0.21.9-r1";
+  version = "0.21.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_viz/0.21.9-1.tar.gz";
-    name = "0.21.9-1.tar.gz";
-    sha256 = "b778ce0f64ccf63273813bce62b749667571ecb1df7739cc07f28bb430b54e53";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/humble/rtabmap_viz/0.21.10-1.tar.gz";
+    name = "0.21.10-1.tar.gz";
+    sha256 = "8b7a93562113622d4d7fc31ef4cff3f751b734a49768a883bc2979350a68f383";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/simple-launch/default.nix
+++ b/distros/humble/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-simple-launch";
-  version = "1.10.1-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "5ab930063dbd44ac9d1f0092c95db0fa01596d8262728e6bd50589ad1112bfad";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/humble/simple_launch/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "b280ea2428f1398d5248b773890223a7a6d7c107fc8fcdb6f28191ba7706ffe5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "460f0dfaba903c72479a696b2f146a153e3b60983cdc52d94ad039a8d39e8f55";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "2a8e143da2859332fdcf873205db39bdb98e799d678b5761cee17cde2c7cf111";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "164edf5ed1da3378bdb44e15ae3bdf714cb95331ac7fe29f8b578ca6f2596d6d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "57b86374f82cb303e1243c803c0e429ec706f831e0705beef5bc68389b516cd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "f2222c7a86458a1bec6f2f185f1ca08b06fef024262cf620385e1e37773bbc08";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "cd297a8e1213de59524347eb68c521c46ea7c08f5e3db1ed10c054ecfccd9323";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-msgs/default.nix
+++ b/distros/humble/turtlebot3-msgs/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-msgs";
-  version = "2.2.3-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/humble/turtlebot3_msgs/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "d460ea8afe21446f242c8fedb27fc0a23fb0c76d1944a31654cb36680c239ea3";
+    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/humble/turtlebot3_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "007956849d09113e04ae084ce75fe1e877e29bbd9e8fbd6138b328a9a032ae92";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS2";
+    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS 2";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.6.0-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "38c124d457b4647078e19b9c8a025d91c7ec8da45053589b39fcd82b40731313";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "56f71a3c8ce9832c893d09a7f4d8398447cab0feb7ec505838661b00652bfaf0";
   };
 
   buildType = "cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "724014cac50d39c9bf070f9ef2372dbddcf6ecdd76b9906c2dcf8736303850bc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "8da9e4a4d531ee5631449dd7bc77ba9a67b1b29b1851cd7cb466bcc7fdc310c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-control/default.nix
+++ b/distros/humble/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-control";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "2e699ea02009ad8045b6636b4925bf1a949abed74141cd0a4cf0eee529870504";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_control/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "df3bbe945104ceda6b3c73a919634e8fbbb4498fda8ccb32fc5f624e6bfb2f50";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-crazyflie/default.nix
+++ b/distros/humble/webots-ros2-crazyflie/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, rclpy, tf-transformations, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-humble-webots-ros2-crazyflie";
+  version = "2025.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_crazyflie/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "15a57c9c2a62de7975a9069ac35701291c9a77d976ec1117bbd5054b27c42edb";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy tf-transformations webots-ros2-driver ];
+
+  meta = {
+    description = "ROS2 package for Crazyflie webots simulator";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/webots-ros2-driver/default.nix
+++ b/distros/humble/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-driver";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "44cfcbe9a6743ad0a3005974c679a03173448fee0ef18d54cfde427996e191b0";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_driver/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "6360e5c05d6093d120d26a499c2e5ebcc3d349a63bc8b0027a1373608ef9cf1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-epuck/default.nix
+++ b/distros/humble/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, python3Packages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-epuck";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "9f2075cd2e7e700468356ed2c0feb4560b42f7307044eac0aaa99bc56cb630f7";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_epuck/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "cabfede4173a34bb0b1f02d610a042621d571e745b48222ad1ba7cde12095bd0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-husarion/default.nix
+++ b/distros/humble/webots-ros2-husarion/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, controller-manager, diff-drive-controller, joint-state-broadcaster, laser-filters, robot-localization, robot-state-publisher, webots-ros2-control, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-humble-webots-ros2-husarion";
+  version = "2025.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_husarion/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "2cc72ce66df6184fd0ae757012733193d7637a111b8d5c11797a52882b1e9cdc";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster laser-filters robot-localization robot-state-publisher webots-ros2-control webots-ros2-driver ];
+
+  meta = {
+    description = "Husarion ROSbot 2R and XL robots ROS2 interface for Webots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/webots-ros2-importer/default.nix
+++ b/distros/humble/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-importer";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "b45a4e0cc02270b6969a13096fc5772dafe56de39ca573592d9d6a50057d6e5e";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_importer/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "eefa40a4426e6518cc5696c597147f1df0a4f2c3f2713f06407788fa1f1d42ee";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-mavic/default.nix
+++ b/distros/humble/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-mavic";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "1fa86c8775aa352ad56fac4462e7f02cdeac16540a800723ecc35b61b3265ccb";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_mavic/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "c9a993caf18961369bf72314a8b1f55478acaace8c3606d0e24516c7b6114196";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-msgs/default.nix
+++ b/distros/humble/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-msgs";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "5ed1cece1570793fdde225438ec814cf96a0214295e62519a3cbcd1acde0ed51";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_msgs/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "81f22b14201c924a577dedc4ed6fc12e867c8a6d8d1ee32b9aa6d86721a59563";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/webots-ros2-tesla/default.nix
+++ b/distros/humble/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tesla";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "a9042d63683a4297c419ce1b0aee4c1067787caf89e47f82be65c3b3a8b75f75";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tesla/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "3ad000ee66f15b194c57b4592c0ccedcef85f42efe2566cf827d0465194cdb15";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-tests/default.nix
+++ b/distros/humble/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tests";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "735bf604c779bd447cd206831c8683db90ece4436bd6f82a2320f0117d2fef89";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tests/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "01ab576f6d816e5dd70730642d85e06f5d375e8d5956bd32977c7a56de50294f";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-husarion webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "System tests for `webots_ros2` packages.";

--- a/distros/humble/webots-ros2-tiago/default.nix
+++ b/distros/humble/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-tiago";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "eb2c0a737f31c350009e2ae0901567e779c5f30838333a84d49657f538999cd1";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_tiago/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "3981d1bf6c0255773faf6e403c41c9286ecb7d2d31381821b535d0151438d29c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-turtlebot/default.nix
+++ b/distros/humble/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-turtlebot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "458e47dd7ae72270ca21c5ecf9da0d569ca1445af596417f51b4131ddaa51c30";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_turtlebot/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "4f042f573e54e2f52091cd8f772b988bd486abefc6633e9caf5f7cd41c235819";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2-universal-robot/default.nix
+++ b/distros/humble/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, python3Packages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2-universal-robot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "020577a80d4d363e8f99841495c370783c02fcc5e777fcba93289fa348c628c1";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2_universal_robot/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "5a61db6c514cbc158efa7fd562e14535f1e0b95332b7dad517b2dd8270e953ba";
   };
 
   buildType = "ament_python";

--- a/distros/humble/webots-ros2/default.nix
+++ b/distros/humble/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-crazyflie, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-humble-webots-ros2";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "9de841ee76af61d4f19fa4cca5153ad89a446c1d15ad76c59e2233423004fb62";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/humble/webots_ros2/2025.0.0-2.tar.gz";
+    name = "2025.0.0-2.tar.gz";
+    sha256 = "1daaee5a6aa56d1618b31457d94b0019d2b1c7f64e7e65cd8d62810de5c60494";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright python3Packages.pytest webots-ros2-tests ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-crazyflie webots-ros2-driver webots-ros2-epuck webots-ros2-husarion webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "Interface between Webots and ROS2";

--- a/distros/jazzy/apriltag/default.nix
+++ b/distros/jazzy/apriltag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-apriltag";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/jazzy/apriltag/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "1451042831b5b0742b24ffb62dd3a97448dfa3a94219b7f912b17f11a7258342";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/jazzy/apriltag/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "0c35ac275619056edd82502e894aefb2173457931b1d8e38dc5eca8a6a1ec60a";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/battery-state-broadcaster/default.nix
+++ b/distros/jazzy/battery-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, pluginlib, realtime-tools, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-battery-state-broadcaster";
-  version = "1.0.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_broadcaster/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "bf35e9ca74db0f52ba515087fbf7c8800ef83fa69f789a7c3b897bf8c95bcce5";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_broadcaster/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2c50a586c6ec242aa23a3ddc85c61c3b9cd7d774d35989b0e6563ef576b3f63e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/battery-state-rviz-overlay/default.nix
+++ b/distros/jazzy/battery-state-rviz-overlay/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, rclcpp, rviz-2d-overlay-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-battery-state-rviz-overlay";
-  version = "1.0.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_rviz_overlay/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d70502f85cf5ce187c8917a88e2e845e66014c7fb093a3f0ab4eb628c9c99fba";
+    url = "https://github.com/ros2-gbp/ros_battery_monitoring-release/archive/release/jazzy/battery_state_rviz_overlay/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e8823b85013cf4c686803e295214f925f8557774c34f47ee0966521e44e1a11b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/chomp-motion-planner/default.nix
+++ b/distros/jazzy/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-chomp-motion-planner";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/chomp_motion_planner/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "e114af3b3d4a346417e74b02b472d776145a07ea328c5766d2450ec02aab94e3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/chomp_motion_planner/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "84e91c0ba2d053711efae250a0446c3c9339b86f62fe45ac4443d8df8dfe43f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-bridge/default.nix
+++ b/distros/jazzy/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "3e85a1f3a4b7a4bc355b5467f1e8f19593b95f5ccdf37d450fa6f622aeb07d62";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "249ad13c5fe5998dc86eab3d615be171d09e099447aa175628f079fc591bc4d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-descriptions/default.nix
+++ b/distros/jazzy/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "63a48c01a54e4808f2ce720ad7f3ccde35bf51c1c0b462c9df05db4676ee71c2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "1b69c3f8c5e66014e730b709a478b22eeef479e985e67a6ded108264328426b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples/default.nix
+++ b/distros/jazzy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "7c30c88a1df69793837e2950b068624d546157f97830487aa8917abfee240307";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "b22aac60dfb7408ed10656e8a5cdeffb0c2217011e7f749915565d56bb56c2f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters/default.nix
+++ b/distros/jazzy/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "839b4dde1b2a03c18b60f04debed4d3b1bf14acaace926fb4faaaf5749af7455";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "49d6d1e930943ee183b6d2589fc06e2d1cde672d4c36759b3c6b9f0f1654c198";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver/default.nix
+++ b/distros/jazzy/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "d09e30ec6a1bd8b614c233fa897f53a23814eb2390c838696068773bb80539d3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "84bfdd887a3329f29748cab9e629a19bda1e539bc3ab12e8eab1c44d99c21fd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-msgs/default.nix
+++ b/distros/jazzy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "ce85144b6260760cf91277874edbe1ff7d23d84db55902a2e9c590d70e9615cf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "68b881325e63e9f54d1dcbede3604a4930c00b2da65e1e593d13c828fa3288a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros/default.nix
+++ b/distros/jazzy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "bf609d3be53179c159164b29abe0bfd14b61c98235e83f4622294dc02a658724";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "70d6c0007fd407ab37358c2f51e576147c6d1514e4a20f2218445e76d5d04b88";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-can/default.nix
+++ b/distros/jazzy/ds-dbw-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msg-filters, dataspeed-can-usb, ds-dbw-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-can";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "238f9b18a6f30bc706f7c224f0fea71194e2fb7e3489161b703c181644d89f95";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_can/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "6b96df5424654cd03f05bf7be3f69bd195fe0b2cbc0fa2b95e87217dd873b2db";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-joystick-demo/default.nix
+++ b/distros/jazzy/ds-dbw-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-msgs, joy, rclcpp, rclcpp-components, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-joystick-demo";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "557d357420c8cad8c34524e71dedcda668e2b0de80b98e0cd22533163836509a";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_joystick_demo/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "31de391777ee10e23313227fba23cfa1a011c6ac1711fc9ade9c3aa60ee746ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw-msgs/default.nix
+++ b/distros/jazzy/ds-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw-msgs";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "a869dce0411e0ee25273221de8cbff41a735f77929ecff7cc517bf443198412b";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "c584f843fa578b491da6eab693e0e2a97568a8ab56249ca1379fca4e7a12e65b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ds-dbw/default.nix
+++ b/distros/jazzy/ds-dbw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ds-dbw-can, ds-dbw-joystick-demo, ds-dbw-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ds-dbw";
-  version = "2.3.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "880568f19dda8947e416bec46d462d5610d89af66701bec4186aa85576a869d1";
+    url = "https://github.com/DataspeedInc-release/dbw_ros-release/archive/release/jazzy/ds_dbw/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "4432ba52995dce0e01cc0ec1eeaef95cbd8e3002079126fea3633058d43ea4a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-interfaces/default.nix
+++ b/distros/jazzy/dynamixel-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-dynamixel-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/jazzy/dynamixel_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "04f2088d3329e58304cc13299bd0d62c63f8961b35e800ecb19f4f0de6b02caa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "dynamixel_interfaces contains base messages and service useful for controlling Dynamixel.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/etsi-its-cam-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "b4f2d0a7eaef9e89fc7f9182bee1afc38cde412644556f773bad5379a62eb7a8";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "89d846d40e27b0fdfe04d823bea59588b7e3f6d963a90d63d9751f650dff2594";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "b2df3f20ed09fb7995f096c50cead7eb45524e9e1d8bc6ca4d5fc47606c9dfed";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "871d59bec4ce1752497ed71ef1af0fb204886930b02326a394fde6b92deca0e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "3c2881341c1a7d00706dc45cb2c59c858b514c39c32496b221fbd241c87ec5b9";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "403b6e12bbf8273e2a0ac1a42791fe60a8f8145fb5d9ca10bd52f4939072e7cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5755b075018065ff1756afef3a0e679ebe39c75f59996d156d7e8aed28ec05c7";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c139021a587db9d4963acab6130659384459599b866160d0efc113c3fac55266";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "cdeeaefe7dd94cfa7fcbf3890077fa2781f76d2eb0b0b36301fb6126c10ac466";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "9948499051860f845de7c105e93b7f78b8b918fc3832dee27eca8a698641d324";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bbd5c099e2c527ea721375bf5c7c67bfcee8f3709c304ca5e7628ed8bbed5129";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "658211488c66da395211bb4698ae021d0405e092f12c0f93794bebd2e58f249a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-coding/default.nix
+++ b/distros/jazzy/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-denm-ts-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0d3e0dc469fc9c3d5903cc467162058182371788a5cd37efb2f9c21ed47dc2ca";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2e875c0b83f86bee5917b025eed1a24025b27b304daa258ce58a174cd3598e17";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-denm-ts-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-conversion/default.nix
+++ b/distros/jazzy/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-denm-ts-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, rclcpp, rclcpp-components, ros-environment, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "eb1a8a009935300fb9b87a7e0c1ed6b3abaa171274472406293a97cb78428e82";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "fdaa24be8f8458f7449bfba0627902f7ffee05b7db36d53972ef5d92e652dfe1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-denm-ts-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion rclcpp rclcpp-components ros-environment std-msgs udp-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8721b1f232b6c58863d858e34d5df7fd1ddf254960e9d885da6db389e43c45a1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b27eeaac6f43a0f7305829e12e77144341d4a778c7bf307e04a1c08b0fd77f0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "fd8eb11b321c4ef8b962d0b0c43a1e8d242d5cf85fd4eb8982f217f09aba0408";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e3ed1de15125665540260a40187e594975967449414c2bb2baed232f4890981d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-cpm-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "619856e20dbcd3177cd8c33bb0716e9946427233bef99529b1cb7422796702a4";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_cpm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "52ad51fe957130ba51cd36df23f90b9dc11e139cc0d2ea2228916a996c0855ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-coding/default.nix
+++ b/distros/jazzy/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "adaaeb3c1cdb7b206eeaab392aedafe875dedd6eee66ee58ab3461e135f6604c";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "dda9cd2f5189299a4f2bd272e80ff5e0fa7d943f45aaa245affbf9f6e1f5554b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-conversion/default.nix
+++ b/distros/jazzy/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "961b0f8db3ecc3b8cf8899d9d3ac911f1f8a428b298aa882faed9672752e6858";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e2f70ad87b3a44e093ecd07305ae563bde90f9cedc099882a5a4c62b99afebf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-msgs/default.nix
+++ b/distros/jazzy/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-denm-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "235ee107da997de219075a7c89c53f3d7469df727fc370280bec511cc2f1430b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "51c2238a3d3040770d4777362590e8d5f918109fed4b310cff6368fe024d564a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-denm-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-denm-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-denm-ts-coding";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1ca6a9307c29790ceb8572cfdd4f0be4b73add9210ed7bf9fe3938ab9a0df494";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS DENMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-denm-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-denm-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-denm-ts-coding, etsi-its-denm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-denm-ts-conversion";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "62c79e767e78b20a3bc7cd9e243c06a47310c9fc801f37aeac2d73c05818470a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ etsi-its-denm-ts-coding etsi-its-denm-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-denm-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-denm-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-etsi-its-denm-ts-msgs";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_denm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7b1d27eb13a11fb9c7d0079219e2d3e883f043c4f6a9c58ea7323a4b9b20f64f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ ros-environment rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS DENM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/etsi-its-mapem-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-mapem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-mapem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1fe753540b1a47f4002af9b35b41de829fc7db6a86f148254653bd3bbbd258c1";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "22302214079867e704fbcbbe68f06c471a2fb03858e782cc3efd9f83db1e67fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-mapem-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-mapem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-mapem-ts-coding, etsi-its-mapem-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-mapem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "911707ecef2b7c37e5565ae8c5018b3355592ce7207de09e289db33e6f069e64";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0a2f1e80ff36e398735f9fa009cc3ffa9c86b74fd6f256a43416bab3e86a9ba8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-mapem-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-mapem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-mapem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ea12cabce14357246b95f51befc4d5e11f66e60d6a08774ddc14d6b81fd8698b";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_mapem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0b0ede539fbc7c489c1ff2d2014f980f711bcd82f8e460a515e1ee5168168a31";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-messages/default.nix
+++ b/distros/jazzy/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-messages";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0d15b1ba13a416c51ec214cad852f369c08e21a68c912328459691da92852c50";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_messages/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "026c4be6bcada9f3a093760262e87e4acfc7a395716896d9947bd9d868ed29a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs-utils/default.nix
+++ b/distros/jazzy/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs-utils";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "8b3c67e87b0b85a35d6f6fc7f17745ca2386984cc741eea0ff5a9ec403f422d2";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs_utils/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ef4e52e6ac74e651a1f4a2c117450b598834e6a465227f67ed87204cfa5d6735";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-msgs/default.nix
+++ b/distros/jazzy/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-denm-ts-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "de9602625c8f63f332e6fb698f26c787ae8a20186bab454f93fde397e9f92aeb";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1ccec098e1e39b945f7b6ed4542a3a948ebb2c5ace3b00ccc7ee995f6d004584";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-denm-ts-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-primitives-conversion/default.nix
+++ b/distros/jazzy/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-primitives-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1d6ac2adca68f89016d0518cb5dbb62d1cf154a981ae2059ab42face8cb18631";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_primitives_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7f9e5c0884f4d1fca17b563b45a23f04b98d294665d0c07cd557f724699cf0b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-rviz-plugins/default.nix
+++ b/distros/jazzy/etsi-its-rviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-msgs, etsi-its-msgs-utils, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-cam-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-msgs-utils, etsi-its-spatem-ts-msgs, pluginlib, python3Packages, qt5, rclcpp, ros-environment, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, rviz-satellite, rviz2, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-rviz-plugins";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0a791ba308da362c1fd2840be21820c25d3c13c0bb0a550629e5014867f96e65";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_rviz_plugins/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "4ef14ee5c2034e40a5a91384464f41e2f3775aed2c4e26a7b751680018af17d1";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ etsi-its-msgs etsi-its-msgs-utils pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-msgs-utils etsi-its-spatem-ts-msgs pluginlib python3Packages.pyproj qt5.qtbase rclcpp ros-environment rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering rviz-satellite rviz2 tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/etsi-its-spatem-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-spatem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-spatem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "83f9f9179a1543b592899a62fa2cccbc1ba28699ee09c2735c00b3928107f395";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "793ed6f8eb6c8cb3d52ab3602266ea02c0d91d26c12a60dd32cd7024985b70f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-spatem-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-spatem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-spatem-ts-coding, etsi-its-spatem-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-spatem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d92a7b0103796bdeeaf57354001fbfbc651de52d68a98ecb7cbc1bacd6e30382";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a4cb577c358d9f6b36cccc1d89eaff73f9d733155450ac0be3a317ba4d5efd7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-spatem-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-spatem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-spatem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "348be6f71e6f81d8f0d2921b9a9f6cc80ab46c7adc7411f420d515baf3338a0f";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_spatem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8c0dc8e3520f328977856022b66e856cce7485bad93fe9b5ec1d6663c80b7d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-coding/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "0107f2ff566e693625d27cad4dec6760e978df3f17fa50c29db6dd1027dc5a2d";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "88cfe5e85c82da05793a870c7c37b12ea1df0ecacbebf9b00fc55e1a617851ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "147c1d62d84f375c0b7642a529600ee1ca8a41b5d7f68880b51ec0b9bd767dac";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7ce081829517a68de6a5b6a678345ee1cba7190ae2bfa44c8a2c9aa5c9e979c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/jazzy/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-etsi-its-vam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "95efef366cf189ae8dfb11c8b49df659767814b80835740030b5ef7786d0f685";
+    url = "https://github.com/ros2-gbp/etsi_its_messages-release/archive/release/jazzy/etsi_its_vam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "3fd2ac102a9451f582599aaec2c48c47388c22879f0080653d7f9f18c9e694c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -182,8 +182,6 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
- automatika-ros-sugar = self.callPackage ./automatika-ros-sugar {};
-
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -554,6 +552,8 @@ self: super: {
 
  dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
 
+ dynamixel-interfaces = self.callPackage ./dynamixel-interfaces {};
+
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
  dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
@@ -677,6 +677,12 @@ self: super: {
  etsi-its-denm-conversion = self.callPackage ./etsi-its-denm-conversion {};
 
  etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
+
+ etsi-its-denm-ts-coding = self.callPackage ./etsi-its-denm-ts-coding {};
+
+ etsi-its-denm-ts-conversion = self.callPackage ./etsi-its-denm-ts-conversion {};
+
+ etsi-its-denm-ts-msgs = self.callPackage ./etsi-its-denm-ts-msgs {};
 
  etsi-its-mapem-ts-coding = self.callPackage ./etsi-its-mapem-ts-coding {};
 
@@ -995,6 +1001,8 @@ self: super: {
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
 
  heaphook = self.callPackage ./heaphook {};
+
+ hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
@@ -1664,6 +1672,10 @@ self: super: {
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  ntrip-client = self.callPackage ./ntrip-client {};
@@ -1725,8 +1737,6 @@ self: super: {
  pal-statistics = self.callPackage ./pal-statistics {};
 
  pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
-
- pangolin = self.callPackage ./pangolin {};
 
  parallel-gripper-controller = self.callPackage ./parallel-gripper-controller {};
 
@@ -2990,9 +3000,13 @@ self: super: {
 
  webots-ros2-control = self.callPackage ./webots-ros2-control {};
 
+ webots-ros2-crazyflie = self.callPackage ./webots-ros2-crazyflie {};
+
  webots-ros2-driver = self.callPackage ./webots-ros2-driver {};
 
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
+
+ webots-ros2-husarion = self.callPackage ./webots-ros2-husarion {};
 
  webots-ros2-importer = self.callPackage ./webots-ros2-importer {};
 

--- a/distros/jazzy/gz-launch-vendor/default.nix
+++ b/distros/jazzy/gz-launch-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-launch-vendor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/jazzy/gz_launch_vendor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "05122a6846b82a7e8df84ae48b8f9393d0c0e23ea7ff2376a8d7bb31a7755020";
+    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/jazzy/gz_launch_vendor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "e1ffffcf4ecf1684ba9560830c17aedf9e25b25734238cd3996f964c9f4c272c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
   propagatedBuildInputs = [ binutils gflags gz-cmake-vendor gz-common-vendor gz-gui-vendor gz-math-vendor gz-msgs-vendor gz-plugin-vendor gz-sim-vendor gz-tools-vendor gz-transport-vendor libwebsockets libyaml tinyxml-2 util-linux xorg.libXi xorg.libXmu ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-launch7 7.1.0
+    description = "Vendor package for: gz-launch7 7.1.1
 
     Gazebo Launch : Run and manage programs and plugins";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-msgs-vendor/default.nix
+++ b/distros/jazzy/gz-msgs-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, protobuf, python3, python3Packages, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-jazzy-gz-msgs-vendor";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/jazzy/gz_msgs_vendor/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "f9db0335909fd39e9831fd6424d4da93e1ef1da14874d7dcd23ee467194dedc2";
+    url = "https://github.com/ros2-gbp/gz_msgs_vendor-release/archive/release/jazzy/gz_msgs_vendor/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "bb33ebc5f45ec2a53b1dd614e21de00f9f110c409d2517673c139e0cf5e46510";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint python3Packages.pytest ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-math-vendor gz-tools-vendor protobuf python3 python3Packages.protobuf tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-msgs10 10.3.1
+    description = "Vendor package for: gz-msgs10 10.3.2
 
     Gazebo Messages: Protobuf messages and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/gz-ros2-control-demos/default.nix
+++ b/distros/jazzy/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control-demos";
-  version = "1.2.10-r1";
+  version = "1.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.10-1.tar.gz";
-    name = "1.2.10-1.tar.gz";
-    sha256 = "226eca69bb825a9b4fe09b253eefec112f7c329dc60d6a847fb73a7b20ea7201";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.11-1.tar.gz";
+    name = "1.2.11-1.tar.gz";
+    sha256 = "e3001448c7c9b18b42e9f4ef4cd5e3ae771c0c7190321458629a386ff349379b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-ros2-control/default.nix
+++ b/distros/jazzy/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control";
-  version = "1.2.10-r1";
+  version = "1.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.10-1.tar.gz";
-    name = "1.2.10-1.tar.gz";
-    sha256 = "cd9593253d6f8b4bf02ca5a9d778f6d61353120e98226fc22422ad43a9331eff";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.11-1.tar.gz";
+    name = "1.2.11-1.tar.gz";
+    sha256 = "f1f59f6bca12705f79cf4947707fd44907dbadfc0bf08eff0c2e4a52440136ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gz-sim-vendor/default.nix
+++ b/distros/jazzy/gz-sim-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-jazzy-gz-sim-vendor";
-  version = "0.0.7-r1";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "ac1208a853d31c61c39576ac25b355c09dcdbb0b699406aa91cdff99c3bce7c8";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/jazzy/gz_sim_vendor/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "53b946ba26654cef76ab53fd13e3f3b84806f3cb84c21f0b938360627265c99e";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim8 8.8.0
+    description = "Vendor package for: gz-sim8 8.9.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/jazzy/hebi-cpp-api/default.nix
+++ b/distros/jazzy/hebi-cpp-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
+buildRosPackage {
+  pname = "ros-jazzy-hebi-cpp-api";
+  version = "3.12.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/jazzy/hebi_cpp_api/3.12.3-1.tar.gz";
+    name = "3.12.3-1.tar.gz";
+    sha256 = "4c6816d54affd2ebb037d18457737cbf9a2d54faecad3f1b666846f957f960ca";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ROS 2 package providing access to the HEBI C++ API.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/moveit-common/default.nix
+++ b/distros/jazzy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-common";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_common/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "8b3c0d8eb2f73cfdb7899389f4e4c8fab8fa3af5250cec6e1c1d972eb2a30465";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_common/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "7d54d5e2b932d5e9b4aff376f07097fa8de81aaad3e7db1c7dd55c43c081a4c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-configs-utils/default.nix
+++ b/distros/jazzy/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-configs-utils";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_configs_utils/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "4cb718b1bcbea788179fd75e007198145aadb0b8554b05a404d555149b22d4b7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_configs_utils/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "40befff1f11c5304c4e8c9090ae1277bd099cf9e535fdeb348423bca96366068";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/moveit-core/default.nix
+++ b/distros/jazzy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-core";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_core/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "e7ad37e4cdef2ddd3e9046cc71c47feef705216033368cd9391617fed2bd5902";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_core/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "1fbc95ee0053f3f1d7c823fbe39e240397fd3ad3419eba9528b445b3ae9b86fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-hybrid-planning/default.nix
+++ b/distros/jazzy/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-hybrid-planning";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_hybrid_planning/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1354484c28dea4665fdc3f3f666d1993f72233544c73fa17b1910fae9fc2c9e6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_hybrid_planning/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c73ea6e88d6c60bc4ae920d92ed0d497e33c36005de97f0a6d8ab677b8fc391c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-kinematics/default.nix
+++ b/distros/jazzy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-kinematics";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_kinematics/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "96636e12d8b76056ee9f432293802243d7d104c51990f319cc3b12b0ff285b9b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_kinematics/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "f91ba89541dfb5cd3919a546b986366f769723788f344234e9b9e955dc7c7f8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners-chomp/default.nix
+++ b/distros/jazzy/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners-chomp";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_chomp/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c7584bec2507e3c5d8fcf51ea96165b4215faf5833b090e51b764de181553ddc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_chomp/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "70a2d5a04d9457ab3c26414a26e5e2676d9f58328f4e070c10d2ff333315f344";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners-ompl/default.nix
+++ b/distros/jazzy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners-ompl";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_ompl/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "a3de8e12a121958bd0d675c27beaccf0632a9e6949526338007d046fc13ace7f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_ompl/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "d2714b713beab315ffc32a330cbfa7657b8cea474ea76b2611d3644ae088fa19";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners-stomp/default.nix
+++ b/distros/jazzy/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners-stomp";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_stomp/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "53c3687d8116a8698d4a59d984098b1dc8330c3b8cd6eefa56d574aa2f8761f0";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners_stomp/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "b39178f3a5b924efe75654c9e59b5834f18575475de763c2532692334866d95a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-planners/default.nix
+++ b/distros/jazzy/moveit-planners/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-planners";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "f872e854bfb9ab00a0455c2fbcf347973450d19c19a34bac119f07513bcd75d8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_planners/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6c2d30f553f8aeeac72dec3d08052e6a6a29af793526e47c10c3e2db307de6bc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ chomp-motion-planner moveit-planners-ompl moveit-planners-stomp pilz-industrial-motion-planner ];
+  propagatedBuildInputs = [ moveit-planners-chomp moveit-planners-ompl moveit-planners-stomp pilz-industrial-motion-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/moveit-plugins/default.nix
+++ b/distros/jazzy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6cfc5989d6ada4584a585bbf37db9966ec2f21f0b54b934a16b27dfbe6fc6b7a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "cc0769999637520fcfcbe05d155e509925bbcffae5b5565a406482b19e992fec";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-py/default.nix
+++ b/distros/jazzy/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, python3Packages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-py";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_py/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "3860b7b39a64770edc11e184c23ac0a34423a68dead76dc693302715bbd69613";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_py/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "822311f7ebdf0aa614fbf7572acbde98293b896db31f534fac2c52e37b5c7083";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_ikfast_manipulator_plugin/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "ce502e8173a2116a6864b2893fe6324067e2a0c570de9c46cc233ae9ef986774";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_ikfast_manipulator_plugin/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "3c688e9337b892f19c986d2217ce417d4968d6ce7734457b708857895b35c5da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-moveit-config";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_moveit_config/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "cfa165d07af5807bc1eae5114644e28ee320e2fe91a8a2559ed45273e3e25191";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_moveit_config/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6c03f32147c795b725d37810c25dee3bf638578614aafa4dfdc409d7c6d0667c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-pg70-support";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_pg70_support/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c4a697f713ad97431d8e4da7b5a52a3f82b85185e42bc17106783a9b60ac7f6f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_pg70_support/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c07877c576d36c02b0bafb00a7d53318463529e9709aca2e177e047410b10e5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-resources-prbt-support/default.nix
+++ b/distros/jazzy/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-resources-prbt-support";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_support/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "0c5506d615d401b0a52c242cad7288c373dc138a604c14cc9c83ae5393d7a165";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_resources_prbt_support/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "f840f9665db9cf5bd297b36c25f03f6c339a389620a854e9bd39de65f90a4f3f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-benchmarks/default.nix
+++ b/distros/jazzy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-benchmarks";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_benchmarks/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1afcfa53d1191596e80f3fa43096df04b1b8a3b41408d073663d2fdeab8971ec";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_benchmarks/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "64c3acca6a75ec96d3452a12342f1b8a666b7b3c4bd4b559e59ee5b21271fd9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-control-interface/default.nix
+++ b/distros/jazzy/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-control-interface";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_control_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "eb2bcf0ff86d074365dd6b15de172a160b799fa257fa9ac5a207ed3fc7dae17b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_control_interface/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "1388d16eb1bd36a5abb117d8c63b6dac73e7b5e09ed9af9707ddfe2cc42c71a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-move-group/default.nix
+++ b/distros/jazzy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-move-group";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_move_group/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "99176001c215396765592e731fdbe65d8f2589fc15d7178c870e4695e986be19";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_move_group/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c0e671dca07873b53660ac0110a060fa38acedb1286fd45da92ced2137c8d5b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/jazzy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-occupancy-map-monitor";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_occupancy_map_monitor/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6e00771b076bd7d47e1765bef0000455db4f9adbaa413bf8aab0db409841acd5";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_occupancy_map_monitor/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "db277727aff31b97bb9b68fe18f0987af7d34bc5f294a61b9be25028ccb727e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-perception/default.nix
+++ b/distros/jazzy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-perception";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_perception/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "07ee7ab9e5a83f50e4da268f39ba37acb1fbf3c282f95f0887a0d78c9e384438";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_perception/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "56cb98f6f6affc9948b4f9d7134aa80f0af64582aa1dc0adb82ac4f605a1dfbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-planning-interface/default.nix
+++ b/distros/jazzy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-planning-interface";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning_interface/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "f31f03179242ad554eeb5f2f9b166c91e8f80c7a1975b0f53f1cd1191dbb31a6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning_interface/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "bc6ca99446de8caefb9c9e3b50b877767a279ebdbd9a15b1f37dc61bf4b4bf65";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-planning/default.nix
+++ b/distros/jazzy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-planning";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6357ba3028ed47fe01466d751ed149e555bf1a376de78f181d07b38d03d48ac9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_planning/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "429e922d233029dc4bd108e7ee16ed50a035d73995bf3fd95e5d4588ce2d45f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-robot-interaction/default.nix
+++ b/distros/jazzy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-robot-interaction";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_robot_interaction/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "127a74e324c0002fb137a1016692e326ab57cd6f62f4508481e75a2e6e74423b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_robot_interaction/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6f7bae479b3ffea3729104544fed517d0b57b6374e50c3b4ead5ee00be443705";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-tests/default.nix
+++ b/distros/jazzy/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-tests";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_tests/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "544cc356b75617bb721e17e396b9537b3ed9e787c1f6168d74704ff833448aa2";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_tests/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "526e81bd7a6a071792469a15d86b8f5718a78a0fd71c5579d3c1fdbe3a1ca166";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-trajectory-cache/default.nix
+++ b/distros/jazzy/moveit-ros-trajectory-cache/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-trajectory-cache";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_trajectory_cache/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "950a29150c8507d9e024316985e1b4483298ebdd5516bd77807002f5f620802d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_trajectory_cache/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "654920beaaef6152322b3c78774546f5f21ccbae46fc76aa43ee16aa9e5ca749";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-visualization/default.nix
+++ b/distros/jazzy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-visualization";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_visualization/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "336e765bb20af30a9b08dbc764c5d4dcb051f646d40e6f96972f33e91180b0a4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_visualization/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "e5ab5a84621e3828d247d6c34a91fa8d8930f087e5d57a64e341ec4d46023ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros-warehouse/default.nix
+++ b/distros/jazzy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros-warehouse";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_warehouse/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "7202bc84224fb5c20afabdff988a0a42dc3a271f4f0e03fc87e8b61a808ee10a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_warehouse/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "f1093738c901a93f22313f8b770fbd8641dacdca408612441933b6e2483e39b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-ros/default.nix
+++ b/distros/jazzy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-ros";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "6fb17e16065198509611fa88eb9671194ab79ec596d777429549e9fc80f2fcc9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "ada9906025923b26ac994a98c9dc8f7a80d9afaf7c82e00100d85b0ab4724841";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-runtime/default.nix
+++ b/distros/jazzy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-runtime";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_runtime/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "1ccb0a570aca9b79c92d414f63048c1585068c5cc6e00c36e3a3360b3a519416";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_runtime/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "4946238083a068dc54610ca58627ba9d29055eb235a7ab64d247b73e4d473a11";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-servo/default.nix
+++ b/distros/jazzy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-servo";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_servo/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "4d69d929b07b1cea94f2c6fe8e95263730e5af0bbdd0271468b9b6ac223e0445";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_servo/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c22e3d175692e6fbc1bff35d73efdb0799a641bc51930eaeb8982bbefa162f56";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-app-plugins/default.nix
+++ b/distros/jazzy/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-app-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_app_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "02e413d6769710d915a88d9b3693dda6e59717b8f256e86758bdc2ba442fdf87";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_app_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "df6241c1218ee5958906352a3ee67da3fd42c58ae81bf65dd09575d5262eab55";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-assistant/default.nix
+++ b/distros/jazzy/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-assistant";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_assistant/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "cbc957b1e5bdbd6f66f742331712cd0b43b7c25cab638b0938ee8fdddd4ad597";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_assistant/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "bb8774f7237754dc445b946cd8a379c80dd56bec47df7675d014ff082fb2eaaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-controllers/default.nix
+++ b/distros/jazzy/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-controllers";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_controllers/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "246e280204e5d5f02630e4f3997ba1c4c19f4f7d1ca8b3e904ec20b8e26d33ce";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_controllers/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "28ab56d265946446f3366fcee4983b348b787ccf846d17683e37d9fe29b60828";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-core-plugins/default.nix
+++ b/distros/jazzy/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-core-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_core_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "dd23ed79ba0c4d2bab1ad3bba5c8d62382dd7d0c467ea42ea0baf0ebaa9d2060";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_core_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "c80826500ea25326c8ad15eead5ebc1b092e8d59473ef01d247b54e80ba774ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-framework/default.nix
+++ b/distros/jazzy/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-framework";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_framework/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "f7112e62783bc5ed8613cd400bbf97023f4f4af4144cfbdac1bfaff48a47d267";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_framework/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "fcebcc61f1ade142ae2b8bed833f8ca00c08c135cb64efd093ecceb53f05f3c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-setup-srdf-plugins/default.nix
+++ b/distros/jazzy/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-setup-srdf-plugins";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_srdf_plugins/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c81ed9b55306edfcf7c89a8406f873a676cbe968ae9c700f53a3a98361687713";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_setup_srdf_plugins/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "26077da941286a8486a0239498faa52f427972c47cb5a4aa8d249e12d0508132";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit-simple-controller-manager/default.nix
+++ b/distros/jazzy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-jazzy-moveit-simple-controller-manager";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_simple_controller_manager/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "590037083306075ddc33eee1ed23a82f2e74adbceb919f9f5af39c30255ef5bb";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_simple_controller_manager/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "bfe1a08b530af09c202e83e3bbcc52d7babee991880454de252977e2ad4cdb4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/moveit/default.nix
+++ b/distros/jazzy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-jazzy-moveit";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "139a46b87065d7102e9092c2639e87af3e7cec39c5e9a9fb8ed063523481492e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "7294fa1bef7b4d1b2911da5bd8f74a5d5386d46ef8890e9b62e4a675b4334440";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-oem7-driver/default.nix
+++ b/distros/jazzy/novatel-oem7-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-novatel-oem7-driver";
+  version = "24.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_driver/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "188d01ed1555897506a96ee0b1b1ca9a4f40750a47acb37e0a04e30459626e83";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake git ];
+  checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros rclpy rosbag2 rosidl-runtime-py ];
+  propagatedBuildInputs = [ boost geographiclib gps-msgs nav-msgs nmea-msgs novatel-oem7-msgs pluginlib rclcpp rclcpp-components sensor-msgs tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake git ];
+
+  meta = {
+    description = "NovAtel Oem7 ROS Driver";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/novatel-oem7-msgs/default.nix
+++ b/distros/jazzy/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-novatel-oem7-msgs";
+  version = "24.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_msgs/24.0.0-1.tar.gz";
+    name = "24.0.0-1.tar.gz";
+    sha256 = "3e66b68d38d52a01c9e8a910f26c654f9618ee1b9437bac6d76e1965b4295428";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "Messages for NovAtel Oem7 family of receivers.";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/jazzy/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-jazzy-pilz-industrial-motion-planner-testutils";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner_testutils/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "746152c01330056355966a4506ef0a49b72f95103971704a9b4cd94673bb0452";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner_testutils/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "6676cd79e2004fd582dae55eb411b67e19e07e4f3935cddeaecba55356aaaa28";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pilz-industrial-motion-planner/default.nix
+++ b/distros/jazzy/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-pilz-industrial-motion-planner";
-  version = "2.12.1-r1";
+  version = "2.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner/2.12.1-1.tar.gz";
-    name = "2.12.1-1.tar.gz";
-    sha256 = "c4252ab60d488e1b4f929b7010d9db7d2b2d547853d96015ff47d31ae0bea507";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/pilz_industrial_motion_planner/2.12.2-1.tar.gz";
+    name = "2.12.2-1.tar.gz";
+    sha256 = "fa13e7c609ef1b5c15c2a2225b908ce2de538620010bbd8c34793bc38fb698f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pinocchio/default.nix
+++ b/distros/jazzy/pinocchio/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, urdfdom }:
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-pinocchio";
-  version = "2.6.21-r3";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/jazzy/pinocchio/2.6.21-3.tar.gz";
-    name = "2.6.21-3.tar.gz";
-    sha256 = "1f3a88fbd0b82eb3d5102a265b56d7a7c2fe4cd15629637c65e7aa5a8e64bd94";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/jazzy/pinocchio/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "b42d5af862d14529c551039662edbce32d9a29567106294b3a667acdf83ac1af";
   };
 
   buildType = "cmake";
   buildInputs = [ clang cmake doxygen git ];
-  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy urdfdom ];
+  propagatedBuildInputs = [ boost eigen eigenpy hpp-fcl python3 python3Packages.numpy ros-environment urdfdom ];
   nativeBuildInputs = [ clang cmake ];
 
   meta = {

--- a/distros/jazzy/realtime-tools/default.nix
+++ b/distros/jazzy/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realtime-tools";
-  version = "3.3.0-r1";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "28f52f42a80f060c51577b71371c17eab1c9edd098adcd41af387e3f90dda962";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "ca810261195c529bcdb17775fae3feb39dd5ad1f22dfded51adf2c8bfcb1be2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-zenoh-cpp/default.nix
+++ b/distros/jazzy/rmw-zenoh-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, zenoh-cpp-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-zenoh-cpp";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "f8aad3517113cc3023850df0c3ef1cde04021a909dbb0fc5c8966843675cae2e";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "af0c94cc556bb9d01ff65cc8d786a2169dfebb90fefbde26e69b5a80882e86fc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp fastcdr rcpputils rcutils rmw rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp zenoh-cpp-vendor ];
+  propagatedBuildInputs = [ ament-index-cpp fastcdr rcpputils rcutils rmw rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp tracetools zenoh-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/simple-launch/default.nix
+++ b/distros/jazzy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-simple-launch";
-  version = "1.10.1-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/jazzy/simple_launch/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "749bcc5bd434ae454981638f2e99ff8146f895d0a01842f03b8c2f2920741472";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/jazzy/simple_launch/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "fbe469ba422bb1feab53500bf9e2e5091cf605e0ec904489c2d5e6b2c3c9a679";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-tools-interfaces/default.nix
+++ b/distros/jazzy/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools-interfaces";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "47688a1f8042523925b72d54a2a222550fda3a0ac86b1ee5fd8bc18c4c38c50f";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools_interfaces/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9a123f2a8f13f7e0512bbe0930f06a5eba56c61aa2916c6870d0b3ea13ed2a3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/topic-tools/default.nix
+++ b/distros/jazzy/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-jazzy-topic-tools";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "37412def2a1c8c8270940066bd5f71bc242579fd2fbad80fffef0ced23bc40a0";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/jazzy/topic_tools/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "9b2616f1093bfd2e0965f7783b95ecf90d09f4b2de8635bcbeea83a1b88d1cc8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/turtlebot3-msgs/default.nix
+++ b/distros/jazzy/turtlebot3-msgs/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-turtlebot3-msgs";
-  version = "2.2.1-r5";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/jazzy/turtlebot3_msgs/2.2.1-5.tar.gz";
-    name = "2.2.1-5.tar.gz";
-    sha256 = "55f9d98593aebddd637a78ef1355b40bfab2280058b33f3d9a17c9f2bd52cdf9";
+    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/jazzy/turtlebot3_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "063b241526090d95e50d2946fbbca3cdbc71b1121af7abfbe8998ddeef160d20";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS2";
+    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS 2";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "1.6.0-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "b1895c725fe2d0b2935b3cceeecc7e914e5ea0857994903681092452629bb771";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "7cfff7fa6a989e44e716e4797c4e4317a8e03c99f86a59afa94ab4961aa99900";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/webots-ros2-control/default.nix
+++ b/distros/jazzy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-control";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_control/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "8c0b409198f0dea7343366a3d5f83c465c50db4012f419fc54b25a8a6b71d4ac";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_control/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "7bf2f9dad0c1fd34ae443f2c3f3fec390a50d8d6b250373e0bece08f46bdf90c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-crazyflie/default.nix
+++ b/distros/jazzy/webots-ros2-crazyflie/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, rclpy, tf-transformations, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-jazzy-webots-ros2-crazyflie";
+  version = "2025.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_crazyflie/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "55ef94c9953ba6c5bf9f882fa6314405e987fd7e61a813f6e143196dc97b6bef";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy tf-transformations webots-ros2-driver ];
+
+  meta = {
+    description = "ROS2 package for Crazyflie webots simulator";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/webots-ros2-driver/default.nix
+++ b/distros/jazzy/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-driver";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_driver/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "caa552be3ee3632007ad4dfd618ffd103cff0c77c23705345d596de341f413de";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_driver/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "e054a133078cf7dc781ffc2f6752c6bc1c166894d21cb2d0a9fbf2029b9acd10";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-epuck/default.nix
+++ b/distros/jazzy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, python3Packages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-epuck";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_epuck/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "9fbed94264a2d0d3097d9e128a7800743cd130972a7f0943bcaebdf4b6f709e6";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_epuck/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "02f0d1f6ad01924af12db0503152b99d6742bfe616789b01b4c354856541fcc8";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-husarion/default.nix
+++ b/distros/jazzy/webots-ros2-husarion/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, controller-manager, diff-drive-controller, joint-state-broadcaster, laser-filters, robot-localization, robot-state-publisher, webots-ros2-control, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-jazzy-webots-ros2-husarion";
+  version = "2025.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_husarion/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "d70f3ce6f114f33eb9c34e6e69888b5dfee71cf445c84577243da7eaf416a8a3";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster laser-filters robot-localization robot-state-publisher webots-ros2-control webots-ros2-driver ];
+
+  meta = {
+    description = "Husarion ROSbot 2R and XL robots ROS2 interface for Webots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/webots-ros2-importer/default.nix
+++ b/distros/jazzy/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-importer";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_importer/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "281f7c67d686666ef1618117e84f76f3a1f83b83d4a3ac70a76c8ee612d5685d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_importer/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "95813d375f4aa3d96f57aeabe476303f6bbc2f73cbdb9851c6b812c4f8eb9725";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-mavic/default.nix
+++ b/distros/jazzy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-mavic";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_mavic/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "678521c76060f410adbb36d98ec1697b8167c1e78f9f812aad89643ef72f441d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_mavic/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "9d31d53721298480efa74cfcf69df25d5bdf5cae45e99b48319e180695db20b4";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-msgs/default.nix
+++ b/distros/jazzy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-msgs";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_msgs/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "b2d69b0547187be071c6c85c9d83d085357641d95e89e5929cb78503c0a3aa85";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_msgs/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "b230a7967e8de47223f9821e41685324e36246e502a75f227afa1190bdaf1afe";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/webots-ros2-tesla/default.nix
+++ b/distros/jazzy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tesla";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tesla/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "e77fa29d2e63ae1abce82e24f713f971c1902bb7301795f1e4cc55ac62212652";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tesla/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "a89827398620dc30805af70929903f2fcaa37bfbd290f4d1ad3b234c1a89a6a7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-tests/default.nix
+++ b/distros/jazzy/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tests";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tests/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "d9f002f838ca43e25144d94c21da50dd3d286041aa885a28a87330eb6401e309";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tests/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "2c340b556715c74a5f67835d0a8865acbdd6ce484b6eb00905bae5fc0ca6d3db";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-husarion webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "System tests for `webots_ros2` packages.";

--- a/distros/jazzy/webots-ros2-tiago/default.nix
+++ b/distros/jazzy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-tiago";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tiago/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "490a79154c59e4ebdd581a0190c86cc381d921f9979f656238adaaf2338c5cb2";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_tiago/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "9ca09b49c702c10f48d20464b9c041f1672efaebfe54cc002c4f4b19d7d81305";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-turtlebot/default.nix
+++ b/distros/jazzy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-turtlebot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "02690b6c535a32c41fbaebb4219cb15e8d12afb6479ecdec4befc630ad9f2514";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_turtlebot/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "12b19e4c8303cabcee5c93d781740d80daaf7649817425138bf4f63f9813ec5b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2-universal-robot/default.nix
+++ b/distros/jazzy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, python3Packages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2-universal-robot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "6c2a39e82afdfa890dddb0dad395803146fdb8ba0332690b683bc5921fc07c04";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2_universal_robot/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "6cd5ac9deb9f72f2611027d257274049fe12ce8798ee263d877e803e9965d287";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/webots-ros2/default.nix
+++ b/distros/jazzy/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-crazyflie, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-jazzy-webots-ros2";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "6ae6ca8b3698e453c8485de2cec26853d2a0158e6edc939575b902c7b2558af4";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/jazzy/webots_ros2/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "c00d1f89a6d2e27abd946bc5b52c8e0b7ae6723f68ff4d43102f893dd856e743";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright python3Packages.pytest webots-ros2-tests ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-crazyflie webots-ros2-driver webots-ros2-epuck webots-ros2-husarion webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "Interface between Webots and ROS2";

--- a/distros/jazzy/zenoh-cpp-vendor/default.nix
+++ b/distros/jazzy/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-jazzy-zenoh-cpp-vendor";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "feaf03310f007e38a76f25cebb24cfa91124b5ff347286814012febefa39e249";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "1e826d47fb9ab055ec58c23c411e3158cc5a0dd6fdbb6580c00ae1843f7a0ef5";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, urdf, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "78cc0af1a6e6de332de2bc2be3329ab7cfaf15d80f47787a9c53a780efbb835a";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "726173ef90bdea41437e23e4025860e3cebf76eb96d46c6931869f3156833fed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "02476c046a8ffdca7a9d348930855d97d455015c9ade2a63348089405194e6bd";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "97472f3f35e10daad0d617edc2ac65cb049c6540a8722ae36bb9b8bc14c53249";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "77bc4ea47dda255c73f734ebac1fd6a6b13dc693b59897fcb3bf153bbb76f71d";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "83ba8d04a946123922f8d7ca149e25da53266b5f5bb04fc0578ff1d5c49878d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, depthai-ros-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "18956974c105d7c122989e77d17a5d66aae82f8be8f797f72a9ba0fb19bfda86";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "50573899a52fadb44450138c7696b25882873639c182c9843f54fa25d126ab38";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "f3b533e3fb8bec43a3893fb5ab936684ea44134cc5f4bcfb943f2946b1b83e40";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "2dca0a740507291e5d25a18852c1004cc7d76a0ecd7f421ab156ddccc8fc75b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "e10daf20a6ec350657502b1e58e5b6cbad828e3d7febffb6c71a2baeb2ab75e0";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "54c13c4a2e3468c7eb9a66f9c5b604342f86a9807dcc800e4e2ebe47dcc2bf77";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.10.5-r1";
+  version = "2.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.10.5-1.tar.gz";
-    name = "2.10.5-1.tar.gz";
-    sha256 = "61d429625bc2801e83962f7cd62efc774507bf668ad434f94902b78b45850396";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.11.0-1.tar.gz";
+    name = "2.11.0-1.tar.gz";
+    sha256 = "80c1eb3996212c3a22c8c25e2e4ed8cd36a94899875b13f9519e1553b2346b08";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ee9a2f5c73ff02919762da34532210be429dd9dbfe8eae8d3fc767495d75c94a";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b10c4597814849f36196b0e43d1cfc999303dd585736a5f316ca6fdd9f0e561f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bf168fa1d1390535e390e556e76ac0b4ff7876a76b988e07e95775b440f23c79";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "69a82b67650e29b65c3683b96fbca511c9726b2eabc33b72b606a174831a487a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "98d23ba2eaeb5f0a86043e1bdde1ebafbdbf7f9c6adb9b152a0d406acba550c8";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "42ea99458bb03baf24f55675d3d7cd83dbd223ccc3ca8da0eac215cdaa510ae9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6759b2d8322f4b8fd38a8af78055d277d083d9de597a8d1e20a2011f72295ea2";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b2ad94d9d5e4b3d11000dc7614ab0591b4cb24f3b3dd3742d0ea03b7094fa1ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-ts-coding, etsi-its-cam-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "7efbef4596f4a952d19724b46508b2dda0754bec8a8cee34589675331217b132";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "d887a38e7ce724d6db7c9998970a32d3cbc453b9c830e43aa50451dee3c2a1c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cam-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-cam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d7c83e41412383dc9e6a47e13366a9f5716a1b13e00c5c31ef86280e09abb990";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7ec52dd734da2896c7feabe8ae6d75e9d1cd2961e2ba05cbafbc2c13440dd77d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-coding/default.nix
+++ b/distros/noetic/etsi-its-coding/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-coding, etsi-its-cam-ts-coding, etsi-its-cpm-ts-coding, etsi-its-denm-coding, etsi-its-denm-ts-coding, etsi-its-mapem-ts-coding, etsi-its-spatem-ts-coding, etsi-its-vam-ts-coding, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "50b5377eaa7ea3f737475444766cbc8d75ff2bbad99127d7c6470ed08463103b";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "6a65a4c0e795e6214944495ecb6be22e930f80cf20c9a72bf70e560ff2f6ae88";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-coding etsi-its-cam-ts-coding etsi-its-cpm-ts-coding etsi-its-denm-coding etsi-its-denm-ts-coding etsi-its-mapem-ts-coding etsi-its-spatem-ts-coding etsi-its-vam-ts-coding ros-environment ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/etsi-its-conversion/default.nix
+++ b/distros/noetic/etsi-its-conversion/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, message-runtime, nodelet, ros-environment, roscpp, std-msgs, udp-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-conversion, etsi-its-cam-ts-conversion, etsi-its-cpm-ts-conversion, etsi-its-denm-conversion, etsi-its-denm-ts-conversion, etsi-its-mapem-ts-conversion, etsi-its-spatem-ts-conversion, etsi-its-vam-ts-conversion, message-runtime, nodelet, ros-environment, roscpp, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "e3882e0b0265f1200010a909e942f36f41d3f46d38f5d3401383fbc70c84daf5";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "206495629a75f714b7484a557bb6e22ab0e8b59adde36e3b4b3f4d9f81d081f3";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion message-runtime nodelet ros-environment roscpp std-msgs udp-msgs ];
+  propagatedBuildInputs = [ etsi-its-cam-conversion etsi-its-cam-ts-conversion etsi-its-cpm-ts-conversion etsi-its-denm-conversion etsi-its-denm-ts-conversion etsi-its-mapem-ts-conversion etsi-its-spatem-ts-conversion etsi-its-vam-ts-conversion message-runtime nodelet ros-environment roscpp std-msgs udp-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/etsi-its-cpm-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f35615a988211c84cc2cd1d93465256cd8492deb64c250c72b5819f3a2970a52";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "d425a9683a5a073cb25e3a298e5f191752813e5a5f6a03d9cefc85f4f75a81ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-cpm-ts-coding, etsi-its-cpm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "76a619065b4a34c2ba522225e2adfb69474778ce49a5d989509481758ddb4925";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "cf576a9ee55409cfe8558de5158409429b95081d548b18466b7748d4d93da795";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-cpm-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-cpm-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-cpm-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "ee497d78386e3b61240e11b349e4d68f25343b8272ad10a16f97e69687be8536";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_cpm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "fe793e31874435592d1afb382505b3a37f2f9dfee11720997c9d8cece88f8ddd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-coding/default.nix
+++ b/distros/noetic/etsi-its-denm-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "81047e7fde0fcda9d46d0719928806bded3844a30f7b9d38ac96b9581d7a92e5";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "e363428145fafb4bd31026c5c03987512228b08b766fcae4fc4427e36df56810";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-conversion/default.nix
+++ b/distros/noetic/etsi-its-denm-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-denm-coding, etsi-its-denm-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2af1b0406494efe4523613ede9a3f558e26376aa8c4aae8cb3465262218503c1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b2761086f1487a334f6fca16a257cb790774cd1c1e46d5695439aafb43a7435b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-msgs/default.nix
+++ b/distros/noetic/etsi-its-denm-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-denm-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "1ceafcb247d54906156f017f3ee419d0ec6394e259bb7848d816ae2819449dd2";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0b1e54699ef6f6a938680990dd38f9acfc47190d13da5c8db4f4cd66cbea9a9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-denm-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-denm-ts-coding/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ros-environment }:
+buildRosPackage {
+  pname = "ros-noetic-etsi-its-denm-ts-coding";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "4774a1202c2bf06ae8c1b40bd59c0a579075581b0ded361cdadc58f5e2609e93";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ ros-environment ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "C++ compatible C source code for ETSI ITS DENMs (TS) generated from ASN.1 using asn1c";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/etsi-its-denm-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-denm-ts-conversion/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-denm-ts-coding, etsi-its-denm-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
+buildRosPackage {
+  pname = "ros-noetic-etsi-its-denm-ts-conversion";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ee0c177843e48efa9408626a6d85ea8d9c78701237cfca0e4fec238e867914d6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ etsi-its-denm-ts-coding etsi-its-denm-ts-msgs etsi-its-primitives-conversion ros-environment ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "Conversion functions for converting ROS messages to and from ASN.1-encoded ETSI ITS DENMs (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/etsi-its-denm-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-denm-ts-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-etsi-its-denm-ts-msgs";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_denm_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "28439c55f4e0d36ef9f0d69b9fd2bef4a08d43bfc9ece5ddc90373cfd2cb0128";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ message-generation message-runtime ros-environment std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "ROS messages for ETSI ITS DENM (TS)";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/etsi-its-mapem-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-mapem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-mapem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_mapem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "bc6e2c80b5e9d6eaa352de97eda1eba370bf3c89947f489404f1f57ab51e6f6f";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_mapem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "4213a9d17a00b30685cace21e24638622e6eb84d70b7f78ecbf0a8bb2b6252ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-mapem-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-mapem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-mapem-ts-coding, etsi-its-mapem-ts-msgs, etsi-its-primitives-conversion, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-mapem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_mapem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "df2696200dad2dd8383cce68637451308c43d38ad15d7629f08563220a6b02a0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_mapem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "057ff50d7aa649d4cf44874f3c1798be85791a8f8af96a1a77391445a4013f8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-mapem-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-mapem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-mapem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_mapem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "cdfd2df95311c3f1c99927c3ac2d506e972218d6208c830e74424b6fd950c133";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_mapem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "138005b4d4c2938c11e282740b26d54bd92474b5a30ca70be777b859d72e143d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-messages/default.nix
+++ b/distros/noetic/etsi-its-messages/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-coding, etsi-its-conversion, etsi-its-msgs, etsi-its-msgs-utils, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-messages";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2fa6851c84483cf527782a7cbc6db699d7c7e72b0171610c2ded1a6669a16037";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_messages/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "ece14e097cf9f2cb3bc1e95173f976ea77e3f0f900854a947f805af2d512f2c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs-utils/default.nix
+++ b/distros/noetic/etsi-its-msgs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-msgs, geographiclib, geometry-msgs, ros-environment, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs-utils";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "937a43a32f78856e2d982d0cde8c5123efae13471f729aef893f549d05053e64";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs_utils/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "7b1ef3968ff81526a1e73b37594608b1626d594d9f4e59040dd32f0f30bad659";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-msgs/default.nix
+++ b/distros/noetic/etsi-its-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
+{ lib, buildRosPackage, fetchurl, catkin, etsi-its-cam-msgs, etsi-its-cam-ts-msgs, etsi-its-cpm-ts-msgs, etsi-its-denm-msgs, etsi-its-denm-ts-msgs, etsi-its-mapem-ts-msgs, etsi-its-spatem-ts-msgs, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "876b3c85f660e44897f95e8a581a3ae2d2e01c382fc0ee7f9ab2bf2be4d0534d";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2cfc933c4a6c9880ec4a5c6e0ad741bf3e59ce76d6e72adf78fc7b11ee2b3aa9";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
+  propagatedBuildInputs = [ etsi-its-cam-msgs etsi-its-cam-ts-msgs etsi-its-cpm-ts-msgs etsi-its-denm-msgs etsi-its-denm-ts-msgs etsi-its-mapem-ts-msgs etsi-its-spatem-ts-msgs etsi-its-vam-ts-msgs ros-environment ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/etsi-its-primitives-conversion/default.nix
+++ b/distros/noetic/etsi-its-primitives-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-primitives-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d06beadcbe83f868dd2e9540d496f1baa9b676d3d7d93123785c103b8d58c6e1";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_primitives_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a9b90ef0cfa7a2f98cca72b74a6e2bd1197de99c9fa20a26c228b749aa1ab442";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-rviz-plugins/default.nix
+++ b/distros/noetic/etsi-its-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-rviz-plugins";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "95ffa6206dd5848994f799d59ecc3744076b96a03d1ccc427d2d7746e73cf0b3";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_rviz_plugins/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "cd2b0c955d09b88444f27eb664030785e905ff056cc1261df25e57065850de49";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-spatem-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-spatem-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-spatem-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_spatem_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "83c15643c5614ffbe1c8040f96ba969c63a62dcc6096a03559c8aa0db9fd62f0";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_spatem_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "fd09db649882e5216303665dee4e1a68566138707ae34fb25e0afa870e456cae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-spatem-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-spatem-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-primitives-conversion, etsi-its-spatem-ts-coding, etsi-its-spatem-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-spatem-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_spatem_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "a15a9aba7f9689b838d4194f324c4f1071e1c6eaa219ce0410f91258c491ead7";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_spatem_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "bbfb4a0bfce48f688c7e672aabeb4d77fdca75bd82cadbd0ee4bacc80a7197e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-spatem-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-spatem-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-spatem-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_spatem_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5247fe0c07a22f70a366c499ce6698ed9102cb9f04041d276ba12a332881b5cb";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_spatem_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "19a01b763cbdc466669164efe93956c51561d712179abb569a3ba7ee5def96b0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-vam-ts-coding/default.nix
+++ b/distros/noetic/etsi-its-vam-ts-coding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-vam-ts-coding";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_coding/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "b802e8bdbb489748033bad0fbac3b69bc23abc9263a783be9bddadc215a77c57";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_coding/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "985b993599fa7d49d13f447b1ccb48f3300d9a5d04da8df74ace8c1d321147df";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-vam-ts-conversion/default.nix
+++ b/distros/noetic/etsi-its-vam-ts-conversion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, etsi-its-primitives-conversion, etsi-its-vam-ts-coding, etsi-its-vam-ts-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-vam-ts-conversion";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_conversion/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d7bf66f020f748ef001caee4a5c55fe28ab106ab3afa71d6054df38ef1a4d93e";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_conversion/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c1a9d60dd1c09712b101eb3c9be4f82e571d79a213b026b00f22d32762389b2e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/etsi-its-vam-ts-msgs/default.nix
+++ b/distros/noetic/etsi-its-vam-ts-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-etsi-its-vam-ts-msgs";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "2dc1a3486a4805b8fce4009ed8667750a231401e0a468b9539c9cec28cbc3685";
+    url = "https://github.com/ika-rwth-aachen/etsi_its_messages-release/archive/release/noetic/etsi_its_vam_ts_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2fa79ba669a4397d8fe4c0f6fb54de3622b79a18733d68002aad37d15e76c65a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fanuc-cr35ia-support/default.nix
+++ b/distros/noetic/fanuc-cr35ia-support/default.nix
@@ -1,0 +1,59 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-cr35ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_cr35ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "1da2e9ec6f5cc9ba02d2af986fa986217671dfb76684e7f805dbb1681cd32bfb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc CR-35iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc CR-35iA manipulators. This currently includes the base model
+      only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>CR-35iA - Normal Range</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot CR-35iA Mechanical Unit Operator's Manual</em> version
+      <em>B-83734EN/01</em>. All urdfs are based on the default motion and
+      joint velocity limits, unless noted otherwise (ie: no support for high
+      speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p>
+      <b>Note</b>: there is currently some confusion over the correct values for
+      the joint limits of joints 2 and 3. Version <em>B-83734EN/01</em> of the
+      Operator's Manual incorrectly states that 1.05 rad equals 120 degrees,
+      and that 0.39 rad equals 45 degrees (joint 2). Additionally, it gives a
+      value of -122.9 degrees for the lower limit of joint 3, whereas (at
+      least) Roboguide Rev K have this limit set to -182 degrees.
+      We advise users to pay extra attention when verifying the xacro in this
+      support package until this is cleared up.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-cr7ia-support/default.nix
+++ b/distros/noetic/fanuc-cr7ia-support/default.nix
@@ -1,0 +1,64 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-cr7ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_cr7ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "3b0572943e1d7eb7ba9c44105034dc5f51c6cf557a781e10787c9736a6395659";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc CR-7iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc CR-7iA manipulators. This currently includes the base and
+      /L model.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>CR-7iA - Normal Range</li>
+      <li>CR-7iA/L - Normal Range</li>
+    </ul>
+    <p>
+      Link lengths are based on information in <em>FANUC Robot CR-4iA, CR-7iA,
+      CR-7iA/L, CR-14iA/L Mechanical Unit Operator's Manual</em> version
+      <em>B-83774EN/04</em>.
+      Joint limits and maximum joint velocities are based on the information in
+      the system variables of the supported variants (either from FRVCs or real
+      controllers).
+      All urdfs are based on the default motion and joint velocity limits,
+      unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p>
+      <b>Note</b>: collaborative robots make use of special safety systems
+      embedded in the OEM controller which continuously monitor the state of
+      the robot and adapt limits where and when necessary.
+      The joint limits specified in the xacros provided by this package are the
+      maximum joint limits as specified by Fanuc. As there is no information
+      available on how the collaborative safety system works, we cannot model
+      it here and thus it's very likely the joint limits in these files are
+      unattainable by the actual robot.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-crx10ia-support/default.nix
+++ b/distros/noetic/fanuc-crx10ia-support/default.nix
@@ -1,0 +1,48 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-crx10ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_crx10ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "f89123e79b83d99a92fc96a220eafbd2e1fb113458e3baa4a483ecafa708d5fe";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc CRX-10iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc CRX-10iA manipulators. This currently includes the /L model only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>CRX-10iA/L - 1418mm reach</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot CRX-10iA, CRX-10iA/L Mechanical Unit Operator's Manual</em>
+      version <em>B-84194EN/01</em>. All urdfs are based on the default motion and
+      joint velocity limits, unless noted otherwise (ie: no support for high
+      speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-driver/default.nix
+++ b/distros/noetic/fanuc-driver/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, industrial-robot-client, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-driver";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_driver/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "18742764e9f494230f89560a0154229491c046f76abd8c7d0fb01843f843b651";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ industrial-robot-client ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+     ROS-Industrial nodes for interfacing with Fanuc robot controllers.
+   </p>
+   <p>
+     This package is part of the ROS-Industrial program and contains nodes
+     for interfacing with Fanuc industrial robot controllers that support
+     the KAREL programming environment.
+   </p>
+   <p>
+     Refer to the readme of this package for a note on the performance of
+     the driver.
+   </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-lrmate200i-support/default.nix
+++ b/distros/noetic/fanuc-lrmate200i-support/default.nix
@@ -1,0 +1,45 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-lrmate200i-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_lrmate200i_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "fc92b04cf349e4b806ea37c7a4b960e1154467502a1b246b7617c059703f5f41";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc LR Mate 200i.
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc LR Mate 200i manipulators. This currently includes the
+      base model only.
+    </p>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robotics LR Mate 200i Datasheet</em> version
+      <em>FRNA-10/9-DS-005</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-lrmate200ib-support/default.nix
+++ b/distros/noetic/fanuc-lrmate200ib-support/default.nix
@@ -1,0 +1,49 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-lrmate200ib-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_lrmate200ib_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2fc967d8c72f26406e80942d87a7a8bb87d74e29001908746f0fa95e5fa2ebd8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc LR Mate 200iB (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc LR Mate 200iB manipulators. This currently includes the base
+      model and the /3L.
+    </p>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>Fanuc LR Mate 200iB-200iB/3L datasheet</em>, dated <em>24-Feb-2003</em>.
+      All urdfs are based on the default motion and joint velocity limits,
+      unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p><b>Contributors</b>:</p>
+    <p>
+      This support package has received contributions from: Victor Lamoine.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-lrmate200ic-support/default.nix
+++ b/distros/noetic/fanuc-lrmate200ic-support/default.nix
@@ -1,0 +1,53 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-lrmate200ic-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_lrmate200ic_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "71859e7c3d59660bcffb01886468637749239c3b3783e372de6c0b1d89a9f95c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc LR Mate 200iC (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc LR Mate 200iC manipulators. This includes the base model
+      (/5C, /5WP), /5H, /5L (/5LC), /5F and the /5HS. Variants in brackets
+      are supported by the files for the referenced model.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>LR Mate 200iC    - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iC/5H - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iC/5L - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iC/5F - &quot;J1 - Normal Range&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot LR Mate 200iC Mechanical Unit Operator's Manual</em>
+      version <em>B-82584EN/07</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-lrmate200id-support/default.nix
+++ b/distros/noetic/fanuc-lrmate200id-support/default.nix
@@ -1,0 +1,59 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-lrmate200id-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_lrmate200id_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "572aa382bc949007f90725095a745e8bbb0f23959a38795519de3d4720822a29";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc LR Mate 200iD (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc LR Mate 200iD manipulators. This includes the base
+      model (/7C, /7WP), /7H, /7L, /7LC and the /4S, /4SC and /4SH.
+      The variants in parentheses are supported by the files for the variant
+      immediately preceeding the parentheses.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>LR Mate 200iD - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iD/4S - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iD/4SC - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iD/4SH - &quot;J1 - Normal Range; J5 - Horizontal Wrist Zero&quot;</li>
+      <li>LR Mate 200iD/7H - &quot;J1 - Normal Range; J5 - Horizontal Wrist Zero&quot;</li>
+      <li>LR Mate 200iD/7L - &quot;J1 - Normal Range&quot;</li>
+      <li>LR Mate 200iD/7LC - &quot;J1 - Normal Range&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot LR Mate 200iD Mechanical Unit Operator's Manual</em>
+      version <em>B-83494EN/03</em> and the
+      <em>FANUC Robot LR Mate 200iD/4S/4SH/4SC Mechanical Unit Operator's Manual</em>
+      version <em>B-83574EN/03</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m10ia-support/default.nix
+++ b/distros/noetic/fanuc-m10ia-support/default.nix
@@ -1,0 +1,50 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m10ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m10ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e1f15a9b0ae6fd3fefa2076aaf1058511690426dd9c9a392c75eb6fa2cfd334b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-10iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-10iA manipulators. This includes the base model and the
+      /7L variant.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-10iA - &quot;Conventional dress-out&quot;</li>
+      <li>M-10iA/7L - &quot;Conventional dress-out&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot M-10iA Mechanical Unit Operator's Manual</em>
+      version <em>B-82754EN/09</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m16ib-support/default.nix
+++ b/distros/noetic/fanuc-m16ib-support/default.nix
@@ -1,0 +1,50 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m16ib-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m16ib_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "27ec9e4d5d4eec06d60119b385c66c6e959919d4b38b7bc487e0df899d50b3ac";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-16iB / ARC Mate 120iB (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-16iB / ARC Mate 120iB manipulators. This currently includes
+      the /20 only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-16iB/20 - &quot;Default J1 range&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot ARC Mate 120iB, Fanuc Robot M-16iB/20 Mechanical
+      Unit Maintenance Manual</em> version <em>B-81765EN/02</em>. All urdfs are
+      based on the default motion and joint velocity limits, unless noted
+      otherwise (ie: no support for high speed joints, extended / limited
+      motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m20ia-support/default.nix
+++ b/distros/noetic/fanuc-m20ia-support/default.nix
@@ -1,0 +1,55 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m20ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m20ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2ff5a4b59c7e8442a44ad28c01dfefb6cbb4d1dd2a6d36b2da071cd2a53eab09";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-20iA / ARC Mate 120iC (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-20iA / ARC Mate 120iC manipulators. This currently includes
+      the base model and /10L.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-20iA - &quot;Cable integrated J3 Arm&quot;</li>
+      <li>M-20iA/10L - &quot;Cable integrated J3 Arm&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot ARC Mate 120iC, FANUC Robot M-20iA Mechanical Unit
+      Operator's Manual</em> version <em>B-82874EN/06</em>. All urdfs are based
+      on the default motion and joint velocity limits, unless noted otherwise
+      (ie: no support for high speed joints, extended / limited motion ranges
+      or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p><b>Contributors</b>:</p>
+    <p>
+      This support package has received contributions from: Joe Spanier (M-20iA/10L).
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m20ib-support/default.nix
+++ b/distros/noetic/fanuc-m20ib-support/default.nix
@@ -1,0 +1,48 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m20ib-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m20ib_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b937eddc0e268413d6bde72e7434d2c4ef158d0e5317dff60618870d533f26f2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-20iB (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-20iB manipulators. This currently includes the /25 model only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-20iB/25 - &quot;Cable integrated J3 Arm&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot M-20iB Mechanical Unit Operator's Manual</em> version
+      <em>B-83754EN/01</em>. All urdfs are based on the default motion and
+      joint velocity limits, unless noted otherwise (ie: no support for high
+      speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m430ia-support/default.nix
+++ b/distros/noetic/fanuc-m430ia-support/default.nix
@@ -1,0 +1,49 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m430ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m430ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "258a9627d65cdf0c03371f0ccc0e43ba41bd3b5ff3d4c1d37685cc84b2e6a816";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-430iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-430iA manipulators. This currently includes the /2F and /2P.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-430iA/2F - &quot;Default J1 range&quot;</li>
+      <li>M-430iA/2P - &quot;Default J1 range&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot M-430iA Mechanical Unit Operator's Manual</em>
+      version <em>B-82554EN/05</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m6ib-support/default.nix
+++ b/distros/noetic/fanuc-m6ib-support/default.nix
@@ -1,0 +1,51 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m6ib-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m6ib_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ef61b946c96b7d20e103c68fa05592496379f37c658d2d8ae13340feb26cd3ea";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-6iB (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-6iB manipulators. This currently includes the base model
+      and the /6S variant.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-6iB - Normal Range</li>
+      <li>M-6iB/6S - Normal Range</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot ARC Mate 100i Model B, FANUC Robot M-6i Model B
+      Maintenance Manual</em> version <em>B-81545EN/01</em>. All urdfs are
+      based on the default motion and joint velocity limits, unless noted
+      otherwise (ie: no support for high speed joints, extended / limited
+      motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m710ic-support/default.nix
+++ b/distros/noetic/fanuc-m710ic-support/default.nix
@@ -1,0 +1,45 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m710ic-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m710ic_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d2c0b576664c5ba6f1d090aba649b5d51aa89719f700deea3075d9cb35ff1af8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-710iC (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-710iC manipulators. This currently includes the /45M and
+      /50 variants.
+    </p>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot M-710iC Mechanical Unit Operator's Manual</em>
+      version <em>B-82274EN/09</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m900ia-support/default.nix
+++ b/distros/noetic/fanuc-m900ia-support/default.nix
@@ -1,0 +1,49 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m900ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m900ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "477b03ed77875cdf0881645376077ff005d16ba42b734265b5fe2af01bb05f61";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-900iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-900iA manipulators. This currently includes the /260 model
+      only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-900iA/260L - &quot;Standard Flange&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot M-900iA/260L Mechanical Manual, Maintenance Manual</em>
+      version <em>B-82135EN/05</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for high
+      speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-m900ib-support/default.nix
+++ b/distros/noetic/fanuc-m900ib-support/default.nix
@@ -1,0 +1,61 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-m900ib-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_m900ib_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e6cca9547b1d8225a39c6b224d9839cbd0ad1dbd1b89f5d758bd10d16fcd606d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc M-900iB (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc M-900iB manipulators. This currently includes the /700 variant
+      only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>M-900iB/700 - Standard Flange</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot M-900iB/700 Mechanical Unit Operator's Manual</em>
+      version <em>B-83444EN/01</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p>
+      <b>Note 1</b>: the xacro for the /700 variant includes optional geometry
+      for the forklift pockets, balancers and counterweight that can be
+      enabled and disabled to correspond to the robot's actual configuration.
+      By default, only the balancers and the counterweight are included, but
+      this can be changed by making use of the provided xacro macro.
+    </p>
+    <p>
+      <b>Note 2</b>: visualisation of the balancers and the counterweight is
+      an approximation only and may not always accurately represent the state
+      of the physical robot.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-r1000ia-support/default.nix
+++ b/distros/noetic/fanuc-r1000ia-support/default.nix
@@ -1,0 +1,48 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-r1000ia-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_r1000ia_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c5469ecd3af23266d253794ddf1d69092266ddd26312fe29dea171b43b2813c7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc R-1000iA (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc R-1000iA manipulators. This currently includes the /80F only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>R-1000iA/80F - &quot;flange: standard flange&quot;, &quot;motion range: standard type&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot R-1000iA Mechanical Unit Operator's Manual</em>
+      version <em>B-83004EN/03</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-r2000ib-support/default.nix
+++ b/distros/noetic/fanuc-r2000ib-support/default.nix
@@ -1,0 +1,49 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-r2000ib-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_r2000ib_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "7e0f7673e2519d128674070e4b8eaa7141f59579a8749a86875138e8d49bc41e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support package for the Fanuc R-2000iB (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc R-2000iB manipulators. This currently includes the /210F
+      variant only.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>R-2000iB/210F - &quot;J1 - Normal Range&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC R-2000iB Mechanical Unit Operator's Manual</em>
+      version <em>B-82234EN/11</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-r2000ic-support/default.nix
+++ b/distros/noetic/fanuc-r2000ic-support/default.nix
@@ -1,0 +1,64 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fanuc-driver, fanuc-resources, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-r2000ic-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_r2000ic_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b113b923b1c80814c11d59a78bda5bff410a4c814edf6e5671440bba7ba6beaa";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ fanuc-driver fanuc-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the Fanuc R-2000iC (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for Fanuc R-2000iC manipulators. This includes the /125L, /165F, /210F,
+      /210L and /270F variants.
+    </p>
+    <p>
+      <b>Note</b>: for use with current ROS packages, the /210F is identical
+      to the /165F and reuses the meshes, kinematic structure and the OPW
+      parameters of the /165. Only the joint limits are different.
+    </p>
+    <p><b>Specifications</b>:</p>
+    <ul>
+      <li>R-2000iC/125L - &quot;Conventional dress-out&quot;</li>
+      <li>R-2000iC/165F - &quot;Conventional dress-out&quot;</li>
+      <li>R-2000iC/210F - &quot;Conventional dress-out&quot;</li>
+      <li>R-2000iC/210L - &quot;Conventional dress-out&quot;</li>
+      <li>R-2000iC/270F - &quot;Conventional dress-out&quot;</li>
+    </ul>
+    <p>
+      Joint limits and maximum joint velocities are based on the information in
+      the <em>FANUC Robot R-2000iC Mechanical Unit Operator's Manual</em>
+      version <em>B-83644EN/01</em>. All urdfs are based on the default motion
+      and joint velocity limits, unless noted otherwise (ie: no support for
+      high speed joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p><b>Contributors</b>:</p>
+    <p>
+      This support package has received contributions from: Timo Birnkraut and
+      Simon Schmeisser (125L), Didier Quirin (210F), Haris Suwignyo (Alten
+      Nederland) (270F) and Ademola Oridate (Wilder Systems) (210L).
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fanuc-resources/default.nix
+++ b/distros/noetic/fanuc-resources/default.nix
@@ -1,0 +1,35 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-fanuc-resources";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/fanuc-release/archive/release/noetic/fanuc_resources/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "bdb502efb9031262e58ad2c9248ae8423792ea9d5c495cde6158025e54e99305";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      Shared configuration data, 3D models and launch files for Fanuc
+      manipulators.
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      that are shared between different Fanuc robot support packages
+      within the ROS-Industrial program.
+
+      This package also contains common urdf / xacro resources used by
+      other Fanuc related packages.
+    </p>";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -926,6 +926,12 @@ self: super: {
 
  etsi-its-denm-msgs = self.callPackage ./etsi-its-denm-msgs {};
 
+ etsi-its-denm-ts-coding = self.callPackage ./etsi-its-denm-ts-coding {};
+
+ etsi-its-denm-ts-conversion = self.callPackage ./etsi-its-denm-ts-conversion {};
+
+ etsi-its-denm-ts-msgs = self.callPackage ./etsi-its-denm-ts-msgs {};
+
  etsi-its-mapem-ts-coding = self.callPackage ./etsi-its-mapem-ts-coding {};
 
  etsi-its-mapem-ts-conversion = self.callPackage ./etsi-its-mapem-ts-conversion {};
@@ -1029,6 +1035,48 @@ self: super: {
  fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
 
  fake-localization = self.callPackage ./fake-localization {};
+
+ fanuc-cr35ia-support = self.callPackage ./fanuc-cr35ia-support {};
+
+ fanuc-cr7ia-support = self.callPackage ./fanuc-cr7ia-support {};
+
+ fanuc-crx10ia-support = self.callPackage ./fanuc-crx10ia-support {};
+
+ fanuc-driver = self.callPackage ./fanuc-driver {};
+
+ fanuc-lrmate200i-support = self.callPackage ./fanuc-lrmate200i-support {};
+
+ fanuc-lrmate200ib-support = self.callPackage ./fanuc-lrmate200ib-support {};
+
+ fanuc-lrmate200ic-support = self.callPackage ./fanuc-lrmate200ic-support {};
+
+ fanuc-lrmate200id-support = self.callPackage ./fanuc-lrmate200id-support {};
+
+ fanuc-m10ia-support = self.callPackage ./fanuc-m10ia-support {};
+
+ fanuc-m16ib-support = self.callPackage ./fanuc-m16ib-support {};
+
+ fanuc-m20ia-support = self.callPackage ./fanuc-m20ia-support {};
+
+ fanuc-m20ib-support = self.callPackage ./fanuc-m20ib-support {};
+
+ fanuc-m430ia-support = self.callPackage ./fanuc-m430ia-support {};
+
+ fanuc-m6ib-support = self.callPackage ./fanuc-m6ib-support {};
+
+ fanuc-m710ic-support = self.callPackage ./fanuc-m710ic-support {};
+
+ fanuc-m900ia-support = self.callPackage ./fanuc-m900ia-support {};
+
+ fanuc-m900ib-support = self.callPackage ./fanuc-m900ib-support {};
+
+ fanuc-r1000ia-support = self.callPackage ./fanuc-r1000ia-support {};
+
+ fanuc-r2000ib-support = self.callPackage ./fanuc-r2000ib-support {};
+
+ fanuc-r2000ic-support = self.callPackage ./fanuc-r2000ic-support {};
+
+ fanuc-resources = self.callPackage ./fanuc-resources {};
 
  fath-pivot-mount-description = self.callPackage ./fath-pivot-mount-description {};
 
@@ -2154,7 +2202,13 @@ self: super: {
 
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
- movie-publisher = self.callPackage ./movie-publisher {};
+ movie-publisher-plugins = self.callPackage ./movie-publisher-plugins {};
+
+ movie-publisher-plugins-copyleft = self.callPackage ./movie-publisher-plugins-copyleft {};
+
+ movie-publisher-plugins-nonfree = self.callPackage ./movie-publisher-plugins-nonfree {};
+
+ movie-publisher-plugins-permissive = self.callPackage ./movie-publisher-plugins-permissive {};
 
  mp2p-icp = self.callPackage ./mp2p-icp {};
 

--- a/distros/noetic/grpc/default.nix
+++ b/distros/noetic/grpc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoconf, catkin, git, libtool, openssl, rsync, zlib }:
 buildRosPackage {
   pname = "ros-noetic-grpc";
-  version = "0.0.16-r1";
+  version = "0.0.16-r2";
 
   src = fetchurl {
-    url = "https://github.com/CogRobRelease/catkin_grpc-release/archive/release/noetic/grpc/0.0.16-1.tar.gz";
-    name = "0.0.16-1.tar.gz";
-    sha256 = "f841902330a8f363535a771617f5ed01bcc188dd2b775ce86b8d01b9ee6f5136";
+    url = "https://github.com/CogRobRelease/catkin_grpc-release/archive/release/noetic/grpc/0.0.16-2.tar.gz";
+    name = "0.0.16-2.tar.gz";
+    sha256 = "516e10d1e9ad6756572e66595f9bd121c2616c146568a0febd839af3ba566379";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport-codecs/default.nix
+++ b/distros/noetic/image-transport-codecs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, cras-cpp-common, cras-topic-tools, dynamic-reconfigure, image-transport, libjpeg_turbo, pluginlib, rosbag, roslint, sensor-msgs, theora-image-transport, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-image-transport-codecs";
-  version = "2.5.0-r1";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.5.0-1/archive.tar.gz";
+    url = "https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils/-/archive/release/noetic/image_transport_codecs/2.5.1-1/archive.tar.gz";
     name = "archive.tar.gz";
-    sha256 = "aee946a19b859f4d92f7a4ca957b8f52abc129a8358ead5b265835191231fe8d";
+    sha256 = "8512b29d7d1e91fbcc0e09179bd972b68a301ce9f062365deb18e8c967e0c6d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/movie-publisher-plugins-copyleft/default.nix
+++ b/distros/noetic/movie-publisher-plugins-copyleft/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exiv2-metadata-extractor }:
+buildRosPackage {
+  pname = "ros-noetic-movie-publisher-plugins-copyleft";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_copyleft/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "14bba374aca4d5bcc90e31f19e1083e667746795dcfc8660910aee75ceb8a621";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ exiv2-metadata-extractor ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "movie_publisher metadata plugins with copyleft licenses";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/movie-publisher-plugins-nonfree/default.nix
+++ b/distros/noetic/movie-publisher-plugins-nonfree/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exiftool-metadata-extractor }:
+buildRosPackage {
+  pname = "ros-noetic-movie-publisher-plugins-nonfree";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_nonfree/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "a2e5605f23cbaa743dcbe0e48285fc226a11af8425a8c5505a4fd97dde92b945";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ exiftool-metadata-extractor ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "movie_publisher metadata plugins with nonfree licenses. exiftool is free for personal use.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/movie-publisher-plugins-permissive/default.nix
+++ b/distros/noetic/movie-publisher-plugins-permissive/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager-metadata-extractor, catkin, lensfun-metadata-extractor, libexif-metadata-extractor }:
+buildRosPackage {
+  pname = "ros-noetic-movie-publisher-plugins-permissive";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_permissive/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "1cc491443c5fae48b18bbafd56dcb5647cdafee805e5f2834cbb953875df7cfb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ camera-info-manager-metadata-extractor lensfun-metadata-extractor libexif-metadata-extractor ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "movie_publisher metadata plugins with permissive licenses";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/movie-publisher-plugins/default.nix
+++ b/distros/noetic/movie-publisher-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, movie-publisher-plugins-copyleft, movie-publisher-plugins-nonfree, movie-publisher-plugins-permissive }:
+buildRosPackage {
+  pname = "ros-noetic-movie-publisher-plugins";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "ebf826cffc47b0d01f0d34451b58e05022d4540c9751effd200f12c233f51315";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ movie-publisher-plugins-copyleft movie-publisher-plugins-nonfree movie-publisher-plugins-permissive ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "movie_publisher metadata plugins (all licenses)";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.6.0-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "c05f4942e9c91f6ccd55eb444fbe5c4920cef73976c907b97627d830bd677a00";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "6fa2deb3ef1615075aa7317690c3424932f16553f99f622060878af6f9ade695";
   };
 
   buildType = "cmake";

--- a/distros/rolling/apriltag/default.nix
+++ b/distros/rolling/apriltag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, opencv, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-apriltag";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "3c3a03ed6163a2cd6de519b0fa8bb08f83840ce004c6ddaf940d333dea70c9f6";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/rolling/apriltag/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "378c6bf011a9396bf4c3cb0face7a17b69e2d77a9bb16aeac16758c4f46ef6a5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/chomp-motion-planner/default.nix
+++ b/distros/rolling/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-chomp-motion-planner";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "cf89b4b3e56636a7fa862d7c4696d990c5753cbd29043b661f3cda28cd106a50";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "95930b1ec207c441f02113a50e0d63c409ce24cc63872d170173e674cb29c12f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dynamixel-interfaces/default.nix
+++ b/distros/rolling/dynamixel-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-dynamixel-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/rolling/dynamixel_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5471ee8d78d167f58ad46f90e3fe23925dd673224d660f0f36e9ebe008ba74c6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = "dynamixel_interfaces contains base messages and service useful for controlling Dynamixel.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -186,8 +186,6 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
- automatika-ros-sugar = self.callPackage ./automatika-ros-sugar {};
-
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -429,6 +427,8 @@ self: super: {
  dummy-sensors = self.callPackage ./dummy-sensors {};
 
  dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
+
+ dynamixel-interfaces = self.callPackage ./dynamixel-interfaces {};
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
@@ -779,6 +779,8 @@ self: super: {
  hatchbed-common = self.callPackage ./hatchbed-common {};
 
  heaphook = self.callPackage ./heaphook {};
+
+ hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
@@ -1414,8 +1416,6 @@ self: super: {
 
  pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
 
- pangolin = self.callPackage ./pangolin {};
-
  parallel-gripper-controller = self.callPackage ./parallel-gripper-controller {};
 
  parameter-traits = self.callPackage ./parameter-traits {};
@@ -1779,6 +1779,8 @@ self: super: {
  rmw-implementation = self.callPackage ./rmw-implementation {};
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
+
+ rmw-security-common = self.callPackage ./rmw-security-common {};
 
  rmw-zenoh-cpp = self.callPackage ./rmw-zenoh-cpp {};
 
@@ -2528,9 +2530,13 @@ self: super: {
 
  webots-ros2-control = self.callPackage ./webots-ros2-control {};
 
+ webots-ros2-crazyflie = self.callPackage ./webots-ros2-crazyflie {};
+
  webots-ros2-driver = self.callPackage ./webots-ros2-driver {};
 
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
+
+ webots-ros2-husarion = self.callPackage ./webots-ros2-husarion {};
 
  webots-ros2-importer = self.callPackage ./webots-ros2-importer {};
 

--- a/distros/rolling/gz-common-vendor/default.nix
+++ b/distros/rolling/gz-common-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, assimp, cmake, ffmpeg, freeimage, gdal, gz-cmake-vendor, gz-math-vendor, gz-utils-vendor, pkg-config, spdlog-vendor, tinyxml-2, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-common-vendor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "d28d765144b93207e6400aa458bbabff6c363e89cd781be6c68999c4835c33d0";
+    url = "https://github.com/ros2-gbp/gz_common_vendor-release/archive/release/rolling/gz_common_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "c1f2674fdb9d6807f40ea81a82dba0c3811090c0b74c9942a519c255ccc8321b";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-common6 6.0.1
+    description = "Vendor package for: gz-common6 6.0.2
 
     Gazebo Common : AV, Graphics, Events, and much more.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-fuel-tools-vendor/default.nix
+++ b/distros/rolling/gz-fuel-tools-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, curl, gflags, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, jsoncpp, libyaml, libzip, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, curl, gflags, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, jsoncpp, libyaml, libzip, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-gz-fuel-tools-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/rolling/gz_fuel_tools_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "3e42cea59426bdd03ebf077b86d4b43a631ed654d0b75b744f1f310b685ee559";
+    url = "https://github.com/ros2-gbp/gz_fuel_tools_vendor-release/archive/release/rolling/gz_fuel_tools_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "981351f3f0f1b65373f0a34a45cc58b9f87482bcac423cd4bb3c5ef64cf78482";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ curl gflags gz-cmake-vendor gz-common-vendor gz-math-vendor gz-msgs-vendor gz-tools-vendor gz-utils-vendor jsoncpp libyaml libzip tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-fuel_tools10 10.0.0
+    description = "Vendor package for: gz-fuel_tools10 10.0.1
 
     Gazebo Fuel Tools: Classes and tools for interacting with Gazebo Fuel";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-gui-vendor/default.nix
+++ b/distros/rolling/gz-gui-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, qt5, tinyxml-2, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, qt5, tinyxml-2, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-gui-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_gui_vendor-release/archive/release/rolling/gz_gui_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "2fe096efcbc287f9f45b6c9444df488b84328c5db53b4b960445af3de1d7dfa5";
+    url = "https://github.com/ros2-gbp/gz_gui_vendor-release/archive/release/rolling/gz_gui_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "49066d2a016878522604d87c8763f454e2088053439908031b15f5b850d594ed";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-common-vendor gz-math-vendor gz-msgs-vendor gz-plugin-vendor gz-rendering-vendor gz-tools-vendor gz-transport-vendor gz-utils-vendor protobuf qt5.qtbase qt5.qtcharts qt5.qtdeclarative qt5.qtgraphicaleffects qt5.qtlocation qt5.qtpositioning qt5.qtquickcontrols qt5.qtquickcontrols2 tinyxml-2 ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-gui9 9.0.0
+    description = "Vendor package for: gz-gui9 9.0.1
 
     Gazebo GUI : Graphical interfaces for robotics applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-launch-vendor/default.nix
+++ b/distros/rolling/gz-launch-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, binutils, cmake, gflags, gz-cmake-vendor, gz-common-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-plugin-vendor, gz-sim-vendor, gz-tools-vendor, gz-transport-vendor, libwebsockets, libyaml, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-launch-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/rolling/gz_launch_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "0cfe22fb99ce95e6e9734b0f73ed992bd42414b6ca3db3b643c4cab4602bdaa7";
+    url = "https://github.com/ros2-gbp/gz_launch_vendor-release/archive/release/rolling/gz_launch_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "7e7f7e96b3ca2e86698b293d4af4cee61c78ea4b1021159a757758d55cb7fa29";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
   propagatedBuildInputs = [ binutils gflags gz-cmake-vendor gz-common-vendor gz-gui-vendor gz-math-vendor gz-msgs-vendor gz-plugin-vendor gz-sim-vendor gz-tools-vendor gz-transport-vendor libwebsockets libyaml tinyxml-2 util-linux xorg.libXi xorg.libXmu ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-launch8 8.0.0
+    description = "Vendor package for: gz-launch8 8.0.1
 
     Gazebo Launch : Run and manage programs and plugins";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-math-vendor/default.nix
+++ b/distros/rolling/gz-math-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, eigen, gz-cmake-vendor, gz-utils-vendor, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-gz-math-vendor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "c4a25fec0fd0f06cc8fd3334afb76309e98fd9245aca940b33434c96a2d39457";
+    url = "https://github.com/ros2-gbp/gz_math_vendor-release/archive/release/rolling/gz_math_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "ac6682e6308295beca3e6787a11049ecd3f882068592ce7539416ff9f4e987ad";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-math8 8.1.0
+    description = "Vendor package for: gz-math8 8.1.1
 
     Gazebo Math : Math classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-physics-vendor/default.nix
+++ b/distros/rolling/gz-physics-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, bullet, cmake, eigen, gbenchmark, gz-cmake-vendor, gz-common-vendor, gz-dartsim-vendor, gz-math-vendor, gz-plugin-vendor, gz-utils-vendor, sdformat-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-physics-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "542717d8a9e56b407b8f7e6f2f9b19b022d2ad716a1f615abbdde22a2e05b670";
+    url = "https://github.com/ros2-gbp/gz_physics_vendor-release/archive/release/rolling/gz_physics_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "954167a052b611c5cf5027b4152a379179c836612f9749a69366279cd8cfc06d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ bullet eigen gbenchmark gz-cmake-vendor gz-common-vendor gz-dartsim-vendor gz-math-vendor gz-plugin-vendor gz-utils-vendor sdformat-vendor ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-physics8 8.0.0
+    description = "Vendor package for: gz-physics8 8.1.0
 
     Gazebo Physics : Physics classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-plugin-vendor/default.nix
+++ b/distros/rolling/gz-plugin-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-tools-vendor, gz-utils-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-tools-vendor, gz-utils-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-plugin-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "d1200cc4611348fdeab78a72505ad04da946430b80a01838b895c548fb689a91";
+    url = "https://github.com/ros2-gbp/gz_plugin_vendor-release/archive/release/rolling/gz_plugin_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2e3e75227c14100fae10db3255a3a7bd66382ed33a89d5755ef2c3d75354714a";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-tools-vendor gz-utils-vendor ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-plugin3 3.0.0
+    description = "Vendor package for: gz-plugin3 3.0.1
 
     Gazebo Plugin : Cross-platform C++ library for dynamically loading plugins.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-ros2-control-demos/default.nix
+++ b/distros/rolling/gz-ros2-control-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control-demos";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "2204c3b6356b9435fe35d014c27a374ac4d9233076b86c4a79569fb003d09644";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "18338cc69d1d0b0623a912779c7306c7be7882f5d02713b7be8999dfd6f7faf3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-ros2-control/default.nix
+++ b/distros/rolling/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "d4abf5981611dba361d2d17abb83a1beae45131c8a14d494e6a0a62b53c041c2";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "7d499ad8176268be7b30507c7cd95646df4fb124bd3c3ab2caf5e3daa2675326";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gz-sensors-vendor/default.nix
+++ b/distros/rolling/gz-sensors-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-common-vendor, gz-math-vendor, gz-msgs-vendor, gz-rendering-vendor, gz-tools-vendor, gz-transport-vendor, sdformat-vendor, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-sensors-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "97ed21937faf665a09a88b8fd92475e3a849a2f86b92e53f76d23af8ca85ec64";
+    url = "https://github.com/ros2-gbp/gz_sensors_vendor-release/archive/release/rolling/gz_sensors_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "349cd6327d9489f7e711bbdbe92570c7c395cbf099359497f20840efc9137a26";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint xorg.xorgserver ];
   propagatedBuildInputs = [ gz-cmake-vendor gz-common-vendor gz-math-vendor gz-msgs-vendor gz-rendering-vendor gz-tools-vendor gz-transport-vendor sdformat-vendor ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sensors9 9.0.0
+    description = "Vendor package for: gz-sensors9 9.1.0
 
     Gazebo Sensors : Sensor models for simulation";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-sim-vendor/default.nix
+++ b/distros/rolling/gz-sim-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, freeglut, freeimage, gbenchmark, glew, gz-cmake-vendor, gz-common-vendor, gz-fuel-tools-vendor, gz-gui-vendor, gz-math-vendor, gz-msgs-vendor, gz-physics-vendor, gz-plugin-vendor, gz-rendering-vendor, gz-sensors-vendor, gz-tools-vendor, gz-transport-vendor, gz-utils-vendor, protobuf, python3Packages, qt5, sdformat-vendor, tinyxml-2, util-linux, xorg }:
 buildRosPackage {
   pname = "ros-rolling-gz-sim-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/rolling/gz_sim_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "7faab833ca44044a48aaa7181604311dde2d73dc40ee5ae269ee54ab5dcb2f99";
+    url = "https://github.com/ros2-gbp/gz_sim_vendor-release/archive/release/rolling/gz_sim_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "7539357780e3a268f823f70d4a874386581e96686daa7947c743d307192d832b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint python3Packages.pytest xorg.xorgserver ];
   propagatedBuildInputs = [ freeglut freeimage gbenchmark glew gz-cmake-vendor gz-common-vendor gz-fuel-tools-vendor gz-gui-vendor gz-math-vendor gz-msgs-vendor gz-physics-vendor gz-plugin-vendor gz-rendering-vendor gz-sensors-vendor gz-tools-vendor gz-transport-vendor gz-utils-vendor protobuf python3Packages.pybind11 qt5.qtbase qt5.qtdeclarative qt5.qtgraphicaleffects qt5.qtquickcontrols qt5.qtquickcontrols2 sdformat-vendor tinyxml-2 util-linux xorg.libXi xorg.libXmu ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-sim9 9.0.0
+    description = "Vendor package for: gz-sim9 9.1.0
 
     Gazebo Sim : A Robotic Simulator";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-transport-vendor/default.nix
+++ b/distros/rolling/gz-transport-vendor/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, cppzmq, gz-cmake-vendor, gz-math-vendor, gz-msgs-vendor, gz-tools-vendor, gz-utils-vendor, pkg-config, protobuf, python3, python3Packages, sqlite, util-linux }:
 buildRosPackage {
   pname = "ros-rolling-gz-transport-vendor";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "89135ee5a0e89c429a4c21a120dd67034e551d86b6e331bdf6d66bf4dfd67a98";
+    url = "https://github.com/ros2-gbp/gz_transport_vendor-release/archive/release/rolling/gz_transport_vendor/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2cb3f6abf985d97524ff92289b6f550c0068d10410c501d2f895afaf4182fe27";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
   propagatedBuildInputs = [ cppzmq gz-cmake-vendor gz-math-vendor gz-msgs-vendor gz-tools-vendor gz-utils-vendor pkg-config protobuf python3 python3Packages.psutil python3Packages.pybind11 python3Packages.pytest sqlite util-linux ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-transport14 14.0.0
+    description = "Vendor package for: gz-transport14 14.0.1
 
     Gazebo Transport: Provides fast and efficient asynchronous message passing, services, and data logging.";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/gz-utils-vendor/default.nix
+++ b/distros/rolling/gz-utils-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-utils-vendor";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "2492872a74f68894013364c8e4cdf2d2b3a572702dea1c8c3d2511dcfac9cc09";
+    url = "https://github.com/ros2-gbp/gz_utils_vendor-release/archive/release/rolling/gz_utils_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "55d7c7860e9091e11e6cf9cc5792dd2b583db7e76c3c58f2814b030534be6f85";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: gz-utils3 3.1.0
+    description = "Vendor package for: gz-utils3 3.1.1
 
     Gazebo Utils : Classes and functions for robot applications";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/hebi-cpp-api/default.nix
+++ b/distros/rolling/hebi-cpp-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen }:
+buildRosPackage {
+  pname = "ros-rolling-hebi-cpp-api";
+  version = "3.12.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hebi_cpp_api-release/archive/release/rolling/hebi_cpp_api/3.12.3-1.tar.gz";
+    name = "3.12.3-1.tar.gz";
+    sha256 = "334b8170478fecb234b1c37f9ca6e8f3449e45a466c2192fafd8580df6291187";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ROS 2 package providing access to the HEBI C++ API.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/moveit-common/default.nix
+++ b/distros/rolling/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-common";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "54ad9060816f909b52d163b66eba3e5a84fda74801db523d8aa139a0af1d77bc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "d645439c68e814e83611988e2eb633af0811c06c5b581663006922ce333b2f40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-configs-utils/default.nix
+++ b/distros/rolling/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-configs-utils";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "2178ff878892edbe02dd9a4eb5d4cebbcaea7fa10204bb769c0bbc5705f53dad";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "5d10eb5a14f1480ff82e531175921260dd95e4725292b5f369d50760964cb375";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/moveit-core/default.nix
+++ b/distros/rolling/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-core";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "7fdc49790587c9c6f002a018c0ae1c9887af68035735461162a603a626cf5583";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "0098232912fdbed18c7bf77b8c434e3e647fd50f09677610a51f721dd57d2f41";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-hybrid-planning/default.nix
+++ b/distros/rolling/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-hybrid-planning";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "d663676bea72aee475df7a219ce5dbaacfebc55cbec6d9bf4591ca79c31df65f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "7b93840c9c5c3f16d7f88b531eba47fe3aa1e9f3802c6f7370f6299afcf7392e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-kinematics/default.nix
+++ b/distros/rolling/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-kinematics";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "a9968917ce4780d24e5b41895e6a568c68a5ccffea692d3dbdc265ef40aca911";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "f1b0be77aed8d14dc2c5970eaaf1334351a751124a7d4d98ae788e150fa561f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-chomp/default.nix
+++ b/distros/rolling/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-chomp";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "dc9caa0992d27efd930f112a6b83a220148f7965b90aa16c3e49aca2fc9854dc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "21bf6e7752aaeb3bc8ddc52f8905b3d460dfd6569a87bd1ff7d4a38e81c5e10e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-ompl/default.nix
+++ b/distros/rolling/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-ompl";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "292a13ba0df5b98880d3dd3eafc3d864d47e806e5ace9600a1a379d56351e88f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "76a2cceb2c874956a380ce52aa220309cdbce79b88c3d8463d5a7d75d9334bf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-stomp/default.nix
+++ b/distros/rolling/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-stomp";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "e1260db9522d69edcbe8865d0d3f323c733afbb628839c90c301ad54ccb396c2";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "c8e88d5dc318bc9e9ac507e63eec7a4f0a0ba0195f18b019cad2c87a2cd476f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners/default.nix
+++ b/distros/rolling/moveit-planners/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "7b01af918f03b08a54857bdb02033f231b201e097e166177e1f5fe9b5c0d901f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "cdad1eb83f1fb1720749353097eba829307128fe9c425ee4447186bde8abdb89";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ chomp-motion-planner moveit-planners-ompl moveit-planners-stomp pilz-industrial-motion-planner ];
+  propagatedBuildInputs = [ moveit-planners-chomp moveit-planners-ompl moveit-planners-stomp pilz-industrial-motion-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/moveit-plugins/default.nix
+++ b/distros/rolling/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-rolling-moveit-plugins";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "1038bf213eee4575ca62a120a9e0cb7ba12b79e06d2d174639c72e7a4003a517";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "4e33dec9bbab9a0c8bfaf27532cda9d6ea79cbfa8221ab77e4e7222d11c1a037";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-py/default.nix
+++ b/distros/rolling/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, python3Packages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-moveit-py";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "f31641d073054ae6e0710c3ae9a58d86077012c0d7fe4e2a0e3b8f08c8c46abc";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "47eeee576d4f2b2d788ed99acce0331f37b792916d7f3da1f4d1ade460baba03";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "f41f0212f256ebe92d654e04fa945bc659c2581497e6f69809dda9f26b68252b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "a2055ed0b01ac999c9379315f30a9c8ecd32b2a30d1636159ce2745b51546427";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-moveit-config";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "5cc8480c1a53d279bae91fc11e1937facca0eb89355a0893bbcb9098340ff2ce";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "e1c6caeb226bc77f45c44e8cb5f87c10b253b0d07d9d626ff070b2e18feea9a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-pg70-support";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "30a7b82f7b726f58a6ea175f6dc63bcf6b805e3e7dcbd9f7fac5d6275dbce2e9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "9efd2ef456b8f3df82c13967a13b9dd308205f0840ea71bfd50a3acaa9c2fe43";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-support";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "018e1633feac56d40ae5fe36e3480d4788980bd0e483e39e26bdc47bf6b5864d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "f42624e2e2f9f66df8a248d7b65dac0c823f9be5a7f3a1544c4a4492811d8200";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-benchmarks/default.nix
+++ b/distros/rolling/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-benchmarks";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "e4942ca790c3cc1f3447e58bc043ed1260c7386c5d819b22f0919c8a74784e05";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "0a46220311a59d37f9aa8594d21385b128c425268ef2c547e41497a14fd4a806";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-control-interface/default.nix
+++ b/distros/rolling/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-control-interface";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "e13a8f6d4ef10d5902f823a6fa94e593b552453755745161f4009eab9ec45d1c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "ded06a0df66d914236fa02813d53cd805f93e18ebd27449e5eab010244b0eba9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-move-group/default.nix
+++ b/distros/rolling/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-move-group";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "3b742876f9df211f322e1e527715a2226abc5df03e2cc1ad79b77a0f3537d9a6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "2ed99651b88d5685e298b3eb3b080e579e20a270d2134391ae8544ceca609373";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-occupancy-map-monitor";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "89112a55cff24e233aa624ccf6a451758fb2b05d0b88b0ef5b29fe9f4f8a6dd6";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "1128fea3213584436bb2748a0c10babfa98190fd876f99b18a69730a9f9403c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-perception/default.nix
+++ b/distros/rolling/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-perception";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "7bc1be20ce12a86bcd25c00ca50968c4db3f29290e5d1e6feb3b523d82a2c9e8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "3e29f6f2efdb8fc3ec4bc0ad40aa767d5d8bf11358a074db4b6a6d5520a8938b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning-interface/default.nix
+++ b/distros/rolling/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning-interface";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "f64b35b9981258b91feeb395dc0232175e8c194b470ec30ad6f32e52132d0624";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "fdd3e99c7e54379fe10b1821dde0222d0f33e2a0970c0d2d586c14439705b2a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning/default.nix
+++ b/distros/rolling/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "aedd36434ea451a73b8b91c1f76f64e74f77ab616b7e8d08a03fb87cbe7a858e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "3c573a0d0cb4fb363fe2d9d908f8cca2dca0bb40cb14d883e53e4018159ff6a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-robot-interaction/default.nix
+++ b/distros/rolling/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-robot-interaction";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "05af5175fe28af7afd22e0cffc04ad931ee4dcb121fc2d6185f204f96139291f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "3c0f110397d59882700c82be65bb641dfc0a799790bc05c2ef7884f9da973f49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-tests/default.nix
+++ b/distros/rolling/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-tests";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "ddea99b80a5c3bc757914396d4d44a0ccbff066953689656b373ed9fd2ef1720";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "4bc22261df5b84c0378f85c3eeedc9f3fb8a4faea44a6fca702498cd2073a18b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-trajectory-cache/default.nix
+++ b/distros/rolling/moveit-ros-trajectory-cache/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-trajectory-cache";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "bef972faecede8132d519468ed444f10d5231c3fb6cee1478409da9f76421493";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "9214e8e4b643d5cb8513c08cf6d28e7c907d57b87a501988ac724947c1ffae2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-visualization/default.nix
+++ b/distros/rolling/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-visualization";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "9e2f1cfd5217337c1ec73b5662507ec238904b9a1c894794a48b12a83b673ac8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "01874472f2d82d0ea202abb71406e53ea33b34823bc5cd84d46940f0ec008974";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-warehouse/default.nix
+++ b/distros/rolling/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-warehouse";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "62a8619e75fa7c3ebf746f1a8ca2bdab99b87ba2305ec14def179e1582213c39";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "9dc06b4b20e1fa054e4602d54bc8c4e6197653203cbcc5992001313e624607fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros/default.nix
+++ b/distros/rolling/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "138ee2bcc379ce5a83a911c650bd3a478488dbe6f88f494f4ac079e8307e5f57";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "e721ef516962c98fe2420363242e5c8534180bc1243a9c373d330ead2b4a4cd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-runtime/default.nix
+++ b/distros/rolling/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-runtime";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "542f8f0ba9c1ceb3b46d34990e8e4484b153b8dcb4e78b2f19dde34a1ad07e66";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "4a838c7ed6b78e6feee48d7003712a25d5006191b41f4388e2839dc338760a13";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-servo/default.nix
+++ b/distros/rolling/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-servo";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "fa8b7ce35a044e8118d87b7e43f3d28b52305339f44a833d277ba3dda0382e1d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "923ad1570ffc7a44e3a185cf4110ac56e4dc13b237162fcafb5da03d158319e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-app-plugins/default.nix
+++ b/distros/rolling/moveit-setup-app-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-app-plugins";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "522ceb10b14b3900b8b10c25f39bf5c172b6a52fa40158a23bfa34e38108dd0b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "c4fd8c2678a1d772aff0b02d9c948fcd1d20d7f385527451f5444ae249da3b30";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-assistant/default.nix
+++ b/distros/rolling/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-assistant";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "5e62ded452bc82cad9a97918bb3814e5a662259537f0e8dec1d6cf1aabc54237";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "53ad4563e17f19904e72b336d3a305a2ec773ed80635d96df3cfb211323a9dd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-controllers/default.nix
+++ b/distros/rolling/moveit-setup-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-controllers";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "dd164cccb417169daac6cb037bf99d322536656a348f1299efb74b404840f192";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "61ffa51687c4e41a5fde71346797cc676f131fc2653edba12eca5d16cc5965eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-core-plugins/default.nix
+++ b/distros/rolling/moveit-setup-core-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-core-plugins";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "f2a1fd78ed9fe870e603acaf8ff4da830bd1eb63ef9478edb9fd3db217d78259";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "5a8965f5520c3b71baf2ede734791ba01ad7a20a13fd5ed9dd723bb30e4cc539";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-framework/default.nix
+++ b/distros/rolling/moveit-setup-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-framework";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "e8d016f729f6a44942a7c5995363da8f1e9b02864a416e286572f703c7b9615a";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "323c0d535423c190184864fa6210ef4ec88c40bf7993868db062e402c38c8d96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-srdf-plugins/default.nix
+++ b/distros/rolling/moveit-setup-srdf-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-srdf-plugins";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "ad7b5dceecfe108c9cddbfdf02967d310d4bbc60edea226cd93be6a4b56f3a5d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "2fb54bd97a8ec65cdc8082fbe672ce3e904983639327c8732850f83352efefa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-simple-controller-manager/default.nix
+++ b/distros/rolling/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-moveit-simple-controller-manager";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "43350bd7c18d2cc47e0d49d0f21e8191b6fc53538929137a63faea6c6b79b18b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "a76345a0c30459a217a5820ebdeef09efbec93f5e1dc5b255d45b9fabfcd72bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit/default.nix
+++ b/distros/rolling/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-rolling-moveit";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "140c0cc94a99977306d4cf9a24a1fa67b025b0fb6f3c098e3f303f7dfee56653";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "466c4314d986ea9b767966cef928b0f935dffe9c8beed49c75f31172f750d466";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner-testutils";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "f5f05e95422e9fd4a3a44c22c6ba0d5afa85a7faec5d8bd5c4f71f18a8c4fe90";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "f1d8a67b41ef9a555b10b24a56fbc48db921c9d287cd53bb2be111d94acacc4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "af62fdbf20db02509b4d946d4d2c8872f26d10f25c1f29252b92f5968da656f2";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "148952aa1762970f501890b685db4f119078db4f983685550ebf2a2da3bb850e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pinocchio/default.nix
+++ b/distros/rolling/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-pinocchio";
-  version = "3.3.0-r1";
+  version = "3.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "968a0cee179dc4ebbd6774428f3cca4f6cc8779e2844388b7b13dffb1eaf1dd5";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/3.4.0-2.tar.gz";
+    name = "3.4.0-2.tar.gz";
+    sha256 = "9b02078ce110d04b6ce0a3a263e99b8b7dcd94c25392fb135ee34d8f776a236d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/realtime-tools/default.nix
+++ b/distros/rolling/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-realtime-tools";
-  version = "4.0.0-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "5633a1881974fc63544b5fbf26b158806ce6c68a4e1da743ede334b944e4faaf";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "bbd3ffd8db645604a4199db9ad13206e32323ca4c3c9a8c1d71baf70a5b22425";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-connextdds-common/default.nix
+++ b/distros/rolling/rmw-connextdds-common/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds-common";
-  version = "0.25.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/0.25.0-1.tar.gz";
-    name = "0.25.0-1.tar.gz";
-    sha256 = "22a674f280a37fb473439f328e50e3953dcb087e40d8c2b342734830c0fd907d";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds_common/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "37a48473ef0bc3e1fc66c105cd3c492165b7c91e6027c335b05808ca7b44dfe0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake fastcdr rcpputils rcutils rmw rmw-dds-common rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp rti-connext-dds-cmake-module tracetools ];
+  propagatedBuildInputs = [ ament-cmake fastcdr rcpputils rcutils rmw rmw-dds-common rmw-security-common rosidl-runtime-c rosidl-runtime-cpp rosidl-typesupport-fastrtps-c rosidl-typesupport-fastrtps-cpp rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp rti-connext-dds-cmake-module tracetools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rmw-connextdds/default.nix
+++ b/distros/rolling/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-connextdds";
-  version = "0.25.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/0.25.0-1.tar.gz";
-    name = "0.25.0-1.tar.gz";
-    sha256 = "023f9c3709eb0e36f794c0fed335f5eaf8211f19bf72df32500a7cc4d05388bb";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rmw_connextdds/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b9e3e4c8516ebb3111dfbcc48245636a84b74321d25e74fe821c8ad52cc77fbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "3.2.0-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "11593425d59b0c3fc8c7858d68b5fcc07c403e31bc12f9b5081e20d1b8caa49e";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "4d1b0bf15ad62c7fdd42600585248c00c3862a69e7c54b3602cc49b0a9205561";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cyclonedds iceoryx-binding-c rcpputils rcutils rmw rmw-dds-common rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
+  propagatedBuildInputs = [ cyclonedds iceoryx-binding-c rcpputils rcutils rmw rmw-dds-common rmw-security-common rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp tracetools ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rmw-dds-common/default.nix
+++ b/distros/rolling/rmw-dds-common/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rmw-security-common, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-c, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-dds-common";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "e7a79f60b3d08471dac6a608cc46af295a6e8dd61307e174cbda3cca7c08e2eb";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/rolling/rmw_dds_common/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "3467e2a6ce610ba1d5ac6ddd396f4b34531df24f262e588753f293c2cce82bb7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common osrf-testing-tools-cpp performance-test-fixture ];
-  propagatedBuildInputs = [ rcpputils rcutils rmw rosidl-default-runtime rosidl-runtime-c rosidl-runtime-cpp ];
+  propagatedBuildInputs = [ rcpputils rcutils rmw rmw-security-common rosidl-default-runtime rosidl-runtime-c rosidl-runtime-cpp ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/rmw-implementation-cmake/default.nix
+++ b/distros/rolling/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation-cmake";
-  version = "7.6.0-r1";
+  version = "7.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.6.0-1.tar.gz";
-    name = "7.6.0-1.tar.gz";
-    sha256 = "f2b1ea7fbd528106df65d2887cc75a9465a0c38f043ef6bb3b480c6f75173f1d";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.7.0-1.tar.gz";
+    name = "7.7.0-1.tar.gz";
+    sha256 = "243c8a4ef50acb160192772982d0c69a60579eaf53fb5332dd08bf5d9d71e2fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-security-common/default.nix
+++ b/distros/rolling/rmw-security-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rcutils, rmw }:
+buildRosPackage {
+  pname = "ros-rolling-rmw-security-common";
+  version = "7.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_security_common/7.7.0-1.tar.gz";
+    name = "7.7.0-1.tar.gz";
+    sha256 = "cdb11636ce9d0386e3246fc62f527b0ef510dc83840f6d86525e3a08593ae724";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rcutils rmw ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Define a common rmw secutiry utils";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/rmw-zenoh-cpp/default.nix
+++ b/distros/rolling/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rmw-zenoh-cpp";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "531f69a9f8ba6f756dda5273c5aa3613b75c51bd3c4d08df5405f8ac487ddef7";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "25f5965261e683b326cab4d640f4c1160cecb154b43eb9011e7d5fa623e6b735";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw/default.nix
+++ b/distros/rolling/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rmw";
-  version = "7.6.0-r1";
+  version = "7.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.6.0-1.tar.gz";
-    name = "7.6.0-1.tar.gz";
-    sha256 = "104ce4a359557abb68db87f127a0242dd397a8c307db69a0c3b724ee53609d56";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.7.0-1.tar.gz";
+    name = "7.7.0-1.tar.gz";
+    sha256 = "d1dbf81a01185e12a6377f80015fdd87649c88f6ac4d0afa1d2227084eae2938";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rti-connext-dds-cmake-module/default.nix
+++ b/distros/rolling/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rti-connext-dds-cmake-module";
-  version = "0.25.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/0.25.0-1.tar.gz";
-    name = "0.25.0-1.tar.gz";
-    sha256 = "65b65fa0cd41a32b89fbd99a64ab844e0195744cfc978753bd9e49b43e76281a";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/rolling/rti_connext_dds_cmake_module/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fcc8cfc8a9b17a9446699fbb7eb3b96c8a1ee43388830fa6ba340588ff87f551";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sdformat-vendor/default.nix
+++ b/distros/rolling/sdformat-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, gz-cmake-vendor, gz-math-vendor, gz-tools-vendor, gz-utils-vendor, libxml2, python3Packages, tinyxml-2, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-sdformat-vendor";
-  version = "0.2.3-r2";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.3-2.tar.gz";
-    name = "0.2.3-2.tar.gz";
-    sha256 = "c157c281b1c38b716277e21c8b5dc3737cf932044756e7e97a95744840b704d0";
+    url = "https://github.com/ros2-gbp/sdformat_vendor-release/archive/release/rolling/sdformat_vendor/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "440648415c3e9ec178f45f23ae7b6903f7d4ce6db4d8a0edbc46f3315b71cdc6";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake ];
 
   meta = {
-    description = "Vendor package for: sdformat15 15.1.1
+    description = "Vendor package for: sdformat15 15.2.0
 
     SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications";

--- a/distros/rolling/simple-launch/default.nix
+++ b/distros/rolling/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-simple-launch";
-  version = "1.10.1-r1";
+  version = "1.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/rolling/simple_launch/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "81c3be980f4744d43cf2c639b96c4f74a8f523804f70bb2f3039bd0463ad6cfc";
+    url = "https://github.com/ros2-gbp/simple_launch-release/archive/release/rolling/simple_launch/1.11.0-1.tar.gz";
+    name = "1.11.0-1.tar.gz";
+    sha256 = "92a74096cef42082aaf90f52861d48cd44035b2c5736201e5860d22427397a40";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools-interfaces/default.nix
+++ b/distros/rolling/topic-tools-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools-interfaces";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "467d7335d17ff7393d30e18e3c715205fc9871f0b4c7513bc95ceef8c6cecb4c";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools_interfaces/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "5fe77f7ff5b4833b120e6922f3e4d6503638d38d2f7bab933e75a215548f20d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/topic-tools/default.nix
+++ b/distros/rolling/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclpy, ros2cli, rosidl-default-generators, rosidl-runtime-py, std-msgs, topic-tools-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-topic-tools";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "aa3765821ae635bf6a873f4f5ceacfb570e2ac2349e1dad431dfc4dd1b081ce1";
+    url = "https://github.com/ros2-gbp/topic_tools-release/archive/release/rolling/topic_tools/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "c43f8287fa40242b4cbc3120c7d37a6c56d5a1a52cc9fdd2177ba186c7d6d850";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/turtlebot3-msgs/default.nix
+++ b/distros/rolling/turtlebot3-msgs/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-turtlebot3-msgs";
-  version = "2.2.1-r4";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/rolling/turtlebot3_msgs/2.2.1-4.tar.gz";
-    name = "2.2.1-4.tar.gz";
-    sha256 = "2512d1abe8a0c3c465c4a77f3a202453ec122f56d4edc3ce57f4c9e394f807e5";
+    url = "https://github.com/ros2-gbp/turtlebot3_msgs-release/archive/release/rolling/turtlebot3_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "10bcdbd35ff7de376ed84b05fd93ee33ccaeb87c1a974dfa1478d26987fdaec2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
-    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS2";
+    description = "Message and service types: custom messages and services for TurtleBot3 packages for ROS 2";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.6.0-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "1342ea8513e80e5ac898c074e156c4b4a095f377ef990d194b03a71e06b6d699";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "b4805b99f81504c19236dd92328dc0b045e919f3ecbef04263c80e2d7df39e81";
   };
 
   buildType = "cmake";

--- a/distros/rolling/webots-ros2-control/default.nix
+++ b/distros/rolling/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, ros-environment, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-control";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "bf409bef7ab0bc06f18b89f5db7164ff4383cc025d63c4f79c5dea174a0ca0db";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_control/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "f3248f0c9f2833043fffff0d3097577b9f70b3f799563e024a6918b14a16225f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-crazyflie/default.nix
+++ b/distros/rolling/webots-ros2-crazyflie/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, rclpy, tf-transformations, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-rolling-webots-ros2-crazyflie";
+  version = "2025.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_crazyflie/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "886a9b4708a7133d2e19426ee14305a00cb53578fac399fffac5f9dd1de210ae";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy tf-transformations webots-ros2-driver ];
+
+  meta = {
+    description = "ROS2 package for Crazyflie webots simulator";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/webots-ros2-driver/default.nix
+++ b/distros/rolling/webots-ros2-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, pluginlib, python-cmake-module, rclcpp, rclpy, ros-environment, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-importer, webots-ros2-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-driver";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "03e07b6b1496ca26d0bdb508cc54d570a7f9dc13c66005bd1b8c2875b4839d09";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_driver/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "d61a2c0414a4bc1e8e3e728d77e0a2d8d9ebb2fdf0559eea199f5d0cf3f31c2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-epuck/default.nix
+++ b/distros/rolling/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, nav-msgs, python3Packages, rclpy, robot-state-publisher, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-control, webots-ros2-driver, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-epuck";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "5b35066fe8015309e635635e28a15c1b4d2e06e6b3778d04e6808d633548bfec";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_epuck/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "f8b425d5daa4c1128814d88279e21019c70d15c62f380751afdb12c810c2d596";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-husarion/default.nix
+++ b/distros/rolling/webots-ros2-husarion/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, controller-manager, diff-drive-controller, joint-state-broadcaster, laser-filters, robot-localization, robot-state-publisher, webots-ros2-control, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-rolling-webots-ros2-husarion";
+  version = "2025.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_husarion/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "a4870aa48e266c37028c09811306de4343ec39a72f9d0efdbbec222e26962442";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-broadcaster laser-filters robot-localization robot-state-publisher webots-ros2-control webots-ros2-driver ];
+
+  meta = {
+    description = "Husarion ROSbot 2R and XL robots ROS2 interface for Webots.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/webots-ros2-importer/default.nix
+++ b/distros/rolling/webots-ros2-importer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-importer";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "f0eadb664b9f4d23e638c5578c17bcab3ed983bb3348338704bd70f8d6144f8d";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_importer/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "215f3b3233f559c45518e535549c456e334eb6d9af0b0d9e53336adee6810045";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-mavic/default.nix
+++ b/distros/rolling/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-mavic";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "cca601ccde4e61f932050b51b86769324c565c917a072d93bf888ed22e3e1096";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_mavic/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "adfa50372233f660146c5d5e506dce00c9f93e42862322c8091ffc3d6772fcb4";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-msgs/default.nix
+++ b/distros/rolling/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-msgs";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "2abda887078365784efede179bd82a7319ef444524b62047917b5282c0f91417";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_msgs/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "79e33c18b043c05ce9cb9e72ed72dcb6ca94a50cae2ba7bcabdffd2ee7993d10";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/webots-ros2-tesla/default.nix
+++ b/distros/rolling/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, builtin-interfaces, python3Packages, rclpy, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tesla";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "0c2b24aca5e8123552832c9ed8801062ba61fef29cf14d3d54d2396b51cb8114";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tesla/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "c6a6eca61383ae0d0a19439fb50815042bff72f815f08ccaeb4eb475d90ee574";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-tests/default.nix
+++ b/distros/rolling/webots-ros2-tests/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2bag, rosbag2-storage-default-plugins, sensor-msgs, std-msgs, std-srvs, tf2-ros, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-mavic, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tests";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "25fed7b6430c61de521b26fced53847c2c80c3657d4410a6d9f124b8b83b6c43";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tests/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "35a863bf3ea91f66bb328f0cb4b60c80acca52e6154d35b67bc610f80bbab964";
   };
 
   buildType = "ament_python";
   buildInputs = [ rclpy ros2bag rosbag2-storage-default-plugins webots-ros2-driver ];
-  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  checkInputs = [ ament-copyright geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.pytest sensor-msgs std-msgs std-srvs tf2-ros webots-ros2-epuck webots-ros2-husarion webots-ros2-mavic webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "System tests for `webots_ros2` packages.";

--- a/distros/rolling/webots-ros2-tiago/default.nix
+++ b/distros/rolling/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, geometry-msgs, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-tiago";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "88cf81bf057ff234eae42977cd6ae19d276e561eb97ff7e165f2cc012f6d824a";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_tiago/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "babfb312a31d5051d0012037e4d5e39f451adb35c1bc2b2dcec29f954e92b123";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-turtlebot/default.nix
+++ b/distros/rolling/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, controller-manager, diff-drive-controller, joint-state-broadcaster, python3Packages, rclpy, robot-state-publisher, rviz2, tf2-ros, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-turtlebot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "43a43b0b5a15a0694d72c70c382c79a2324ba41126f278e34ea0e5317cb254df";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_turtlebot/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "4cbe5a480ae8107dde3585c4b70e34ffade706b999ec9ea92a37e6cc868b22a0";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2-universal-robot/default.nix
+++ b/distros/rolling/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, control-msgs, controller-manager, joint-state-broadcaster, joint-trajectory-controller, python3Packages, rclpy, robot-state-publisher, rviz2, trajectory-msgs, webots-ros2-control, webots-ros2-driver, xacro }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2-universal-robot";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "7c2ddf4cc2325193b6060850a918457f2ef21c328f42e7be0d555f48ef6be411";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2_universal_robot/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "0ad814670a85569255ec03b794c6f2bdcadbf80c8c8ddcc198f5aba1fadebf06";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/webots-ros2/default.nix
+++ b/distros/rolling/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-driver, webots-ros2-epuck, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, builtin-interfaces, python3Packages, rclpy, std-msgs, webots-ros2-control, webots-ros2-crazyflie, webots-ros2-driver, webots-ros2-epuck, webots-ros2-husarion, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tests, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-rolling-webots-ros2";
-  version = "2023.1.3-r1";
+  version = "2025.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2023.1.3-1.tar.gz";
-    name = "2023.1.3-1.tar.gz";
-    sha256 = "88d045b361d88db007d35c71710f67a9940a6b4c7df076eeba781a962365ea97";
+    url = "https://github.com/ros2-gbp/webots_ros2-release/archive/release/rolling/webots_ros2/2025.0.0-1.tar.gz";
+    name = "2025.0.0-1.tar.gz";
+    sha256 = "4a82ff4554fd4259a362611a2c4d60ca8f24dc5f4330fa37a07f8800f96ebcb5";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright python3Packages.pytest webots-ros2-tests ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-driver webots-ros2-epuck webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-control webots-ros2-crazyflie webots-ros2-driver webots-ros2-epuck webots-ros2-husarion webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-universal-robot ];
 
   meta = {
     description = "Interface between Webots and ROS2";

--- a/distros/rolling/zenoh-cpp-vendor/default.nix
+++ b/distros/rolling/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-rolling-zenoh-cpp-vendor";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "03e737f5a7c42fc656aef6ec9ec6500e77d857189d32fb3509c8e6ff2d7c450a";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "f8a3750e8140906da727158d93b33db008ea8e73007c5afac7ed6eb50a1e0650";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 711d683bc2540539d1d2456f488a506272842734.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.41.0-r1 --> 2.42.0-r1*
* *admittance-controller 2.41.0-r1 --> 2.42.0-r1*
* *apriltag 3.4.2-r1 --> 3.4.3-r1*
* *bicycle-steering-controller 2.41.0-r1 --> 2.42.0-r1*
* *camera-calibration-parsers 3.1.10-r1 --> 3.1.11-r1*
* *camera-info-manager 3.1.10-r1 --> 3.1.11-r1*
* *camera-info-manager-py 3.1.10-r1 --> 3.1.11-r1*
* *coal 3.0.0-r1 --> 3.0.1-r1*
* *depthai-bridge 2.10.5-r1 --> 2.11.0-r1*
* *depthai-descriptions 2.10.5-r1 --> 2.11.0-r1*
* *depthai-examples 2.10.5-r1 --> 2.11.0-r1*
* *depthai-filters 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-driver 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-msgs 2.10.5-r1 --> 2.11.0-r1*
* *diff-drive-controller 2.41.0-r1 --> 2.42.0-r1*
* *dynamixel-hardware-interface 1.3.0-r1*
* *dynamixel-interfaces 1.0.0-r1*
* *dynamixel-sdk 3.7.60-r1 --> 3.8.1-r1*
* *dynamixel-sdk-custom-interfaces 3.7.60-r1 --> 3.8.1-r1*
* *dynamixel-sdk-examples 3.7.60-r1 --> 3.8.1-r1*
* *effort-controllers 2.41.0-r1 --> 2.42.0-r1*
* *eigenpy 3.8.2-r1 --> 3.10.3-r1*
* *etsi-its-cam-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-ts-coding 3.1.0-r1*
* *etsi-its-denm-ts-conversion 3.1.0-r1*
* *etsi-its-denm-ts-msgs 3.1.0-r1*
* *etsi-its-mapem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-messages 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs-utils 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-primitives-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-rviz-plugins 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *force-torque-sensor-broadcaster 2.41.0-r1 --> 2.42.0-r1*
* *forward-command-controller 2.41.0-r1 --> 2.42.0-r1*
* *gpio-controllers 2.41.0-r1 --> 2.42.0-r1*
* *gripper-controllers 2.41.0-r1 --> 2.42.0-r1*
* *gz-ros2-control-tests 0.7.11-r1 --> 0.7.12-r1*
* *ign-ros2-control-demos 0.7.11-r1 --> 0.7.12-r1*
* *image-common 3.1.10-r1 --> 3.1.11-r1*
* *image-transport 3.1.10-r1 --> 3.1.11-r1*
* *imu-sensor-broadcaster 2.41.0-r1 --> 2.42.0-r1*
* *joint-state-broadcaster 2.41.0-r1 --> 2.42.0-r1*
* *joint-trajectory-controller 2.41.0-r1 --> 2.42.0-r1*
* *kitti-metrics-eval 1.6.0-r1 --> 1.6.1-r1*
* *mola 1.6.0-r1 --> 1.6.1-r1*
* *mola-bridge-ros2 1.6.0-r1 --> 1.6.1-r1*
* *mola-demos 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-euroc-dataset 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-kitti-dataset 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-kitti360-dataset 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-mulran-dataset 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-paris-luco-dataset 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-rawlog 1.6.0-r1 --> 1.6.1-r1*
* *mola-input-rosbag2 1.6.0-r1 --> 1.6.1-r1*
* *mola-kernel 1.6.0-r1 --> 1.6.1-r1*
* *mola-launcher 1.6.0-r1 --> 1.6.1-r1*
* *mola-metric-maps 1.6.0-r1 --> 1.6.1-r1*
* *mola-msgs 1.6.0-r1 --> 1.6.1-r1*
* *mola-pose-list 1.6.0-r1 --> 1.6.1-r1*
* *mola-relocalization 1.6.0-r1 --> 1.6.1-r1*
* *mola-traj-tools 1.6.0-r1 --> 1.6.1-r1*
* *mola-viz 1.6.0-r1 --> 1.6.1-r1*
* *mola-yaml 1.6.0-r1 --> 1.6.1-r1*
* *pid-controller 2.41.0-r1 --> 2.42.0-r1*
* *pinocchio 3.3.0-r1 --> 3.4.0-r1*
* *pose-broadcaster 2.41.0-r1 --> 2.42.0-r1*
* *position-controllers 2.41.0-r1 --> 2.42.0-r1*
* *range-sensor-broadcaster 2.41.0-r1 --> 2.42.0-r1*
* *ros2-controllers 2.41.0-r1 --> 2.42.0-r1*
* *ros2-controllers-test-nodes 2.41.0-r1 --> 2.42.0-r1*
* *rqt-joint-trajectory-controller 2.41.0-r1 --> 2.42.0-r1*
* *rtabmap-conversions 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-demos 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-examples 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-launch 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-msgs 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-odom 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-python 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-ros 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-rviz-plugins 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-slam 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-sync 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-util 0.21.9-r1 --> 0.21.10-r1*
* *rtabmap-viz 0.21.9-r1 --> 0.21.10-r1*
* *simple-launch 1.10.1-r1 --> 1.11.0-r1*
* *steering-controllers-library 2.41.0-r1 --> 2.42.0-r1*
* *tricycle-controller 2.41.0-r1 --> 2.42.0-r1*
* *tricycle-steering-controller 2.41.0-r1 --> 2.42.0-r1*
* *turtlebot3-msgs 2.2.3-r1 --> 2.3.0-r1*
* *ur-client-library 1.6.0-r1 --> 1.7.0-r1*
* *velocity-controllers 2.41.0-r1 --> 2.42.0-r1*
* *webots-ros2 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-control 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-crazyflie 2025.0.0-r2*
* *webots-ros2-driver 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-epuck 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-husarion 2025.0.0-r2*
* *webots-ros2-importer 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-mavic 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-msgs 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-tesla 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-tests 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-tiago 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-turtlebot 2023.1.3-r1 --> 2025.0.0-r2*
* *webots-ros2-universal-robot 2023.1.3-r1 --> 2025.0.0-r2*

Jazzy Changes:
--------------
* *apriltag 3.4.2-r1 --> 3.4.3-r1*
* *battery-state-broadcaster 1.0.1-r1 --> 1.0.0-r1*
* *battery-state-rviz-overlay 1.0.1-r1 --> 1.0.0-r1*
* *chomp-motion-planner 2.12.1-r1 --> 2.12.2-r1*
* *depthai-bridge 2.10.5-r1 --> 2.11.0-r1*
* *depthai-descriptions 2.10.5-r1 --> 2.11.0-r1*
* *depthai-examples 2.10.5-r1 --> 2.11.0-r1*
* *depthai-filters 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-driver 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-msgs 2.10.5-r1 --> 2.11.0-r1*
* *ds-dbw 2.3.1-r1 --> 2.3.2-r1*
* *ds-dbw-can 2.3.1-r1 --> 2.3.2-r1*
* *ds-dbw-joystick-demo 2.3.1-r1 --> 2.3.2-r1*
* *ds-dbw-msgs 2.3.1-r1 --> 2.3.2-r1*
* *dynamixel-interfaces 1.0.0-r1*
* *etsi-its-cam-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-ts-coding 3.1.0-r1*
* *etsi-its-denm-ts-conversion 3.1.0-r1*
* *etsi-its-denm-ts-msgs 3.1.0-r1*
* *etsi-its-mapem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-messages 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs-utils 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-primitives-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-rviz-plugins 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *gz-launch-vendor 0.0.4-r1 --> 0.0.5-r1*
* *gz-msgs-vendor 0.0.5-r1 --> 0.0.6-r1*
* *gz-ros2-control 1.2.10-r1 --> 1.2.11-r1*
* *gz-ros2-control-demos 1.2.10-r1 --> 1.2.11-r1*
* *gz-sim-vendor 0.0.7-r1 --> 0.0.8-r1*
* *hebi-cpp-api 3.12.3-r1*
* *moveit 2.12.1-r1 --> 2.12.2-r1*
* *moveit-common 2.12.1-r1 --> 2.12.2-r1*
* *moveit-configs-utils 2.12.1-r1 --> 2.12.2-r1*
* *moveit-core 2.12.1-r1 --> 2.12.2-r1*
* *moveit-hybrid-planning 2.12.1-r1 --> 2.12.2-r1*
* *moveit-kinematics 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners-chomp 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners-ompl 2.12.1-r1 --> 2.12.2-r1*
* *moveit-planners-stomp 2.12.1-r1 --> 2.12.2-r1*
* *moveit-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-py 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-moveit-config 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-pg70-support 2.12.1-r1 --> 2.12.2-r1*
* *moveit-resources-prbt-support 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-benchmarks 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-control-interface 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-move-group 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-occupancy-map-monitor 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-perception 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-planning 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-planning-interface 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-robot-interaction 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-tests 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-trajectory-cache 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-visualization 2.12.1-r1 --> 2.12.2-r1*
* *moveit-ros-warehouse 2.12.1-r1 --> 2.12.2-r1*
* *moveit-runtime 2.12.1-r1 --> 2.12.2-r1*
* *moveit-servo 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-app-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-assistant 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-controllers 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-core-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-framework 2.12.1-r1 --> 2.12.2-r1*
* *moveit-setup-srdf-plugins 2.12.1-r1 --> 2.12.2-r1*
* *moveit-simple-controller-manager 2.12.1-r1 --> 2.12.2-r1*
* *novatel-oem7-driver 24.0.0-r1*
* *novatel-oem7-msgs 24.0.0-r1*
* *pilz-industrial-motion-planner 2.12.1-r1 --> 2.12.2-r1*
* *pilz-industrial-motion-planner-testutils 2.12.1-r1 --> 2.12.2-r1*
* *pinocchio 2.6.21-r3 --> 3.4.0-r1*
* *realtime-tools 3.3.0-r1 --> 3.4.0-r1*
* *rmw-zenoh-cpp 0.2.1-r1 --> 0.2.2-r1*
* *simple-launch 1.10.1-r1 --> 1.11.0-r1*
* *topic-tools 1.3.2-r1 --> 1.3.3-r1*
* *topic-tools-interfaces 1.3.2-r1 --> 1.3.3-r1*
* *turtlebot3-msgs 2.2.1-r5 --> 2.3.0-r1*
* *ur-client-library 1.6.0-r1 --> 1.7.0-r1*
* *webots-ros2 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-control 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-crazyflie 2025.0.0-r1*
* *webots-ros2-driver 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-epuck 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-husarion 2025.0.0-r1*
* *webots-ros2-importer 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-mavic 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-msgs 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tesla 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tests 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tiago 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-turtlebot 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-universal-robot 2023.1.3-r1 --> 2025.0.0-r1*
* *zenoh-cpp-vendor 0.2.1-r1 --> 0.2.2-r1*

Noetic Changes:
---------------
* *depthai-bridge 2.10.5-r1 --> 2.11.0-r1*
* *depthai-descriptions 2.10.5-r1 --> 2.11.0-r1*
* *depthai-examples 2.10.5-r1 --> 2.11.0-r1*
* *depthai-filters 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-driver 2.10.5-r1 --> 2.11.0-r1*
* *depthai-ros-msgs 2.10.5-r1 --> 2.11.0-r1*
* *etsi-its-cam-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-cpm-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-denm-ts-coding 3.1.0-r1*
* *etsi-its-denm-ts-conversion 3.1.0-r1*
* *etsi-its-denm-ts-msgs 3.1.0-r1*
* *etsi-its-mapem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-mapem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-messages 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-msgs-utils 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-primitives-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-rviz-plugins 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-spatem-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-coding 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-conversion 3.0.0-r1 --> 3.1.0-r1*
* *etsi-its-vam-ts-msgs 3.0.0-r1 --> 3.1.0-r1*
* *fanuc-cr35ia-support 0.6.0-r1*
* *fanuc-cr7ia-support 0.6.0-r1*
* *fanuc-crx10ia-support 0.6.0-r1*
* *fanuc-driver 0.6.0-r1*
* *fanuc-lrmate200i-support 0.6.0-r1*
* *fanuc-lrmate200ib-support 0.6.0-r1*
* *fanuc-lrmate200ic-support 0.6.0-r1*
* *fanuc-lrmate200id-support 0.6.0-r1*
* *fanuc-m10ia-support 0.6.0-r1*
* *fanuc-m16ib-support 0.6.0-r1*
* *fanuc-m20ia-support 0.6.0-r1*
* *fanuc-m20ib-support 0.6.0-r1*
* *fanuc-m430ia-support 0.6.0-r1*
* *fanuc-m6ib-support 0.6.0-r1*
* *fanuc-m710ic-support 0.6.0-r1*
* *fanuc-m900ia-support 0.6.0-r1*
* *fanuc-m900ib-support 0.6.0-r1*
* *fanuc-r1000ia-support 0.6.0-r1*
* *fanuc-r2000ib-support 0.6.0-r1*
* *fanuc-r2000ic-support 0.6.0-r1*
* *fanuc-resources 0.6.0-r1*
* *grpc 0.0.16-r1 --> 0.0.16-r2*
* *image-transport-codecs 2.5.0-r1 --> 2.5.1-r1*
* *movie-publisher-plugins 2.0.2-r1*
* *movie-publisher-plugins-copyleft 2.0.2-r1*
* *movie-publisher-plugins-nonfree 2.0.2-r1*
* *movie-publisher-plugins-permissive 2.0.2-r1*
* *ur-client-library 1.6.0-r1 --> 1.7.0-r1*

Rolling Changes:
----------------
* *apriltag 3.4.2-r1 --> 3.4.3-r1*
* *chomp-motion-planner 2.12.0-r1 --> 2.13.0-r1*
* *dynamixel-interfaces 1.0.0-r1*
* *gz-common-vendor 0.2.2-r1 --> 0.2.3-r1*
* *gz-fuel-tools-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-gui-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-launch-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-math-vendor 0.2.2-r1 --> 0.2.3-r1*
* *gz-physics-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-plugin-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-ros2-control 2.0.5-r1 --> 2.0.6-r1*
* *gz-ros2-control-demos 2.0.5-r1 --> 2.0.6-r1*
* *gz-sensors-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-sim-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-transport-vendor 0.2.0-r1 --> 0.2.1-r1*
* *gz-utils-vendor 0.2.1-r1 --> 0.2.2-r1*
* *hebi-cpp-api 3.12.3-r1*
* *moveit 2.12.0-r1 --> 2.13.0-r1*
* *moveit-common 2.12.0-r1 --> 2.13.0-r1*
* *moveit-configs-utils 2.12.0-r1 --> 2.13.0-r1*
* *moveit-core 2.12.0-r1 --> 2.13.0-r1*
* *moveit-hybrid-planning 2.12.0-r1 --> 2.13.0-r1*
* *moveit-kinematics 2.12.0-r1 --> 2.13.0-r1*
* *moveit-planners 2.12.0-r1 --> 2.13.0-r1*
* *moveit-planners-chomp 2.12.0-r1 --> 2.13.0-r1*
* *moveit-planners-ompl 2.12.0-r1 --> 2.13.0-r1*
* *moveit-planners-stomp 2.12.0-r1 --> 2.13.0-r1*
* *moveit-plugins 2.12.0-r1 --> 2.13.0-r1*
* *moveit-py 2.12.0-r1 --> 2.13.0-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.12.0-r1 --> 2.13.0-r1*
* *moveit-resources-prbt-moveit-config 2.12.0-r1 --> 2.13.0-r1*
* *moveit-resources-prbt-pg70-support 2.12.0-r1 --> 2.13.0-r1*
* *moveit-resources-prbt-support 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-benchmarks 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-control-interface 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-move-group 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-occupancy-map-monitor 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-perception 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-planning 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-planning-interface 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-robot-interaction 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-tests 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-trajectory-cache 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-visualization 2.12.0-r1 --> 2.13.0-r1*
* *moveit-ros-warehouse 2.12.0-r1 --> 2.13.0-r1*
* *moveit-runtime 2.12.0-r1 --> 2.13.0-r1*
* *moveit-servo 2.12.0-r1 --> 2.13.0-r1*
* *moveit-setup-app-plugins 2.12.0-r1 --> 2.13.0-r1*
* *moveit-setup-assistant 2.12.0-r1 --> 2.13.0-r1*
* *moveit-setup-controllers 2.12.0-r1 --> 2.13.0-r1*
* *moveit-setup-core-plugins 2.12.0-r1 --> 2.13.0-r1*
* *moveit-setup-framework 2.12.0-r1 --> 2.13.0-r1*
* *moveit-setup-srdf-plugins 2.12.0-r1 --> 2.13.0-r1*
* *moveit-simple-controller-manager 2.12.0-r1 --> 2.13.0-r1*
* *pilz-industrial-motion-planner 2.12.0-r1 --> 2.13.0-r1*
* *pilz-industrial-motion-planner-testutils 2.12.0-r1 --> 2.13.0-r1*
* *pinocchio 3.3.0-r1 --> 3.4.0-r2*
* *realtime-tools 4.0.0-r1 --> 4.1.0-r1*
* *rmw 7.6.0-r1 --> 7.7.0-r1*
* *rmw-connextdds 0.25.0-r1 --> 1.0.0-r1*
* *rmw-connextdds-common 0.25.0-r1 --> 1.0.0-r1*
* *rmw-cyclonedds-cpp 3.2.0-r1 --> 4.0.0-r1*
* *rmw-dds-common 3.2.0-r1 --> 3.2.1-r1*
* *rmw-implementation-cmake 7.6.0-r1 --> 7.7.0-r1*
* *rmw-security-common 7.7.0-r1*
* *rmw-zenoh-cpp 0.3.1-r1 --> 0.4.0-r1*
* *rti-connext-dds-cmake-module 0.25.0-r1 --> 1.0.0-r1*
* *sdformat-vendor 0.2.3-r2 --> 0.2.4-r1*
* *simple-launch 1.10.1-r1 --> 1.11.0-r1*
* *topic-tools 1.4.1-r1 --> 1.4.2-r1*
* *topic-tools-interfaces 1.4.1-r1 --> 1.4.2-r1*
* *turtlebot3-msgs 2.2.1-r4 --> 2.3.0-r1*
* *ur-client-library 1.6.0-r1 --> 1.7.0-r1*
* *webots-ros2 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-control 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-crazyflie 2025.0.0-r1*
* *webots-ros2-driver 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-epuck 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-husarion 2025.0.0-r1*
* *webots-ros2-importer 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-mavic 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-msgs 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tesla 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tests 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-tiago 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-turtlebot 2023.1.3-r1 --> 2025.0.0-r1*
* *webots-ros2-universal-robot 2023.1.3-r1 --> 2025.0.0-r1*
* *zenoh-cpp-vendor 0.3.1-r1 --> 0.4.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_dev
 * [ ] gazebo_msgs
 * [ ] gazebo_ros
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

