### PR TITLE
Automatic updates of ament_vendor patching

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,10 +20,6 @@ jobs:
           nix-env -f . -iA python3Packages.rosdep superflore
       - name: Update overlay
         env:
-          # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
-          # triggering a build
-          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
-          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
           ROS_OS_OVERRIDE: nixos
           ROSDEP_SOURCE_PATH: rosdep-sources
         run: |
@@ -37,8 +33,28 @@ jobs:
               echo "username=lopsided98"
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
-          superflore-gen-nix \
+          superflore-gen-nix --dry-run \
             --tar-archive-dir "${{ runner.temp }}/tar" \
             --output-repository-path . \
             --upstream-branch develop \
             --all
+      - name: Update ament_vendor info
+        continue-on-error: true
+        run: |
+          # permittedInsecurePackages is needed for updating some gz-*-vendor packages.
+          # Note that this runs without access to SUPERFLORE_GITHUB_TOKEN.
+          mkdir -p ~/.config/nixpkgs
+          echo '{ permittedInsecurePackages = [ "freeimage-unstable-2021-11-01" ]; }' > ~/.config/nixpkgs/config.nix
+          NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh || ret=$?
+          git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
+          exit $ret
+      - name: Create PR
+        env:
+          # Don't use secrets.GITHUB_TOKEN because it prevents the PR from
+          # triggering a build
+          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
+          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
+        run: |
+          superflore-gen-nix --pr-only \
+            --output-repository-path . \
+            --upstream-branch develop \

--- a/distros/jazzy/gz-cmake-vendor/vendored-source.json
+++ b/distros/jazzy/gz-cmake-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-cmake.git",
+  "rev": "gz-cmake3_3.5.4",
+  "hash": "sha256-mP0bBPWWAoUFsUwKn95Eqv1lW3lJdPEu3hhfmiK3mNQ="
+}

--- a/distros/jazzy/gz-common-vendor/vendored-source.json
+++ b/distros/jazzy/gz-common-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-common.git",
+  "rev": "gz-common5_5.7.1",
+  "hash": "sha256-vNCjCSQYCSUHXKwXnq8vwWXiSK2+cD3yPSLT1FdAWrE="
+}

--- a/distros/jazzy/gz-dartsim-vendor/vendored-source.json
+++ b/distros/jazzy/gz-dartsim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/dartsim/dart.git",
+  "rev": "v6.13.2",
+  "hash": "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g="
+}

--- a/distros/jazzy/gz-fuel-tools-vendor/vendored-source.json
+++ b/distros/jazzy/gz-fuel-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-fuel-tools.git",
+  "rev": "gz-fuel-tools9_9.1.1",
+  "hash": "sha256-XQoBcCtzwzzPypS1kIeTCIbjtxrzaW3JvZLCYbwXAOk="
+}

--- a/distros/jazzy/gz-gui-vendor/vendored-source.json
+++ b/distros/jazzy/gz-gui-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-gui.git",
+  "rev": "gz-gui8_8.4.0",
+  "hash": "sha256-gf9XZzAX2g6r9ThIA0v2H2X/+uu9VnwvyvrdL5ZazM0="
+}

--- a/distros/jazzy/gz-launch-vendor/vendored-source.json
+++ b/distros/jazzy/gz-launch-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-launch.git",
+  "rev": "gz-launch7_7.1.1",
+  "hash": "sha256-S63DWe/c3cnEztxr3uJc0A4AmuiQk4o6m9yXj0X97Yk="
+}

--- a/distros/jazzy/gz-math-vendor/vendored-source.json
+++ b/distros/jazzy/gz-math-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-math.git",
+  "rev": "gz-math7_7.5.2",
+  "hash": "sha256-LwYeyv8nwX06n5ju+ra2uqNMedMSLRumem8qDHXtNns="
+}

