### PR TITLE
Fix ros-jazzy-gz-common-vendor version mismatch in cmake

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -48,8 +48,8 @@ in {
   };
 
   gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
-    version = "5.7.0";
-    hash = "sha256-RBu49rxjzo4mc7ma4WpabUxUT7cvabJRinR98it10r4=";
+    version = "5.7.1";
+    hash = "sha256-vNCjCSQYCSUHXKwXnq8vwWXiSK2+cD3yPSLT1FdAWrE=";
   }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {


### PR DESCRIPTION
Fixes this error:
```
       > CMake Error at CMakeLists.txt:114 (message):
       >   Mismatch in ros-jazzy-gz-common-vendor version (Nix: 5.7.0, upstream:
       >   5.7.1).  Fix this in overrides.nix.
```

The new hash is retrieved with `nix flake prefetch github:gazebosim/gz-common/gz-common5_5.7.1` command that returns correct old hash for the previous revision.