### PR TITLE
rosdistro sync, Fri Feb 28 13:21:12 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "67d5e815663ad338f5fa0a4aa69406289c902454798dd177b536c8b98629972f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "f505f2ca44a6a8801d62ece682b0ab17acc274e04a6e020338fb370a97e09c57";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, filters, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "de0cd3605e72b6ae95a698b387d5648d5ec20d066bbeaf9352f0cb5f75c20196";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "348cf0a412322814c6da7a9fa359a6426b903955f5637a091f693d26394c3287";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface filters generate-parameter-library geometry-msgs hardware-interface kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library geometry-msgs hardware-interface kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "53361991d490fe03e552526e65f2aef853863d831867d6801114b3bff9d2e779";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "84f31052acaf3cd036ee22aef52a7a2e461a62e1af1650a6502769155bbe3a6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "25f476e613c2dfc2ab5ac1c0525f6a421ccca06f8a5219a69d6e7ba238e41832";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "e5d2f0c2a0bab6b1a7a0bf47b51e75d621370b51c7f4dd77db2260a60c78ef2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-workbench-msgs/default.nix
+++ b/distros/humble/dynamixel-workbench-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-workbench-msgs";
-  version = "2.0.3-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/humble/dynamixel_workbench_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "eb9b0c36bf9594621e8afb7c7fa3218bc1f5069515d8616bb5d8efc9e6663222";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/humble/dynamixel_workbench_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "e6157799919ebd1b39d28af1573d39583fb5a48f537e45556a2a614b80f2bb5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "033f73774fc6b82122a50989f4982e29ccd0baf27cbbdd6a0e49ba17c71b81dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "82a804374163c8863fdc4552516ef7bcc0bdbb6e95cb7b6c19cfc7463cf93a20";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fastrtps/default.nix
+++ b/distros/humble/fastrtps/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/humble/fastrtps/2.6.9-1.tar.gz";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/humble/fastrtps/2.6.9-1.tar.gz";
     name = "2.6.9-1.tar.gz";
-    sha256 = "05cb89165ef4476c59e7f56d645dfe10a4a03924bf22aa3038ede50d174f7dd9";
+    sha256 = "b407e603155a2d2bd9bfa963e052e8dc62d1fecd6261314c41fea5de47ee550e";
   };
 
   buildType = "cmake";

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "b447c2250bdca6dd6616baccecf0da6a093d9368328a9dbd61e104530eae97db";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "fb6de7d2f42f1d29a42a186fc70c5c60f951e6ad06a9eb23ec7f160c3c019f69";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "8ff32f363c5f28db9aada3d2dd138bfd938466f3ed6a41ef604462914d373f8d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "d735add91efc7329953c76f229e61562cb6701d77591ab4116734ee152ebe83d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1648,6 +1648,8 @@ self: super: {
 
  mola-demos = self.callPackage ./mola-demos {};
 
+ mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
+
  mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
 
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
@@ -3147,6 +3149,8 @@ self: super: {
  swri-system-util = self.callPackage ./swri-system-util {};
 
  swri-transform-util = self.callPackage ./swri-transform-util {};
+
+ synapticon-ros2-control = self.callPackage ./synapticon-ros2-control {};
 
  sync-parameter-server = self.callPackage ./sync-parameter-server {};
 

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "29e813af7ecdab9e30559bc4b154a078508988e2ce99852db7a4afaaa9dada92";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "a8973fb383e81746a1b3f9548be2658a1a33e37a61c93f1b1111416d7e2bf648";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "6264afea72db38e74c9fa1d2756ee25618172d9e896cad9935250aec6e7e52a7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "fef863187b2038112cd43393d5b248137e5045357c059e03d2621af1f2325c09";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hls-lfcd-lds-driver/default.nix
+++ b/distros/humble/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-hls-lfcd-lds-driver";
-  version = "2.0.4-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/humble/hls_lfcd_lds_driver/2.0.4-3.tar.gz";
-    name = "2.0.4-3.tar.gz";
-    sha256 = "4ccdcb3e3af90bcc365752b031aa9ae6770ecd63fbd56320a1a9accdc63fd779";
+    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/humble/hls_lfcd_lds_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "35f931ea29ec14a41d986da9204569bc194eea0a701030197836eb50e73d0285";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ROS package for LDS(HLS-LFCD2).
+    description = "ROS package for LDS-01(HLS-LFCD2).
     The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.";
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "f2781dd52d38ad16401237f417fb3abfc2fa650986362cc5f833fa80f9f26ad7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "644034e0350a158962c33a0ae91a53b6ad7a4909896558cfbf9c8dbfd6742ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "f87f8957358eabcdf79e5d099721e4cee49104147b17928b09f717f5c20e92a4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "2cb68ff19d2588115fb6493a28c6594ad69cdfb71dad6117c518468f9f6f8bdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "6a2aff4fc2cf48e92772b584be90dadd9f07aa0c96c43b552d7554f1686b72b5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "b5920766ac7ba7a310ece1c16b9c96fb2ba592fe70430c32d2d459db86b7abff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "bde66d80ba3b09f33a8345edc55dcc93e1585bcc14b5c703504f0d1c3b0757b5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "a8abc79c0148c824ad422b862dae6e3623966fad1aef2c490eabc81c0ac44497";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "704fbc2ba49faba0496001fd54206f3c58a8c9046fb8e466daa45f5f643ad8eb";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "012e0ee129d48b13b522b819014f85fddb6ca8cc6e7d0f41b3c430658355cc15";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "8bebc6da2315bbff1d53215f8996cf5c3819c06e374b737b368d27cefed7dc96";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "d5b2b3cf513d44fa1f7e85e9c2283c5c436474243067a770b2871fd6bf17cbff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-gnss-to-markers/default.nix
+++ b/distros/humble/mola-gnss-to-markers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libobs, mrpt-nav-interfaces, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-humble-mola-gnss-to-markers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_gnss_to_markers-release/archive/release/humble/mola_gnss_to_markers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6bf414c85555c84b01c4e1736c33ad2125afdbbecc4e461c0dbdd8f63b9dcc69";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mrpt-libobs mrpt-nav-interfaces rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Takes GNSS (GPS) readings, a MOLA georeferenced map, and publishes markers to visualize the datums as ellipsoids on the map";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "6efb6fa59c906089d6c58777460fa4bba121f00ec933d92c621a310c18dabb31";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "aef4a832494240d9b53aebb7ff4b6d34f6e8d1c86de8a8a75af767dadb3a048d";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "21c448a4f2bfc5a2053ee56b2b713a438200bffbf76a00d32f702e80b997c018";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "12c80d7e7beeaf2f454a784b41ad4affc7d2c27d11e862ce722af26e578b5cf6";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "d06f01bcf5bb3a69d1c95b5d5f062395adf0285314c37a55bfdec263a2c590e3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "fa943a54348d715b5bd3429343e7c4161f2d0ba0a273c98daf77d5b656976f8c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5356ca1d2a6d3c0681676f37ddacd2a553d063f498d6a179942c197636ee62bf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "a1033df07e68f2971063d5ea6ca4fecc34f716fec2c5e28228bfc50631d48720";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "1294fc96ac60a2475ef35aa357ba59ba70aa59fdc0ce8badbe4fc73d796f63d3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ad088afc17688d00f683b6431476939d0398662e7f6e8739e1c330920c420bf0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5ed912baf67ec567bccc1c7a07c8ad019c606d69ccd7884f1ec7f0d3e2d7753d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "674c5261bacb364c97a49cbfdee6f24b02b5a7188a4d5625d08355d8b935c61e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "f90e49a8a72128a44fe3d9f7e733671564877afee63c8464574f3d0f00713ac9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "beb854376eeba791a55bc1acc658ed8bcf807035b7228978b8f8f0e5b503db26";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "ea734da85a9bd9197e6cc09e6f6a13e757d4f0678904b7de91315bebaac0e3dc";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "3588e335f510ff6f524f5933e3dd2bcd6d073e27f44a454782ba9f5ab4bfee31";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "7f8ba1af6177fe5995b6a1b1e6dfa57a155cf7e5ecf39e41b854dc26ec55a5ad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "bb45c37f592c958389d7238576c8308592c693a52d8996c1784a39d5734bd12c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "797e7394d90a11cae9e3b0d47df98354f58064f818e8ecabb2de718dbf803f6f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "d9c7284d9e522942c984bb007d7d25aa17119bfdfafc37020c48400554cfa59a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "8f8f6f732f59590f3f839fcf637b99f6ba665c670678ed51101befbff89f1585";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "4d99234f0882ba0bed63c548fdbb741d474e5dcaba9f147997d46af3e3da8b72";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3050303d57fc70566281da3f308e6303a58da5bfc63d947673389efa130f8b25";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "f53765bb7fffdb36f827f88880f79ba1c03b823ed0ebd653113308fb5a0986ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "58e32028ee538fa321aa24781d1248cce8876a4e52437b015c639491a05a4c3c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "b0103836e44762f3257036c63144e7bc2c6d7e5b6f96fcf33ac0e254812155ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3c83d74d0aa0cc12014d8d828d2e3cfde65844c51229c92237182b8b3c3b014e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "4041d3a8466dcc1edb3bb785a906915dcdedd2574cdaee1ee45cbe5cdd74857e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "250a02463838113bfb74ff0e0482a12a6f2a743a466559bd54801a18c5f2ae16";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c0f00a8744afe947ffcd9151bddd56148fbf4563c49d6df1a083d9ca501be01a";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-simple/default.nix
+++ b/distros/humble/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-simple";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "96fc3f1deaeec519a605c19eaa7a995991637d6495ed3f2da442cb21209392b7";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "77885846dc4de98e787ed8c83c2267eee0486d6d38f44c695fd38b9be7041bc5";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-smoother/default.nix
+++ b/distros/humble/mola-state-estimation-smoother/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-smoother";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5003fe830a14ebaed7f89a5db4e9303dc8b8ba19e9d22c1076d1e25682d5e1fd";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "10a788ce50787ec62c668e67a6336efa0430567338f97771b5291c2f4c775a48";
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake gtsam ];
-  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  buildInputs = [ boost cmake ];
+  propagatedBuildInputs = [ gtsam mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/humble/mola-state-estimation/default.nix
+++ b/distros/humble/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5f4ec4b7477fd62552694ab5751585781219af92a83148436737a375b708495b";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "601d5f5fb1bb270e57e697fa5bad6730f73e4f92651e9a2777daf3dc2cc64849";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "84d11214a535652ddd67a87502e48b62ecb76ba57535f1d27ccb37b7ec2dbb4e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "a985b269134510868326946d272bf591876a5e2085a0d9319651b5348fc89324";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "32fcb9aea8cfdc1f388363972a7cbde396933d104eb3accbb02e3f13ee767650";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "5b407038d5df6135f8f0db370a5fd5294455b31e8bd65a53cc63c598c6e163a8";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "baf4b896912c6432866d50206dbc03e518d46c92c0221f0951dc76673bb2cf10";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6348875fcc05b01ba612d77f839c1261c149bbd0f89e30b70890082c7e7e01f9";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "8b31bd7e1d2df14e563fbd706fddcea81963b103fbdac3c372eb6828650884ba";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "e4082d06ae0b1a2b14089107508f5c4d8ff2c75692dbd55108bf1d3f553ec82d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mp2p-icp/default.nix
+++ b/distros/humble/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-humble-mp2p-icp";
-  version = "1.6.5-r1";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "3647c3750b0be4a00f39f1f4374da3da13c2826a36614c5abd35f1d1abee698a";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/humble/mp2p_icp/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "7ae171688fe14a2690bb923ccd594d3098a441b5c785c36f714c1a66bacf6536";
   };
 
   buildType = "cmake";

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "be71f88a2be92493167a75458d2dce0b32bea7e2f63097dbfc385cc15c1a65c1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "3171ae83ddd5d5899f43b95360163efdca26905e7a11d7002f184ac8b19bd81b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pinocchio/default.nix
+++ b/distros/humble/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-humble-pinocchio";
-  version = "3.4.0-r1";
+  version = "3.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "ce62bb3501debe54a747785519d90cce9beb8bb9ef9985ec04de13b8d03f76ca";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/humble/pinocchio/3.4.0-2.tar.gz";
+    name = "3.4.0-2.tar.gz";
+    sha256 = "1f1d86573b4039bbf79367131edce27859da681d5f39065dd8272df451e70962";
   };
 
   buildType = "cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "62dc074344c66403a0e37e7f9aa4b4a48df7bd98f87db65d17ee9adbac6d0cf6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "3ed139cfb9c9e26bf7ad8a3f2d2d94db8498b355d9086538966e45fccc574fbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "b89ffc60549770efa2197abc4e1fe6d12f02aae481b085901dd3f37f2bd21e85";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "0dcde352d51d6dac7289b6f7b66581f9c60310b0d440bf22a746174c551a2499";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "9ad3132f85d692bad0df939eddafb2d557f658fd1dd8d850289f14254f6fa6e6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "8b697553715dd51fb6ca685ce91f2566568c28f0c1a1d6ca64de38ba953ddf97";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "d81b200dbf9e7c89bb7f53a9e8f9484cea19fa3114dddfef570c963673d484f3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "50bc2a1ec3cc5575bfdd31de11fa3cc7ce96f08b61e9d6345eb1ccd075bd2e3e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "a94a0effc5851f362b60c4f4f805994beb75deb46143e11c814dcd0fb67e5ec0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "642641be368b35e1bc50d49648dd7463026aeeeac448dfd6bda103d41d64ee89";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "43cf8b17cb389846310830d466f29622b5f6bd1c79962060e590b33f165c9796";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "ecf3fa32bb418e3a300233f35d317300984fa12106ff8483079af9fa526ede80";
   };
 
   buildType = "ament_python";

