### PR TITLE
rosdistro sync, Sat Mar  1 18:33:54 2025

### DIFF
--- a/distros/rolling/camera-calibration/default.nix
+++ b/distros/rolling/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-camera-calibration";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "d8b9e2c3828fd374da1360c77ec659518a8dbc34c23cf8cdb2576166a3b10d78";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/camera_calibration/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "55911076bbb044bbf70228b282d53fdab963a90c4e1ee133b141c981775c7094";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/depth-image-proc/default.nix
+++ b/distros/rolling/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-proc, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-depth-image-proc";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "d00f3dee6897129034e823aa8ab64ffddf6d7eba16a2a59ebc84447fd4461f90";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/depth_image_proc/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "7b858bdc796c03a30b02acb3d5a0a51b783209784952216d5fcdba804440df47";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastdds/default.nix
+++ b/distros/rolling/fastdds/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-rolling-fastdds";
+  version = "3.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "167c2dca35012b69b5124d1ddc1eeb5a3362899d7d78ba970af9380959a4ff34";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ asio cmake ];
+  propagatedBuildInputs = [ fastcdr foonathan-memory-vendor openssl python3 tinyxml-2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "*eprosima Fast DDS* is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium. RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard. *eProsima Fast DDS* expose an API to access directly the RTPS protocol, giving the user full access to the protocol internals.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -586,7 +586,7 @@ self: super: {
 
  fastcdr = self.callPackage ./fastcdr {};
 
- fastrtps = self.callPackage ./fastrtps {};
+ fastdds = self.callPackage ./fastdds {};
 
  fastrtps-cmake-module = self.callPackage ./fastrtps-cmake-module {};
 
@@ -1776,12 +1776,6 @@ self: super: {
 
  rmw-desert = self.callPackage ./rmw-desert {};
 
- rmw-fastrtps-cpp = self.callPackage ./rmw-fastrtps-cpp {};
-
- rmw-fastrtps-dynamic-cpp = self.callPackage ./rmw-fastrtps-dynamic-cpp {};
-
- rmw-fastrtps-shared-cpp = self.callPackage ./rmw-fastrtps-shared-cpp {};
-
  rmw-implementation = self.callPackage ./rmw-implementation {};
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
@@ -1967,8 +1961,6 @@ self: super: {
  rosidl-default-runtime = self.callPackage ./rosidl-default-runtime {};
 
  rosidl-dynamic-typesupport = self.callPackage ./rosidl-dynamic-typesupport {};
-
- rosidl-dynamic-typesupport-fastrtps = self.callPackage ./rosidl-dynamic-typesupport-fastrtps {};
 
  rosidl-generator-c = self.callPackage ./rosidl-generator-c {};
 

--- a/distros/rolling/image-pipeline/default.nix
+++ b/distros/rolling/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-rolling-image-pipeline";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "be340409f987b97e004915eb787bc0649a816434d178a4aea9e5374ea2f43a5f";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_pipeline/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "a02bf726cd9d9d0de84fa9d1108ed15b78f412c87f7e5c4e1ec054d833c7d4a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-proc/default.nix
+++ b/distros/rolling/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, geometry-msgs, image-geometry, image-transport, opencv, rclcpp, rclcpp-components, rcutils, sensor-msgs, tf2, tf2-geometry-msgs, tracetools-image-pipeline }:
 buildRosPackage {
   pname = "ros-rolling-image-proc";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "081e3bf566e250ddc076f41eeff7036132a301c3131363277f876103a89f8109";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_proc/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "2e733e82dc046b3e58403f795eef9749589f1548b0b335473252745e33c017f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-publisher/default.nix
+++ b/distros/rolling/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, image-transport, rcl-interfaces, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-rolling-image-publisher";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "87eecbd3c6ec3e79ddf81e0857ed1963b09f921782bb69d1b6c2e7a08473033e";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_publisher/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "f0453d79c9547a1df80ec5104d2516f6290c8032e840084e99aa3b05a310294f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-rotate/default.nix
+++ b/distros/rolling/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, geometry-msgs, image-transport, opencv, rcl-interfaces, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-image-rotate";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "4b3d667908916d04464816e9a97e47fe261ff637c2422a5b9443e740581ae328";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_rotate/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "5a7225586c74ec99cde233f71cfdbe009b1ea4bd10cea2309473c0e3892442cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/image-view/default.nix
+++ b/distros/rolling/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, rclpy, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-image-view";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "02f82fab6f7c4ab23a865942be3073a43d3168afab2508c94c918dd09a6a307f";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/image_view/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "9ad6ed1acdc87404748efa714774c0bfb66980f896f252dabc66d785b6c9dce1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-pytest/default.nix
+++ b/distros/rolling/launch-pytest/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-launch-pytest";
-  version = "3.7.1-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "61eb79e7a0cb234a9aa1ad2bd8c7688f45a99c2c8e7ef1d7238915ce34e00c34";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_pytest/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "9f0d27588d6e9d51b57e6b17a2f54009f644749e103b87d34e4da3af861152d0";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint ];
   propagatedBuildInputs = [ ament-index-python launch launch-testing osrf-pycommon python3Packages.pytest ];
 
   meta = {

--- a/distros/rolling/launch-testing-ament-cmake/default.nix
+++ b/distros/rolling/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing-ament-cmake";
-  version = "3.7.1-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "dd4785211fbb91c2600fa6ea2804bc8173da8c291b50a388b0bd6f9272326f49";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing_ament_cmake/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "46390515e40940fd8264f4df572667d1b245a5f62b6221377f0dc6a4d86d4e83";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/launch-testing/default.nix
+++ b/distros/rolling/launch-testing/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-xml, launch-yaml, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-launch-testing";
-  version = "3.7.1-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "4f21c90ff2536826fc7e8a426f92e575e44e2308748fc7061ac21c0f7d19290b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_testing/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "6335c0f906398457973d9f9f1c284d1da658d460e7f987e42945afc6416efa2d";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint launch ];
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint ];
   propagatedBuildInputs = [ ament-index-python launch launch-xml launch-yaml osrf-pycommon python3Packages.pytest ];
 
   meta = {

--- a/distros/rolling/launch-xml/default.nix
+++ b/distros/rolling/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-launch-xml";
-  version = "3.7.1-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "d06a0c932e8f22502cbcad078881febcaa757a4a6c249fd574e8edfc72d4af32";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_xml/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "637e11e4cdd320f31b6d75f9a5a08b489e5569cf402867ee7d54a29c9095aebb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch-yaml/default.nix
+++ b/distros/rolling/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-launch-yaml";
-  version = "3.7.1-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "3820c8c5d584bce2baaa9e9dedda44063ae5f26f488a8345ec6576f9cb0e0d48";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch_yaml/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "8dbe2deab02d03fca386e17c1d0ba9a9d1e1bbb0b711f051042179d2853f6d78";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/launch/default.nix
+++ b/distros/rolling/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, ament-xmllint, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-launch";
-  version = "3.7.1-r1";
+  version = "3.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.7.1-1.tar.gz";
-    name = "3.7.1-1.tar.gz";
-    sha256 = "52ab011638f43f66b53db8bd225ac85b07e269ee521b84bf3e444085d67567b1";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/rolling/launch/3.8.0-1.tar.gz";
+    name = "3.8.0-1.tar.gz";
+    sha256 = "449d0db97e02121b24ceef8b75b384cd7c626724266efbea1b9934a51c9058e1";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "a56acf0cac95056941834edd5dbfda1facc9b82c20d8419d56d1a23ed692f146";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "cc9dcd132046e1e6cbd0d257b1e5f56cc66bc2a18526322747f9ea36e331067c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "b881d1c2664e76d9faa4e9211335bf6abe5b5e105332af6c0da8bdd5041e38b7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "ea4e5440ad8375e7153708da72521e1dd8f6eebeb78a6c62b7c6ac00a4e35541";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "d67789c951ca9b8661e200a8934523c043dbded66ef5909b6f3c396adfe486b7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "ceb45ebba63c81a045fa59935b25ebbe77c7dbb56c7b5b54c7432fc566a3ad19";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "274b5005343f9235f0092f7943c4dab0e3ffb23e7c52e621152311bb241d9667";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "2045c56d1182cb3b81b294f45bc01ae2276f22506e71e8bfd67ce9ec4c50d5d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "b498377136ed6c40982c9a7f652d9c17b98c2eaf4daeec03c3df2d9eca42d478";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "be19bc8f0cf7eacc01097e9a759a76ba56fd6c51e15531cf9363eb5ced67bfdc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "ddea9db88b67a2b3dcbb5bf4617e1c153f3f742b47ded9995d936b8f2856d783";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "33e652d79e6fc61a8b3a52a29b91caa02735044698ec02a68133b226e69f3a32";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "8b4e2bda4d47cc0f00420ee33e4886e77f052e6f2bb76bc9c204bf0458669236";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "a59d70905db8431e1b3a4d755da009c10d4dc2ba0c416f2a3491c7561abf2c11";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.4.2-r1";
+  version = "14.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "feb1a5bf610ac10a44678e62272f83a84f5e0360699bec08d8c1362bd15b6c8c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.3-1.tar.gz";
+    name = "14.4.3-1.tar.gz";
+    sha256 = "4ffdff06eedc1f74cc53a21309a4abbe9c3133bd7de76809b519e9fc8902a6e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-image-proc/default.nix
+++ b/distros/rolling/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, ros-testing, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-image-proc";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "c03327b0d3985846c3afe5ef38ead0c9c890d1517ec7998ab5665e4d57ac555b";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/stereo_image_proc/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "d98d85451666b24582f6ac324212d34cc58882b01ed7f6d1922043f869a8ab25";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tracetools-image-pipeline/default.nix
+++ b/distros/rolling/tracetools-image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-rolling-tracetools-image-pipeline";
-  version = "6.0.9-r1";
+  version = "6.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/6.0.9-1.tar.gz";
-    name = "6.0.9-1.tar.gz";
-    sha256 = "ef57d75cae5f5f4526301e2e7373cfe564d4bb162f98632ac5c885b0ef26ce71";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/rolling/tracetools_image_pipeline/6.0.10-1.tar.gz";
+    name = "6.0.10-1.tar.gz";
+    sha256 = "117075e6272985424d0b42c762af4f9d00dd0fc53744b29fafe09efaf523446c";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit fd8d6a850487f007487a577cb641bc6408469e2a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Rolling Changes:
----------------
* *camera-calibration 6.0.9-r1 --> 6.0.10-r1*
* *depth-image-proc 6.0.9-r1 --> 6.0.10-r1*
* *fastdds 3.1.2-r1*
* *image-pipeline 6.0.9-r1 --> 6.0.10-r1*
* *image-proc 6.0.9-r1 --> 6.0.10-r1*
* *image-publisher 6.0.9-r1 --> 6.0.10-r1*
* *image-rotate 6.0.9-r1 --> 6.0.10-r1*
* *image-view 6.0.9-r1 --> 6.0.10-r1*
* *launch 3.7.1-r1 --> 3.8.0-r1*
* *launch-pytest 3.7.1-r1 --> 3.8.0-r1*
* *launch-testing 3.7.1-r1 --> 3.8.0-r1*
* *launch-testing-ament-cmake 3.7.1-r1 --> 3.8.0-r1*
* *launch-xml 3.7.1-r1 --> 3.8.0-r1*
* *launch-yaml 3.7.1-r1 --> 3.8.0-r1*
* *rviz-assimp-vendor 14.4.2-r1 --> 14.4.3-r1*
* *rviz-common 14.4.2-r1 --> 14.4.3-r1*
* *rviz-default-plugins 14.4.2-r1 --> 14.4.3-r1*
* *rviz-ogre-vendor 14.4.2-r1 --> 14.4.3-r1*
* *rviz-rendering 14.4.2-r1 --> 14.4.3-r1*
* *rviz-rendering-tests 14.4.2-r1 --> 14.4.3-r1*
* *rviz-visual-testing-framework 14.4.2-r1 --> 14.4.3-r1*
* *rviz2 14.4.2-r1 --> 14.4.3-r1*
* *stereo-image-proc 6.0.9-r1 --> 6.0.10-r1*
* *tracetools-image-pipeline 6.0.9-r1 --> 6.0.10-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] fastrtps
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] velodyne_description
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