--- a/distros/jazzy/gz-msgs-vendor/vendored-source.json
+++ b/distros/jazzy/gz-msgs-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-msgs.git",
+  "rev": "gz-msgs10_10.3.2",
+  "hash": "sha256-gxhRqLzBCaDmK67T5RryDpxbDR3WLgV9DFs7w6ieMxQ="
+}

--- a/distros/jazzy/gz-ogre-next-vendor/vendored-source.json
+++ b/distros/jazzy/gz-ogre-next-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre-next.git",
+  "rev": "v2.3.3",
+  "hash": "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM="
+}

--- a/distros/jazzy/gz-physics-vendor/vendored-source.json
+++ b/distros/jazzy/gz-physics-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-physics.git",
+  "rev": "gz-physics7_7.5.0",
+  "hash": "sha256-75myTqDeEybvj5rsJxRambLPle1cen6HIatZGbVoXro="
+}

--- a/distros/jazzy/gz-plugin-vendor/vendored-source.json
+++ b/distros/jazzy/gz-plugin-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-plugin.git",
+  "rev": "gz-plugin2_2.0.4",
+  "hash": "sha256-iL4+EdFFAU55FVqE/CvyTv1zNaXxBWqWx44L0BeG2MU="
+}

--- a/distros/jazzy/gz-rendering-vendor/vendored-source.json
+++ b/distros/jazzy/gz-rendering-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-rendering.git",
+  "rev": "gz-rendering8_8.2.2",
+  "hash": "sha256-x+QHn8d+19U12CG1+HEmP0KcM3beY00Vvrc8mrxvAs0="
+}

--- a/distros/jazzy/gz-sensors-vendor/vendored-source.json
+++ b/distros/jazzy/gz-sensors-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sensors.git",
+  "rev": "gz-sensors8_8.2.2",
+  "hash": "sha256-TRDMCMesJXVSVGA3bnRngtXTi4VVf0y12AJQ79EEMiI="
+}

--- a/distros/jazzy/gz-sim-vendor/vendored-source.json
+++ b/distros/jazzy/gz-sim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sim.git",
+  "rev": "gz-sim8_8.9.0",
+  "hash": "sha256-hvhq2XBzcIoupJdJyJzk38LDXoEnd9iBCCiXvPZsPqY="
+}

--- a/distros/jazzy/gz-tools-vendor/vendored-source.json
+++ b/distros/jazzy/gz-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-tools.git",
+  "rev": "gz-tools2_2.0.2",
+  "hash": "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg="
+}

--- a/distros/jazzy/gz-transport-vendor/vendored-source.json
+++ b/distros/jazzy/gz-transport-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-transport.git",
+  "rev": "gz-transport13_13.4.1",
+  "hash": "sha256-hCP+yVoyl1c3KNmQ5jKrYvPT1IlAy9JkCh0c0mOF+KM="
+}

--- a/distros/jazzy/gz-utils-vendor/vendored-source.json
+++ b/distros/jazzy/gz-utils-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-utils.git",
+  "rev": "gz-utils2_2.2.1",
+  "hash": "sha256-utVW8pTP/emEWblTxVb6jzulKdxss+2VfS552MWMqm4="
+}

--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -42,36 +42,20 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor {
-    version = "3.5.4";
-    hash = "sha256-mP0bBPWWAoUFsUwKn95Eqv1lW3lJdPEu3hhfmiK3mNQ=";
-  };
+  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor { };
 