--- a/distros/humble/septentrio-gnss-driver/default.nix
+++ b/distros/humble/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-septentrio-gnss-driver";
-  version = "1.4.1-r1";
+  version = "1.4.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "7da5c3dacf4bc3a07172c249dabc3722331d05ce78d47ada9b343430229663e7";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/humble/septentrio_gnss_driver/1.4.2-2.tar.gz";
+    name = "1.4.2-2.tar.gz";
+    sha256 = "622526f1e640ff8c8f24e11f4e134b95fe45f0a75d4a3ffbfbf54c4c1785144e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "2a8e143da2859332fdcf873205db39bdb98e799d678b5761cee17cde2c7cf111";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "7635fadbc9422f7f248b45b6397eb5e68d4b18015a98f8b8a41ef1c5d0899572";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/synapticon-ros2-control/default.nix
+++ b/distros/humble/synapticon-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, libcap, pluginlib, rclcpp, rclcpp-lifecycle, robot-state-publisher, ros2controlcli, ros2launch, xacro }:
+buildRosPackage {
+  pname = "ros-humble-synapticon-ros2-control";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/synapticon/synapticon_ros2_control-release/archive/release/humble/synapticon_ros2_control/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "e3b3aba1610313fa5e6490f7a4a504c025441b5bb59200afddc9150ab8a02be7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller hardware-interface joint-state-broadcaster joint-trajectory-controller libcap pluginlib rclcpp rclcpp-lifecycle robot-state-publisher ros2controlcli ros2launch xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ros2_control interface for Synapticon motor drivers";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "57b86374f82cb303e1243c803c0e429ec706f831e0705beef5bc68389b516cd6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "1ebdaaa89e6086d22d14c2574a88ea5aaa8e1ab3e06604f4f837abfefc83fc02";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "cd297a8e1213de59524347eb68c521c46ea7c08f5e3db1ed10c054ecfccd9323";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "29d15fb516ed6994075a079d89368d38549cd2f98a70563f3f71cde551bbe17d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "56f71a3c8ce9832c893d09a7f4d8398447cab0feb7ec505838661b00652bfaf0";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "610330c823b34656afcf9cd27b060287f8628c28408549be8bdbd28f124bee04";
   };
 
   buildType = "cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.42.0-r1";
+  version = "2.42.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "8da9e4a4d531ee5631449dd7bc77ba9a67b1b29b1851cd7cb466bcc7fdc310c3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.42.1-1.tar.gz";
+    name = "2.42.1-1.tar.gz";
+    sha256 = "459252299e7fecf1a03694de8072b954e71b0ea9f7f6f45086e30890aa70be2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-workbench-msgs/default.nix
+++ b/distros/jazzy/dynamixel-workbench-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-workbench-msgs";
-  version = "2.0.3-r5";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/jazzy/dynamixel_workbench_msgs/2.0.3-5.tar.gz";
-    name = "2.0.3-5.tar.gz";
-    sha256 = "9475d98f7df8c05bd66e119efffefc8172743dd799e17ec6ffad7ba04e32e1fe";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/jazzy/dynamixel_workbench_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "110608cd5db8b26c0f15b7100134ffcf0a7716bcc936157ac09727eaa9d31636";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/fastrtps/default.nix
+++ b/distros/jazzy/fastrtps/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.14.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/jazzy/fastrtps/2.14.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/jazzy/fastrtps/2.14.4-1.tar.gz";
     name = "2.14.4-1.tar.gz";
