### PR TITLE
rosdistro sync, Fri Mar 14 13:29:43 2025

### DIFF
--- a/distros/humble/clearpath-common/default.nix
+++ b/distros/humble/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-common";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6fb2862a197ac95169204b461605586c862f244fc0bfef69993d930545c3bce8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_common/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "bb754d7af6a1adf9b0a139108b91e91b8c2b3c8d5dd8ca923654f6ad33a05ffe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-control/default.nix
+++ b/distros/humble/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-mecanum-drive-controller, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-humble-clearpath-control";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "c9f2230e9f20fc9f21150cacdb0ea6b3b3471aa9266cacf6310a247d3de09011";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_control/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "c9b08863317b4c79d7453b795a48c22449a3185ffacacc1eb2b56af3391579eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-customization/default.nix
+++ b/distros/humble/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-humble-clearpath-customization";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "663af6bf57d2c9a88cdbb934ba2116a3ad7b7030c11fca72ca4ab99f3c7b6587";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_customization/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "aed2711137bddd63904e6fa3274bfdce9b0ec8ab68efef7983bae452dccb528c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-description/default.nix
+++ b/distros/humble/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-description";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "2f09ad8efbad1b2c1611766ca8349dbb76101b69a36492d10ec8691773a5132b";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "54fa4dbd450c6f29046f32e3e6774c014fdb2a5bde7505f9fcbfab4c52947952";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-generator-common/default.nix
+++ b/distros/humble/clearpath-generator-common/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-humble-clearpath-generator-common";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "01f51cff93d0c62eca1388f75e27952d89e07bc014a55915cf4d17607964710c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_generator_common/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9d2fd3812745357482c282c278e50b1fa30645b3ac599537c0f546fbf88146d4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake moveit-setup-srdf-plugins ];
+  buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ clearpath-config clearpath-control clearpath-description clearpath-manipulators ];
+  propagatedBuildInputs = [ clearpath-config clearpath-control clearpath-description clearpath-manipulators moveit-setup-srdf-plugins ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-manipulators-description/default.nix
+++ b/distros/humble/clearpath-manipulators-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, franka-description, kortex-description, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators-description";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "e13476241bd928e2104a86bb6934043c92139ed9072226b3aa8ab4a02a679585";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8e9068f43dcae7e060fd1caffebab7ea167b6ac1ddd0e475ecdcf7ebbbc24430";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ kortex-description robot-state-publisher robotiq-description ur-description urdf xacro ];
+  propagatedBuildInputs = [ franka-description kortex-description robot-state-publisher robotiq-description ur-description urdf xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/clearpath-manipulators/default.nix
+++ b/distros/humble/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-manipulators";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d059b890e12fe6c9e72ec2100cb89e5a2fcc30dbca04edcce05a3f100133fb48";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_manipulators/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "871ef23e5df1389e9eda2fce5c5f32ade682ad6358d9f6aad45e075959b0280e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mounts-description/default.nix
+++ b/distros/humble/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mounts-description";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6f005d7a20fe0c614d8edef883b608dd5b007485ab2d4b21d49f5b406dc7ef46";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_mounts_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "157c3bb291f61b6fcc2c49b33ca44f30c4e44758fbab08ac1a1e2b30fbe69dd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-platform-description/default.nix
+++ b/distros/humble/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-platform-description";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "73279619c40b6ee80a6e73895323e9c645d60a1ef93afc5f90d2a857af23438b";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_platform_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5491b74a3c1a77f547964d5a8e8f3403dccb0cc59c75aca2c530a9d159fcd155";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-sensors-description/default.nix
+++ b/distros/humble/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-humble-clearpath-sensors-description";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a750e1c0bb000bdf6dde8334c67add4e34b9c73827f78b76493d068b38df4857";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/humble/clearpath_sensors_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e14b4da8a8c1da23f5e5975a3aee518c8485f46dc69968ad3f5c4583d75bb645";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-can-msg-filters/default.nix
+++ b/distros/humble/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-can-msg-filters";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_msg_filters/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "383d790502fa6265df366f448193069e9db258a98e02c0f7ddf5864571b45f6b";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_msg_filters/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "71791bcca3641826630df9ec03b09eea02cced3881f62939c3cc2c0e5295b5b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-can-msgs/default.nix
+++ b/distros/humble/dataspeed-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-can-msgs";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_msgs/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "3811cae0302280cb9c6c2af0beacb8c5fc5163496d9f0be58aaecc43c3539caf";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_msgs/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "009a3124b489ec78f2bfd067e86a841174f9bb70118758f7f5918fe33e114651";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-can-tools/default.nix
+++ b/distros/humble/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msgs, rclcpp, rosbag2-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-can-tools";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_tools/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "e3e02e8eb4ef3c95ad9c068dedf91b79eb7338024fd8e353eb6f5087477483e9";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_tools/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "f24d5db650e6b00e8d4df826bed304f1db742114daffe27d51f8262b0efd51a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-can-usb/default.nix
+++ b/distros/humble/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, lusb, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-can-usb";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_usb/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "b948f3f2497aef063904d877ff9d88d9ea417e34e1a00cb5de96c7755547b342";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can_usb/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "2fa4d45a483545b3c023af736c8bce99625ff698744a2cabccbae2f0fe329622";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dataspeed-can/default.nix
+++ b/distros/humble/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-can-msg-filters, dataspeed-can-msgs, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-humble-dataspeed-can";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "240c3fb0ed4eea2f05a2dbcfd05e56aaff4509f26fb753570316fae61bea0896";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/humble/dataspeed_can/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "f6e8d8a4c1edd26a917a8538f9c8de773068d8943f1722b8d7454147f597ab04";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-interfaces/default.nix
+++ b/distros/humble/dynamixel-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-interfaces";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/humble/dynamixel_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ae34f8bbe347f3463f8f32d927f8503db44d3a272f4c6862a1767c55257d8d8c";
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/humble/dynamixel_interfaces/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b31e0a947f62889e09dee727360e4ebe8d2a4b3d8877b1e312be53b27f29dba8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-workbench-toolbox/default.nix
+++ b/distros/humble/dynamixel-workbench-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-workbench-toolbox";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/humble/dynamixel_workbench_toolbox/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "15b2872e92f1e716935d0271fbdf935786659c71df9bcad54cee9236a9aa8a6e";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/humble/dynamixel_workbench_toolbox/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "379e9bea0c1b30ceba2fbee5f5b315f7dd4feba6ba0abfc15ebe76ec7cec0c24";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-workbench/default.nix
+++ b/distros/humble/dynamixel-workbench/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-workbench-toolbox }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-workbench";
-  version = "2.2.3-r1";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/humble/dynamixel_workbench/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "149f8fce05e435676882dc47d4cbfdaa916b7d760cdca327e082a06e066514d7";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/humble/dynamixel_workbench/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "a9bddab555c826a1a7a9631a2d6bf25d0e8a72280add98642a53572f2d1f1ece";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ffmpeg-image-transport/default.nix
+++ b/distros/humble/ffmpeg-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, ffmpeg-image-transport-msgs, image-transport, libogg, opencv, pkg-config, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ffmpeg-image-transport";
-  version = "1.1.2-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/humble/ffmpeg_image_transport/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "f2c4613ebb0159cd0092bfc11f57a28e248d51f8836b7ef13003b066721d791c";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/humble/ffmpeg_image_transport/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "c72123a736ffe01f3de87df7f507ad0797813968258fe0754d70797cf28f3c6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/openeb-vendor/default.nix
+++ b/distros/humble/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-humble-openeb-vendor";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/humble/openeb_vendor/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "b5ae87c3af4c9195a4255683d3f78ae9bf3e5d8f22bbfe202a628722afdc3053";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/humble/openeb_vendor/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "abf3869a423748d204616819b5f0f61f5f90caff50ec2929baf5322c9f04905a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2-msgs/default.nix
+++ b/distros/humble/play-motion2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-play-motion2-msgs";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "23a2accb6ab5703f5fdb651cc4a8e755a1ecb55bea906f1e8bcf2894cad16660";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "59fac3b08b150f5344c43a229da28912a1af9dd07c2a58d2eb9aaddfb4eaf9db";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/play-motion2/default.nix
+++ b/distros/humble/play-motion2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-broadcaster, joint-trajectory-controller, launch, launch-pal, launch-ros, launch-testing-ament-cmake, lifecycle-msgs, moveit-ros-planning-interface, play-motion2-msgs, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, realtime-tools, robot-state-publisher, sensor-msgs, std-msgs, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-play-motion2";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "339b737b757de74b721f2b4692c23b6cfd11c4140bc557fa54aace6af1092e39";
+    url = "https://github.com/pal-gbp/play_motion2-release/archive/release/humble/play_motion2/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "e91f5eea58b7e4d39673b85cd5630b280c34ec33d4d02888eedfdc078e88b55f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-desert/default.nix
+++ b/distros/humble/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-humble-rmw-desert";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/humble/rmw_desert/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "9ce9aa1be88782708d5f288e77b5e1dd47d0cfff36687206fc81622509ed3803";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/humble/rmw_desert/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7f2e283844bfe55898548ae55a12e4ad40d6d177d414f00efe4cc5db6f8fc8aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-tests/default.nix
+++ b/distros/jazzy/clearpath-tests/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, can-utils, clearpath-config, clearpath-generator-common, clearpath-motor-msgs, clearpath-platform-msgs, diagnostic-msgs, geometry-msgs, nav-msgs, rclpy, sensor-msgs, simple-term-menu-vendor, std-msgs, stress, tf-transformations, tf2-geometry-msgs, tf2-msgs, wireless-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-tests";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "8bcd3527c6b6a56258f92bcd79d2557302be5beec9f2fec0760010e1305b9d38";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-utils clearpath-config clearpath-generator-common clearpath-motor-msgs clearpath-platform-msgs diagnostic-msgs geometry-msgs nav-msgs rclpy sensor-msgs simple-term-menu-vendor std-msgs stress tf-transformations tf2-geometry-msgs tf2-msgs wireless-msgs ];
+
+  meta = {
+    description = "Clearpath Tests";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/dataspeed-can-msg-filters/default.nix
+++ b/distros/jazzy/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-dataspeed-can-msg-filters";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_msg_filters/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "a934291f47c43b32233f1a1e2e3d5bcacc1a09016ad4b6f6700d8e11f9d67114";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_msg_filters/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "d18f5e77523ee21e418688c38778aa7e4bb6af9e318519cd918758550d82f987";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dataspeed-can-msgs/default.nix
+++ b/distros/jazzy/dataspeed-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dataspeed-can-msgs";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_msgs/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "4c3b0c58bd3c9090dfee7a6fb40d9cd773a8380acb6a3b154d1ff3af94c96fb5";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_msgs/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "4a63724abcb1f5642f04385bd9174d45ad47c589957b3fcd68049bcf2c978f8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dataspeed-can-tools/default.nix
+++ b/distros/jazzy/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, dataspeed-can-msgs, rclcpp, rosbag2-cpp, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dataspeed-can-tools";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_tools/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "18b013a031531527d1e6ce3d0f21d48ec741c4eee41489a0fd6274e8fb967f41";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_tools/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "6dfbe4679e2fbcb32797ade10a75d5d541e2cf92f315f0214814923effaa678c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dataspeed-can-usb/default.nix
+++ b/distros/jazzy/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, can-msgs, lusb, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dataspeed-can-usb";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_usb/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "c10b2b5f83d016742d1c62055a6aec731428ea8fa59c62f8f2902998598affee";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can_usb/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "44c824d7cb4f595a7edfccd891e232496d7ef6ac10cd126fec9a50ccebca9233";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dataspeed-can/default.nix
+++ b/distros/jazzy/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dataspeed-can-msg-filters, dataspeed-can-msgs, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-jazzy-dataspeed-can";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "eb7435fe89ab65a494db965a62c5f734524031c4fad84e043bde927261a5ae5c";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/jazzy/dataspeed_can/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "a7f0c1216328694fe55c3f49ffcdb7bf2edbc00a740660d2f0cafeca365559e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-interfaces/default.nix
+++ b/distros/jazzy/dynamixel-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-interfaces";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/jazzy/dynamixel_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "04f2088d3329e58304cc13299bd0d62c63f8961b35e800ecb19f4f0de6b02caa";
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/jazzy/dynamixel_interfaces/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bec8c8e31e423145cf419b3324d3b7288b021f8da79869cab31e60ff9e07b796";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-workbench-toolbox/default.nix
+++ b/distros/jazzy/dynamixel-workbench-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-workbench-toolbox";
-  version = "2.2.3-r5";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/jazzy/dynamixel_workbench_toolbox/2.2.3-5.tar.gz";
-    name = "2.2.3-5.tar.gz";
-    sha256 = "e1cc1f0e4fe1a7e6c8acd9679e1af181b49658f86b7d093bdaa60d4b84d4b6dc";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/jazzy/dynamixel_workbench_toolbox/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "3820a2e2386cec33422a783f03f779119cab8def599bf18097f69b8ed0eb4ac5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-workbench/default.nix
+++ b/distros/jazzy/dynamixel-workbench/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-workbench-toolbox }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-workbench";
-  version = "2.2.3-r5";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/jazzy/dynamixel_workbench/2.2.3-5.tar.gz";
-    name = "2.2.3-5.tar.gz";
-    sha256 = "28a72f25ed7db72325019e40e449f5dac85a269ceb89b3ae26c5f286ef15b28b";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/jazzy/dynamixel_workbench/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "d63caaa388c0b213fe95a0cafb2756e78b08ddcf6dcfdf8567e9ebe4647c3980";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffmpeg-image-transport/default.nix
+++ b/distros/jazzy/ffmpeg-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, ffmpeg-image-transport-msgs, image-transport, libogg, opencv, pkg-config, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ffmpeg-image-transport";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/jazzy/ffmpeg_image_transport/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "a1c2e52f60164d8cd752c86b83d9152c044ca5488b48dc65d305ebebae467a15";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/jazzy/ffmpeg_image_transport/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "c1c008f00379127d0ce08576ed8f32d567b8a427fec639e11ef12c08d8f0ffc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -382,6 +382,8 @@ self: super: {
 
  clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
 
+ clearpath-tests = self.callPackage ./clearpath-tests {};
+
  clearpath-viz = self.callPackage ./clearpath-viz {};
 
  clips-vendor = self.callPackage ./clips-vendor {};
@@ -1671,6 +1673,8 @@ self: super: {
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nmea-navsat-driver = self.callPackage ./nmea-navsat-driver {};
+
+ nobleo-socketcan-bridge = self.callPackage ./nobleo-socketcan-bridge {};
 
  nodl-python = self.callPackage ./nodl-python {};
 

--- a/distros/jazzy/nobleo-socketcan-bridge/default.nix
+++ b/distros/jazzy/nobleo-socketcan-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, ament-lint-auto, can-msgs, diagnostic-msgs, diagnostic-updater, fmt, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-jazzy-nobleo-socketcan-bridge";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nobleo_socketcan_bridge-release/archive/release/jazzy/nobleo_socketcan_bridge/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "af55b6f7526cd7673e7964f305e1ba8f7069ba15fcabfe916d2eb85eb8209f18";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ can-msgs diagnostic-msgs diagnostic-updater fmt rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Simple wrapper around SocketCAN";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/openeb-vendor/default.nix
+++ b/distros/jazzy/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-jazzy-openeb-vendor";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/jazzy/openeb_vendor/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "683804040ec43c2a666b917ada8856241b139bc8e416c7a820dc3b7501aa3205";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/jazzy/openeb_vendor/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "38eeb6cf69c65382231d6de581e4728f61b08c82bbd559fc42232782f15cf3b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-desert/default.nix
+++ b/distros/jazzy/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-desert";
-  version = "1.0.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/jazzy/rmw_desert/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1400df334619467e97bb95f2f0dfe4d967493d026c8617c0cb05ed459c3e9f27";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/jazzy/rmw_desert/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "8135a71d212e182576a81cf19db5f1073f8bac2cd4ee5f0a263c781dcb70c434";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-msgs/default.nix
+++ b/distros/rolling/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-control-msgs";
-  version = "5.3.0-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "62864e50ab0bebcc8f559144ed960109066cdcd181a1bf098b18a53261734e65";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/rolling/control_msgs/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "9c10b434f01b64e3b4cf974a40206b74b2ef10150d7dd733ed7b18bc8c634f08";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "4.0.1-r1";
+  version = "5.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "71c5be112106f01cc22c12fbac268dc91d71a4a7ffc13bab2ad5d065d227f084";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "ca5e5df2e6b44b04983aa63c14202a6478e0f44552e33f52acbf15d2f880fd76";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gmock rclcpp-lifecycle ];
   propagatedBuildInputs = [ control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/dynamixel-interfaces/default.nix
+++ b/distros/rolling/dynamixel-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-interfaces";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/rolling/dynamixel_interfaces/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5471ee8d78d167f58ad46f90e3fe23925dd673224d660f0f36e9ebe008ba74c6";
+    url = "https://github.com/ros2-gbp/dynamixel_interfaces-release/archive/release/rolling/dynamixel_interfaces/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d8adc25b0bc3c78ec7d7e4862c100cd558dbfef0bbf6ee580bdd875f830632a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ffmpeg-image-transport/default.nix
+++ b/distros/rolling/ffmpeg-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, ffmpeg-image-transport-msgs, image-transport, libogg, opencv, pkg-config, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ffmpeg-image-transport";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/rolling/ffmpeg_image_transport/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c06d3aa352b915c4735492b8e317bc6092f272db2f671ceda4e6bca2b6c786ca";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/rolling/ffmpeg_image_transport/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "71e6c369c6c739528613ced0206c9d54877e7d9b488cca51eec57012fae0b9d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -214,8 +214,6 @@ self: super: {
 
  autoware-internal-planning-msgs = self.callPackage ./autoware-internal-planning-msgs {};
 
- autoware-lanelet2-extension = self.callPackage ./autoware-lanelet2-extension {};
-
  autoware-lanelet2-extension-python = self.callPackage ./autoware-lanelet2-extension-python {};
 
  autoware-lint-common = self.callPackage ./autoware-lint-common {};
@@ -231,8 +229,6 @@ self: super: {
  autoware-sensing-msgs = self.callPackage ./autoware-sensing-msgs {};
 
  autoware-system-msgs = self.callPackage ./autoware-system-msgs {};
-
- autoware-utils = self.callPackage ./autoware-utils {};
 
  autoware-v2x-msgs = self.callPackage ./autoware-v2x-msgs {};
 
@@ -1361,6 +1357,8 @@ self: super: {
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nmea-navsat-driver = self.callPackage ./nmea-navsat-driver {};
+
+ nobleo-socketcan-bridge = self.callPackage ./nobleo-socketcan-bridge {};
 
  nodl-python = self.callPackage ./nodl-python {};
 

--- a/distros/rolling/kinematics-interface-kdl/default.nix
+++ b/distros/rolling/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface-kdl";
-  version = "1.2.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "0cca0b27f446d278730d59c7bed1645a816b0ca6d148c22109cf7b8733530610";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface_kdl/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "64524bf432c632b0c8b74936b6b4ed34f3232fca3208ab3fc96685581816c6b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kinematics-interface/default.nix
+++ b/distros/rolling/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-rolling-kinematics-interface";
-  version = "1.2.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "a1d982c5f662c5eb86dbabde55dd5c9b59e5d083d3c421d7039313cb3244d887";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/rolling/kinematics_interface/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "ace23030671ccdaca07a8729aa37cd2b02dc4453c4aaf7028a5ecb47116bc0a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "7.0.1-r1";
+  version = "7.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.0.1-1.tar.gz";
-    name = "7.0.1-1.tar.gz";
-    sha256 = "7a0e229d9560e5e9c1c674ccdfaf1cb637ec8a2e6d7cb766e34e578ee17e67b7";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.0.2-1.tar.gz";
+    name = "7.0.2-1.tar.gz";
+    sha256 = "0fb7b6913b1bc6c7f472087df189d3046f27c41c323cf06c11dcd442cf6fcebd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/metavision-driver/default.nix
+++ b/distros/rolling/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-metavision-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/rolling/metavision_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "abfb4fc56f8a9a5ff11ee4c4d1940b25b764c480ee6f9c8d557b2a4f64ffa2b5";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/rolling/metavision_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "536e4d2fc1cd1902d5256deaa710d8cc09ca0f57b68910186ea61ce37fb39ef4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nobleo-socketcan-bridge/default.nix
+++ b/distros/rolling/nobleo-socketcan-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, ament-lint-auto, can-msgs, diagnostic-msgs, diagnostic-updater, fmt, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-rolling-nobleo-socketcan-bridge";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nobleo_socketcan_bridge-release/archive/release/rolling/nobleo_socketcan_bridge/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "abd9ba457d8c1241f16c9a7afe91ea53e54ddd30e2dda7f062e335d900a9b6bf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-ros ];
+  checkInputs = [ ament-cmake-clang-format ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-lint-cmake ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ can-msgs diagnostic-msgs diagnostic-updater fmt rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Simple wrapper around SocketCAN";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/openeb-vendor/default.nix
+++ b/distros/rolling/openeb-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, boost, cmake, curl, ffmpeg, git, glew, glfw3, gtest, hdf5, libusb-compat-0_1, libusb1, opencv, openscenegraph, pkg-config, protobuf, unzip, wget }:
 buildRosPackage {
   pname = "ros-rolling-openeb-vendor";
-  version = "2.0.1-r2";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/rolling/openeb_vendor/2.0.1-2.tar.gz";
-    name = "2.0.1-2.tar.gz";
-    sha256 = "5e5c299b127b2ef6f1b52933eea6f2086207963e7d9d70000570a5934b9fe459";
+    url = "https://github.com/ros2-gbp/openeb_vendor-release/archive/release/rolling/openeb_vendor/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "c09b339d66bab06a3c6af30b7ac1dea5ab591e21ac376d63f857e60122874297";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-cyclonedds-cpp/default.nix
+++ b/distros/rolling/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-cyclonedds-cpp";
-  version = "4.0.0-r1";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "4d1b0bf15ad62c7fdd42600585248c00c3862a69e7c54b3602cc49b0a9205561";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/rolling/rmw_cyclonedds_cpp/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "535399c46b2f640f5ec72a758758f4a3409c01ba4e422c3692342d0a2f64ed17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-desert/default.nix
+++ b/distros/rolling/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-desert";
-  version = "1.0.2-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "884cf7624c589a8a219310e9a41f34d947795b2f03468cc2dba9913b4e89e9f0";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "c3d7beb6b5dd49058ae14820d280a2ecea25df22e9013e82b0e9bf114db447f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-cpp";
-  version = "9.3.0-r1";
+  version = "9.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.3.0-1.tar.gz";
-    name = "9.3.0-1.tar.gz";
-    sha256 = "30c0d52caa2043721c6f13b18a359dd2c14cd06590efc89f0d928b99a33e7c8e";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_cpp/9.3.1-1.tar.gz";
+    name = "9.3.1-1.tar.gz";
+    sha256 = "d76524b6abc89bd76c44b8ce6342a162e569d4f642b5f7e9ceab37db0c45ee4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-dynamic-cpp";
-  version = "9.3.0-r1";
+  version = "9.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.3.0-1.tar.gz";
-    name = "9.3.0-1.tar.gz";
-    sha256 = "01fc3b864f3b68b2eb38146287e328713def70ba9be816e24ed7689ee9ad940b";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_dynamic_cpp/9.3.1-1.tar.gz";
+    name = "9.3.1-1.tar.gz";
+    sha256 = "79f6f5384ede2c5b795b42e0fd46228e3ae7b08e915e0e662c5fb5fa67606787";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/rolling/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastdds, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-security-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rmw-fastrtps-shared-cpp";
-  version = "9.3.0-r1";
+  version = "9.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.3.0-1.tar.gz";
-    name = "9.3.0-1.tar.gz";
-    sha256 = "ae852cf58bc20756740aa37d74e843fa34dedb41c9e8188b319860a2a8dec570";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/rolling/rmw_fastrtps_shared_cpp/9.3.1-1.tar.gz";
+    name = "9.3.1-1.tar.gz";
+    sha256 = "5cdb42e94c3ef8c42f181df9ca8d0d23b46d3b85a6cbcbfee392aa34d78d76f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation-cmake/default.nix
+++ b/distros/rolling/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation-cmake";
-  version = "7.8.0-r1";
+  version = "7.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.8.0-1.tar.gz";
-    name = "7.8.0-1.tar.gz";
-    sha256 = "68fa286fea0475431d6bbaa55590da4b3d114df420248f7074a29ae72b18c676";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_implementation_cmake/7.8.1-1.tar.gz";
+    name = "7.8.1-1.tar.gz";
+    sha256 = "e08cbee135d9cbcc5897c87027f3d73dcbc1789a0aba7cb33aa714aa037b56ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-implementation/default.nix
+++ b/distros/rolling/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-rolling-rmw-implementation";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "bbbedb78b897909986349648d85ee9738e46bcbdb422c83ac164bf17e646236e";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/rolling/rmw_implementation/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "7be0544c9456cc2d178a22cb22e2fdb692c6bdaaea52f5a94df91ef8e3680a1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-security-common/default.nix
+++ b/distros/rolling/rmw-security-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rmw-security-common";
-  version = "7.8.0-r1";
+  version = "7.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_security_common/7.8.0-1.tar.gz";
-    name = "7.8.0-1.tar.gz";
-    sha256 = "d081711341a8c8ceb5d33290a02e01d7d94a8c449d4dfffc02bdd548b5c1d5be";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw_security_common/7.8.1-1.tar.gz";
+    name = "7.8.1-1.tar.gz";
+    sha256 = "5cf7e688cf61c8704bc75352a04475bf6028df3229d6e5c90b2aae45555948e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw/default.nix
+++ b/distros/rolling/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-rolling-rmw";
-  version = "7.8.0-r1";
+  version = "7.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.8.0-1.tar.gz";
-    name = "7.8.0-1.tar.gz";
-    sha256 = "b566c0119f44b784e43935cdc69cb2fccbfe2ad1e52a843137c02ef2238324ea";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/rolling/rmw/7.8.1-1.tar.gz";
+    name = "7.8.1-1.tar.gz";
+    sha256 = "f2ba14c6ad23c86796e5440e5e0a2be621a61b712445cc7f39e7c5ec1b30c986";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit e6bfafcd05932e92b10e171a9d536c45fdcd0adf.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *clearpath-common 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-control 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-customization 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-description 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-generator-common 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-manipulators 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-manipulators-description 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-mounts-description 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-platform-description 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-sensors-description 1.1.1-r1 --> 1.2.0-r1*
* *dataspeed-can 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-msg-filters 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-msgs 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-tools 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-usb 2.0.5-r1 --> 2.0.6-r1*
* *dynamixel-interfaces 1.0.0-r1 --> 1.0.1-r1*
* *dynamixel-workbench 2.2.3-r1 --> 2.2.4-r1*
* *dynamixel-workbench-toolbox 2.2.3-r1 --> 2.2.4-r1*
* *ffmpeg-image-transport 1.1.2-r1 --> 1.0.2-r1*
* *openeb-vendor 2.0.1-r1 --> 2.0.2-r2*
* *play-motion2 1.5.0-r1 --> 1.5.1-r1*
* *play-motion2-msgs 1.5.0-r1 --> 1.5.1-r1*
* *rmw-desert 1.0.2-r1 --> 1.0.3-r1*

Jazzy Changes:
--------------
* *clearpath-tests 0.2.2-r1*
* *dataspeed-can 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-msg-filters 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-msgs 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-tools 2.0.5-r1 --> 2.0.6-r1*
* *dataspeed-can-usb 2.0.5-r1 --> 2.0.6-r1*
* *dynamixel-interfaces 1.0.0-r1 --> 1.0.1-r1*
* *dynamixel-workbench 2.2.3-r5 --> 2.2.4-r1*
* *dynamixel-workbench-toolbox 2.2.3-r5 --> 2.2.4-r1*
* *ffmpeg-image-transport 1.0.1-r2 --> 1.0.2-r1*
* *nobleo-socketcan-bridge 1.0.1-r1*
* *openeb-vendor 2.0.1-r1 --> 2.0.2-r2*
* *rmw-desert 1.0.2-r1 --> 2.0.0-r1*

Rolling Changes:
----------------
* *control-msgs 5.3.0-r1 --> 6.0.0-r1*
* *control-toolbox 4.0.1-r1 --> 5.0.0-r1*
* *dynamixel-interfaces 1.0.0-r1 --> 1.0.1-r1*
* *ffmpeg-image-transport 1.0.1-r1 --> 1.0.2-r1*
* *kinematics-interface 1.2.1-r1 --> 2.0.0-r1*
* *kinematics-interface-kdl 1.2.1-r1 --> 2.0.0-r1*
* *message-filters 7.0.1-r1 --> 7.0.2-r1*
* *metavision-driver 2.0.0-r1 --> 2.0.1-r1*
* *nobleo-socketcan-bridge 1.0.1-r1*
* *openeb-vendor 2.0.1-r2 --> 2.0.2-r1*
* *rmw 7.8.0-r1 --> 7.8.1-r1*
* *rmw-cyclonedds-cpp 4.0.0-r1 --> 4.0.1-r1*
* *rmw-desert 1.0.2-r1 --> 2.0.0-r1*
* *rmw-fastrtps-cpp 9.3.0-r1 --> 9.3.1-r1*
* *rmw-fastrtps-dynamic-cpp 9.3.0-r1 --> 9.3.1-r1*
* *rmw-fastrtps-shared-cpp 9.3.0-r1 --> 9.3.1-r1*
* *rmw-implementation 3.0.3-r1 --> 3.0.4-r1*
* *rmw-implementation-cmake 7.8.0-r1 --> 7.8.1-r1*
* *rmw-security-common 7.8.0-r1 --> 7.8.1-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] fastrtps_cmake_module
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