-  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
-    version = "5.7.1";
-    hash = "sha256-vNCjCSQYCSUHXKwXnq8vwWXiSK2+cD3yPSLT1FdAWrE=";
-  }).overrideAttrs ({
+  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
     # https://github.com/gazebo-release/gz_common_vendor/pull/2
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
-  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor {
-    url = "https://github.com/dartsim/dart.git";
-    rev = "v6.13.2";
-    fetchgitArgs.hash = "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g=";
-  };
+  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor { };
 
-  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor {
-    version = "9.1.1";
-    hash = "sha256-XQoBcCtzwzzPypS1kIeTCIbjtxrzaW3JvZLCYbwXAOk=";
-  };
+  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor { };
 
-  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor {
-    version = "8.4.0";
-    hash = "sha256-gf9XZzAX2g6r9ThIA0v2H2X/+uu9VnwvyvrdL5ZazM0=";
-  }).overrideAttrs ({
+  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor { }).overrideAttrs ({
     postInstall ? "", ...
   }: {
     # "RPATH of binary libGrid3D.so contains a forbidden reference to
@@ -81,58 +65,27 @@ in {
     '';
   });
 
-  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor {
-    version = "7.1.1";
-    hash = "sha256-S63DWe/c3cnEztxr3uJc0A4AmuiQk4o6m9yXj0X97Yk=";
-  };
+  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor { };
 
-  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor {
-    version = "7.5.2";
-    hash = "sha256-LwYeyv8nwX06n5ju+ra2uqNMedMSLRumem8qDHXtNns=";
-  };
+  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor { };
 
-  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
-    version = "10.3.2";
-    hash = "sha256-gxhRqLzBCaDmK67T5RryDpxbDR3WLgV9DFs7w6ieMxQ=";
-  };
+  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor { };
 
-  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {
-    url = "https://github.com/OGRECave/ogre-next.git";
-    rev = "v2.3.3";
-    fetchgitArgs.hash = "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM=";
-  }).overrideAttrs({ ... }: {
+  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor { }).overrideAttrs({ ... }: {
     dontFixCmake = true;
   });
 
-  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor {
-    version = "7.5.0";
-    hash = "sha256-75myTqDeEybvj5rsJxRambLPle1cen6HIatZGbVoXro=";
-  };
+  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor { };
 
-  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor {
-    version = "2.0.4";
-    hash = "sha256-iL4+EdFFAU55FVqE/CvyTv1zNaXxBWqWx44L0BeG2MU=";
-  };
+  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor { };
 
-  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor {
-    version = "8.2.2";
-    hash = "sha256-x+QHn8d+19U12CG1+HEmP0KcM3beY00Vvrc8mrxvAs0=";
-  };
+  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor { };
 
-  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor {
-    version = "8.2.2";
-    hash = "sha256-TRDMCMesJXVSVGA3bnRngtXTi4VVf0y12AJQ79EEMiI=";
-  };
+  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor { };
 
-  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor {
-    version = "8.9.0";
-    hash = "sha256-hvhq2XBzcIoupJdJyJzk38LDXoEnd9iBCCiXvPZsPqY=";
-  };
+  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor { };
 
-  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
-    version = "2.0.2";
-    hash = "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg=";
-  }).overrideAttrs({
+  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor { }).overrideAttrs({
     nativeBuildInputs ? [],
     propagatedNativeBuildInputs ? [],
     qtWrapperArgs ? [],
@@ -154,19 +107,13 @@ in {
     '';
   });
 
-  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
-    version = "13.4.1";
-    hash = "sha256-hCP+yVoyl1c3KNmQ5jKrYvPT1IlAy9JkCh0c0mOF+KM=";
-  }).overrideAttrs({
+  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor { }).overrideAttrs({
     buildInputs ? [], ...
   }: {
     buildInputs = buildInputs ++ [ self.libsodium ];
   });
 
-  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
-    version = "2.2.1";
-    hash = "sha256-utVW8pTP/emEWblTxVb6jzulKdxss+2VfS552MWMqm4=";
-  };
+  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor { };
 
   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
     patches ? [], ...