-    sha256 = "d4e9b39d38d0a6db4296089c12cdf385d50b02061c74c8927e1fc57f2bb1f9c1";
+    sha256 = "6ebb9b74e4b03e93810e0d322dc26edebb7c9ab30ce5fb528ce666c80820ff54";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -372,8 +372,6 @@ self: super: {
 
  clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
 
- clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
-
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
  clips-vendor = self.callPackage ./clips-vendor {};
@@ -1331,6 +1329,8 @@ self: super: {
  mola-common = self.callPackage ./mola-common {};
 
  mola-demos = self.callPackage ./mola-demos {};
+
+ mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
 
  mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
 
@@ -2692,6 +2692,8 @@ self: super: {
 
  swri-transform-util = self.callPackage ./swri-transform-util {};
 
+ synapticon-ros2-control = self.callPackage ./synapticon-ros2-control {};
+
  system-fingerprint = self.callPackage ./system-fingerprint {};
 
  system-modes = self.callPackage ./system-modes {};
@@ -2960,8 +2962,6 @@ self: super: {
 
  velodyne = self.callPackage ./velodyne {};
 
- velodyne-description = self.callPackage ./velodyne-description {};
-
  velodyne-driver = self.callPackage ./velodyne-driver {};
 
  velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
@@ -2969,8 +2969,6 @@ self: super: {
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
-
- velodyne-simulator = self.callPackage ./velodyne-simulator {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/jazzy/hls-lfcd-lds-driver/default.nix
+++ b/distros/jazzy/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-hls-lfcd-lds-driver";
-  version = "2.0.4-r6";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/jazzy/hls_lfcd_lds_driver/2.0.4-6.tar.gz";
-    name = "2.0.4-6.tar.gz";
-    sha256 = "188f79b336bd714e8d512e7a8b810f0b9a0c2976084d5609853b622a2f0f2e9f";
+    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/jazzy/hls_lfcd_lds_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "2e3ba07e71a1d2a5042fde3ad9182a0d55c4d2ef3f2dccec9baff069142e4bb5";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ROS package for LDS(HLS-LFCD2).
+    description = "ROS package for LDS-01(HLS-LFCD2).
     The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.";
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "33be2f610d7d2f3a048167c77bd4293034a640a6decf975276efbdeeeb919973";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "e4cca7f934114dea7dd6c2e3abca7a8bbef7c771d9173cb3f2394fbbb52d5f30";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5ba2cf8ad8ab374cba8a323932a444c0f8b870af956b74cccd80ff2bf2b86682";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "49f54780219f063a06be3bf4c288d7862917fd5346b8f1fce3b33d533df3b0b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "5f9fdbbbc4e4e2c9fa4d8b596c5eaab603b77d78a10975738c86b73603cdd207";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "fe84c40ea8bdf777fc237b0cd51b356ce487bbb979f4243da9e70c28d00e8e6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-gnss-to-markers/default.nix
+++ b/distros/jazzy/mola-gnss-to-markers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libobs, mrpt-nav-interfaces, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-mola-gnss-to-markers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_gnss_to_markers-release/archive/release/jazzy/mola_gnss_to_markers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "cb85e9dcaaebca5e4c710d2db5e3d88c24a646089d4a744b6f10be1694576a87";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mrpt-libobs mrpt-nav-interfaces rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Takes GNSS (GPS) readings, a MOLA georeferenced map, and publishes markers to visualize the datums as ellipsoids on the map";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3b5fedecbfa56daff78178ba09df8afa602520bd48fcf3d37ff6e78e1772c6c6";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "748b10b41db86f9f50aa0ba045c3b08c48ea7e7e1f43c558dc2c74486cd0b872";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "72ad120383bcd6bb641c4b5258e6f34faafdbe0cd1a559cd1dfa2e9ed4736a0c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "08d22aa801376fda04371e1188662d7ce421a014c937e5d4affa6066b7effd16";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "325ffa569319399eaa347812608dd4eb03e50f3258951746f1ea90639b1ad6ab";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6c1b52488d8a0e4cb686fd7ad3da78149ef598e3f5899c424f82257fe38c1fad";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "e3ee3865b28de2fa4b257187a501c38df0e8baffb0d30c78ebb93f654fa826fd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ea2a26d7f44252b1d57d38aff805a0a3e49309a28894af39746e6374eb29aae3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "348dc083bcecbe773b18d5d2bc071d0d029f2831e6b0909776ecec5a03973222";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6e9fd9771009494a865fbe441b0b01dd5b6f9e039d4655ec8a2438eb1582fef7";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "45710d58dffb3ca46f9e6d9684d21d4e250315163864a4e781b7cd2b1a300648";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ba7151f22fb7d42a9a69a162a1d56572e4d6c849e71f691ba78468af616518a3";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "f953e98a1dd10d843c6152055f1f849e6a1a6d21113fa0434056656e380e76d6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "65c73ee590e63725abee437b48324053dbc9522f710de1767aa7d9d79be772c6";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "39c4a4539da41d8b611ebb47552bcdccb9b34c646b6b27ab9439a02b397b22d0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "03dabc68b33c8cb5fb657f68e115d283da113eedb25a27da541e90feaeb87b69";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "c8b3d70d04774696aace196c54faa1ad388b811571bde63382d014015bbca3c7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "1b76d9ee4bd80cc5115821efbfb8ce669654bd287cb1f094af7d8d6c9ff0578c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "d4f054831ca2a64648873e152e21e7f10ff1f674f4718b940c2226a850f8baa6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "17352377c09d60f8568655615800e170607342c3f4dfca066cf9d21b4c32c6ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "2d757f0f591e6cff1b1f39234d90582ce8b0495a65bc8f768329f98e9636d571";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "42d88cc0a535105e0771be3b7b0975e6835c723f2fc4f59d404a7b34a9976e2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "0e6e6aca656651e1e4a6877a9f471e38c3a46b4d60737bc7f0e6a64975021c46";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "f8327c311d2f975ad2d16d11302ebee43aab21bdb26ad86138d14a494236e6bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "b88023918188f0361ed05c4697b5a56cac2af04e4508499e55bfa5984e0f38b4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "284e5bb901a780dade92d7bf06538aefe457777be68ee20ed1942ff41a3dad86";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "52c41bb5a20427b1be185b675cce032f21c972b4fbc6c711a809a8ad363cab41";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "a9a704ef6f4da5f175c1704a123dfdabbe771f93b3577581793323ceb2459b04";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "c856a476e8e05c1f430bb947dd2c67b809fe9b42f12d8a1077a556d024d117ef";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "af20c49ce7f351138dc4ddd1fb4d57d80920913367d85d7c266f2a52b0a27d5b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-simple/default.nix
+++ b/distros/jazzy/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-simple";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "6fcebd863d7e79166c5fae43db5ee20090e8c806863cd30c27293307a977e261";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "53e3fd7ffaaebb896cb76cd2d9af8f234f436d511e2e7261ce29a674d1c8656b";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-smoother/default.nix
+++ b/distros/jazzy/mola-state-estimation-smoother/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-smoother";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "74188eb19febd68be6998571f63a65d4955d72a709f875b1a5e9350b2a2de3bc";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "bb10b661e2d9fcc9d6474489f7135fad843817f38062d4cc8fb78b8aa066def7";
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake gtsam ];
-  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  buildInputs = [ boost cmake ];
+  propagatedBuildInputs = [ gtsam mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/jazzy/mola-state-estimation/default.nix
+++ b/distros/jazzy/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "f1086239aaa9fa0951f60df0f5b1c4daa4e25064ea230a7d292091a735696b89";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "072264aa0468da5742376292dd399c3d8e719cb792ad4b25f3c699ed8aaca428";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "a86a13ea07c13c19bc4f8fb261ef2c74ad3beafcf16a10a2525708cf112f5bc8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "0e64f5fdad332b0838907b731a30e6b671067d70e2f87a5a93d187f5912f5a00";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "701288f3b2d2ee6828b671175981839b3b8c8a83ac47f84b01601b352cba8248";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "10c53cd65ac34c20b68c35a7ea3756520818689f82cceae3ab3d2e23c91a8eb0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3df7d51cf48a6875f94bc5d066d86f61d224b8999a915fe39a2b118e697559e2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c72646d1b12aba989451757479f14539e112bd4a0edab797a128cf8930b04ed4";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "fad49c86f169f7f4b7570f6945f72feba8bbc3efa7326c43b0f2da3e1709e50a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "2d59c09b17d7dc228ea72a973b3c652f7a38a5a58d5c4f36eecf38d387be329c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "1.6.5-r1";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "739e798f83f41b6dd4186dd712a6674e10454e27fd27b47fdee444c20b695601";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "4970463f7c44e12138d2cb23481ae72efcb7fca0cbd1828456468aff6e450563";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/pinocchio/default.nix
+++ b/distros/jazzy/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-jazzy-pinocchio";
-  version = "3.4.0-r1";
+  version = "3.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/jazzy/pinocchio/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "b42d5af862d14529c551039662edbce32d9a29567106294b3a667acdf83ac1af";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/jazzy/pinocchio/3.4.0-2.tar.gz";
+    name = "3.4.0-2.tar.gz";
+    sha256 = "e4b44521bb7be9015f9df2049a25e9759c644758b3a751be2d0d33ec8adb2b64";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/rosapi-msgs/default.nix
+++ b/distros/jazzy/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b6c3ed4a465f98c0950cad840eb9cefbb614cb92a52a89c36e6e60889a6232a4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a2ef75d06c7dbf62f361f71a6e9dd14a8e87983147b519d3242cb0461767e4e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosapi/default.nix
+++ b/distros/jazzy/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosapi";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4c97ead7a072adbe1c28061151fa593af621e19610716b7b38760e46951c46a5";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosapi/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "52c9e1ba46b70ca3052ef92b5b8f5270fce48dedd72595fd70a1934eb4d8adb0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosapi-msgs rosbridge-library ];
+  checkInputs = [ ament-cmake-mypy ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2service ros2topic rosapi-msgs rosbridge-library ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/jazzy/rosbridge-library/default.nix
+++ b/distros/jazzy/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-library";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "480c31fcb705efec657fd65eaade555126a862d1030c94e88461c6faa8c7f51b";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_library/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "dd8e64b301a29e0a8a20d83ac5c3684d8d063e3d6e55512affcaf694f0bf298a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-mypy ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/jazzy/rosbridge-msgs/default.nix
+++ b/distros/jazzy/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0e898807bcc4b73d7a7d02e477c282441517166ffe424825e7406ba101c87e9a";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ffae87a79ca0d64c242db71185761a7374a82b9bad8f201add3a7046285259a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-server/default.nix
+++ b/distros/jazzy/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-server";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "c38ae48fdd47570d1dfa403b7e737dbac5d95e1664889a293003248abe0545d4";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_server/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "793f3cec42224a4a8ffd260c5ddb7ef260a87049cb00f3f03d4d9a2b15d84aac";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ ament-cmake-mypy example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/jazzy/rosbridge-suite/default.nix
+++ b/distros/jazzy/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-suite";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "45edc8921c5dc6ca4479e4f61b9ec4d855af820a4e95ffb82290c07ebd9ade91";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_suite/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f5fd423ac6f646221586b6c7082fe3d698488d70c8648c7ca1a958cc2292e77f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rosbridge-test-msgs/default.nix
+++ b/distros/jazzy/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rosbridge-test-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6dd7e7c24d596b4bc0df3e20ef5ec1ae505f55a8e5329d6a2eee3bd09a7dbd55";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/jazzy/rosbridge_test_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "46e83ee3a91142d4d22871ff40c630dedbe16e228f54f1ab1af3c5d397a9c9ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/septentrio-gnss-driver/default.nix
+++ b/distros/jazzy/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-septentrio-gnss-driver";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "79d191f5e2fbb5ac76ce9f4e2bcb2d25c8c0a58979c9d6bebc52c4934e885bfb";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/jazzy/septentrio_gnss_driver/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "8cec94a2bcd6439dda03aa5bd5caa10869a657dc0431a626088f747aa759f10b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/synapticon-ros2-control/default.nix
+++ b/distros/jazzy/synapticon-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, libcap, pluginlib, rclcpp, rclcpp-lifecycle, robot-state-publisher, ros2controlcli, ros2launch, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-synapticon-ros2-control";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/synapticon/synapticon_ros2_control-release/archive/release/jazzy/synapticon_ros2_control/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "a0974b6db1912fd7a2d2290cc7b24655a3e44e6ac17282cb977ba544aec69e25";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller hardware-interface joint-state-broadcaster joint-trajectory-controller libcap pluginlib rclcpp rclcpp-lifecycle robot-state-publisher ros2controlcli ros2launch xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ros2_control interface for Synapticon motor drivers";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "7cfff7fa6a989e44e716e4797c4e4317a8e03c99f86a59afa94ab4961aa99900";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "c80594dcf5f8a9eac439e1614e7273d1d000c3583f8f9a366bdabe0dd88d2d31";
   };
 
   buildType = "cmake";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "9758fcaad89bbb56ed24cefd23c60aff1059a967c14cf97e7f808d2aed599fd3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "d13970ed30d2c75b6b04f3c00cfa92dac436f3d3b524611e360a102e6e1ba571";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-bridge/default.nix
+++ b/distros/noetic/foxglove-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, catkin, gtest, nlohmann_json, nodelet, openssl, resource-retriever, ros-babel-fish, ros-environment, roscpp, rosgraph-msgs, roslib, rostest, rosunit, std-msgs, std-srvs, websocketpp, zlib }:
 buildRosPackage {
   pname = "ros-noetic-foxglove-bridge";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "ebf3a322d2d024560b361ded3a2ff54d3ca68abcc632553d726b2ea7f27606f4";
+    url = "https://github.com/foxglove/ros_foxglove_bridge-release/archive/release/noetic/foxglove_bridge/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "06086c4aa808dd9f57c52f07d6cdf9fbd1d6dc9bd868c467113ac7a0cf8e8c9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-dev/default.nix
+++ b/distros/noetic/gazebo-dev/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo_11 }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-dev";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_dev/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "a594abb4b5f4da4c29c18f676ea9ade011da49794613788f1ddbe5c4273689bb";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_dev/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "2dd050266fb546009ebe4df9bb16265afa2db419122009a93a52386bfeac17f9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-msgs/default.nix
+++ b/distros/noetic/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-msgs";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_msgs/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "45114343951b0c49c73cc33840dc3c8a1d83e169d4c6e7798da9dfaa048a079b";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_msgs/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "4bfea68e935ed7135d680652da21318b065faf19d01b2dbe5883de8373668a73";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-plugins/default.nix
+++ b/distros/noetic/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, camera-info-manager, catkin, cv-bridge, diagnostic-updater, dynamic-reconfigure, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, polled-camera, rosconsole, roscpp, rosgraph-msgs, rospy, rostest, sensor-msgs, std-msgs, std-srvs, tf, tf2-ros, trajectory-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-plugins";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_plugins/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "0c7aba61f1e6f811387bc63b6d5a1679758754af6784d93a7efd3045fe6a7a43";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_plugins/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "333a309c3722f3f1fc0a90546aba5c72bead124344e4c31a1e8efd0ea52b806c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-ros-control/default.nix
+++ b/distros/noetic/gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, joint-limits-interface, pluginlib, roscpp, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-ros-control";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_control/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "0e862d58508c1bf22aaf47c26aae4f7233863ea8da4e6d1e9ac1e21bb527501d";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_control/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "8ab4bf8ca1211a731f4a88836ee14c4d0fad49f1372b94e5a20025ae93128991";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-ros-pkgs/default.nix
+++ b/distros/noetic/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-ros-pkgs";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_pkgs/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "b76529d93b6990c44f07168651fa5c355b3e1377fec10ba07189f387dfd3dff4";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_pkgs/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "b37b339540491cd54b6af566e159ca392c6a884d9a9b10fbb9f391b2ace9e30b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-ros/default.nix
+++ b/distros/noetic/gazebo-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, gazebo-dev, gazebo-msgs, geometry-msgs, python, roscpp, rosgraph-msgs, roslib, std-msgs, std-srvs, tf, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-ros";
-  version = "2.9.2-r1";
+  version = "2.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros/2.9.2-1.tar.gz";
-    name = "2.9.2-1.tar.gz";
-    sha256 = "24232fe990ef4d5802f18b33b0a0dcf527595adfa9ed5fe16f4b4e55d73be5b2";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros/2.9.3-1.tar.gz";
+    name = "2.9.3-1.tar.gz";
+    sha256 = "60ff0273a9bb668c72d310f44b7b2bf736218b1a831d88d747a865c2a65a2216";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "887d0d7e422cb0df97163ef72989039f85c9301c8836fb59e71559151640062c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "e9b4fcc4fcdd8281d4e1ba194022d1d1eee458101a0c6f70230bec33ded18d74";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "fd31bf2cfcfe4eb3932549058a3e951e9de36613094d0333a04ae2b8c887f6ea";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "f4cd8ddd4bfd40f8700c1b69ed32905e53b95254c7e6ca12e39c989367d8d085";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-data-structures/default.nix
+++ b/distros/noetic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-marti-data-structures";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "a67b17e049c3821463e666259f06639b15a73ee12e6a5e9aa1c477b9dfad4333";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "a178c3e88912fce469d99bdbb57855cdc7633ee39da060ec40a0fe189496bb6e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/movie-publisher-plugins-copyleft/default.nix
+++ b/distros/noetic/movie-publisher-plugins-copyleft/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exiv2-metadata-extractor }:
 buildRosPackage {
   pname = "ros-noetic-movie-publisher-plugins-copyleft";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_copyleft/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "14bba374aca4d5bcc90e31f19e1083e667746795dcfc8660910aee75ceb8a621";
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_copyleft/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "3996a22585781c90437ef29104151ad6782e570e10cfd71047358369be420da8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/movie-publisher-plugins-nonfree/default.nix
+++ b/distros/noetic/movie-publisher-plugins-nonfree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exiftool-metadata-extractor }:
 buildRosPackage {
   pname = "ros-noetic-movie-publisher-plugins-nonfree";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_nonfree/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "a2e5605f23cbaa743dcbe0e48285fc226a11af8425a8c5505a4fd97dde92b945";
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_nonfree/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "4ad92e722e39785460e47d84e50d09547cf770b94e2355b0fe5443dc9597ec6a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/movie-publisher-plugins-permissive/default.nix
+++ b/distros/noetic/movie-publisher-plugins-permissive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager-metadata-extractor, catkin, lensfun-metadata-extractor, libexif-metadata-extractor }:
 buildRosPackage {
   pname = "ros-noetic-movie-publisher-plugins-permissive";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_permissive/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "1cc491443c5fae48b18bbafd56dcb5647cdafee805e5f2834cbb953875df7cfb";
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins_permissive/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "63dcab50dc2c6974bfa20eab7af0936985db9186792ec9ab4042a6c7edbeabd5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/movie-publisher-plugins/default.nix
+++ b/distros/noetic/movie-publisher-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, movie-publisher-plugins-copyleft, movie-publisher-plugins-nonfree, movie-publisher-plugins-permissive }:
 buildRosPackage {
   pname = "ros-noetic-movie-publisher-plugins";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "ebf826cffc47b0d01f0d34451b58e05022d4540c9751effd200f12c233f51315";
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/noetic/movie_publisher_plugins/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2815986c227304130386465ee7a08d30699ffb11aedfee28f706b504d277c66c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mp2p-icp/default.nix
+++ b/distros/noetic/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-noetic-mp2p-icp";
-  version = "1.6.3-r1";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.6.3-1.tar.gz";
-    name = "1.6.3-1.tar.gz";
-    sha256 = "31cc33ddd8e483230c1445266d5192446ac6e2aceda103a8dea53a27b336d766";
+    url = "https://github.com/mrpt-ros-pkg-release/mp2p_icp-release/archive/release/noetic/mp2p_icp/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "ed35b9aefc9a552d583b1f32a8446a103d2649e4c826521f154897e5ab0facb4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "89c73c3debe4a22f288581494d989f08df1bfea21c93be99e438f8b36325623c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "9432ad5d041ec942afe02fa4adc92da606ae6749aaacb98a749a25bcabfebbbc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "18f368b6e3886c4a02da43b54190c11a31c6c57e61422d4874c23b22324b7abd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "ddc22bd7d7bb5dda783b630e871fc88a5931d9b4fc651b1184fc65ae8a1d7f80";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "61193d1bb9c9ac810adad5fb8f04f88742ec9b2f1dcbcb54bd602086b32e66e7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "4686af3bfd76845a44f1f3bdfa80410583af531dc892bdbe34cfce5ba476688d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "fba51df95c11473be4223e2cc7eec8facf2c8006694011dfa1f7c88736dfd20e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "c5f35f86a02a296a8f4e10b403d5c300f38d2d9b8f2f0c5293473537f3a442f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "3ac6a874263a1070a487f257b18673741b7d92b76aab9218e41d9f34d0fc9c76";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "d608135e366c3a43b8e895d4e6550e644bb01019f8c8834dea3a4006745acccb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "1372c7ca7a1e004483923c873ad95a43784a17e75bf42a97f1ea62d17cd131d6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "caba1028401352df34a29eaf3f0001099d8f17610c25b1474dca9bc21e89a561";
   };
 
   buildType = "catkin";

--- a/distros/noetic/septentrio-gnss-driver/default.nix
+++ b/distros/noetic/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, geographiclib, geometry-msgs, gps-common, libpcap, message-generation, message-runtime, nav-msgs, nmea-msgs, roscpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-septentrio-gnss-driver";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "ceabe786a10ef4d6665701d152b09c6c0f0dac20dc70f27e23be160f1974d99e";
+    url = "https://github.com/septentrio-users/septentrio_gnss_driver-release/archive/release/noetic/septentrio_gnss_driver/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "aad9a8e635c22403e67455d2b09c1dc60f5cecd72cff8da6fa177a4d14577e12";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-cli-tools/default.nix
+++ b/distros/noetic/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, marti-introspection-msgs, rosgraph, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-swri-cli-tools";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_cli_tools/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "35b20dcb0abcac1bffda2f72b7151ce45ea9a46d3fa375f53b44a310ac653a14";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_cli_tools/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "af08828b627f634f19c58956b3fe56ea8306b959ebdcff8a91ce55c3f6d2722a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-console-util/default.nix
+++ b/distros/noetic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-noetic-swri-console-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "a11c68708782868b4908759254507795fabfccc32fc61ce30be9813702723690";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "bcadb115a0ca09e60d04f56340225b8ff6751dc05134bb4f21f9c3d18c25e865";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-dbw-interface/default.nix
+++ b/distros/noetic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-swri-dbw-interface";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "425c4701169a6488a1194c203aecbccab0df86efed20514d33262a1bfe2e7993";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "a4fb256e86097ffa5559ef2bc3c49ab5abce98c454eb2779a666c49ca155ecd8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-geometry-util/default.nix
+++ b/distros/noetic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-noetic-swri-geometry-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "629c6d619c9feec388641c26dae35e196fa12270dc9e38b59aed22f58561909d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "13f0fc2be0ba44026d056491a9bec9b935cfb68dd5739c0961cadc7ac4ad1c98";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-image-util/default.nix
+++ b/distros/noetic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-swri-image-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "a5f902c36520303143781a5c53f544d5ef15f66cc5ad06f411f1f66b7c3d0eb8";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "492f2c86f954f484370800a15e30de0e610cf7398e103d07c9784a5eace8c697";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-math-util/default.nix
+++ b/distros/noetic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-math-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "a4e5b19bcae98a22ea9d831b53b25c3ec7978b25a6594cf781e6eecdb58d8687";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "792db7a581692eec4fcbfc4d4b4dfdccdab204176fdfd7c88fc1406bb3502880";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-nodelet/default.nix
+++ b/distros/noetic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-swri-nodelet";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "e4569638c2b3528c9aa8837dd4eaaafd9ae571cd292684f14733198bb7879001";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "35da65a27c3e90d48fe0d54c07d4084da81a8d091e68ce48cd757abe0bbc5086";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-opencv-util/default.nix
+++ b/distros/noetic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-noetic-swri-opencv-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "88191075c951b11757814bb2515d9ea440c0635ce26ef71510951a03ecb17bdb";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "8492e56c0663ed76e4280a2d925e7b02430c3b3257d6735f826af4da9d93c66b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-prefix-tools/default.nix
+++ b/distros/noetic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-swri-prefix-tools";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "48a69316dd816101ba5a6303d6505f665d94745d126727c27d6a2deef163e818";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "e16d46914c5fdb7963b04fabfcdf63d2f1c2bcbfac82dd9f7063ab815ef1e13d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-roscpp/default.nix
+++ b/distros/noetic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, marti-common-msgs, marti-introspection-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-roscpp";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "8249abbba7bcc983cc8cb7c527873080b7cd7c7e51499b30177c8dca65ca4da8";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "df39a498255c612b420c344649a3c78954116a5247d043745d52750505324269";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {
-    description = "swri_roscpp";
+    description = "Enhancements to roscpp functionality to reduce boilerplate code and implement common patterns.";
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/swri-rospy/default.nix
+++ b/distros/noetic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-swri-rospy";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "fbedbd28cd710df0e01abdb494abf562ece6cff23f172489fac0ebaf5b46fecc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "39ce047e970b758bda0b10f3578939678a1925d43394b5ddaa07f20853cc9e19";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-route-util/default.nix
+++ b/distros/noetic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-swri-route-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "8d3b7bb7e6356611a443e919aca5be5159ab4f1f5254bdd1e4e482a50474ae40";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "015a9079ab63bc4552a4d25fd234063ffff6c438cf951169541053e0895e8b45";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-serial-util/default.nix
+++ b/distros/noetic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-noetic-swri-serial-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "dd1362d27361c7ce27bd26a51d8b44342ff55ba446db0ba309e689a926ab50d7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "0cde1f14016971d8008db6d795bb75a5a9484878a25e05e5f6e122fc267b7558";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-string-util/default.nix
+++ b/distros/noetic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-string-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "e6a8cea407bfe527a0eca5c37b759a4d2d74d55eb6c784a57cdacae8f3219b3a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "4ab1a6c8d451a6fbdd50d4999bd2986b88b4999c7f7c81ff6e46692b3d3a2251";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-system-util/default.nix
+++ b/distros/noetic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-system-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "a1a3dc26cefd19d3797fd561ea86a4bdb222affe1002cae62d1ca40770587cdc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "0190c13b867e91c96bbacd6f1b09595e672dcc232baadf7e63858084a2693ed7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-transform-util/default.nix
+++ b/distros/noetic/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, genpy, geographic-msgs, geometry-msgs, geos, gps-common, marti-nav-msgs, nodelet, pkg-config, proj, python3Packages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-transform-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "b13f9b412a95b3f02362ff166edbb3dcb90ddc1582d49de1962b1de983b526ee";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "3618e1d080c097e3960a0f424769d103a22128eacab64e7f580515c9fa09497d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-yaml-util/default.nix
+++ b/distros/noetic/swri-yaml-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, pkg-config, roscpp, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-swri-yaml-util";
-  version = "2.15.2-r1";
+  version = "2.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.15.2-1.tar.gz";
-    name = "2.15.2-1.tar.gz";
-    sha256 = "f5c313869382f93b4beb71385bc63d0ac04ae1bd545bd67c1c02015bededc1a7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.15.4-1.tar.gz";
+    name = "2.15.4-1.tar.gz";
+    sha256 = "36ee1dd1c39654320b1a072aaaa0e53b72916b9ade666d7249bb82ce72e69f77";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "a5494854b87592513d9d9d07ca1aee527c9b4b3ffc2ad09a95a74bfc330e23bd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "6cae05b1ccf150e0c737741ac70403209b191a75028443e8e0de812f5a20a6f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.17.4-r1";
+  version = "0.17.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.4-1.tar.gz";
-    name = "0.17.4-1.tar.gz";
-    sha256 = "87b0f6e654cb8c420fcb8da44001029c92aba66174815d250d633f780c36fb6b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.5-1.tar.gz";
+    name = "0.17.5-1.tar.gz";
+    sha256 = "07d7d4eba4f5fddcb2f21fcd641ca14a28d20da570a354fd195861721f419184";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-calibration/default.nix
+++ b/distros/noetic/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, rosunit, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-ur-calibration";
-  version = "2.1.5-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_calibration/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "01019141950e48408b34786c7cef0b98456edaa65f3d41c9bcdda36948a8895e";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_calibration/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a582ee778834c844163937f4c4e75e6f01eb2fcf71505750612d92d9a72433d4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "6fa2deb3ef1615075aa7317690c3424932f16553f99f622060878af6f9ade695";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "5020d31c1f8af5babc87dd8ec2c1a73ef6faf55c2a4fd6c129832233f9964dfd";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ur-dashboard-msgs/default.nix
+++ b/distros/noetic/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ur-dashboard-msgs";
-  version = "2.1.5-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_dashboard_msgs/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "ae5ea347b618a129655b1d330d7f398266e92446a8fbb5b96395147cf5aa211b";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_dashboard_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "3ad298c657f185c413c6944a69a1bbd63650424ef89caead0a6684afa2dccb3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-msgs/default.nix
+++ b/distros/noetic/ur-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ur-msgs";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ur_msgs-release/archive/release/noetic/ur_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "302d4840bd347c2f3d4371e1ce04e168ce558bd25e290378cc3d377c353e1f75";
+    url = "https://github.com/ros-industrial-release/ur_msgs-release/archive/release/noetic/ur_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "81f332b3aad52e47aba99fa092f5d3a5b02bf1a79afa3ea8a92e7c61b119808a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-robot-driver/default.nix
+++ b/distros/noetic/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, boost, cartesian-trajectory-controller, catkin, control-msgs, controller-manager, controller-manager-msgs, force-torque-sensor-controller, geometry-msgs, hardware-interface, industrial-robot-status-controller, industrial-robot-status-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pass-through-controllers, pluginlib, robot-state-publisher, roscpp, rostest, scaled-joint-trajectory-controller, sensor-msgs, socat, speed-scaling-interface, speed-scaling-state-controller, std-srvs, tf, tf2-geometry-msgs, tf2-msgs, trajectory-msgs, twist-controller, ur-client-library, ur-dashboard-msgs, ur-description, ur-msgs, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ur-robot-driver";
-  version = "2.1.5-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_robot_driver/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "660d9f14dab3b1930c5f2ca42e4684ddbf82273df0be257497876d048e3f1152";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release/archive/release/noetic/ur_robot_driver/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a581b8744b454c886fb2e143e498ac0bd0e5432a6eba279c258e48696ffba920";
   };
 
   buildType = "catkin";

--- a/distros/rolling/boost-sml-vendor/default.nix
+++ b/distros/rolling/boost-sml-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, git }:
+buildRosPackage {
+  pname = "ros-rolling-boost-sml-vendor";
+  version = "1.1.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/boost_sml_vendor-release/archive/release/rolling/boost_sml_vendor/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "6f4bbf8e803ddb3eee126a352eb112df3f035b214149501be3c92eaa9feb81db";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package git ];
+
+  meta = {
+    description = "Vendor package for the Boost SML (State Machine Language)";
+    license = with lib.licenses; [ mit "BSL-1.0" ];
+  };
+}

--- a/distros/rolling/dynamixel-workbench-msgs/default.nix
+++ b/distros/rolling/dynamixel-workbench-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-workbench-msgs";
-  version = "2.0.3-r4";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/rolling/dynamixel_workbench_msgs/2.0.3-4.tar.gz";
-    name = "2.0.3-4.tar.gz";
-    sha256 = "e6fb182c8bb5fba4996c6387d2ea61b90f9e8318e86b2fe9ba5cb06275d4e370";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench_msgs-release/archive/release/rolling/dynamixel_workbench_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8439330581cb42f8fb5d2728828253864806bf9d144d5c31dcf32cb75f9e9656";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastrtps/default.nix
+++ b/distros/rolling/fastrtps/default.nix
@@ -8,9 +8,9 @@ buildRosPackage {
   version = "2.14.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.14.4-1.tar.gz";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastrtps/2.14.4-1.tar.gz";
     name = "2.14.4-1.tar.gz";
-    sha256 = "bdab8deb01e68f8f446bbdfc404307f3d08c2c93dcaeb61cbb812af2144504b1";
+    sha256 = "664cb833db22e0ca4d868037fca0b0378c7030c8b3bea7a8b679d31d4ecc9250";
   };
 
   buildType = "cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -268,6 +268,8 @@ self: super: {
 
  boost-geometry-util = self.callPackage ./boost-geometry-util {};
 
+ boost-sml-vendor = self.callPackage ./boost-sml-vendor {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -1104,6 +1106,8 @@ self: super: {
 
  mola-demos = self.callPackage ./mola-demos {};
 
+ mola-gnss-to-markers = self.callPackage ./mola-gnss-to-markers {};
+
  mola-imu-preintegration = self.callPackage ./mola-imu-preintegration {};
 
  mola-input-euroc-dataset = self.callPackage ./mola-input-euroc-dataset {};
@@ -1770,6 +1774,8 @@ self: super: {
 
  rmw-dds-common = self.callPackage ./rmw-dds-common {};
 
+ rmw-desert = self.callPackage ./rmw-desert {};
+
  rmw-fastrtps-cpp = self.callPackage ./rmw-fastrtps-cpp {};
 
  rmw-fastrtps-dynamic-cpp = self.callPackage ./rmw-fastrtps-dynamic-cpp {};
@@ -2252,6 +2258,8 @@ self: super: {
 
  swri-transform-util = self.callPackage ./swri-transform-util {};
 
+ synapticon-ros2-control = self.callPackage ./synapticon-ros2-control {};
+
  system-fingerprint = self.callPackage ./system-fingerprint {};
 
  system-modes = self.callPackage ./system-modes {};
@@ -2490,8 +2498,6 @@ self: super: {
 
  velodyne = self.callPackage ./velodyne {};
 
- velodyne-description = self.callPackage ./velodyne-description {};
-
  velodyne-driver = self.callPackage ./velodyne-driver {};
 
  velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
@@ -2499,8 +2505,6 @@ self: super: {
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
-
- velodyne-simulator = self.callPackage ./velodyne-simulator {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/rolling/gz-cmake-vendor/default.nix
+++ b/distros/rolling/gz-cmake-vendor/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-vendor-package, ament-cmake-xmllint, cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-gz-cmake-vendor";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "9b548ccd4309b2bbe9f54cb87d739f0ae68b5c555759475fd32057578b88042a";
+    url = "https://github.com/ros2-gbp/gz_cmake_vendor-release/archive/release/rolling/gz_cmake_vendor/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "7dc425a490e28b60478e72cb0cefb2cee62adfb16cd92b88fa568ef1c28e6e57";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
-  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint cmake ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package ];
+  buildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ament-cmake-xmllint ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-cmake-vendor-package cmake pkg-config ];
 
   meta = {
-    description = "Vendor package for: gz-cmake4 4.1.0
+    description = "Vendor package for: gz-cmake4 4.1.1
 
     Gazebo CMake : CMake Modules for Gazebo Projects";
     license = with lib.licenses; [ asl20 ];

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3f33de13afe29c5396e00ba4389107d3b6eae2789c15478c27bd0d6aac75203f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "de8238ab71b7a70380fc9c9a7ddf0738ee19e204851838d5b7477138ea80d614";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "83e8ecf610db600e70f52c39a1ee699da77dd313e27a340c21174699a92b47aa";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c6cd4a5ff25f588f94a751baf623fea08a08af05dc696b7daf128d256f7a2862";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "876c4924b7415b4754e4283ad83d4af6f73f3d013e0a54d48da1d1525588fee0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "48ec79cc4374282a5f1b978b49eed6b4c1fc92c13319704320dc70b06219dc38";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-gnss-to-markers/default.nix
+++ b/distros/rolling/mola-gnss-to-markers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, mrpt-libobs, mrpt-nav-interfaces, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-mola-gnss-to-markers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/mola_gnss_to_markers-release/archive/release/rolling/mola_gnss_to_markers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "82dbb812292934f9ef051b72a5808ecabc8e857cc0632ad844d169ac46b801c0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ mrpt-libobs mrpt-nav-interfaces rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Takes GNSS (GPS) readings, a MOLA georeferenced map, and publishes markers to visualize the datums as ellipsoids on the map";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3e565a9ba77fee22cc905298a9266efe216120abedf4a0239a34fdbe3354546d";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "6336fd926a7e0e3decc4a878a9f6e89caeddbdadeebde31ecce3e74b15a93815";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "9b29ab1d90cd30c7e622300b043b2fe839a0981d07c842f672a004d4c27a1dd9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "febfd9a9625138ba26b2cc0f6ca14ad68d81b5120d1e1a4a4f3c38f4d53a845d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "634be33cdd00e254d97f96e1cb1f15ef4e51ed13f7714f51d6fad39bcd2cec1d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "13d50dfe160ff165bbdcb2c88d4bb27ce37255a672511ac6580f9a20d5ea6a0d";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "92c8bb00a79f114a3b5b3adbb33f84dfdfb3ae33c6f39f4834a0e1d332b40155";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c134737576f8b7f4fdb4a146c645a20f5aa74e74ca7dc3406077b80588f1d272";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "08756d6705da82da952d77b0859958cb46e194152977b12cdcb99819a9f1f346";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c4d6902d154e8a427b847e09f6ffda8c0fe8d1942423305552ac3a8e92166f8b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "2870bd597ddac9cdaa4a471bd3ab9b2f64e1b9b8125d7834fcb7c5012c2b4cac";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "c74ac35771bc3fe2b8c3a6d55ddc4a5ecab2ec011306ceaa2cc8b1b7516750ca";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "656ee7d02d314a63c3c4d97540567501185b0d6d3b1b003c8f03cccb1a1743c3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "5f1cde8cd5b36c2d31150869a9ae8698d38c3f099c28df2c088ad7ebfcff2acd";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "80d37ce3a9c79747c81c3b20207940118002a132fe16bfaad7a7d7996a17452b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "3a44ce6efdc6c60701c192d94a3ebbc95d81552ddf3901d72f34440bf4bae375";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "b67a9b3c6cc9bf90c988ce6629fdc113390151d1cba210562aff3a2dfcc1e4a2";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ede9ab46fdde2b1122892b243952a9fa731bff5207158b6747b20d95e4726133";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "65dcdb8e5e17d3cd81ae615339f596313718ddd6a5e94c9c3be397470d66fe45";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "73926fc2098ea77ddec7cc50b7cce0048862c7ccebe6d88d3da6e859eb3928ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "75aaa92c5a37bf405b10f473ea250b9e03ff369a817d420ae93b3eefb08ac81c";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "bd9b43288dc31b24bc2b13ad181b98ef09bf27305cc2cf252c2f18ad5d8e60dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "4bd2193975c4784e6815157bfbc237c4c352d6ba82a57d956f59a8a9366c2d2f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "5fa0fcccdd698ea33ab143e7c9da314d9380eddf968325f036a7d8f7b1dc7cc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "39ca71109327a6ab63a0201996d6604f450c95dc0a39a230b4179f376859463a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "453b4880f8501274be5f6a4df5145048b2aa77496a70029f8d1a612b3ac12d8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "a57f316a0ee6fb573fe5d1a8e206bee8897cddb955c2e1ea3bdf63c43c836095";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6d6d8c42341d4330ffe09a9ae73d11362150ac1a76f4526a7d4ce208b8bd3851";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "4f795879ed8e85e94676d6756261d365ce669810b520fd199f8069fc4464db1f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "db7dcb1a5cbdabe29bac3ca6a30d997ba621c9dff17763652de5e6e953d505f1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-simple/default.nix
+++ b/distros/rolling/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-simple";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "7b673a15d03ffc9e9635b50d38d2ab9ce427b496385f0b3ca561523b8266f7f2";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "c55de2e2be648bd38bfb965650162c3c027d3c3c83631d61cfba3e885a99a9d5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-smoother/default.nix
+++ b/distros/rolling/mola-state-estimation-smoother/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-smoother";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "8dd737cc9c26001c01cf877b53434065373af3f7da50a29d47ac3dc92d96c2fd";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "1630b05996f28589a060edccb047f4185f67387ed413631a4c4b1f9a8d3bfe57";
   };
 
   buildType = "cmake";
-  buildInputs = [ boost cmake gtsam ];
-  propagatedBuildInputs = [ mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
+  buildInputs = [ boost cmake ];
+  propagatedBuildInputs = [ gtsam mola-common mola-imu-preintegration mola-kernel mrpt-libobs ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/rolling/mola-state-estimation/default.nix
+++ b/distros/rolling/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation";
-  version = "1.6.1-r1";
+  version = "1.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "257b5025fd2d7ffc9cd7cbebcf9b9a60dd4827214a95946f91d1d65386dc544a";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.7.0-1.tar.gz";
+    name = "1.7.0-1.tar.gz";
+    sha256 = "67f61fbbe122da5103a29238d4ce4bc5c2b331cf9f1a80e2bcd9407400262e6a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "bab9d078a19db3ffa7dc042e88fe18ead820d2015c7aad947885664938a8c3de";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "08c3b24471cf2f0d95b232a746eda773f08f77c934ac74ff56731c0135d1b2cf";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "65770fecb9a7014c0f560ad1c8fd84af8fead4811c7587305979851b4da77bb8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "fddae7a61d060b2966ecb106f23be032a6283af969df6d99018fb293ae4502e3";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "426b66ae06c0b954ce8cc006cc388586d2ccaf1469d8c4b50ebcc4d6afbb2a93";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "8215a672fbdbfb7d55a81db6fb8055c6e32446ca98b924e13847afd107b07569";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "81a371d247a5c968e60b5200fc21ee972172253feebfb8041937cbcfbda3ed3b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "4f55bebfa8c61ca2d2bb358194b6aaff7f826105f123a2bc7f7b0264443ada02";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mp2p-icp/default.nix
+++ b/distros/rolling/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-rolling-mp2p-icp";
-  version = "1.6.5-r1";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "b2d3da8bdd38bbf09475e330bc812f6ce06bdab87ba1e264733df370591cb891";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/rolling/mp2p_icp/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "784e2249000a3f8d79c1dcf20e9b7797f697e9508c2b0dcabd9c5043d0a49e75";
   };
 
   buildType = "cmake";

--- a/distros/rolling/pinocchio/default.nix
+++ b/distros/rolling/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, doxygen, eigen, eigenpy, git, hpp-fcl, python3, python3Packages, ros-environment, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-pinocchio";
-  version = "3.4.0-r2";
+  version = "3.4.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/3.4.0-2.tar.gz";
-    name = "3.4.0-2.tar.gz";
-    sha256 = "9b02078ce110d04b6ce0a3a263e99b8b7dcd94c25392fb135ee34d8f776a236d";
+    url = "https://github.com/ros2-gbp/pinocchio-release/archive/release/rolling/pinocchio/3.4.0-3.tar.gz";
+    name = "3.4.0-3.tar.gz";
+    sha256 = "c0390cec01c261e7728b5c3386a58c50c24b5ddd5d522dc4bdb05c1c3fe0e79b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/rmw-desert/default.nix
+++ b/distros/rolling/rmw-desert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rclcpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+buildRosPackage {
+  pname = "ros-rolling-rmw-desert";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9a073296647bc12b81baac944fd3be4e4f75e5c58fa88a472e6388ea82374e1a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-ros ];
+  propagatedBuildInputs = [ ament-cmake rclcpp rcpputils rcutils rmw rmw-dds-common rosidl-cmake rosidl-runtime-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros rosidl-cmake ];
+
+  meta = {
+    description = "Implement the ROS middleware interface using the DESERT protocol stack for underwater communications.";
+    license = with lib.licenses; [ gpl3Only ];
+  };
+}

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "70a6bdd8e654ad794500771f0d2566d8d24c1703675ae150b5c9a0ceadfdafa8";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "22900fdd6a91c5072c581638a78d8de684f33fb1d63aa5b0554affb252dec1f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "4c2d20cfafa97563c1c35d62c0960bbcf5e0ce6e54c113a5c32c3d6204b537f6";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "b6ec9cf8215d87d09af12ca5f609b18241064d77b8373d153d4b1c978d3db17e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "37a5cb80698b475a08e0de7d76bb562e8aa4042967746ca795dc82e5590a6248";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "07384a6e5d4b01c91a5a5613b11851b32d6ad1a55791caede7d8a797e198672b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "d08d90f351687d5644e1287425d11f08d95028133dd71f5246e921f5b74bf705";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "7597ce0f59294c6bf3ece7ade0b4bac4e1f6d91502dccb9ccc9f8a71165e0c96";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "50bc38a146af85c5353b624f6042e9b5cfdec400b10a4b3aef06fcc19a8221ca";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "9c4df09395fcd76aa89ec54755cd000af92848b4d0427972d69a95a5bb6e97eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "c47d244745d638a86317f056ddd2e08c0327ec5ab04292f2c4fcf5b0ac4bb164";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "05f5bf9e5dd0203556e6fd606683b38944f888cd55c4af72f539f3c1683b3eed";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosapi-msgs/default.nix
+++ b/distros/rolling/rosapi-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosapi-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ec2fdf43d400dc2cd55d41e107a29deeaaa590c17c0ec4180dc1db1a1083156f";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "73c2e7ce3bd1e4e8e409491836b8379505171a5a73639e08b51006f4f31408fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosapi/default.nix
+++ b/distros/rolling/rosapi/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, geometry-msgs, rcl-interfaces, rclpy, rmw-dds-common, ros2node, ros2service, ros2topic, rosapi-msgs, rosbridge-library, sensor-msgs, shape-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosapi";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6373d76c7f6ca47b26f90eefa243bfec09d8748a96ca26f853b2001b2e271844";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosapi/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a4ad6d57c59b4f68294dcc02133f0dc0ef6486ea46c8f0a2ea7f0b1590e7c4e8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-ros ];
-  checkInputs = [ ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
-  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosapi-msgs rosbridge-library ];
+  checkInputs = [ ament-cmake-mypy ament-cmake-pytest geometry-msgs rmw-dds-common sensor-msgs shape-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2service ros2topic rosapi-msgs rosbridge-library ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/rolling/rosbridge-library/default.nix
+++ b/distros/rolling/rosbridge-library/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-mypy, ament-cmake-pytest, ament-cmake-ros, builtin-interfaces, control-msgs, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, python3Packages, rclpy, rosbridge-test-msgs, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-library";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "2f1209f376bb29a21260930ee1ebd8b64dcb41314412f02e675fb20b3d3f3f35";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_library/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "178ebb18b61afa952f36072a0b16313b97cadcfc8688696d644276f1e2e19992";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ action-msgs ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  checkInputs = [ action-msgs ament-cmake-mypy ament-cmake-pytest builtin-interfaces control-msgs diagnostic-msgs example-interfaces geometry-msgs nav-msgs rosbridge-test-msgs sensor-msgs std-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
   propagatedBuildInputs = [ python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/rolling/rosbridge-msgs/default.nix
+++ b/distros/rolling/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d2d4d92ec53604f443bff9c8b6366e4ff5e7d4634e84eeeba6d018f681d29b00";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "bebffea95a167757b34010820433921dccd415b4f096c6de8c9a16ef24e96fad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-server/default.nix
+++ b/distros/rolling/rosbridge-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-mypy, ament-cmake-ros, example-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-server";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "30ffea60049813652a0608a55a5362955879fd48280f130601a67e6fc1ba6046";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_server/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "7ea42a0d4838f0b1078ea927f7c8f4e881f106a7ef3c736ba6b114a5bc6cdc24";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ];
-  checkInputs = [ example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
+  checkInputs = [ ament-cmake-mypy example-interfaces launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn std-srvs ];
   propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ];
 

--- a/distros/rolling/rosbridge-suite/default.nix
+++ b/distros/rolling/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-suite";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "b30d9a13999ec633a8b7acb1699e635d7fe3c3feee3bbfd1df48add77863c27e";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_suite/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "3712640cd032836c0d9c0d9f310c4e70e42b37e3389a4d2321342daacbe8a011";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rosbridge-test-msgs/default.nix
+++ b/distros/rolling/rosbridge-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-pytest, builtin-interfaces, diagnostic-msgs, example-interfaces, geometry-msgs, nav-msgs, rclpy, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rosbridge-test-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "69a27154c4a291ea0f6d1383ff1c559ac39fb272e6705a706a2afabebbf71364";
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/rolling/rosbridge_test_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ce77664b6cc31c0e6bf9162fd06b7c888ed3d0d7c5611b40d7254c185dd88887";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/septentrio-gnss-driver/default.nix
+++ b/distros/rolling/septentrio-gnss-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, diagnostic-msgs, geographiclib, geometry-msgs, gps-msgs, libpcap, nav-msgs, nmea-msgs, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-septentrio-gnss-driver";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "0fb8d315803e89621a85d2fbc219faa083b2832608711b1d41a435fc9a207039";
+    url = "https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release/archive/release/rolling/septentrio_gnss_driver/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f2ded09f919cb78be201ec0340d76c134d44f90309ac7645315af1c608160665";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/synapticon-ros2-control/default.nix
+++ b/distros/rolling/synapticon-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, forward-command-controller, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, libcap, pluginlib, rclcpp, rclcpp-lifecycle, robot-state-publisher, ros2controlcli, ros2launch, xacro }:
+buildRosPackage {
+  pname = "ros-rolling-synapticon-ros2-control";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/synapticon/synapticon_ros2_control-release/archive/release/rolling/synapticon_ros2_control/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "b584a7d0f6f40f84d83dfac0b11b91bd38cd75969c5f3876708a11d4d7bc4b27";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager forward-command-controller hardware-interface joint-state-broadcaster joint-trajectory-controller libcap pluginlib rclcpp rclcpp-lifecycle robot-state-publisher ros2controlcli ros2launch xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A ros2_control interface for Synapticon motor drivers";
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/rolling/test-ros-gz-bridge/default.nix
+++ b/distros/rolling/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-rolling-test-ros-gz-bridge";
-  version = "2.1.4-r1";
+  version = "2.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "1d31250688f85c49d4897600aaeb348a6283a1cefc72488bc448b539fb7db39c";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.5-1.tar.gz";
+    name = "2.1.5-1.tar.gz";
+    sha256 = "40d377da21eb6eebcfde54891f97a7f914db93287e6f2e591532265f95cd9392";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.7.0-r1";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "b4805b99f81504c19236dd92328dc0b045e919f3ecbef04263c80e2d7df39e81";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "38faebe1417d05274c111839e2aedcbf0800959c04334ce55ac7f9bb8be0fefd";
   };
 
   buildType = "cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit c961d3098031641eaa5b6e4074cd6d5572bbfb0e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.42.0-r1 --> 2.42.1-r1*
* *admittance-controller 2.42.0-r1 --> 2.42.1-r1*
* *bicycle-steering-controller 2.42.0-r1 --> 2.42.1-r1*
* *diff-drive-controller 2.42.0-r1 --> 2.42.1-r1*
* *dynamixel-workbench-msgs 2.0.3-r1 --> 2.1.0-r1*
* *effort-controllers 2.42.0-r1 --> 2.42.1-r1*
* *force-torque-sensor-broadcaster 2.42.0-r1 --> 2.42.1-r1*
* *forward-command-controller 2.42.0-r1 --> 2.42.1-r1*
* *gpio-controllers 2.42.0-r1 --> 2.42.1-r1*
* *gripper-controllers 2.42.0-r1 --> 2.42.1-r1*
* *hls-lfcd-lds-driver 2.0.4-r3 --> 2.1.0-r1*
* *imu-sensor-broadcaster 2.42.0-r1 --> 2.42.1-r1*
* *joint-state-broadcaster 2.42.0-r1 --> 2.42.1-r1*
* *joint-trajectory-controller 2.42.0-r1 --> 2.42.1-r1*
* *kitti-metrics-eval 1.6.1-r1 --> 1.6.2-r1*
* *mola 1.6.1-r1 --> 1.6.2-r1*
* *mola-bridge-ros2 1.6.1-r1 --> 1.6.2-r1*
* *mola-demos 1.6.1-r1 --> 1.6.2-r1*
* *mola-gnss-to-markers 0.1.0-r1*
* *mola-imu-preintegration 1.6.1-r1 --> 1.7.0-r1*
* *mola-input-euroc-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti360-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-mulran-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-paris-luco-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rawlog 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rosbag2 1.6.1-r1 --> 1.6.2-r1*
* *mola-kernel 1.6.1-r1 --> 1.6.2-r1*
* *mola-launcher 1.6.1-r1 --> 1.6.2-r1*
* *mola-lidar-odometry 0.6.1-r1 --> 0.7.0-r1*
* *mola-metric-maps 1.6.1-r1 --> 1.6.2-r1*
* *mola-msgs 1.6.1-r1 --> 1.6.2-r1*
* *mola-pose-list 1.6.1-r1 --> 1.6.2-r1*
* *mola-relocalization 1.6.1-r1 --> 1.6.2-r1*
* *mola-state-estimation 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-simple 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-smoother 1.6.1-r1 --> 1.7.0-r1*
* *mola-traj-tools 1.6.1-r1 --> 1.6.2-r1*
* *mola-viz 1.6.1-r1 --> 1.6.2-r1*
* *mola-yaml 1.6.1-r1 --> 1.6.2-r1*
* *mp2p-icp 1.6.5-r1 --> 1.6.6-r1*
* *pid-controller 2.42.0-r1 --> 2.42.1-r1*
* *pinocchio 3.4.0-r1 --> 3.4.0-r2*
* *pose-broadcaster 2.42.0-r1 --> 2.42.1-r1*
* *position-controllers 2.42.0-r1 --> 2.42.1-r1*
* *range-sensor-broadcaster 2.42.0-r1 --> 2.42.1-r1*
* *ros2-controllers 2.42.0-r1 --> 2.42.1-r1*
* *ros2-controllers-test-nodes 2.42.0-r1 --> 2.42.1-r1*
* *rqt-joint-trajectory-controller 2.42.0-r1 --> 2.42.1-r1*
* *septentrio-gnss-driver 1.4.1-r1 --> 1.4.2-r2*
* *steering-controllers-library 2.42.0-r1 --> 2.42.1-r1*
* *synapticon-ros2-control 0.1.2-r1*
* *tricycle-controller 2.42.0-r1 --> 2.42.1-r1*
* *tricycle-steering-controller 2.42.0-r1 --> 2.42.1-r1*
* *ur-client-library 1.7.0-r1 --> 1.7.1-r1*
* *velocity-controllers 2.42.0-r1 --> 2.42.1-r1*

Jazzy Changes:
--------------
* *dynamixel-workbench-msgs 2.0.3-r5 --> 2.1.0-r1*
* *hls-lfcd-lds-driver 2.0.4-r6 --> 2.1.0-r1*
* *kitti-metrics-eval 1.6.1-r1 --> 1.6.2-r1*
* *mola 1.6.1-r1 --> 1.6.2-r1*
* *mola-bridge-ros2 1.6.1-r1 --> 1.6.2-r1*
* *mola-demos 1.6.1-r1 --> 1.6.2-r1*
* *mola-gnss-to-markers 0.1.0-r1*
* *mola-imu-preintegration 1.6.1-r1 --> 1.7.0-r1*
* *mola-input-euroc-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti360-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-mulran-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-paris-luco-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rawlog 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rosbag2 1.6.1-r1 --> 1.6.2-r1*
* *mola-kernel 1.6.1-r1 --> 1.6.2-r1*
* *mola-launcher 1.6.1-r1 --> 1.6.2-r1*
* *mola-lidar-odometry 0.6.1-r1 --> 0.7.0-r1*
* *mola-metric-maps 1.6.1-r1 --> 1.6.2-r1*
* *mola-msgs 1.6.1-r1 --> 1.6.2-r1*
* *mola-pose-list 1.6.1-r1 --> 1.6.2-r1*
* *mola-relocalization 1.6.1-r1 --> 1.6.2-r1*
* *mola-state-estimation 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-simple 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-smoother 1.6.1-r1 --> 1.7.0-r1*
* *mola-traj-tools 1.6.1-r1 --> 1.6.2-r1*
* *mola-viz 1.6.1-r1 --> 1.6.2-r1*
* *mola-yaml 1.6.1-r1 --> 1.6.2-r1*
* *mp2p-icp 1.6.5-r1 --> 1.6.6-r1*
* *pinocchio 3.4.0-r1 --> 3.4.0-r2*
* *rosapi 2.1.0-r1 --> 2.2.0-r1*
* *rosapi-msgs 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-library 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-msgs 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-server 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-suite 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-test-msgs 2.1.0-r1 --> 2.2.0-r1*
* *septentrio-gnss-driver 1.4.1-r1 --> 1.4.2-r1*
* *synapticon-ros2-control 0.1.2-r1*
* *ur-client-library 1.7.0-r1 --> 1.7.1-r1*

Noetic Changes:
---------------
* *costmap-cspace 0.17.4-r1 --> 0.17.5-r1*
* *foxglove-bridge 0.8.3-r1 --> 0.8.4-r1*
* *gazebo-dev 2.9.2-r1 --> 2.9.3-r1*
* *gazebo-msgs 2.9.2-r1 --> 2.9.3-r1*
* *gazebo-plugins 2.9.2-r1 --> 2.9.3-r1*
* *gazebo-ros 2.9.2-r1 --> 2.9.3-r1*
* *gazebo-ros-control 2.9.2-r1 --> 2.9.3-r1*
* *gazebo-ros-pkgs 2.9.2-r1 --> 2.9.3-r1*
* *joystick-interrupt 0.17.4-r1 --> 0.17.5-r1*
* *map-organizer 0.17.4-r1 --> 0.17.5-r1*
* *marti-data-structures 2.15.2-r1 --> 2.15.4-r1*
* *movie-publisher-plugins 2.0.2-r1 --> 2.0.3-r1*
* *movie-publisher-plugins-copyleft 2.0.2-r1 --> 2.0.3-r1*
* *movie-publisher-plugins-nonfree 2.0.2-r1 --> 2.0.3-r1*
* *movie-publisher-plugins-permissive 2.0.2-r1 --> 2.0.3-r1*
* *mp2p-icp 1.6.3-r1 --> 1.6.6-r1*
* *neonavigation 0.17.4-r1 --> 0.17.5-r1*
* *neonavigation-common 0.17.4-r1 --> 0.17.5-r1*
* *neonavigation-launch 0.17.4-r1 --> 0.17.5-r1*
* *obj-to-pointcloud 0.17.4-r1 --> 0.17.5-r1*
* *planner-cspace 0.17.4-r1 --> 0.17.5-r1*
* *safety-limiter 0.17.4-r1 --> 0.17.5-r1*
* *septentrio-gnss-driver 1.4.1-r1 --> 1.4.2-r1*
* *swri-cli-tools 2.15.2-r1 --> 2.15.4-r1*
* *swri-console-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-dbw-interface 2.15.2-r1 --> 2.15.4-r1*
* *swri-geometry-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-image-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-math-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-nodelet 2.15.2-r1 --> 2.15.4-r1*
* *swri-opencv-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-prefix-tools 2.15.2-r1 --> 2.15.4-r1*
* *swri-roscpp 2.15.2-r1 --> 2.15.4-r1*
* *swri-rospy 2.15.2-r1 --> 2.15.4-r1*
* *swri-route-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-serial-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-string-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-system-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-transform-util 2.15.2-r1 --> 2.15.4-r1*
* *swri-yaml-util 2.15.2-r1 --> 2.15.4-r1*
* *track-odometry 0.17.4-r1 --> 0.17.5-r1*
* *trajectory-tracker 0.17.4-r1 --> 0.17.5-r1*
* *ur-calibration 2.1.5-r1 --> 2.2.0-r1*
* *ur-client-library 1.7.0-r1 --> 1.7.1-r1*
* *ur-dashboard-msgs 2.1.5-r1 --> 2.2.0-r1*
* *ur-msgs 1.4.0-r1 --> 1.5.0-r1*
* *ur-robot-driver 2.1.5-r1 --> 2.2.0-r1*

Rolling Changes:
----------------
* *boost-sml-vendor 1.1.11-r1*
* *dynamixel-workbench-msgs 2.0.3-r4 --> 2.1.0-r1*
* *gz-cmake-vendor 0.2.1-r1 --> 0.2.2-r1*
* *kitti-metrics-eval 1.6.1-r1 --> 1.6.2-r1*
* *mola 1.6.1-r1 --> 1.6.2-r1*
* *mola-bridge-ros2 1.6.1-r1 --> 1.6.2-r1*
* *mola-demos 1.6.1-r1 --> 1.6.2-r1*
* *mola-gnss-to-markers 0.1.0-r1*
* *mola-imu-preintegration 1.6.1-r1 --> 1.7.0-r1*
* *mola-input-euroc-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-kitti360-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-mulran-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-paris-luco-dataset 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rawlog 1.6.1-r1 --> 1.6.2-r1*
* *mola-input-rosbag2 1.6.1-r1 --> 1.6.2-r1*
* *mola-kernel 1.6.1-r1 --> 1.6.2-r1*
* *mola-launcher 1.6.1-r1 --> 1.6.2-r1*
* *mola-lidar-odometry 0.6.1-r1 --> 0.7.0-r1*
* *mola-metric-maps 1.6.1-r1 --> 1.6.2-r1*
* *mola-msgs 1.6.1-r1 --> 1.6.2-r1*
* *mola-pose-list 1.6.1-r1 --> 1.6.2-r1*
* *mola-relocalization 1.6.1-r1 --> 1.6.2-r1*
* *mola-state-estimation 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-simple 1.6.1-r1 --> 1.7.0-r1*
* *mola-state-estimation-smoother 1.6.1-r1 --> 1.7.0-r1*
* *mola-traj-tools 1.6.1-r1 --> 1.6.2-r1*
* *mola-viz 1.6.1-r1 --> 1.6.2-r1*
* *mola-yaml 1.6.1-r1 --> 1.6.2-r1*
* *mp2p-icp 1.6.5-r1 --> 1.6.6-r1*
* *pinocchio 3.4.0-r2 --> 3.4.0-r3*
* *rmw-desert 1.0.1-r1*
* *ros-gz 2.1.4-r1 --> 2.1.5-r1*
* *ros-gz-bridge 2.1.4-r1 --> 2.1.5-r1*
* *ros-gz-image 2.1.4-r1 --> 2.1.5-r1*
* *ros-gz-interfaces 2.1.4-r1 --> 2.1.5-r1*
* *ros-gz-sim 2.1.4-r1 --> 2.1.5-r1*
* *ros-gz-sim-demos 2.1.4-r1 --> 2.1.5-r1*
* *rosapi 2.1.0-r1 --> 2.2.0-r1*
* *rosapi-msgs 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-library 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-msgs 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-server 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-suite 2.1.0-r1 --> 2.2.0-r1*
* *rosbridge-test-msgs 2.1.0-r1 --> 2.2.0-r1*
* *septentrio-gnss-driver 1.4.1-r1 --> 1.4.2-r1*
* *synapticon-ros2-control 0.1.2-r1*
* *test-ros-gz-bridge 2.1.4-r1 --> 2.1.5-r1*
* *ur-client-library 1.7.0-r1 --> 1.7.1-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] velodyne_description
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

