### PR TITLE
colcon-meson: init at 0.4.5

### DIFF
--- a/pkgs/colcon/meson.nix
+++ b/pkgs/colcon/meson.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path, meson }:
+
+buildPythonPackage rec {
+  pname = "colcon-meson";
+  version = "0.4.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-DqjGKFOJLXPEmFjo8TyDwHCY8H1gi4vtWTyxEMflILI=";
+  };
+
+  propagatedBuildInputs = [
+    colcon-core
+    colcon-library-path
+    meson
+  ];
+
+  # Requires unpackaged dependencies
+  #doCheck = false;
+
+  meta = with lib; {
+    description = "Extension for colcon to support Meson packages";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -96,6 +96,8 @@ self: super: with self.lib; {
 
       colcon-library-path = pyFinal.callPackage ./colcon/library-path.nix { };
 
+      colcon-meson = pyFinal.callPackage ./colcon/meson.nix { };
+
       colcon-metadata = pyFinal.callPackage ./colcon/metadata.nix { };
 
       colcon-mixin = pyFinal.callPackage ./colcon/mixin.nix { };


### PR DESCRIPTION
This is useful for building packages that use meson as a buildsystem. For example libcamera mentioned in #598.