@@ -222,9 +169,6 @@ in {
   });
 
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
-    url = "https://github.com/OGRECave/ogre.git";
-    rev = "v1.12.10";
-    fetchgitArgs.hash = "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY=";
     tarSourceArgs.hook = let
       version = "1.79";
       imgui = self.fetchFromGitHub rec {
@@ -255,10 +199,7 @@ in {
     sha256 = "sha256-TyFt3d78GidhDGD17KgjAaZl/qvAcGJP8lmu4EOxpYg=";
   };
 
-  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
-    version = "14.7.0";
-    hash = "sha256-p2e01bCoMpDhia1yOFa5wIP2ritBiWNT5jYbp/bg1+g=";
-  };
+  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor { };
 
   urdfdom = rosSuper.urdfdom.overrideAttrs ({
     patches ? [], ...

--- a/distros/jazzy/rviz-ogre-vendor/vendored-source.json
+++ b/distros/jazzy/rviz-ogre-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre.git",
+  "rev": "v1.12.10",
+  "hash": "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY="
+}

--- a/distros/jazzy/sdformat-vendor/vendored-source.json
+++ b/distros/jazzy/sdformat-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/sdformat.git",
+  "rev": "sdformat14_14.7.0",
+  "hash": "sha256-p2e01bCoMpDhia1yOFa5wIP2ritBiWNT5jYbp/bg1+g="
+}

--- a/distros/rolling/gz-cmake-vendor/vendored-source.json
+++ b/distros/rolling/gz-cmake-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-cmake.git",
+  "rev": "gz-cmake4_4.1.1",
+  "hash": "sha256-BWgRm+3UW65Cu7TqXtFFG05JlYF52dbpAsIE8aDnJM0="
+}

--- a/distros/rolling/gz-common-vendor/vendored-source.json
+++ b/distros/rolling/gz-common-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-common.git",
+  "rev": "gz-common6_6.0.2",
+  "hash": "sha256-sY9g+AatS+ddYSUAjqumfZNi2JIc+DFbiVYMaWKMC78="
+}

--- a/distros/rolling/gz-dartsim-vendor/vendored-source.json
+++ b/distros/rolling/gz-dartsim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/dartsim/dart.git",
+  "rev": "v6.13.2",
+  "hash": "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g="
+}

--- a/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-fuel-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-fuel-tools.git",
+  "rev": "gz-fuel-tools10_10.0.1",
+  "hash": "sha256-/Xfhec6kpv6srSp+hudqBaK4dKFn0QK45aGqxzNyytw="
+}

--- a/distros/rolling/gz-gui-vendor/vendored-source.json
+++ b/distros/rolling/gz-gui-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-gui.git",
+  "rev": "gz-gui9_9.0.1",
+  "hash": "sha256-ZBDgd37TPBOldorGZimsCk57fVa7tTc8wRwUGFBZnDk="
+}

--- a/distros/rolling/gz-launch-vendor/vendored-source.json
+++ b/distros/rolling/gz-launch-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-launch.git",
+  "rev": "gz-launch8_8.0.1",
+  "hash": "sha256-el+4sVBOmeBj8VJqKut8pIhVJeyEyodrt6titunbBF0="
+}

--- a/distros/rolling/gz-math-vendor/vendored-source.json
+++ b/distros/rolling/gz-math-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-math.git",
+  "rev": "gz-math8_8.1.1",
+  "hash": "sha256-E7u3EtpqNLvcqI5ycezwwAlbVHM3JdqeyLFWYlEaOYo="
+}

--- a/distros/rolling/gz-msgs-vendor/vendored-source.json
+++ b/distros/rolling/gz-msgs-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-msgs.git",
+  "rev": "gz-msgs11_11.0.2",
+  "hash": "sha256-PUhFOmVPRiOVWfOjAU8z8dcxKPdcoTrgRwDGXP/vsUs="
+}

--- a/distros/rolling/gz-ogre-next-vendor/vendored-source.json
+++ b/distros/rolling/gz-ogre-next-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre-next.git",
+  "rev": "v2.3.3",
+  "hash": "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM="
+}

--- a/distros/rolling/gz-physics-vendor/vendored-source.json
+++ b/distros/rolling/gz-physics-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-physics.git",
+  "rev": "gz-physics8_8.1.0",
+  "hash": "sha256-FnVKVbPCn3B6/sZKiPJqUjUgVilwoeP/H97eg/dirz8="
+}

