### PR TITLE
introduce dontSkipBuildRpath option

### DIFF
--- a/distros/rosidl-generator-py-setup-hook.sh
+++ b/distros/rosidl-generator-py-setup-hook.sh
@@ -1,6 +1,8 @@
 _rosidlGeneratorPyPreConfigureHook() {
   # Prevent "RPATH of binary ... contains a forbidden reference to /build/"
   # when cross-compiling
-  cmakeFlags+=" -DCMAKE_SKIP_BUILD_RPATH:BOOL=ON"
+  if [ -z "${dontSkipBuildRpath-}" ]; then
+    cmakeFlags+=" -DCMAKE_SKIP_BUILD_RPATH:BOOL=ON"
+  fi
 }
 preConfigureHooks+=(_rosidlGeneratorPyPreConfigureHook)


### PR DESCRIPTION
Hi,

In a downstream package, this `CMAKE_SKIP_BUILD_RPATH` flag is somehow breaking our unit tests with eg.
```
linear-feedback-controller> 1/4 Test #1: test_robot_model_builder ..........***Failed    0.06 sec
linear-feedback-controller> -- run_test.py: invoking following command in '/build/source/build':
linear-feedback-controller>  - /build/source/build/test_robot_model_builder --gtest_output=xml:/build/source/build/test_results/linear_feedback_controller/test_robot_model_builder.gtest.xml
linear-feedback-controller> /build/source/build/test_robot_model_builder: error while loading shared libraries: liblinear_feedback_controller.so: cannot open shared object file: No such file or directory
linear-feedback-controller> -- run_test.py: return code 127
```

Our  current workaround is
```nix
  postConfigure = ''
    cmake $cmakeDir -DCMAKE_SKIP_BUILD_RPATH:BOOL=OFF
  '';
```

But I guess a flag would be cleaner

Ref. https://github.com/loco-3d/linear-feedback-controller/pull/77