### PR TITLE
libcamera: Fix builds for jazzy and rolling

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -189,6 +189,24 @@ in {
     };
   };
 
+  libcamera = rosSuper.libcamera.overrideAttrs ({
+    postPatch ? "",
+    nativeBuildInputs ? [],
+    ...
+  }: {
+    # Nixpkgs defaults to enabling all optional features, but we
+    # enable only features for which ROS package.xml declares
+    # dependencies.
+    mesonAutoFeatures = "auto";
+    postPatch = postPatch + ''
+      patchShebangs --build \
+        src/py/libcamera/*.py \
+        utils/codegen/*.py \
+        utils/codegen/ipc/*.py
+    '';
+    nativeBuildInputs = nativeBuildInputs ++ [ self.ninja ];
+  });
+
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {
     url = "https://www.phidgets.com/downloads/phidget22/libraries/linux/libphidget22/libphidget22-1.19.20240304.tar.gz";
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";

--- a/distros/rolling/overrides.nix
+++ b/distros/rolling/overrides.nix
@@ -189,6 +189,24 @@ in {
     };
   };
 
+  libcamera = rosSuper.libcamera.overrideAttrs ({
+    postPatch ? "",
+    nativeBuildInputs ? [],
+    ...
+  }: {
+    # Nixpkgs defaults to enabling all optional features, but we
+    # enable only features for which ROS package.xml declares
+    # dependencies.
+    mesonAutoFeatures = "auto";
+    postPatch = postPatch + ''
+      patchShebangs --build \
+        src/py/libcamera/*.py \
+        utils/codegen/*.py \
+        utils/codegen/ipc/*.py
+    '';
+    nativeBuildInputs = nativeBuildInputs ++ [ self.ninja ];
+  });
+
   libphidget22 = lib.patchVendorUrl rosSuper.libphidget22 {
     url = "https://www.phidgets.com/downloads/phidget22/libraries/linux/libphidget22/libphidget22-1.19.20240304.tar.gz";
     hash = "sha256-GpzGMpQ02s/X/XEcGoozzMjigrbqvAu81bcb7QG+36E=";


### PR DESCRIPTION
This fixes libcamera builds for jazzy and rolling. The version for humble is still broken, because its build system depends on Python module imp, which was removed from Python 3.12.

Fixes #598