--- a/distros/rolling/gz-plugin-vendor/vendored-source.json
+++ b/distros/rolling/gz-plugin-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-plugin.git",
+  "rev": "gz-plugin3_3.0.1",
+  "hash": "sha256-7v6fzylJ4R1uoyQFM+eyl2/bXVy5MGC5dPjS7/taB8U="
+}

--- a/distros/rolling/gz-rendering-vendor/vendored-source.json
+++ b/distros/rolling/gz-rendering-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-rendering.git",
+  "rev": "gz-rendering9_9.1.0",
+  "hash": "sha256-L2xkd93zhXtvbbzRrdjsoxbDtopp/RpcWBh1tfGvLeM="
+}

--- a/distros/rolling/gz-sensors-vendor/vendored-source.json
+++ b/distros/rolling/gz-sensors-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sensors.git",
+  "rev": "gz-sensors9_9.1.0",
+  "hash": "sha256-dMqJqp5229r/mKjBzUJD/tEbsYZANAFNycHYc7CIkz8="
+}

--- a/distros/rolling/gz-sim-vendor/vendored-source.json
+++ b/distros/rolling/gz-sim-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-sim.git",
+  "rev": "gz-sim9_9.1.0",
+  "hash": "sha256-niVXuqMvEhwCW2NcrEhIChh3DsD2M8ZTspDi+zF0kBc="
+}

--- a/distros/rolling/gz-tools-vendor/vendored-source.json
+++ b/distros/rolling/gz-tools-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-tools.git",
+  "rev": "gz-tools2_2.0.2",
+  "hash": "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg="
+}

--- a/distros/rolling/gz-transport-vendor/vendored-source.json
+++ b/distros/rolling/gz-transport-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-transport.git",
+  "rev": "gz-transport14_14.0.1",
+  "hash": "sha256-pSoadkpVaAEswmZuK13Y7PhxgvzTK1G2wI5+Fomlm/o="
+}

--- a/distros/rolling/gz-utils-vendor/vendored-source.json
+++ b/distros/rolling/gz-utils-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/gz-utils.git",
+  "rev": "gz-utils3_3.1.1",
+  "hash": "sha256-fYzysdB608jfMb/EbqiGD4hXmPxcaVTUrt9Wx0dBlto="
+}

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -42,36 +42,20 @@ in {
     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
   };
 
-  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor {
-    version = "4.1.1";
-    hash = "sha256-BWgRm+3UW65Cu7TqXtFFG05JlYF52dbpAsIE8aDnJM0=";
-  };
+  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor { };
 
