### PR TITLE
Fix the changed hash of the osqp-vendor package

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -126,7 +126,7 @@ let
         rev = "v0.6.2";
         revVariable = "git_tag";
         fetchgitArgs = {
-          hash = "sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=";
+          hash = "sha256-RYk3zuZrJXPcF27eMhdoZAio4DZ+I+nFaUEg1g/aLNk=";
         };
       })
     ];

--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -127,7 +127,6 @@ let
         revVariable = "git_tag";
         fetchgitArgs = {
           hash = "sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=";
-          leaveDotGit = true;
         };
       })
     ];

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -53,7 +53,6 @@ in with lib; {
     rev = "b63a0b6f79d3ea91dc221724b42dae49894449fc";
     fetchgitArgs = {
       hash = "sha256-x9JCU2Ryssq424n90IzVOxixnvsoYTukyCOL3zNbwt4=";
-      leaveDotGit = true;
     };
   };
 

--- a/distros/jazzy/fastrtps/default.nix
+++ b/distros/jazzy/fastrtps/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/jazzy/fastrtps/2.14.4-1.tar.gz";
     name = "2.14.4-1.tar.gz";
-    sha256 = "d4e9b39d38d0a6db4296089c12cdf385d50b02061c74c8927e1fc57f2bb1f9c1";
+    sha256 = "0m7z404chrp6ii9gpr8cnfd7rfyydv12schd1s0r6gmhwis9pfvf";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -185,7 +185,6 @@ in {
     rev = "b63a0b6f79d3ea91dc221724b42dae49894449fc";
     fetchgitArgs = {
       hash = "sha256-x9JCU2Ryssq424n90IzVOxixnvsoYTukyCOL3zNbwt4=";
-      leaveDotGit = true;
     };
   };
 

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -185,7 +185,6 @@ in {
     rev = "b63a0b6f79d3ea91dc221724b42dae49894449fc";
     fetchgitArgs = {
       hash = "sha256-x9JCU2Ryssq424n90IzVOxixnvsoYTukyCOL3zNbwt4=";
-      leaveDotGit = true;
     };
   };
 


### PR DESCRIPTION
Fixes the following error:

```
error: hash mismatch in fixed-output derivation '/nix/store/11abdpwg3pjbny9bp880hrlpdm7ipan9-osqp.drv':
         specified: sha256-0BbUe1J9qzvyKDBLTz+pAEmR3QpRL+hnxZ2re/3mEvs=
            got:    sha256-DDO7CCDE2mTi/GSaD9wATxnXHvY9Ndz8WI1oQuEbxeI=
```