### PR TITLE
jazzy: Fix failing patchelf for gz-gui-8

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -77,7 +77,7 @@ in {
     # "RPATH of binary libGrid3D.so contains a forbidden reference to
     # /build/" (see https://github.com/gazebosim/gz-gui/issues/627).
     postInstall = postInstall + ''
-      ${self.patchelf}/bin/patchelf --remove-rpath $out/lib64/gz-gui-8/plugins/libGrid3D.so
+      ${self.patchelf}/bin/patchelf --remove-rpath $out/lib*/gz-gui-8/plugins/libGrid3D.so
     '';
   });
 


### PR DESCRIPTION
Fixes
```
> patchelf: getting info about '/nix/store/44picdxg6lxgn6d3f3ndipwc9df87a6z-ros-jazzy-gz-gui-vendor-0.0.5-r1/lib64/gz-gui-8/plugins/libGrid3D.so': No such file or directory
```