-  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
-    version = "6.0.0";
-    hash = "sha256-Oo4dGN2vsVaElKf/KYjjJq6tlYLRPr0/uh6urGxvDdc=";
-  }).overrideAttrs ({
+  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor { }).overrideAttrs ({
     nativeBuildInputs ? [], ...
   }: {
     # https://github.com/gazebo-release/gz_common_vendor/pull/2
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
-  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor {
-    url = "https://github.com/dartsim/dart.git";
-    rev = "v6.13.2";
-    fetchgitArgs.hash = "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g=";
-  };
+  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor { };
 
-  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor {
-    version = "10.0.0";
-    hash = "sha256-9WskZnci7D09aW32lzmdtlhRBM+hcmhG6iNgf3OC1js=";
-  };
+  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor { };
 
-  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor {
-    version = "9.0.0";
-    hash = "sha256-/YJW6XmdGwbyd5Nx3wcTqnRlpwE1unVGaNX91qfZmiM=";
-  }).overrideAttrs ({
+  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor { }).overrideAttrs ({
     postInstall ? "", ...
   }: {
     # "RPATH of binary libGrid3D.so contains a forbidden reference to
@@ -81,58 +65,27 @@ in {
     '';
   });
 
-  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor {
-    version = "8.0.0";
-    hash = "sha256-K2W2SSlhJvF9mxEMNa7tZa3/3/LIvxZMGeVb0Mi6Vso=";
-  };
+  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor { };
 
-  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor {
-    version = "8.1.0";
-    hash = "sha256-3jQk98HJ0ru2Q4fTqoiaPRaIHaWQKQlnqj+gN2PLxkE=";
-  };
+  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor { };
 
-  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
-    version = "11.0.2";
-    hash = "sha256-PUhFOmVPRiOVWfOjAU8z8dcxKPdcoTrgRwDGXP/vsUs=";
-  };
+  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor { };
 
-  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {
-    url = "https://github.com/OGRECave/ogre-next.git";
-    rev = "v2.3.3";
-    fetchgitArgs.hash = "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM=";
-  }).overrideAttrs({ ... }: {
+  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor { }).overrideAttrs({ ... }: {
     dontFixCmake = true;
   });
 
-  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor {
-    version = "8.0.0";
-    hash = "sha256-PjwrJG3xvRYrkHDTaBUgoaW8NglEYDPuJrk4QjJjTHU=";
-  };
+  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor { };
 
-  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor {
-    version = "3.0.0";
-    hash = "sha256-h2Dx0KcFmJlS67q0v1zbd9nQkTCKgHkxt5KKTT5v+fw=";
-  };
+  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor { };
 
-  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor {
-    version = "9.0.0";
-    hash = "sha256-e3OPLeqV6OgjnQrbpwRj59e7Z0BqN2wOee/gAaMHfqU=";
-  };
+  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor { };
 
-  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor {
-    version = "9.0.0";
-    hash = "sha256-8Ato7/YRL7JebbVPASD6VF9lf/Uyq26MIg2l+jQ4GDk=";
-  };
+  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor { };
 
-  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor {
-    version = "9.0.0";
-    hash = "sha256-gsWKknqcTiJc4YHIkmg1YGItwHG1As2OUnpPBQIwqj8=";
-  };
+  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor { };
 
-  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
-    version = "2.0.2";
-    hash = "sha256-CY+W1jWIkszKwKuLgKmJpZMXHn0RnueMHFSDhOXIzLg=";
-  }).overrideAttrs({
+  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor { }).overrideAttrs({
     nativeBuildInputs ? [],
     propagatedNativeBuildInputs ? [],
     qtWrapperArgs ? [],
@@ -154,19 +107,13 @@ in {
     '';
   });
 
-  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
-    version = "14.0.0";
-    hash = "sha256-zoGphy2cpmqJsnyS1LNVm4eGtHCWkAwIblga4RdVj4k=";
-  }).overrideAttrs({
+  gz-transport-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor { }).overrideAttrs({
     buildInputs ? [], ...
   }: {
     buildInputs = buildInputs ++ [ self.libsodium ];
   });
 
-  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
-    version = "3.1.0";
-    hash = "sha256-pbbFO/4h3Tos+uigPC8XHWzv+Yuyd6EdzLWQPdmXaN8=";
-  };
+  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor { };
 
   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
     patches ? [], ...
@@ -229,9 +176,6 @@ in {
   };
 
   rviz-ogre-vendor = lib.patchAmentVendorGit rosSuper.rviz-ogre-vendor {
-    url = "https://github.com/OGRECave/ogre.git";
-    rev = "v1.12.10";
-    fetchgitArgs.hash = "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY=";
     tarSourceArgs.hook = let
       version = "1.79";
       imgui = self.fetchFromGitHub rec {
@@ -257,10 +201,7 @@ in {
     '';
   });
 
-  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
-    version = "15.1.1";
-    hash = "sha256-4/0pVaev++v0+wHQiGeTl8XtTDzh2li32dND0EjfjwA=";
-  };
+  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor { };
 
   shared-queues-vendor = lib.patchVendorUrl rosSuper.shared-queues-vendor {
     url = "https://github.com/cameron314/readerwriterqueue/archive/ef7dfbf553288064347d51b8ac335f1ca489032a.zip";

--- a/distros/rolling/rviz-ogre-vendor/vendored-source.json
+++ b/distros/rolling/rviz-ogre-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/OGRECave/ogre.git",
+  "rev": "v1.12.10",
+  "hash": "sha256-Z0ixdSmkV93coBBVZ5R3lPLfVMXRfWsFz/RsSyqPWFY="
+}

--- a/distros/rolling/sdformat-vendor/vendored-source.json
+++ b/distros/rolling/sdformat-vendor/vendored-source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/gazebosim/sdformat.git",
+  "rev": "sdformat15_15.2.0",
+  "hash": "sha256-RarpOKoJ9w+yJw5HU5exZYjx1zVdtkE05+8PBADhOwY="
+}

--- a/lib/ament_cmake_vendor_packageConfig.cmake
+++ b/lib/ament_cmake_vendor_packageConfig.cmake
@@ -1,0 +1,32 @@
+# CMake package that defines alternative version of ament_vendor macro
+# to extract information about vendored source to
+# vendored-source.json. Normally, the ament_vendor macro is defined in
+# the ament_cmake_vendor_package and it downloads the vendored source
+# code at compile time. This is not possible with Nix, because Nix
+# builds packages without network access. Therefore, we inject this
+# alternative macro to cmake at update time and it extracts the
+# information needed by Nix to download the source code. The main
+# entry point to all this functionality is in the patchAmentVendorGit
+# function.
+
+if(NOT ament_cmake_vendor_package_FIND_QUIETLY)
+  message(STATUS "Found ament_cmake_vendor_package: Dummy version for Nix patching (${ament_cmake_vendor_package_DIR})")
+endif()
+
+find_program(JQ jq)
+find_program(NIX_PREFETCH_GIT nix-prefetch-git)
+
+macro(ament_vendor TARGET_NAME)
+  cmake_parse_arguments(_ARG "GLOBAL_HOOK;SKIP_INSTALL" "SOURCE_SUBDIR;VCS_TYPE;VCS_URL;VCS_VERSION;SATISFIED" "CMAKE_ARGS;PATCHES" ${ARGN})
+  if(_ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "ament_vendor() called with unused arguments: "
+      "${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  execute_process(
+    COMMAND ${NIX_PREFETCH_GIT} --url ${_ARG_VCS_URL} --rev ${_ARG_VCS_VERSION}
+    COMMAND ${JQ} "{url: \"${_ARG_VCS_URL}\", rev: \"${_ARG_VCS_VERSION}\", hash: .hash}"
+    OUTPUT_FILE ${CMAKE_BINARY_DIR}/vendored-source.json
+    COMMAND_ECHO STDOUT
+    COMMAND_ERROR_IS_FATAL ANY)
+endmacro()

--- a/maintainers/scripts/ament-vendor-update-order.nix
+++ b/maintainers/scripts/ament-vendor-update-order.nix
@@ -1,0 +1,8 @@
+{ candidates }:
+with import ../../. {};
+let
+  updatable = lib.filter (pkg: if pkg ? updateAmentVendor then true else lib.warn "${pkg.pname} not updatable" false) candidates;
+  isDependent = a: b: builtins.elem a (b.buildInputs ++ b.propagatedBuildInputs ++ b.nativeBuildInputs);
+  sorted = (lib.toposort isDependent updatable).result;
+in
+map (p: let name = lib.removePrefix "ros-${p.rosDistro}-" p.pname; in "${p.rosDistro}.${name}") sorted

--- a/maintainers/scripts/update-ament-vendor.sh
+++ b/maintainers/scripts/update-ament-vendor.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash --pure --keep NIX_PATH
+#! nix-shell -p nix-eval-jobs jq nix rush-parallel
+
+set -euo pipefail
+
+# Scrip to generate/update vendored-source.json files needed by
+# patchAmentVendorGit.
+#
+# Run it from the top-level directory of this repo, i.e.,
+# ./maintainers/scripts/update-ament-vendor.sh
+
+# Find potential candidates for updating
+candidates=$(
+    # Extract all rosPackages (ignoring eval errors)
+    nix-eval-jobs --expr '(import ./. {}).rosPackages' |
+        # Select only packages that depend on ament-cmake-vendor-package
+        jq -r 'select(.inputDrvs|objects|keys|any(contains("ament-cmake-vendor-package"))).attr')
+
+# Some *-vendor packages depend on others. For the update to work,
+# dependencies must be updated first followed by dependent packages.
+update_order=$(
+    nix-instantiate \
+        --eval --strict --json \
+        --arg candidates "with (import ./. {}).rosPackages; [ $candidates ]" \
+        "$(dirname $0)/ament-vendor-update-order.nix" | jq -r '.[]')
+
+ok_cmds=$(mktemp)
+trap "rm $ok_cmds" EXIT
+
+# First try updating all packages in parallel. This is the fast path,
+# which is sufficient if there are no updates or updates in just a few
+# root packages in the dependency tree.
+if ! rush --keep-order --verbose -c --succ-cmd-file $ok_cmds -- \
+     bash -c '$(nix-build -A rosPackages.{}.updateAmentVendor) 2>&1' <<<"$update_order"
+then
+    # If the parallel update fails, it's likely due to the update
+    # deeper in the dependency tree. Then it is usually more efficient
+    # to run all updates serially in the topologic order, which is
+    # guaranteed not to fail due to dependencies between to-be-updated
+    # packages.
+    printf "\nFalling back to serial execution\n"
+    rush -j1 --verbose --continue --succ-cmd-file $ok_cmds -- \
+         bash -c '$(nix-build -A rosPackages.{}.updateAmentVendor) 2>&1' <<<"$update_order"
+fi

--- a/pkgs/superflore/default.nix
+++ b/pkgs/superflore/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "superflore";
-  version = "unstable-2024-03-22";
+  version = "unstable-2025-03-03";
 
   src = fetchFromGitHub {
     owner = "lopsided98";
     repo = pname;
-    rev = "f3b2aceae47ced2d0a0af868cd4cce2b6de5effa";
-    hash = "sha256-YRgzRuMvG7AXHkTFO87GLBobaQArO6gxpacifDq1CPo=";
+    rev = "62104b9ae54faf53991a7d94bf84c8ddfc8573df";
+    hash = "sha256-it6cje1nkG4pjakn5Vvwhw0NGyc23xblmhXMEwUpTbg=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
These changes perform automatic updates of `ament_vendor` patching. Update of all packages can be performed by `maintainers/scripts/update-ament-vendor.sh` script, which can be run manually and is also run in CI after overlay updates by superflore.

`patchAmentVendorGit` is changed to not read information about patching from call arguments, but from `vendored-source.json` files stored along the package definition. These files look like this:

    {
      "url": "https://github.com/gazebosim/gz-math.git",
      "rev": "gz-math7_7.5.2",
      "hash": "sha256-LwYeyv8nwX06n5ju+ra2uqNMedMSLRumem8qDHXtNns="
    }

and can be automatically updated/generated by running:

    $(nix-build -A rosPackages.jazzy.gz-math-vendor.updateAmentVendor)

This is implemented by using some CMake tricks to reliably extract the required information from the `CMakeLists.txt` files (see individual commit messages and comments for details).

Compared to the current `develop` branch, this PR fixes build of 7 `gz-*-vendor` packages from rolling, where the patching data are not up to date.
    
An example PR generated by these changes can be seen [here](https://github.com/wentasah/nix-ros-overlay/pull/19). Logs of the GitHub Action generating that PR are [here](https://github.com/wentasah/nix-ros-overlay/actions/runs/13650231906/job/38156917832).