### PR TITLE
rosdistro sync, Fri Mar 28 13:26:52 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "f505f2ca44a6a8801d62ece682b0ab17acc274e04a6e020338fb370a97e09c57";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "aa82d5f13068cae4ba3e704e0c2b0077959214806dda3c73b6a1662e06b276e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/actionlib-msgs/default.nix
+++ b/distros/humble/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-actionlib-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/actionlib_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "cd77e252feadb04e8bac724025c759e6be370d354d25aa150dad6c9db34eb962";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/actionlib_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "605075c251f9aaa88c57acbccdb7d79b7f8a4503f0ed6dae487793d617ce9132";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "348cf0a412322814c6da7a9fa359a6426b903955f5637a091f693d26394c3287";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "6a74551fe29f4a35b2ce4cec4efe72e6c04a461175492b7372f258ec750a7c0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-clang-format/default.nix
+++ b/distros/humble/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-clang-format";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_format/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "52bc20440e4796d227ed4b3bb9b947d8eb6554f14f1b9687b19dba81ce9db27c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_format/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "01d74f7bbc1d2746ac0fe2875e21fea0b27f10ec8ce897a1d77c579c73173d27";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-clang-tidy/default.nix
+++ b/distros/humble/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-clang-tidy";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_tidy/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "17cbb8345747f81989428fcd8faa28fa5c95238b9e615cbfdc423c67c3f9a601";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_clang_tidy/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "40cd1713cbd2fbb33d1215335b4ae5b33b7a5930a6ce5b78c88743e61167ca07";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cmake-clang-format/default.nix
+++ b/distros/humble/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-clang-format";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_format/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "5009ae47ceb65195a6dc554465ec2443fe6fe5f130c495b03861409297e7a347";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_format/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "637799930b6337fb6532a989716f0fab90fb67cd34da322fc5481b04145586fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-clang-tidy/default.nix
+++ b/distros/humble/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-clang-tidy";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_tidy/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "b1900d38fd4a7d943872995cb2f6dd261f2d26cfe92ea36885e29c6e8c4aed03";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_clang_tidy/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "ccc10dfc77fc571ed6a247374d0f01687da020f772529cac3e1209b9fa6d42e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-copyright/default.nix
+++ b/distros/humble/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-copyright";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_copyright/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "05ef090ecb26419020fc219a078191d42a98f74c79cb4515fa3ed4591e6e70ca";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_copyright/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "400920f1dfc81b244db65777bf432fd3bdfde08f793af97061c9482a9646c84c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-cppcheck/default.nix
+++ b/distros/humble/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-cppcheck";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cppcheck/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "4e771d9bf79813fb3106f03c892dd101c07886a37584d5abda2fcd5707636262";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cppcheck/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "4ea27eb62ea773179fbb6c0bc779e6a6c40593a98ed2c1b5aa9dafd6f76cad79";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-cpplint/default.nix
+++ b/distros/humble/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-cpplint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cpplint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "4ef621ebcc11bd6773788e56ee62538dddf30d65d2e000aae70b982da15b4f7f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_cpplint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "6367433eae9ef1d95ab6a40043ab43fcca615f476b118b59aba2c02a70abe9e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-flake8/default.nix
+++ b/distros/humble/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-flake8";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_flake8/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "3dc0b9f44cd176c7fb4bb4190ee97db8f2550cef6ffb29d2210371366f4063a8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_flake8/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "0344d0b18aec635ded21a60046857a2a57bd9547f07c8ab8979ddce0f6dd001d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-lint-cmake/default.nix
+++ b/distros/humble/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-lint-cmake";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_lint_cmake/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "db267eadb8e11765f3b53feafbd48b11b18469e1cd442cec92f2d3a8b276b1c1";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_lint_cmake/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "1387aaa486185dd9fde4f93ba467c843929eafc81a10947cb95c9f34b5dae4d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-mypy/default.nix
+++ b/distros/humble/ament-cmake-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-mypy }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-mypy";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_mypy/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "5a0a0076a9859055aa44728ca25dafcff15505aaa95fc1b0d160b903b5ed5486";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_mypy/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "ef56b44b3c86d5278dcbac76a1465c8ac27dad6df07c82c81c5a8287473a33f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pclint/default.nix
+++ b/distros/humble/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pclint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pclint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "f22ad37fa20f465dccaeacedde650ac2575637be302464c1d30b71a62e5c4e41";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pclint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "552d46f1b8a51e07612255cc5a32dcfa5c1c8d5d9dec1eb7ab20b844382d51d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pep257/default.nix
+++ b/distros/humble/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pep257";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pep257/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "c84341146cf6cb7ec23cd8d77c7722e3ca3ecdcab804dadfb27ae670b770de95";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pep257/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "d57ebefb62112d7ae5f96240007a05d65f291cba2c3028fbcd865b3255951d36";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pycodestyle/default.nix
+++ b/distros/humble/ament-cmake-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pycodestyle }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pycodestyle";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pycodestyle/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "8780dc5321ea9af4bc7c4fa977c049cb6ba7ca38308f5147b23c548c4f65ca88";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pycodestyle/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "cfd3d3abbbec6302f4c78b55e22ed248c08a4fea008b495ae40855994e4b2aa3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-pyflakes/default.nix
+++ b/distros/humble/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-pyflakes";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pyflakes/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "4329e1e7cb0c7a390f0631a23da7ecb27955ba4bb52af54a4bce4d33b5d2ada7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_pyflakes/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "a5227899a902546f070d1e6edeed67d5d2c01f7bbf954d775b91ca2bcfe7b32d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-uncrustify/default.nix
+++ b/distros/humble/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-uncrustify";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_uncrustify/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "33d9276228328a5bb80e5358b6a46adef7a29e170e9d607d39a008575dc9d49d";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_uncrustify/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "e785caba52397623a04aa3b9dc9f1db3a48785d6ff2ff3f1ef7602517c2dcb58";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-cmake-xmllint/default.nix
+++ b/distros/humble/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-cmake-xmllint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_xmllint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "46cd8f4795e68c5ed506716ef4b283cb44a0befa26d849e3eb0ef2c3a456952e";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cmake_xmllint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "f073adda34ac3e9454ec87b3d8836fc29a2c8f3b93ded1f04fd330fd7f9c4cd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-copyright/default.nix
+++ b/distros/humble/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-copyright";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_copyright/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "8206f617b6a3402dedb2025bf33d2e7e5aaed68345f5345d96220b6d8332b1af";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_copyright/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "5a27fcc7698b02a26e5a5d6914f01afb752a7e041d4e427977f5cbff3b660ed5";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cppcheck/default.nix
+++ b/distros/humble/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-humble-ament-cppcheck";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cppcheck/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "a315882e48caced56337f4c35526619922b60be805a1d7708a354e3907e44f9f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cppcheck/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "0b2e6a998169126c95a4733507ad1c0a0d59a7c9741351e0029d8c72fa76218a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-cpplint/default.nix
+++ b/distros/humble/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-cpplint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cpplint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "b9c958e60e19fe767b7cc6e41fa7f23a7a7a9b7c6589ca3ec0adfb3c5ac2fd3a";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_cpplint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "ee77189eb922c6654ac4749c32ef8b032c4248d76b9a378c9f7f81afa984cde6";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-flake8/default.nix
+++ b/distros/humble/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-flake8";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_flake8/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "93e81e940fb075a4bac67444d9585819b2789d8492b0cc56eba51b63fec86987";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_flake8/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "821c386de12789517af643be00681fe760ad9c5e626ba563251b5eaf34834543";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-lint-auto/default.nix
+++ b/distros/humble/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-auto";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_auto/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "fc92182876af3e78d3a9441f65e1937b5809eb554c9ab339fa2356b8a32c5076";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_auto/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "78b935768b414ecd8ad4ba926072a864025ec6cedbad5fe7ade049df2e89bc48";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-lint-cmake/default.nix
+++ b/distros/humble/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-cmake";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_cmake/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "ae1c640c2b424dd4a67f654783aaf46d02511fab8525c92ad59f058bda9f289c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_cmake/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "b4abefd54cc548eb47733f727b6dfeae0171420ca9de8121647c477fd6becac7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-lint-common/default.nix
+++ b/distros/humble/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-ament-lint-common";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_common/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "e2035cdf50bf53a25562926481b6d66440cf52cc7b228a1e097fe1d3c44ac751";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint_common/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "88dc3ba773c42ca6741009a7e97c9b426c3aa90464d2eaec7d90c62b3753379e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ament-lint/default.nix
+++ b/distros/humble/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-humble-ament-lint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "6748cfc3afd167ac3573a06b4a6d3c7ccaa463bfb27b69bb771882a4521d4474";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_lint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "0ff1c8c4df3a0c4f21ac7e6933b30e0f1c19d8791f946d76f1ffd79fd76c8163";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-mypy/default.nix
+++ b/distros/humble/ament-mypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-mypy";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_mypy/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "6cd1c6016fbd90ca593e609c0c436ddf4e7e94927b5fd239f10553250caabf90";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_mypy/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "6f083a3a33b24a002958df53724fe8674c6521e7b3fbf64e653e9888601992f2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pclint/default.nix
+++ b/distros/humble/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-pclint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pclint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "40e215d9cf732452da534e8ae300905ef2b95c6ff1cc45688b1c488525d3a5e4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pclint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "3d9325be6c29aa1448d5a5c1d631e450f0cbb5968279acb2d217dd359179c982";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pep257/default.nix
+++ b/distros/humble/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-pep257";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pep257/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "0e0d1c94c3b8224b498df1b4845573c0ec6caf3a22ece840ed6d1443a6f0a2b3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pep257/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "03bb1cb2f0f226bed4b0dad16ace6773a4538cefce42270d2fed3cacb76f1fca";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pycodestyle/default.nix
+++ b/distros/humble/ament-pycodestyle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-pycodestyle";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pycodestyle/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "37bcf8dbe365dc7c333e138b4863b4ad0863bd853ca0a330c2ab4032100d4117";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pycodestyle/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "6b3e8ac2de593645c811654bb57f09cc6801d3b7a364ffa712d1e363cc7ad90b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-pyflakes/default.nix
+++ b/distros/humble/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pycodestyle, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-pyflakes";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pyflakes/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "78d2486edaaa5c9deff1c82e9aac8bf5137a65393a6d4101ed704239a1951d8b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_pyflakes/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "691cc5e49dc6ba5db46c693ccd539e67abdaadb91d0b34df8de16271ae2a3640";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-uncrustify/default.nix
+++ b/distros/humble/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-pycodestyle, python3Packages, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-humble-ament-uncrustify";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_uncrustify/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "db2355ca53a298a6cfbdd7e0d92003cbb7e25db2f3ad9e8ee52cd7ee27b177a4";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_uncrustify/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "79ed973354bd07f6377fb028125d1374a14d261dc3b767edb125d22cb30acec0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ament-xmllint/default.nix
+++ b/distros/humble/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-ament-xmllint";
-  version = "0.12.11-r1";
+  version = "0.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_xmllint/0.12.11-1.tar.gz";
-    name = "0.12.11-1.tar.gz";
-    sha256 = "3cf0d69df006af2f53feb5898a581954e529013d4b652507be8d033adc1c6d97";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/humble/ament_xmllint/0.12.12-1.tar.gz";
+    name = "0.12.12-1.tar.gz";
+    sha256 = "3b3f2ceee6c5c0781093f6b9d88e7a1735a7f32395524bd06520bfa64b44bf6e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/autoware-cmake/default.nix
+++ b/distros/humble/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-autoware-cmake";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_cmake/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "9e0691fbe0103cf71bd339c02ffc4bbcee6fe2dc21588a47f6c8dea09168402b";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_cmake/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "208d48aaf1436c5f296d853b85ab24c4459b34e902d9776087bc32a469f8b37f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension-python/default.nix
+++ b/distros/humble/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension-python";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "d5d618b373c3b008025a8f25eb4a1e11a870d531ce0bd35e48e73e1ad4d5ea56";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "40c0c3c523b3a81357c8af4aeeda357c62920e00696685b3a378081d5a3e502e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension/default.nix
+++ b/distros/humble/autoware-lanelet2-extension/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "c5256b2bddde6aa049036a31aa24730c6b381aaa7a3bd5d22da982dce9a83fbc";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "15d740fc79e4ad09acd5ccfad7bda99c105a0705cb31562d69f0854c0ae51046";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lint-common/default.nix
+++ b/distros/humble/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-autoware-lint-common";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_lint_common/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "4a80f68ac0cfe1b5a15793e27026de58f7cf628b7f75ac5bb6ef299429456f16";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_lint_common/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "06420aec748a3ca645b184a3547cf885089d0110da2efccfc5eff871d8a707b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "84f31052acaf3cd036ee22aef52a7a2e461a62e1af1650a6502769155bbe3a6f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "c3cb7cf7057a815b9fbddc2c15a8af47a017f7218f97c50a2585dde3ff876451";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config-live/default.nix
+++ b/distros/humble/clearpath-config-live/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, clearpath-generator-common, python3Packages, rclpy, xacro }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config-live";
-  version = "1.0.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "fc8d0ee1fc51723b020190d286206a3dc9f3f083f9503540eb0bccbf80fb0cab";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_config_live/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4c134969dcb2d435918025dcaaee90a36d14a8a0b8c76159d2bf4e98beaec221";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-config/default.nix
+++ b/distros/humble/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-clearpath-config";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "de113ff30b9172a6f7cc7baf9bdc30bb3f6b60e6b6e0afde81c0b9c3af61cffc";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/humble/clearpath_config/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "22e109db6ebacaab351cdf3e075c684ff5cea1a9dfb9013f93b43662f324c875";
   };
 
   buildType = "ament_python";

--- a/distros/humble/clearpath-desktop/default.nix
+++ b/distros/humble/clearpath-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-config-live, clearpath-platform-msgs, clearpath-viz }:
 buildRosPackage {
   pname = "ros-humble-clearpath-desktop";
-  version = "1.0.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "84f7a8ef40830598690c31beea5005bcb3868a7f8a43bdfd957b7cf3a13a9ccd";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_desktop/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "223bfaf366f87ab2f9ad20c5ae440e2f99f2f64fff25f10452f22f3ce65460a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-viz/default.nix
+++ b/distros/humble/clearpath-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-platform-description, joint-state-publisher-gui, rqt-robot-monitor, rviz2 }:
 buildRosPackage {
   pname = "ros-humble-clearpath-viz";
-  version = "1.0.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "182edcb7ec769c9e36dab764a342f4c5dc8d62b301d2360ce8e36c7a428ae910";
+    url = "https://github.com/clearpath-gbp/clearpath_desktop-release/archive/release/humble/clearpath_viz/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "cd4fe57142eb16e903c4d65d93b36f482a24e652d1ec64b1cdb0b2567067fdee";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/common-interfaces/default.nix
+++ b/distros/humble/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-common-interfaces";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/common_interfaces/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "976ed12578424787a89584f51dbbd039b065896be39a4c83fb9a834b41b87fec";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/common_interfaces/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "722009410670649fb670c4b5bbc0839448ab48c540614339ff7a7bc39cab7664";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/control-msgs/default.nix
+++ b/distros/humble/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-control-msgs";
-  version = "4.7.0-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/humble/control_msgs/4.7.0-1.tar.gz";
-    name = "4.7.0-1.tar.gz";
-    sha256 = "5d7aa7fa17e55da387e15a8a0e768399a529ac21a98ac90908e797832fc0b93f";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/humble/control_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "649104fd393d0b0facb666939dca517f803b987fec82ad19bb493d729a2aaba4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "d981ade5fc542d3c6949cfee66fcd5244deed8a8c89e952ea09bf12d02c5b7b1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "763809855f6b0b32f69ebea189db1c6227e67a9f6e9fec9a91d47513e53e224d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "b6903c6bbf0bb42346694cd5eb5ba9a78484e6458ac14e82266d20cc60f0d749";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "4d85428613a9e469f0583465e43892b133563cc11da18a12e5a0b11c7107eef4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, hardware-interface-testing, launch, launch-ros, pluginlib, python3Packages, rclcpp, rcpputils, realtime-tools, ros2-control-test-assets, ros2param, ros2run, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "d2a6a62952960d844579abad1993ef7dfa5426d583e0ffc450ec767aad56fc8e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "4eb56a818bf7d04c74809600d73cbf3d99657ceb75e47962373251b4a3a3b49f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-pytest hardware-interface-testing python3Packages.coverage ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-pytest hardware-interface-testing launch launch-testing launch-testing-ros python3Packages.coverage rclpy robot-state-publisher ros2-control-test-assets sensor-msgs ];
   propagatedBuildInputs = [ ament-index-cpp backward-ros controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 

--- a/distros/humble/depthai-bridge/default.nix
+++ b/distros/humble/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-bridge";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "9f5f87ec8d320d2d49371efed68fb36f9606d809dd58a157b12f638b5b1023a7";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_bridge/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "efe501f5829eee35f015d3ff82f61a92c3874a4f0b439d54391204c0fa44066b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-descriptions/default.nix
+++ b/distros/humble/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-descriptions";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "9d475fb6b85da920f33ec3454e3f2a6a78447903792d3019eddd42950adb7e17";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_descriptions/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "d750d4508e24099172c8ad7a0d85dfe4bb9756322ecfbda924dc9bc4f5caf7f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-examples/default.nix
+++ b/distros/humble/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-humble-depthai-examples";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "89c4e3059ce3cb985390e4c36d2d5bb8c01581b960c7e37840656fb65d099560";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_examples/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "92a51ffc70388ea352c0564e994b866a080c6ea72cd1a2d4f6eff458ae54dfde";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-filters/default.nix
+++ b/distros/humble/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-filters";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "43a933b932456d432cd92ad7b995d06083a6ea76da1d97b630d76f98a25d1ad9";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_filters/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "7a535d6a2fe27e1c81f2afc892c08c7e78c7e515fa4eb813e38afb71d5b9a710";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-driver/default.nix
+++ b/distros/humble/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-driver";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "117a8c85982a6275b295aae41b9b6dfbecf9802be7a6c3f19625704acc600dbf";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_driver/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "f27f9ad17ab448352075fe1fe0ec6507d1ec77809f94b48b1488636b6a1f6a11";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros-msgs/default.nix
+++ b/distros/humble/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros-msgs";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "d319a27bf39c19ff0fb0c8a7edfe3a1e452520ce0dcc47e93532833d26e86259";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai_ros_msgs/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "f21eab977509fc17e2c7281948052badcc1a777677ca4309af712a5dd8e036ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai-ros/default.nix
+++ b/distros/humble/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-humble-depthai-ros";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "9eefdc02c02ad0ed11712f699467f52d051c1f79a720b290aeb9d20c84895e94";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/humble/depthai-ros/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "56f50b1f25b391e50ad4e757d94210c2c59cc9bbb121f48a067b8367034c6296";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/depthai/default.nix
+++ b/distros/humble/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-depthai";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "c12282fcfd2add04d9f1196209a14eef4da552febe960ec4c94ea8302a2989b0";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/humble/depthai/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "b9996db984f281586baa2a92bc8e4129d8421291259ef23bb66202042e0b96fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-msgs/default.nix
+++ b/distros/humble/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/diagnostic_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "fe0c1716635ac0aa987b25be50d2489d6898c6da7005bf4c4c2ee9f6c9466283";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/diagnostic_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "cd72c4479f3db25192f2ee64279fd07b231fe1310835b0d4cc33d8c09f82d3a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "e5d2f0c2a0bab6b1a7a0bf47b51e75d621370b51c7f4dd77db2260a60c78ef2d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "22135b7b52eb4ef5ca2e9c4596dad7ecd1d574e907df95b0dc4b179ae5d62efb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-hardware-interface/default.nix
+++ b/distros/humble/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-hardware-interface";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "26a3d690bbc0b6899fdcb5a1991ddd80b40773158d5d3b6f871f3816ce0f91d0";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "b371ab5c0039c2a7f72450c11a7d2b3fadfcb2171fdaf9190f274f1c74896eb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/humble/dynamixel-sdk-custom-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-sdk-custom-interfaces";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_custom_interfaces/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "93757af672881b8dd2c968a48181df64720b1b3aaf7a1e8ed778a1e6d71ebbf5";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_custom_interfaces/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "402cefc3fca8082627898c3ea569af98c44d5ec211688520ee974e3a74624aaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-sdk-examples/default.nix
+++ b/distros/humble/dynamixel-sdk-examples/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-sdk-examples";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_examples/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "4a871d63aa6406318a490b8170b7a8b18ccb817435745bc710afde280f3c8173";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk_examples/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "5089ec74a9966e1d9adbe412703c41fde464e7012b6f074a2b9a0a81368953b8";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "ROS 2 examples using ROBOTIS DYNAMIXEL SDK";

--- a/distros/humble/dynamixel-sdk/default.nix
+++ b/distros/humble/dynamixel-sdk/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-sdk";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "42ad9fde7a326163d440452d731f2bbbd2041410e81bf2fb692df984ecf1c97e";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/humble/dynamixel_sdk/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "bb8ca4495a013b8d2802a4f11ca9e3161115b4ae1078b7aedf6c3007a300d768";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "82a804374163c8863fdc4552516ef7bcc0bdbb6e95cb7b6c19cfc7463cf93a20";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "1c75bb52bc0214fdb4c6cb88a0a69b505fcf63837c0af5927625dca4271b05a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ffmpeg-encoder-decoder/default.nix
+++ b/distros/humble/ffmpeg-encoder-decoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ffmpeg-encoder-decoder";
-  version = "1.0.1-r2";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/humble/ffmpeg_encoder_decoder/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "8cb7b4eba4d5e39e1ac0b38daa50ea107e18e716c2ec1ceb777f56d11fd3c8e0";
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/humble/ffmpeg_encoder_decoder/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6eef1f84eb269c2df3a662e51321d538f72d8c2fce56ab563ad4d099a096866c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ffmpeg-image-transport-tools/default.nix
+++ b/distros/humble/ffmpeg-image-transport-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg-image-transport, ffmpeg-image-transport-msgs, rclcpp, ros-environment, rosbag2-cpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, rclcpp, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-ffmpeg-image-transport-tools";
-  version = "1.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release/archive/release/humble/ffmpeg_image_transport_tools/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1a30bb6dd6ea0c994367ca4856dadca8abf3d44682fdf0a6bb7b59d9f511effa";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release/archive/release/humble/ffmpeg_image_transport_tools/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "cb75dd6f76d93c647792cdf7c76dfc4fee9b990c6dfd2d1e5978de2378e27dff";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg-image-transport ffmpeg-image-transport-msgs rclcpp rosbag2-cpp sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg-encoder-decoder ffmpeg-image-transport-msgs rclcpp rosbag2-cpp rosbag2-storage sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/humble/ffmpeg-image-transport/default.nix
+++ b/distros/humble/ffmpeg-image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, ffmpeg-image-transport-msgs, image-transport, libogg, opencv, pkg-config, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ffmpeg-image-transport";
-  version = "1.0.2-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/humble/ffmpeg_image_transport/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "c72123a736ffe01f3de87df7f507ad0797813968258fe0754d70797cf28f3c6e";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/humble/ffmpeg_image_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "627268201e891127bc6d7da0d2b7cc9a7cf70138c26e54e0fe6f40607bee585b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg ffmpeg-image-transport-msgs image-transport libogg opencv opencv.cxxdev pluginlib rclcpp rcutils sensor-msgs std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  propagatedBuildInputs = [ ffmpeg-encoder-decoder ffmpeg-image-transport-msgs image-transport pluginlib rclcpp rcutils sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {
     description = "ffmpeg_image_transport provides a plugin to image_transport for

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "fb6de7d2f42f1d29a42a186fc70c5c60f951e6ad06a9eb23ec7f160c3c019f69";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "e90030ce1e0fc4d4f4085402f4f2d00127746c8ff23bc7f03d1a91006d13fed1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "d735add91efc7329953c76f229e61562cb6701d77591ab4116734ee152ebe83d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "dc3ae677e109790259f77930458f0a02c5447fbe9ecb2f64630cfcdd6f7dcc21";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -1466,6 +1466,8 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ ld08-driver = self.callPackage ./ld08-driver {};
+
  lely-core-libraries = self.callPackage ./lely-core-libraries {};
 
  leo = self.callPackage ./leo {};
@@ -1589,6 +1591,8 @@ self: super: {
  mavros-msgs = self.callPackage ./mavros-msgs {};
 
  mcap-vendor = self.callPackage ./mcap-vendor {};
+
+ mecanum-drive-controller = self.callPackage ./mecanum-drive-controller {};
 
  menge-vendor = self.callPackage ./menge-vendor {};
 

--- a/distros/humble/geometry-msgs/default.nix
+++ b/distros/humble/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-geometry-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/geometry_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "a7443664eb369fe021532721e0fc763b756b9105ff3c1857c57fe7ad1754cee9";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/geometry_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "14bc429f7c42367f3c6a78fbf11adc33fba0dd9efb270b54410a316323e95ec3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "a8973fb383e81746a1b3f9548be2658a1a33e37a61c93f1b1111416d7e2bf648";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "1ae9a435114641f1e573bf34c3bf59220265478e047b5ec6657fbab57b795a80";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "fef863187b2038112cd43393d5b248137e5045357c059e03d2621af1f2325c09";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "3c931e2c833e6f88e054626b3a5055fcb7039940f7d1403070181e17bb751a7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface-testing/default.nix
+++ b/distros/humble/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface-testing";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "3e805396a5ea7b3ef2616e59fa3b8327f17beea8cdd6721043abc639b0b3b963";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "2e4e54100be8b03eba9a4cde27a7bd62624e2e0f60631d993e7f594d24b95acb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "a4f2d8dd9b110a5bd57a9d0bd6af59d696a895c655f534e6aec0926486771e5a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "b5020d09755cea18ebbd40ba8ee7a91d7e8afad274fb9d08cf08b96797651090";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "644034e0350a158962c33a0ae91a53b6ad7a4909896558cfbf9c8dbfd6742ddc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "70926ca4d557ae3eabe5a3c8f3c72ededf5a50cb9f515992b740b33c7d3ac741";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, launch-ros, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "d8025303581a42c8d72f18d669b2480ba12370a5e5a61a81339f8390cc9d4c60";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "16368ea7305707e7bba8a203edaba22b4cdc7fb700e85237eb0ffea3310a7b70";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "2cb68ff19d2588115fb6493a28c6594ad69cdfb71dad6117c518468f9f6f8bdd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "08eceb2c22009b1745a29bbddcf55d9cf77abeb2b4abd88ad45a3d970bea0652";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "b5920766ac7ba7a310ece1c16b9c96fb2ba592fe70430c32d2d459db86b7abff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "fcf0c13bd685cb7f7215f7dd02b246a5ec5b4a9f830db25a23a71a745f850f0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kitti-metrics-eval/default.nix
+++ b/distros/humble/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-humble-kitti-metrics-eval";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "a8abc79c0148c824ad422b862dae6e3623966fad1aef2c490eabc81c0ac44497";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/kitti_metrics_eval/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "20719d9154675a0aa13f85baf3a5d26473d47b9bb878b3a01353e63f058be40f";
   };
 
   buildType = "cmake";

--- a/distros/humble/launch-pytest/default.nix
+++ b/distros/humble/launch-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-testing, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-pytest";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_pytest/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "919147f83de65f9e7fc68fddc15d4d5c8a0cfe991ce4dd125a586dc4537da438";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_pytest/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "31ea09bb743dace67b45800124d629820118c15f77897eb779fbde7fe0fb1d35";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-ros/default.nix
+++ b/distros/humble/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-launch-ros";
-  version = "0.19.8-r1";
+  version = "0.19.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.8-1.tar.gz";
-    name = "0.19.8-1.tar.gz";
-    sha256 = "aba9de0942a38141341385f63b8cf69294d4a85552137deae5a50a48c1404e8c";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_ros/0.19.9-1.tar.gz";
+    name = "0.19.9-1.tar.gz";
+    sha256 = "6fe9ca6e83dca0191fcf5d794d1ce11c8d125ca75b0ef373e625e8bf24fca752";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing-ament-cmake/default.nix
+++ b/distros/humble/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ament-cmake";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing_ament_cmake/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c68106e8925f5613116552aa8f623dd1b2b4e9dd0f2082ac142edb23c789afff";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing_ament_cmake/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "5e57fd1eff21cc10fa55f86df10953f291f18d92c0a06de33151fe64a2d52a7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/launch-testing-ros/default.nix
+++ b/distros/humble/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, python3Packages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-launch-testing-ros";
-  version = "0.19.8-r1";
+  version = "0.19.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.8-1.tar.gz";
-    name = "0.19.8-1.tar.gz";
-    sha256 = "3eb7f63b33346b4922143f40285d2560d6c40566c73daffb3ca5aecb9d43b120";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/launch_testing_ros/0.19.9-1.tar.gz";
+    name = "0.19.9-1.tar.gz";
+    sha256 = "f96b83618b52127e85a3d1411fb947e3551e89cf26ceff0b085f815a051288b3";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-testing/default.nix
+++ b/distros/humble/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-xml, launch-yaml, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-testing";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a51eede6fa423f8cddcc1918dbaa12c0dccae3a70298f4a7b27d42720def1a21";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_testing/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "93ded397593fa2b832c4dccb29740460bb17dcf4e46b3daa65b5baf7123b87a4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-xml/default.nix
+++ b/distros/humble/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-xml";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_xml/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c235a1cac3088a8847124f8008f4358250d6bd6a7ecec48033029850e49b2d06";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_xml/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "29908110ebb06a69ac658f81f910bba8440e0e846421b0b836233b0ef221e1d8";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch-yaml/default.nix
+++ b/distros/humble/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch-yaml";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_yaml/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1306d99f1622574c4ff008e628252e0a1a5f161a55989355d2dbe0e468e1e9db";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch_yaml/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8204803478024278fa2c16c6780aa03bbbbbb4b1ef28046b3447506ec80655f1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/launch/default.nix
+++ b/distros/humble/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-launch";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "95720b36e3ce39bfa169dd0cf61a84d121b427e648a396f54ba301e673d98e16";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/humble/launch/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e52389adfc3b9f958f961e5ef09484a34266ef953d6b8740d149114d9f49e97d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ld08-driver/default.nix
+++ b/distros/humble/ld08-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs, udev }:
+buildRosPackage {
+  pname = "ros-humble-ld08-driver";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/humble/ld08_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6b4c03d37736cb345dcc0890e745e26e50e7c35e27cf7f523a5d4c85998234df";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ boost rclcpp sensor-msgs udev ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS package for LDS-02(LD08) Lidar.
+    The Lidar sensor sends data to the Host controller for the Simultaneous Localization And Mapping(SLAM).";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/libcurl-vendor/default.nix
+++ b/distros/humble/libcurl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, curl, file, pkg-config }:
 buildRosPackage {
   pname = "ros-humble-libcurl-vendor";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/humble/libcurl_vendor/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "e9d1100eb201ed07e31c2549eded35fe16a49c4e862107046a22fed8f69a5c29";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/humble/libcurl_vendor/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "69e7b93668ff8b2dccfaad0e2a378d476a71142ffe02a786e7edba9bb258f533";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mcap-vendor/default.nix
+++ b/distros/humble/mcap-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-mcap-vendor";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "9a48a5ed09ac08a7c7da6e7aed983978926f80667934930b495802c3b1386ad2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/mcap_vendor/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "f879da1ee559405136b1fba9019c014ceca441f18313f64bb343b8287fcbcfa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mecanum-drive-controller/default.nix
+++ b/distros/humble/mecanum-drive-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-humble-mecanum-drive-controller";
+  version = "2.43.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "c8c1af7fab0d211f6ec8d3a9c688073bcba2c34dcc16c680b369cd69680fbf08";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake generate-parameter-library ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Implementation of mecanum drive controller for 4 wheel drive.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.5-r1";
+  version = "4.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.5-1.tar.gz";
-    name = "4.3.5-1.tar.gz";
-    sha256 = "47ae144dd748d730505a462eabba1014172373cc16235b1d9512846ed80de1cc";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.6-1.tar.gz";
+    name = "4.3.6-1.tar.gz";
+    sha256 = "8a3b96aab1487fc648f82147a18481453841c63e8f5df84d178713d3f394aaec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/metavision-driver/default.nix
+++ b/distros/humble/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-metavision-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "4c2ed0a50d5827c9d379df905329eab552f69112ec9f4360aab0e1cf3b2157f5";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/humble/metavision_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "192f0492aaabaf24cdf5a0ff2ce9a32f0b865748d8cc6da0a42744b06b617347";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-bridge-ros2/default.nix
+++ b/distros/humble/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-mola-bridge-ros2";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "012e0ee129d48b13b522b819014f85fddb6ca8cc6e7d0f41b3c430658355cc15";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_bridge_ros2/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "059b036e12f1f3d0a74371ff6f77c65ef62eac980e9fca09602da0ce62238fb9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-demos/default.nix
+++ b/distros/humble/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-demos";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "d5b2b3cf513d44fa1f7e85e9c2283c5c436474243067a770b2871fd6bf17cbff";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_demos/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "4dbd89d4c9c22eb1ab2854f28387b4b5ea72a8b7acf238a441485da6dab02417";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-imu-preintegration/default.nix
+++ b/distros/humble/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-imu-preintegration";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "aef4a832494240d9b53aebb7ff4b6d34f6e8d1c86de8a8a75af767dadb3a048d";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_imu_preintegration/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "b8b6e30e123ae6e137b3f796bfc4e1fe354b0aab9305a85453619d6eca9d0484";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-euroc-dataset/default.nix
+++ b/distros/humble/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-euroc-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "12c80d7e7beeaf2f454a784b41ad4affc7d2c27d11e862ce722af26e578b5cf6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_euroc_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "7e5c5012c320d504291f83fef5f31fde7a8030e41ea0a27b82524fb68dadb96c";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti-dataset/default.nix
+++ b/distros/humble/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "fa943a54348d715b5bd3429343e7c4161f2d0ba0a273c98daf77d5b656976f8c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "28f85e239b1b45f0e978a5d78841273ac2ad4220e3236e9df2afdeb1e85826d7";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-kitti360-dataset/default.nix
+++ b/distros/humble/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-kitti360-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "a1033df07e68f2971063d5ea6ca4fecc34f716fec2c5e28228bfc50631d48720";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_kitti360_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "0384ac123da75649bd78e4ffe602b7680fd92b81236a5029adb630dbf3ce9bd3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-mulran-dataset/default.nix
+++ b/distros/humble/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-input-mulran-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "ad088afc17688d00f683b6431476939d0398662e7f6e8739e1c330920c420bf0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_mulran_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "62e5b4e2404d0c24b9f673f5a50a547d11b4b91a48da484628d448bb96cc2d51";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-paris-luco-dataset/default.nix
+++ b/distros/humble/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-humble-mola-input-paris-luco-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "674c5261bacb364c97a49cbfdee6f24b02b5a7188a4d5625d08355d8b935c61e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_paris_luco_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "ca81ded485d98439e4584a8b3b2a90fb6f466054f706376c4916c25baf6e6f95";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rawlog/default.nix
+++ b/distros/humble/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rawlog";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "beb854376eeba791a55bc1acc658ed8bcf807035b7228978b8f8f0e5b503db26";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rawlog/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "a29683da44b435a59c9b772e2a52e68a62711cfd2fda2e523e5d8bc1a5287fab";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-input-rosbag2/default.nix
+++ b/distros/humble/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-humble-mola-input-rosbag2";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "3588e335f510ff6f524f5933e3dd2bcd6d073e27f44a454782ba9f5ab4bfee31";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_input_rosbag2/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "2ffd08535d8aa742472601bb00301e0fac7b188c8b1804788fa266d2281a6ae3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-kernel/default.nix
+++ b/distros/humble/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-kernel";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "bb45c37f592c958389d7238576c8308592c693a52d8996c1784a39d5734bd12c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_kernel/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "a52263fdd011e22ecf238e280cd98cfba71a00ca25647a4f9f12796b114d471e";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-launcher/default.nix
+++ b/distros/humble/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-launcher";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "d9c7284d9e522942c984bb007d7d25aa17119bfdfafc37020c48400554cfa59a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_launcher/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "9a0aa38efac0ea897a9835e3c75ed28ae36297ad8ab4e8c12a2c25711d5fa259";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-lidar-odometry/default.nix
+++ b/distros/humble/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-humble-mola-lidar-odometry";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "4d99234f0882ba0bed63c548fdbb741d474e5dcaba9f147997d46af3e3da8b72";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/humble/mola_lidar_odometry/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "b06af6c768d82c7f65ea03a9b0bc22f4d30309f6bf044d187d78334c43d15b5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-metric-maps/default.nix
+++ b/distros/humble/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-mola-metric-maps";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "f53765bb7fffdb36f827f88880f79ba1c03b823ed0ebd653113308fb5a0986ad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_metric_maps/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "7f0166172c19a76f31a0d8749e680d35b44e00296c1ff4372de44197b5e6ffae";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-msgs/default.nix
+++ b/distros/humble/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-mola-msgs";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "b0103836e44762f3257036c63144e7bc2c6d7e5b6f96fcf33ac0e254812155ef";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_msgs/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "68fd825badd584ad91b717d047ef5ac6d9cd658ea231fa592ce17ba195c4d75a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-pose-list/default.nix
+++ b/distros/humble/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-pose-list";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "4041d3a8466dcc1edb3bb785a906915dcdedd2574cdaee1ee45cbe5cdd74857e";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_pose_list/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "f3b7ab8bdd49369c9f3c6d4490ba73aca4ae9f11be1beabc6df5d2be3994f900";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-relocalization/default.nix
+++ b/distros/humble/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-humble-mola-relocalization";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c0f00a8744afe947ffcd9151bddd56148fbf4563c49d6df1a083d9ca501be01a";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_relocalization/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "9261455ef2f27373a291a6ec7854a675e35d41dcd7dbfd5f9b04f09470237540";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-simple/default.nix
+++ b/distros/humble/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-simple";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "77885846dc4de98e787ed8c83c2267eee0486d6d38f44c695fd38b9be7041bc5";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_simple/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "c6b2c412bc23291b9b85cb849173cebf121d579207996eb35ea86bc586e288a3";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation-smoother/default.nix
+++ b/distros/humble/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation-smoother";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "10a788ce50787ec62c668e67a6336efa0430567338f97771b5291c2f4c775a48";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation_smoother/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "a8ba1c2f43389bfab348cc18e1db891470af05a9d4aa18962e23426ca2c21902";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-state-estimation/default.nix
+++ b/distros/humble/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-humble-mola-state-estimation";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "601d5f5fb1bb270e57e697fa5bad6730f73e4f92651e9a2777daf3dc2cc64849";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/humble/mola_state_estimation/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "092f748558fc709cfcc5ae2be8a535d22d7878c0d39ec05bc3619f39980fbb9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mola-traj-tools/default.nix
+++ b/distros/humble/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-humble-mola-traj-tools";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "a985b269134510868326946d272bf591876a5e2085a0d9319651b5348fc89324";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_traj_tools/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "31e972e6f785b679224e64c77106dfae64e78edcd5f04352a808f80a167c8fa0";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-viz/default.nix
+++ b/distros/humble/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-humble-mola-viz";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "5b407038d5df6135f8f0db370a5fd5294455b31e8bd65a53cc63c598c6e163a8";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_viz/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "04026d595921e200d0327547ab0281a853943d4a04d3cadcbf426c96bdfa56ff";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola-yaml/default.nix
+++ b/distros/humble/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-humble-mola-yaml";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "6348875fcc05b01ba612d77f839c1261c149bbd0f89e30b70890082c7e7e01f9";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola_yaml/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "f80568cc7460c6ba78f2be62e44387a573c53f9dbd5d3216eb31a61aeb718702";
   };
 
   buildType = "cmake";

--- a/distros/humble/mola/default.nix
+++ b/distros/humble/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-humble-mola";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "e4082d06ae0b1a2b14089107508f5c4d8ff2c75692dbd55108bf1d3f553ec82d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/humble/mola/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "8fe46491b7d00e8d0f891f5111c2fd9f1d5f98091f215cb2ca27a4770b573bf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/nav-msgs/default.nix
+++ b/distros/humble/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-nav-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/nav_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "2069a52f28279403153bf3040cf90711ded75ee259991c058afa0294eb027829";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/nav_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "e19eb546e8a2c8b4a732e77e0b1fbfca6dea6cd58879a36f4e7cdc6e0438ffd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-oem7-driver/default.nix
+++ b/distros/humble/novatel-oem7-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-oem7-driver";
-  version = "20.6.0-r1";
+  version = "20.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_driver/20.6.0-1.tar.gz";
-    name = "20.6.0-1.tar.gz";
-    sha256 = "f32d68d582e8d8a5e54a8aa657abcd714da829c3164a03dbf8512214fa22deaf";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_driver/20.7.0-1.tar.gz";
+    name = "20.7.0-1.tar.gz";
+    sha256 = "9cdb5ca489c3705c66ba7d66e28590628a6b82317d82093555d1c14f71877e35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/novatel-oem7-msgs/default.nix
+++ b/distros/humble/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-novatel-oem7-msgs";
-  version = "20.6.0-r1";
+  version = "20.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_msgs/20.6.0-1.tar.gz";
-    name = "20.6.0-1.tar.gz";
-    sha256 = "7cb0371afe7fd932009b6fa4ceea0ba50651f67494baa58786aa15cbfaceac2d";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/humble/novatel_oem7_msgs/20.7.0-1.tar.gz";
+    name = "20.7.0-1.tar.gz";
+    sha256 = "07870df041eedb254e6e03875600cc0e22b8469648cc80bc9ee1f5196df4ffe8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/osrf-pycommon/default.nix
+++ b/distros/humble/osrf-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-osrf-pycommon";
-  version = "2.1.4-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/humble/osrf_pycommon/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "7eb7f928ef424bd59d5a691afc7ea4c7fb508022a3df6da8f8700b5503abe54d";
+    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/humble/osrf_pycommon/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "c078a9e27c6c39f3646f4d6c6242500bc267f6da2bab029d175815eb44c4611a";
   };
 
   buildType = "ament_python";

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "3171ae83ddd5d5899f43b95360163efdca26905e7a11d7002f184ac8b19bd81b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "29d612165530aab65c766325724d972c768a8dbbc38fa93728cfcd5bd0b4bc35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "3ed139cfb9c9e26bf7ad8a3f2d2d94db8498b355d9086538966e45fccc574fbb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "dbd894f581a0ea63e817dc64638fc78c36b905e5265c49821098aa36f6dc5cac";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "0dcde352d51d6dac7289b6f7b66581f9c60310b0d440bf22a746174c551a2499";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "7a274d9f95a67772fd7a3a6cbe1b4011bc824cad2195d5f708083e8e80f29b1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-dotgraph/default.nix
+++ b/distros/humble/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-qt-dotgraph";
-  version = "2.2.3-r2";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_dotgraph/2.2.3-2.tar.gz";
-    name = "2.2.3-2.tar.gz";
-    sha256 = "99eafd3af2158dc40eb80fa03e5498ff7526bb5b4169c26f5cb8a10ce4c47694";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_dotgraph/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "c59ef370752d10685c4f9eb1f4e26c8edd98691652ae303ba849c5577a45ba46";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-app/default.nix
+++ b/distros/humble/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-app";
-  version = "2.2.3-r2";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_app/2.2.3-2.tar.gz";
-    name = "2.2.3-2.tar.gz";
-    sha256 = "84c6c16cce3a61eaaef700b2f66c424e1894e9ba97fe6d3ef4c81efc4a60b4b6";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_app/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "7521e6b1f336f3be80e89aa56c81becf33e549d13e43e38d4fa1a5b04a4a45f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-core/default.nix
+++ b/distros/humble/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-core";
-  version = "2.2.3-r2";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_core/2.2.3-2.tar.gz";
-    name = "2.2.3-2.tar.gz";
-    sha256 = "57ce27a65a22605dbdd6b4e4577a6cb4d361b02025fd3e75d681923b04fac21b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_core/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "6f7c0869848b935fb2dd9148a71e0934a6f846327ed37c3d3d28618fbe28d34c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-cpp/default.nix
+++ b/distros/humble/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, rcpputils, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-cpp";
-  version = "2.2.3-r2";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_cpp/2.2.3-2.tar.gz";
-    name = "2.2.3-2.tar.gz";
-    sha256 = "73e105e32f764990a18de1ea28347bc201edc9ef4a55cbd7cfee5dddddfd050b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_cpp/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "2ce8a2500ca3fd90ca09c825168b4a085bf03ccce33714a88610dbd87e141eab";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui-py-common/default.nix
+++ b/distros/humble/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-humble-qt-gui-py-common";
-  version = "2.2.3-r2";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_py_common/2.2.3-2.tar.gz";
-    name = "2.2.3-2.tar.gz";
-    sha256 = "38452d3ae6ebf90ba833ba6010cd8aa7d133328c5145e8ffad3f449f3a892f2a";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui_py_common/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "780922bad169daa1b7c6e23ac6d7957d2aa271d0c0e20d4fa8877a208240441a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/qt-gui/default.nix
+++ b/distros/humble/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-humble-qt-gui";
-  version = "2.2.3-r2";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui/2.2.3-2.tar.gz";
-    name = "2.2.3-2.tar.gz";
-    sha256 = "1d10e41d843388b6e3823b14442a5157d90bb21b57b23a3a877020913474572e";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/humble/qt_gui/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "a1eb03ceeb39342cc08e4fb4211bc9af02c195464a351eaa17787112ac0aa4bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "8b697553715dd51fb6ca685ce91f2566568c28f0c1a1d6ca64de38ba953ddf97";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "fef477b524f16718f08507844e7f0a9dfecc703257102a040315e53c3af99fb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-action/default.nix
+++ b/distros/humble/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-action";
-  version = "16.0.11-r1";
+  version = "16.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.11-1.tar.gz";
-    name = "16.0.11-1.tar.gz";
-    sha256 = "bedd54adba7a72de4890513ded7d161003bddd8c2ecdcf30b0ce0d8aa3f3aec8";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_action/16.0.12-1.tar.gz";
+    name = "16.0.12-1.tar.gz";
+    sha256 = "3cebc52b839be931acc4ac420fa44fa5925a07f4b8d6e8e6c2c9a81843eb92a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-components/default.nix
+++ b/distros/humble/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-components";
-  version = "16.0.11-r1";
+  version = "16.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.11-1.tar.gz";
-    name = "16.0.11-1.tar.gz";
-    sha256 = "62299fb090b35effeb73c2e6572f5d9e30fdd1c34f34b7ada27e81829fbe5ca6";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_components/16.0.12-1.tar.gz";
+    name = "16.0.12-1.tar.gz";
+    sha256 = "dc45d1353b245219ac8af0e020f2f4229519c499b7a1b37636e1d2a2d57c97ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp-lifecycle/default.nix
+++ b/distros/humble/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclcpp-lifecycle";
-  version = "16.0.11-r1";
+  version = "16.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.11-1.tar.gz";
-    name = "16.0.11-1.tar.gz";
-    sha256 = "e9383f97647416c3eedacb481e84c43228c1f76b1ca1aff76933bdb99e997871";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp_lifecycle/16.0.12-1.tar.gz";
+    name = "16.0.12-1.tar.gz";
+    sha256 = "4f514c81e9fb9945c59cb94e9b66bb5ee53adc26060d3556f81e26958e5e78ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclcpp/default.nix
+++ b/distros/humble/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-humble-rclcpp";
-  version = "16.0.11-r1";
+  version = "16.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.11-1.tar.gz";
-    name = "16.0.11-1.tar.gz";
-    sha256 = "8ecf24a23575fa6e67000b977f7fa0363b98d775740fbd15cffe1f5fef5358de";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/humble/rclcpp/16.0.12-1.tar.gz";
+    name = "16.0.12-1.tar.gz";
+    sha256 = "07595f9dd862b2bf75b60a2e372910cddd1de073f175dfb9fef235c262836732";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rclpy/default.nix
+++ b/distros/humble/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, pybind11-vendor, python-cmake-module, python3Packages, rcl, rcl-action, rcl-interfaces, rcl-lifecycle, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rosidl-runtime-c, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-rclpy";
-  version = "3.3.15-r1";
+  version = "3.3.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.15-1.tar.gz";
-    name = "3.3.15-1.tar.gz";
-    sha256 = "8be73b988640c972749829398ebcfb7a56ce57867e11751da53d22e1273cf81c";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/humble/rclpy/3.3.16-1.tar.gz";
+    name = "3.3.16-1.tar.gz";
+    sha256 = "993bf3ced83980520551671ba5ceb9aeea1d69fd7aa3095803fde9836e9c60df";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rcpputils/default.nix
+++ b/distros/humble/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-cmake-xmllint, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rcpputils";
-  version = "2.4.4-r1";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "54b758ba1de0a95e6a8830b33df232f1e346a923d9604add4f216cda055a92a3";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/humble/rcpputils/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "108add0031e0f2a685614f54dd42a2e3f940709194133f4f9567a054a7831936";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/resource-retriever/default.nix
+++ b/distros/humble/resource-retriever/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, libcurl-vendor, python-cmake-module, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-resource-retriever";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/humble/resource_retriever/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "725ce4822659501f2075d1aa38082160009bcc6c9eab87bd0636f5080ba758c3";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/humble/resource_retriever/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "fe0e577a5d63c56acfccc62834795fcfe4d85a399b46f38a14bdfbf3e5a5ed38";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rmw-desert/default.nix
+++ b/distros/humble/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-humble-rmw-desert";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/humble/rmw_desert/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "7f2e283844bfe55898548ae55a12e4ad40d6d177d414f00efe4cc5db6f8fc8aa";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/humble/rmw_desert/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "3af5d47700c021da4c44f5fe4db162a8c8bd7a1fa6acee6343bbb5b7db977283";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "af3bf9a0cfb6ac5b4a3d567486a6a4791fdbd3431aa21b40a245bd4c81e28d84";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "44ad3ed0b86c00fc843d648f88834a0d885efcebbe79828c9340bcf735b1a26e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "5407663173d14dde61097603e8c44b3a0a7ba5d7f8c827f5bb72a44a174caa12";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "f4058c69e77e8ad63ddf1311d97e09b40aa04c1656d9ee6bbd2dda5326bbef2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "50bc2a1ec3cc5575bfdd31de11fa3cc7ce96f08b61e9d6345eb1ccd075bd2e3e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "4f077a7fad776eddc8fdd9e0689abb00c034c25365ba8b98d97f7c1551d08ad0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "642641be368b35e1bc50d49648dd7463026aeeeac448dfd6bda103d41d64ee89";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "7cfbbc5ea4ba59f1c9d6154d5d08f8a0d7d988c24ef9065fbf5dac40cdce002f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller gpio-controllers gripper-controllers imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller pid-controller pose-broadcaster position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller gpio-controllers gripper-controllers imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller mecanum-drive-controller pid-controller pose-broadcaster position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ros2action/default.nix
+++ b/distros/humble/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2action";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "3ef9993e8118dad249f9e86b5172d5c0ef06efdbe402dd84d512861f97b5083a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2action/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "30caa00ccdbd40cc3ba7937ca651b8929b2e9eceea1f2bf45122bba09b01051c";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2bag/default.nix
+++ b/distros/humble/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosbag2-py, rosbag2-storage-default-plugins }:
 buildRosPackage {
   pname = "ros-humble-ros2bag";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "ca4aa39499c3a5ec65e11a545f8fe408460e05591da8d5674261a16d5c7290e6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/ros2bag/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "87f18545f8b4fb8dd23f51e7b3ed2338d524729ab2ea82fdc8afca22c9458bf9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2cli-test-interfaces/default.nix
+++ b/distros/humble/ros2cli-test-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ros2cli-test-interfaces";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "6c416b0ebac68fd782758a79e9c324be06be98b4ef28d65a6495710de9f34d70";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli_test_interfaces/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "d2372597040ba48f5d3c42c54d2e6f68183c5197acf680732b32c9b70fe12b7b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2cli/default.nix
+++ b/distros/humble/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2cli";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "66d21e05b5af229f19c03acfe769dbeeb22db45cb65ccb55bfca740631dd2213";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2cli/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "3688891683c7c45203f8e009e38b34e1eb51301c0c48d6bbf072f8051169bf6f";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2component/default.nix
+++ b/distros/humble/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, python3Packages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2component";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "a52d58a4b5bf2a61aa3e108b006144f622dd98249ae608adc047b944c6da215f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2component/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "1abaff4556222a382f9c84c596b429a6739bbf42bcefa77830a5b07428246505";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "cb3a6a38fd25c2f29e18adcf7963ef33aa9c476258b7f2e9b03e30dbbe3e8d46";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "30740e7102bda6d781e9a2ab593966e11b2bb8dfc5e5b43460cdf3af51f50d6b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2doctor/default.nix
+++ b/distros/humble/ros2doctor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros-environment, ros2cli, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2doctor";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "2b486383cde6d5560321f22b873e016d763ca88d906fd4769aab666ea1531f3b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2doctor/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "408816c0d5daaa18ff32123a0cf8d1d0c5736da387000c4dec5cc86a8fd89fa0";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2interface/default.nix
+++ b/distros/humble/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli, ros2cli-test-interfaces, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2interface";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "77c87603a353c741496ebf026901a408e3e7f5992654b1b4abc5ab9c3bf32a7b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2interface/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "51041e078a7dff302ec8fed8296be5d236bbb41f1e889ac0a970b9c4e4362375";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2launch/default.nix
+++ b/distros/humble/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, launch-xml, launch-yaml, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2launch";
-  version = "0.19.8-r1";
+  version = "0.19.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.8-1.tar.gz";
-    name = "0.19.8-1.tar.gz";
-    sha256 = "0c98668e4e45ddc7df4de62acaafceeb319d737afba017cba9a624a0c9eb7fa2";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/humble/ros2launch/0.19.9-1.tar.gz";
+    name = "0.19.9-1.tar.gz";
+    sha256 = "67f2dbb0f5adffde3ef0a393a8bc647e4b5b498efc141f54bad36524a5547beb";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/humble/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle-test-fixtures";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "de25d91f6f4e065fc3b7ff43a74fd69a563f0d577f708e564c2a83e53ad2e7bf";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle_test_fixtures/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "6683b7dd3fbbb630b14d9c14416d986453d645e9a0e82304fd281b7d73bc84fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2lifecycle/default.nix
+++ b/distros/humble/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, lifecycle-msgs, python3Packages, rclpy, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2lifecycle";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "f073a4ae6a19c9420e16152f62307f934429d47bbb0029534aaea2ec51904b71";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2lifecycle/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "bf7fbc33d5f10a91339106bae50a0135cb977ea1f162aa730bf36cb62e9168ee";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2multicast/default.nix
+++ b/distros/humble/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2multicast";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "4bcdac65a3ebbe3b4e17d2fed708bf313f8e66a0481735342879b6b9c3aab8f3";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2multicast/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "a18459a84b661bb4badf3e78349ea70cbe9dff6064ee04cd51a0cac412a26f73";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2node/default.nix
+++ b/distros/humble/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2node";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "7cc6de1cfa0fca4a40ce4ac33552a7091e8f912ea26547c552c635a793234c3c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2node/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "37000777c60b5dda6d247586cbb0d6d4e1b85462f789a3f7ad5e863f29675943";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2param/default.nix
+++ b/distros/humble/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-humble-ros2param";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "8027be6b9b6eede75dcc82c764423fb490c7e7d5adc65ea722da77d15a224e94";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2param/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "cc2fde71aa5464c4e30a2b39a3fed0b3189445e88ae31b8b67135ae957f1eff1";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2pkg/default.nix
+++ b/distros/humble/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, launch, launch-testing, launch-testing-ros, python3Packages, ros2cli }:
 buildRosPackage {
   pname = "ros-humble-ros2pkg";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "732d77015f9075d27039428f16aa5a62ec7274438c3d18cc2a7ac9a3ebf6d095";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2pkg/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "d5f6ca7b7b980b78b3cc44adf9918a5bdf2dd9819bf12c1b296f409ba7f8cef4";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2run/default.nix
+++ b/distros/humble/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-humble-ros2run";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "62bc73260b894d6230f64fdfd48082eee08dabe0569a7ff86146b0abaa0ff6fd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2run/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "a050817f98603d270541f32d507753e4f64aebc428017d209259cf040b996ebe";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2service/default.nix
+++ b/distros/humble/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2service";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "b15dcfaa4c3c76f5af43dac5dc5392d2c31dc173934f9c0365a42e3d16b10bc5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2service/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "670f790a8d8e491024acc87b31d0d656fc852d6aa600eb2a1e702fb3aada4d6e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2topic/default.nix
+++ b/distros/humble/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, python3Packages, rclpy, ros2cli, rosgraph-msgs, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2topic";
-  version = "0.18.11-r1";
+  version = "0.18.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.11-1.tar.gz";
-    name = "0.18.11-1.tar.gz";
-    sha256 = "75908db164fdc666cf9e66106e8d5ce25295ab009d2292da0008bafc7ffc1afd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/humble/ros2topic/0.18.12-1.tar.gz";
+    name = "0.18.12-1.tar.gz";
+    sha256 = "5acc214009fcdeeffbb41a50fa81782f959adaf81b5c96d7dc4288df0baee304";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rosbag2-compression-zstd/default.nix
+++ b/distros/humble/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression-zstd";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "c6592762972eef99145b43fffe21f9fabb10cd573c36b0c6990fbddd2935cfc9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression_zstd/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "ab60108b16d379cc98613bf9d7ca223ca146451210d2353b2b691b78d43f7c1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-compression/default.nix
+++ b/distros/humble/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-compression";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "915795abcd25d59a62d913f0baf0f61f843348d4b50a195f808e8f10b278ae6f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_compression/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "0631bc3c92800e9e841586b5b025dc81b25f03da1550c154018c86a6b78d4bfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-cpp/default.nix
+++ b/distros/humble/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-storage-mcap, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-cpp";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "35de47814b6a08c311df06571b947e99a76d1b5a7b16e4e7b844ede859671e9c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_cpp/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "4c19bc66aedd962654a4e5d6a9bd060cef20ad18db22184bf5ebcb487275bcfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-interfaces/default.nix
+++ b/distros/humble/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-interfaces";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "855c9075848dbf29a1a0571b71c6ee0c0cded8302cb63de463c332cba5175d47";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_interfaces/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "86d05c69d8984a1da6d426391521cb6da5b9445a08a82860034607aa0fa0c777";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-performance-benchmarking/default.nix
+++ b/distros/humble/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rmw, rosbag2-compression, rosbag2-cpp, rosbag2-storage, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-performance-benchmarking";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "6ef285173177dc6120edf83d2403c86538475fe5027ea540eee150a66a2172cb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_performance_benchmarking/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "77649654351e09f4a17f8834a83da7b8c1ca9b041f4e6e8abbf7e9b0456161a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-py/default.nix
+++ b/distros/humble/rosbag2-py/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, python3, python3Packages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-py";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "8e8b07943b5acb809bb11da4d132965ed319cd0ed89b703abce46b90abaed8f7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_py/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "697681ee363873c43c728e0d252a81a10cf86453455bc0e0bcd707f9cc220026";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];
+  buildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module python3 ];
   checkInputs = [ ament-lint-auto ament-lint-common python3Packages.pytest rcl-interfaces rclpy rosbag2-storage-default-plugins rosidl-runtime-py std-msgs ];
   propagatedBuildInputs = [ pybind11-vendor rosbag2-compression rosbag2-cpp rosbag2-storage rosbag2-transport rpyutils ];
   nativeBuildInputs = [ ament-cmake-python ament-cmake-ros python-cmake-module ];

--- a/distros/humble/rosbag2-storage-default-plugins/default.nix
+++ b/distros/humble/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-default-plugins";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "a93153a08e0fc62c75e036a28cd1ede1d904394ebe9e8b1d1f6fe65f3f57d303";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_default_plugins/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "4327a2243c164dbf2a666ba8abbaaab46e75be86f27eb81312c08c637858ccaf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap-testdata/default.nix
+++ b/distros/humble/rosbag2-storage-mcap-testdata/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap-testdata";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "e57a767ff0f38d0bbaed03e6948f8bbca86f146c5c84aee0e172b2486c5ff4a4";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap_testdata/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "b4808addf0c6f7067ee954dd97addb5a99c333717038ecc3a009da6847c6b0d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage-mcap/default.nix
+++ b/distros/humble/rosbag2-storage-mcap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, mcap-vendor, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-storage-mcap-testdata, rosbag2-test-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage-mcap";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "79fba85fd39572239bcacf8285060d843e0cffe9085f2b6f05334f140195bc2f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage_mcap/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "689a71f9b5164d7a86ea70946803dbd354eef57e7e189e9c8b3ca7aef90f970d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-storage/default.nix
+++ b/distros/humble/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-storage";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "f185047a68febcabce66825db530df34af66ee2e9f608052fb6923d1a4fa98c2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_storage/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "19c86e96484e5272f048af042f34446d94a2640d174af5fa7b766877c80d9949";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-test-common/default.nix
+++ b/distros/humble/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-test-common";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "400a7c0f1886017ac738becb13d93351aa507f5c838de56a89f04d3e9630d9dc";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_test_common/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "38d26f8799d449126f2355b29f70868eb3855fdfabddc28aa3f6f21a556661e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-tests/default.nix
+++ b/distros/humble/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-tests";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "93b636c94e6c4c53ea3493b6dcd1ccf06aa5285584f779b6185a1f147b31b92b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_tests/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "d378da5e19a5762ba518e02f0802a4924728c6d54521d17be45be291f2c760fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2-transport/default.nix
+++ b/distros/humble/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, keyboard-handler, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2-transport";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "a59dd2de797a200447da7bd764dac152cac1a334c5ffe4688aa53464ada5396a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2_transport/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "e9735d2d5b875b85bdb53b42387505d81d0891dd2c5448b77980f87abdefaa19";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rosbag2/default.nix
+++ b/distros/humble/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-humble-rosbag2";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "1e6867d7ae1e5c0abf4c084ef9b1376bdeb50108d614a4fdf0285cd4446fef44";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/rosbag2/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "311798c248bcccd5a9d58e77a7a47aab374be0835f2a6ed4df40ae527d6a2063";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "0fa0d19bd3b6767ffe2b129f5017e84584bfe8f3e8f2298e32258abfe5b0611d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "dcfc2210b355b4da7d0a71ba79398f8ccb32aa47864f77f1130c42da4c8df45b";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "ecf3fa32bb418e3a300233f35d317300984fa12106ff8483079af9fa526ede80";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "0efc8501a15882ac2f8c5e6359bf1505a0c2fb8ca7dbeb37e7643d41d3866cb7";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-plot/default.nix
+++ b/distros/humble/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-plot";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/humble/rqt_plot/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "353b96ab67b55a5c209a95fd0e535ac7b177357ff4b13e2713c229ff5dd011f4";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/humble/rqt_plot/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "bdb2222085242a691b9299d051051f545e61bca4d7813b94374005b4c19b8222";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-robot-steering/default.nix
+++ b/distros/humble/rqt-robot-steering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, geometry-msgs, python-qt-binding, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-robot-steering";
-  version = "1.0.0-r4";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/humble/rqt_robot_steering/1.0.0-4.tar.gz";
-    name = "1.0.0-4.tar.gz";
-    sha256 = "9059965d71f3e4b81b2f9bc45e927ab913e92818905c62abdbae1fd162ee4541";
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/humble/rqt_robot_steering/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ce41516115ea231af1ac41f18545faa6d16ffae09abf3cd0fe43fbdeb49e5871";
   };
 
   buildType = "ament_python";

--- a/distros/humble/sensor-msgs-py/default.nix
+++ b/distros/humble/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-sensor-msgs-py";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/sensor_msgs_py/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "c036af1acd8792b116eb2f47832d928986e4ec13f060db953098fa0834f6de6c";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/sensor_msgs_py/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "2141662f0904f212461158022e25a4360fb0d5ec25e9cfe5fa825efdf2dff904";
   };
 
   buildType = "ament_python";

--- a/distros/humble/sensor-msgs/default.nix
+++ b/distros/humble/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-sensor-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/sensor_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "c9cdabad13067c910808841b6531c2d56ec6ee49705ee68d9926bb943322968f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/sensor_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "3eecd0467236c83152440b9f23484ecad1ec7c2fc25865ff9e149f51005f9eb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/shape-msgs/default.nix
+++ b/distros/humble/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-shape-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/shape_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "e06e8bbaaffaaef600acf6e4ad39aabcce9b281ebf3747a9209dea1aed02ef54";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/shape_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "b23412c09f35e5454c0b96420389da1098401705a83ecbcf8646b54f3ba8df48";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/shared-queues-vendor/default.nix
+++ b/distros/humble/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-shared-queues-vendor";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "81a4928710ae888143f4b78ee63c9f76218f52f1eec8a9a682e6bdd6adc19781";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/shared_queues_vendor/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "aa46a843361e8e8bee8e407ae185576b3d746cd1a90c11543bc17d4b1e85c0ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sqlite3-vendor/default.nix
+++ b/distros/humble/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-humble-sqlite3-vendor";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "6edbfddefab71d09c82c4e6c0385696e41e1c9699c29a08b36587fc97c96aae9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/sqlite3_vendor/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "3d0a617466acebb0f1d806305f62b06f0c76c84b3f1aadb4aa26735aa4c9fceb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sros2-cmake/default.nix
+++ b/distros/humble/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-humble-sros2-cmake";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/humble/sros2_cmake/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "b68229c75ca71df8094507a6528ac6a1d367a4bb6615e25b470263c285e261a5";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/humble/sros2_cmake/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "492f1db2971e4368d39f8ad615c88fd57aa28fd7a8a52df4bd2ccd7caad5e4d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/sros2/default.nix
+++ b/distros/humble/sros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, python3Packages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-sros2";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/humble/sros2/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "cf366b1b175cd34f356dab2be1274265537fe3ea125be6675f055bb1243b70e5";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/humble/sros2/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "5a266c165dc74df60d34520e280ae2e65ac25f41ebd1b841b81a28fe90a53cde";
   };
 
   buildType = "ament_python";

--- a/distros/humble/std-msgs/default.nix
+++ b/distros/humble/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-std-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/std_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "56c156205d43e65f902c681c9972743d2bee904f11ac0d4e9cdee2535b255910";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/std_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "d8f2f19836d6cd933e8ef3821ce52d1aa994ac40e96ac40063cdbfa1136c993b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/std-srvs/default.nix
+++ b/distros/humble/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-std-srvs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/std_srvs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "0049bc8de2a2ac117fc6b5763f21749ad501d244eee6d9ac193d9ff5ccf51b19";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/std_srvs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "6172e2b4b87d45fe25bbbaecb0ef19124afee0d38a830cac884837c9d08a9ce8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "7635fadbc9422f7f248b45b6397eb5e68d4b18015a98f8b8a41ef1c5d0899572";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "e71b6f56768c38d7e2dfdb6b30c966d3401688f8a73651f7fe64e9797b125001";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/stereo-msgs/default.nix
+++ b/distros/humble/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-stereo-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/stereo_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "820bba8c341eb3284eba36c2f3a067c7bb5bf7773659d184f702797f3d1a9278";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/stereo_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "739669dd42d353899498b07c3552f6f5f52d784e100fe317033715f055d23e72";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/trajectory-msgs/default.nix
+++ b/distros/humble/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-trajectory-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/trajectory_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "65f06f977eea2873a6370b63efcd2da931dcbc3efc25a4f8c25f51be18bbc9d8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/trajectory_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "d94310cafca93228848eb2e080c3cb1dbeb885af5e9efa2050317b118f12ae93";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.48.0-r1";
+  version = "2.49.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "9738e5df6f5021699cb9d7c76b363e6505641d6b138b70396f0ad195adb015b4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.49.0-1.tar.gz";
+    name = "2.49.0-1.tar.gz";
+    sha256 = "cf79dda4921826ab7962bddbd2a0efbc18e0c070c80f14ad4b98b7c37a7488d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "1ebdaaa89e6086d22d14c2574a88ea5aaa8e1ab3e06604f4f837abfefc83fc02";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "7836871be7c7d25aa2110769d36353027401b722a198912441d68e109073ec87";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "29d15fb516ed6994075a079d89368d38549cd2f98a70563f3f71cde551bbe17d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "6194a1859784e337e4fa5878aa52fa5d87f15abcdaa86c670b9c8fee94c9e3a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-bringup/default.nix
+++ b/distros/humble/turtlebot3-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, hls-lfcd-lds-driver, robot-state-publisher, rviz2, turtlebot3-description, turtlebot3-node }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-bringup";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_bringup/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "a977ec054028a87f8e21ce5e44dae3fe7ffb4e23b78e181644317539075c9c06";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_bringup/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "a897d663bbe434b4641834315f65eaae7a5ab88582cd484d31aabf5a60ec9935";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-cartographer/default.nix
+++ b/distros/humble/turtlebot3-cartographer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer-ros }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-cartographer";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_cartographer/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "e4c91424a42e773b3f6bf41c56cb43bd4e975ca039cc7a72ae4ea64ab431ef35";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_cartographer/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "f1aa77451256b2989a3796dd6cee8664f68e95f57b8ef5dcd27ad217f8a74285";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-description/default.nix
+++ b/distros/humble/turtlebot3-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-description";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_description/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "28ac59116690e5f0c57bde8c74578c1727788dd995cfe207bd65ef93f4ae5db7";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_description/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "ebbbd03035288e871e87722fd6c012f4f8f990b2aab284b00702923a373f7ca8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-example/default.nix
+++ b/distros/humble/turtlebot3-example/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, turtlebot3-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, tf-transformations, turtlebot3-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-example";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_example/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "22e2c299d1330b74a496a92129cd7821413b02d9fabeb8128680e5c16b753e34";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_example/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "0a4c66534ae380b687373a3080928554fdbba6cddf73add2bb078bab69a2021b";
   };
 
   buildType = "ament_python";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy sensor-msgs turtlebot3-msgs ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy sensor-msgs tf-transformations turtlebot3-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/turtlebot3-navigation2/default.nix
+++ b/distros/humble/turtlebot3-navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-navigation2";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_navigation2/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "d86c6480db51e1e321baac1d7438d157f1dcb3f8116a478e0a7f23f871c96726";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_navigation2/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "98bceb691d1c6b17228456b546d80e341d8bae91f00f55c25a53df91d1a4a378";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-node/default.nix
+++ b/distros/humble/turtlebot3-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, geometry-msgs, message-filters, nav-msgs, rclcpp, rcutils, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-node";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_node/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "9269171788c34a5a8baa58bc9dc89845520d93da5a40274ef1eaffe263610bb3";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_node/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "bdbb603ebc8d51411c17fb7816e1e61eece7b60dfa575166f9f09b8b9ee51e07";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-teleop/default.nix
+++ b/distros/humble/turtlebot3-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rclpy }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-teleop";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_teleop/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "13b92dbda7241dcaa188416f813bcb14676f8e8abc908d72903d2594a3cc2896";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_teleop/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "8b6f22439d6b60d83e8eb9ad17771729c81347c0fb4ce81663a5a981bdc1d4d9";
   };
 
   buildType = "ament_python";

--- a/distros/humble/turtlebot3/default.nix
+++ b/distros/humble/turtlebot3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-bringup, turtlebot3-cartographer, turtlebot3-description, turtlebot3-example, turtlebot3-navigation2, turtlebot3-node, turtlebot3-teleop }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3";
-  version = "2.1.5-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "6d86273def64bcfd3e07449a7662ca9a971abd37be209a327455da3bd0b3b1ec";
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "c5dc9ecf0dcacf6217dbf4725763ac3eb3b5ca41931f63666a04e9f99514d6c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "e0cc46fa9dfdfab99d413ea4c3ba3db974755579ad5d4de28c52c9a0e4243b88";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "32b35d21ffd31e41de75cf5f9c08171c8230b62aa4056cfb27ae86d181693a67";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "7d4d3e31aa717f34e006bbb8187d88aa3a3e80f1eb0215854b92ce9c9adbf3fd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "5f9ba617549f308c3b2c09653b85eda0dfd279fa1bd030c3cc34eb8a4a6c362c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-client-library/default.nix
+++ b/distros/humble/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-humble-ur-client-library";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "610330c823b34656afcf9cd27b060287f8628c28408549be8bdbd28f124bee04";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/humble/ur_client_library/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "40b4c0cfe4ffb6573a7813b7b77ba4af8be30b893b58b402e476fa666889a0c2";
   };
 
   buildType = "cmake";

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "6bb9a172ed857acca48f40e3bafef999ba6e98204a0706225cb1b8f927bb3dd1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "05d3a4d6a853eb1d43fb0b288232923eb90ffa0ff403a6d925d8c4abc4f2c555";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ controller-manager hardware-interface-testing ros2-control-test-assets ];
-  propagatedBuildInputs = [ action-msgs angles control-msgs controller-interface geometry-msgs hardware-interface joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs std-srvs tf2-geometry-msgs tf2-ros trajectory-msgs ur-dashboard-msgs ur-msgs ];
+  propagatedBuildInputs = [ action-msgs angles control-msgs controller-interface generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs std-srvs tf2-geometry-msgs tf2-ros trajectory-msgs ur-dashboard-msgs ur-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "72a3ed735f084aa89689b9407ce6e625cf47707abe877c147ddf91348c5ea562";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "79410cc2a05c4e8018fec1c21c77500b05faccbc75d9cc4f51e85f30ad940210";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-description/default.nix
+++ b/distros/humble/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-description";
-  version = "2.1.10-r1";
+  version = "2.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.1.10-1.tar.gz";
-    name = "2.1.10-1.tar.gz";
-    sha256 = "86ef5f71d1e0a0faeeab92fc40e38d6621d353805f56043ee073b4733d217429";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/humble/ur_description/2.1.11-1.tar.gz";
+    name = "2.1.11-1.tar.gz";
+    sha256 = "a454c23c851ce37a97407c669d9c21b328c2d9279d9d6a7b6c3c9680dad2ccfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "7ed046099603d3369af52bef70c6016b9da94828e4b27d2a390c96206d1d775e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "587372f9d2b94eaddbe9c9e07efa7c0d95e28c8ec293bef4fd6a199586359f48";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-msgs/default.nix
+++ b/distros/humble/ur-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/humble/ur_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "4c96afd5bef26743c67daad232c5348ebe3774e234d902bf1a7913a3db5704be";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/humble/ur_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "136b41fcd4acbe1619aaf70ce183fb9f0d8dc8567220c1629e003a80214cef15";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "03a8fd8a96a0d0d1dc2bea08019df4403e75f2b835a268f41368632b41eac008";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "48b011942de11b8867580aeece58ab4e7d86d32978d0080e8da2ba8a670c6181";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.5.2-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.5.2-1.tar.gz";
-    name = "2.5.2-1.tar.gz";
-    sha256 = "2314f1e82b930d9d7939912127d8fd8a15907ee228fe4c77d207033c4c0e34f5";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "4280f73858b98d683d6e0c81c4e31de98dce2e58412b18356ca3950db958e506";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.42.1-r1";
+  version = "2.43.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.42.1-1.tar.gz";
-    name = "2.42.1-1.tar.gz";
-    sha256 = "459252299e7fecf1a03694de8072b954e71b0ea9f7f6f45086e30890aa70be2a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.43.0-1.tar.gz";
+    name = "2.43.0-1.tar.gz";
+    sha256 = "6d6f51600d9303d103155d7da44e84e4f73139b1abd89797f56536351a34fb63";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/visualization-msgs/default.nix
+++ b/distros/humble/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-visualization-msgs";
-  version = "4.2.4-r1";
+  version = "4.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/visualization_msgs/4.2.4-1.tar.gz";
-    name = "4.2.4-1.tar.gz";
-    sha256 = "70c280b7ff6bbd9f8b4272339b67930ff1c932e4d0a44b3f35821a7f80f14956";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/humble/visualization_msgs/4.8.0-1.tar.gz";
+    name = "4.8.0-1.tar.gz";
+    sha256 = "8c5860c9d7b6e2ff4bdac8f3c760938430a29499c415237ca8e7c92d775598fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/xacro/default.nix
+++ b/distros/humble/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-xacro";
-  version = "2.0.8-r1";
+  version = "2.0.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/humble/xacro/2.0.8-1.tar.gz";
-    name = "2.0.8-1.tar.gz";
-    sha256 = "c22d190f937583558590106b7047cd1207b7a38b7b09032e3598c230bed5fc00";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/humble/xacro/2.0.13-1.tar.gz";
+    name = "2.0.13-1.tar.gz";
+    sha256 = "a6b3b6dc1483d1bc3a748018aa82f16b9d89b7ddb976fa26854b9bc47315001b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zed-msgs/default.nix
+++ b/distros/humble/zed-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-zed-msgs";
-  version = "4.2.2-r1";
+  version = "4.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/zed-ros2-interfaces-release/archive/release/humble/zed_msgs/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "ffaa216b7cd342b466d7ac7e2569e7d3a276076e544368eb2fcd9e577dadbf1d";
+    url = "https://github.com/ros2-gbp/zed-ros2-interfaces-release/archive/release/humble/zed_msgs/4.2.5-1.tar.gz";
+    name = "4.2.5-1.tar.gz";
+    sha256 = "a312f20e56376d320184232d34ec8a6e682f1805563d20ced55b36fa4729edfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/zstd-vendor/default.nix
+++ b/distros/humble/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, git, zstd }:
 buildRosPackage {
   pname = "ros-humble-zstd-vendor";
-  version = "0.15.13-r1";
+  version = "0.15.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.13-1.tar.gz";
-    name = "0.15.13-1.tar.gz";
-    sha256 = "587bcfc92e0c3d3882fc094ed123af83dfc3056a2d0cac044a200aefce228c0c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/humble/zstd_vendor/0.15.14-1.tar.gz";
+    name = "0.15.14-1.tar.gz";
+    sha256 = "6a59ee90d92fc743851df3256b0b60a5a1588028c3bc400b376c539b80a8460f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "b96030c642f4f5069af7711e31f61a7986cade5be1c7cc4f1d9b81ffc44c22b5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "b4043eec8df8ecf2e5f6586e64c21a33940eb8a867ec2707fb36d27ec4205f71";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/actionlib-msgs/default.nix
+++ b/distros/jazzy/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-actionlib-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/actionlib_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "9023963df0f7d5ac4d329af46ef19a4c31c1f0c122ea14ae946593d5af39f497";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/actionlib_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "2183130288a0da95984ad3349e4851cd0696f29e37cdc718e28f647e5574535b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "310db0d372ad11468a89635728ca71e75969ae4a81375b918bacaf8d7b5efca9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "7134bfad29508548ddb99a1b263aa7121536749d58b576c7fee6f07d3a38626c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-cmake/default.nix
+++ b/distros/jazzy/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-cmake";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_cmake/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "dff2289313a9bf4579a1b6a1b3b880ded73b51781eb2873fa3f4958ea27e94be";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_cmake/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "68b384fafc2b4a9784e83c2fc9e8af0aa8fb0bd9c049b1c168083c39280c3c8b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lint-common/default.nix
+++ b/distros/jazzy/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lint-common";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_lint_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2c97fd6c49a4108b6c0c3699cd75f664e2fbd7f992608b114a7c6a9795f0841b";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_lint_common/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8a8e36cc9fb338341aaca34724f1965e07869431ae98bb49686565ef7217c358";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "f133772acff101e507c79ac66c867d7b3ffeb14e2546a7fa2aa7db0de6e93776";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "4b798a9b2b00b60ac42e21c3da75e4f90bada431229aadb84aaf3226b4075128";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6bde5dc11b620aa626edb5245700d7cb1005d445d0731902a8bc9feec9d2bb4e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0a23f4f6a42494d9bb5bdda2780516a67bca7354ebeaeab09eb42a4109a2a6e7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ac6e2b2e0541cb2a16ff649acc81530f8a0cda664b9ef40838e831580e882013";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "65e382490c67d7a9f2dee673ad00160511227c150f69ad2ccb94be94f5ccdc2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.1.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "77808137ec3c0f1fcfc4328dbaa232c3ca5f5945acbf326a284977fdb12ac015";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "6756e687a2f868e36c4293109d15b40e2cdd2a653a8740e53a37e851690eb25b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "26955cd652df70c97fe032af93639b175498757ca0aaf10a2d06a7dff9c7ca79";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1eaa4a9ff5399ca72eafba9e9d210809ce5300c1e585c672c5fe7f358eab2274";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8a47c7956b779b4859e06903790ddcf97d378837a36d97117738d21452aa23c2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1cf55170cce77537aa49be4af2c58cee6e798dd66660efe793f2ddde59dd9b10";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "53e04aaef26ee580bf9575cefe8e31adb8d08d515a7db97ce95b3ca6d88102b5";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "41f0fd564cd77fc8029b7bfc5cd346aa8b2411253fa7a5fa4cd5906b8763a5b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "1df25d67b6795fd31a860085a0602a9c4986c72375d4b3b8626d83541e3b01eb";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d90e67ffd511465f6eaeeadfd9f56cd5f3c0ced86932e1f619ed760e8597551e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-gz/default.nix
+++ b/distros/jazzy/clearpath-generator-gz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common, cv-bridge, ptz-action-server-msgs, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-generator-gz";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d20fe91f56290d7826c2c70fed90266593f58b1d43aa912c85afa3e6fa8f9ff9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-config clearpath-generator-common cv-bridge ptz-action-server-msgs sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath Gazebo Generator";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-gz/default.nix
+++ b/distros/jazzy/clearpath-gz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, gz-ros2-control, ros-gz }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-gz";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "91dbbdafdd0d815809d0b091ccbb31dc4ae88f44d7ec1fca86fc3c9b4eba1dbe";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-common clearpath-generator-gz clearpath-viz gz-ros2-control ros-gz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath Gazebo Simulator";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "d103ba2a4267ccd815fdac96218e1891fdbf71a5f477f3a297b37ef7b3b5940f";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "37183d2359f2120d86e0b9b54a6ef0d2b99f61fb5bba1561ec85d3c14d0f5489";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "a35495adf803b1ea4526a692efd06e460cc0f757642850b40861e55b5f15d29f";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a2ea3c29c0d2f5b2fea6e5a44fbb73f7e526128d59b6702c806eba3ec8311bb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-motor-msgs/default.nix
+++ b/distros/jazzy/clearpath-motor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-motor-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "cad6631f674c18216a638ffd7e26bfa7da53751fab05ca6c014076755d5f0a89";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "f1245b099d30decf99d26642e85da96667c6b5ec0995ec070ca81dc7e021f729";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "c01a29c24b7584a4599b2cc89b526b1ca80123583b0e1bcca57e918c829c41f4";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "731734d0b909d7d04b7c04aaedcbfb4b65d0ce305387ed69ba55fe9706500c1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-msgs/default.nix
+++ b/distros/jazzy/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-motor-msgs, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "28dc5f6ad87dd990f7ec1289d25e6b4d87aa2095a018bf41dfee14976e260da6";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "98f7a26d7c6f19dd3f5f304a22f6306e5703ea6fa38293a169d5ac79022e7891";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "3944c4ae0b1792eb42f48eacb53038f01e60c1736fa79bae94d84e52890ce86e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "7879f731495683b6b7f63f6e3ab27f6f9786f8cb651bdf9b02ef6042a8c0c640";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-msgs/default.nix
+++ b/distros/jazzy/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "558b1c43206371fe28b04f44705a401323450b38adedf41c1130cf64e817f40c";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "e7b84cd5c1d800c4329d94b77b9af259c4cc2c1eaf619dd6e77d710ca80614fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "f4892d06888680d2498695af11117e9f05c2ec260cbe8da2a2384abeec12c10e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "119bf02902011b53299b259fdb2be2ed1455908c8b7be806ff182884f5ea2e12";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-simulator/default.nix
+++ b/distros/jazzy/clearpath-simulator/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
+buildRosPackage {
+  pname = "ros-jazzy-clearpath-simulator";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "944163c7defcc3a8fd91c9fa8a42a4184c19f38e633bde0cc65ac501b3c5c8ba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ clearpath-generator-gz clearpath-gz ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Clearpath Simulator Metapackage";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/clearpath-tests/default.nix
+++ b/distros/jazzy/clearpath-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, can-utils, clearpath-config, clearpath-generator-common, clearpath-motor-msgs, clearpath-platform-msgs, diagnostic-msgs, geometry-msgs, nav-msgs, rclpy, sensor-msgs, simple-term-menu-vendor, std-msgs, stress, tf-transformations, tf2-geometry-msgs, tf2-msgs, wireless-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-tests";
-  version = "0.2.2-r1";
+  version = "0.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "8bcd3527c6b6a56258f92bcd79d2557302be5beec9f2fec0760010e1305b9d38";
+    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/0.2.9-1.tar.gz";
+    name = "0.2.9-1.tar.gz";
+    sha256 = "bb7b9c6c62326967f57f8a9417bce2198291cca047a3548e15dfdb83a02d2e4c";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/common-interfaces/default.nix
+++ b/distros/jazzy/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-common-interfaces";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/common_interfaces/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "8ce5fb299b5d157052c8e37a411e872a0747b82da60e5b8d22dacbc99bbbee66";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/common_interfaces/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "bce08a14bb4e0fd9dc55e6af9cc668696162e638360b29b00c5b6066c1f05fd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/control-msgs/default.nix
+++ b/distros/jazzy/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-control-msgs";
-  version = "5.3.0-r1";
+  version = "5.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/jazzy/control_msgs/5.3.0-1.tar.gz";
-    name = "5.3.0-1.tar.gz";
-    sha256 = "b43b883f65f9ca58bc13976248446dede87758a973a8482ce846ac7a5ac21250";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/jazzy/control_msgs/5.4.0-1.tar.gz";
+    name = "5.4.0-1.tar.gz";
+    sha256 = "346a272dbcbd8b49f13eecfa1d4f92348158c4b9e6fff0fabca1db2f457d399e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-bridge/default.nix
+++ b/distros/jazzy/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, camera-info-manager, composition-interfaces, cv-bridge, depthai, depthai-ros-msgs, ffmpeg-image-transport-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-bridge";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "249ad13c5fe5998dc86eab3d615be171d09e099447aa175628f079fc591bc4d5";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_bridge/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "e53b8eb0104d7767a93d5de64b4764cc674d597c66ff06b20e901592e0a1396f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-descriptions/default.nix
+++ b/distros/jazzy/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-descriptions";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "1b69c3f8c5e66014e730b709a478b22eeef479e985e67a6ded108264328426b3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_descriptions/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "337eecacaee37b7fff055162d8c4415b66a506a59f8ddd90d539552cbd776ed7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-examples/default.nix
+++ b/distros/jazzy/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-info-manager, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, opencv, rclcpp, robot-state-publisher, ros-environment, rviz-imu-plugin, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-examples";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "b22aac60dfb7408ed10656e8a5cdeffb0c2217011e7f749915565d56bb56c2f3";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_examples/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "c02a25d94394c917421ffc08c44b4771115119d5ffbc44746573268c3ff05250";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-filters/default.nix
+++ b/distros/jazzy/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, cv-bridge, depthai-ros-msgs, image-transport, message-filters, opencv, rclcpp, rclcpp-components, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-filters";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "49d6d1e930943ee183b6d2589fc06e2d1cde672d4c36759b3c6b9f0f1654c198";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_filters/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "86d51c2fecf4cb161331ddd7a9d07cb2bfc85baae14dea0461d2cfce9fa3fde8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-driver/default.nix
+++ b/distros/jazzy/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, camera-calibration, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, ffmpeg-image-transport-msgs, image-pipeline, image-transport, image-transport-plugins, pluginlib, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-driver";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "84bfdd887a3329f29748cab9e629a19bda1e539bc3ab12e8eab1c44d99c21fd2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_driver/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "ebe7cabee548192c848791a6051e3eed490e56aa2f677ab686f42cfc1fb35ccc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros-msgs/default.nix
+++ b/distros/jazzy/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros-msgs";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "68b881325e63e9f54d1dcbede3604a4930c00b2da65e1e593d13c828fa3288a2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai_ros_msgs/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "c917510fe6b79d5be5ed837ee1ce6891db7b807ffef36cb4740c25aeb7691c4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai-ros/default.nix
+++ b/distros/jazzy/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-depthai-ros";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "70d6c0007fd407ab37358c2f51e576147c6d1514e4a20f2218445e76d5d04b88";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/jazzy/depthai-ros/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "1de6f330b5a4227856c050759f9888e5c7e6830dcab2f81733be363cc582eb21";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/depthai/default.nix
+++ b/distros/jazzy/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-depthai";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/jazzy/depthai/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "bcbfbc992a5d5fa67f4a0230a54d643c64fe2937bb1d4776a104b62b5b03a85c";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/jazzy/depthai/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "a764abdff64b246db0940663a7096a319e2a4010a2c2981f4ca5c7842412ef09";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diagnostic-msgs/default.nix
+++ b/distros/jazzy/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/diagnostic_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "e501682f430edf74c1551d5759743e773b1043dd7c70810658a70e33979edeef";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/diagnostic_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "a56e34b487d066b0d518e978dbed67ebd181d8278c2c7a485c3060527a64b80c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "d00f2ef5438056846677074307d4b5443c7cb8f21c3ace8afebf9c228175cf68";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "fc92fe1b5b6088e0b4abe2e04c9ba35f81509657fab668d719097b1ecb8b45c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-hardware-interface/default.nix
+++ b/distros/jazzy/dynamixel-hardware-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
+buildRosPackage {
+  pname = "ros-jazzy-dynamixel-hardware-interface";
+  version = "1.4.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "8fd4914e2bde9d3d6d2a9aa774227010ef83c71bbd0dafff6cd578c2f50f8eb4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-interfaces dynamixel-sdk hardware-interface pluginlib rclcpp realtime-tools std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 package providing a hardware interface for controlling Dynamixel motors via the ROS 2 control framework.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/jazzy/dynamixel-sdk-custom-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-sdk-custom-interfaces";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/jazzy/dynamixel_sdk_custom_interfaces/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "a185bd31fcfd2e10d5ae1751796b89a21992a49db72948ed91aeed915a6e1e8a";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/jazzy/dynamixel_sdk_custom_interfaces/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "ddf227f1bb61286903c473f42fcf2081bd748d3693ab1d0e265061fc89f338fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-sdk-examples/default.nix
+++ b/distros/jazzy/dynamixel-sdk-examples/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-sdk-examples";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/jazzy/dynamixel_sdk_examples/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "1c526066001e37e7889f26b9e67f0aea225c144cd3b6208e674f281c74701716";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/jazzy/dynamixel_sdk_examples/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "1c5449ac7847c5706f57f6f2c0442203e0b2bfc93f835273a39f0f73c7bbd744";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "ROS 2 examples using ROBOTIS DYNAMIXEL SDK";

--- a/distros/jazzy/dynamixel-sdk/default.nix
+++ b/distros/jazzy/dynamixel-sdk/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-sdk";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/jazzy/dynamixel_sdk/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "f259dbec959f0492ee24a7611789f2eec3cda87aa805d35eed5aa20f7f088bc2";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/jazzy/dynamixel_sdk/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "d007ea8ac24145bfdaaf99e006078a2e17320d5edd91248e7f7ec912555a45ab";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "54d95f492ef3d3bbdd8219965879596404860171c7d8ccf1119e40dda9a0e9ff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "1924427b23a6928c949498ca9ec372abade625577b81c0eab23e593d2c9ce9e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffmpeg-encoder-decoder/default.nix
+++ b/distros/jazzy/ffmpeg-encoder-decoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ffmpeg-encoder-decoder";
-  version = "1.0.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/jazzy/ffmpeg_encoder_decoder/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6cd96058c1d501a69c80ae369c2f7993a1bc5a1422aae6d7444194d67030f9d9";
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/jazzy/ffmpeg_encoder_decoder/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "80e0e08fc23981bcf546f2efc0467a4cb395d616f329d4b42b7f940670484961";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ffmpeg-image-transport-tools/default.nix
+++ b/distros/jazzy/ffmpeg-image-transport-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg-image-transport, ffmpeg-image-transport-msgs, rclcpp, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, rclcpp, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ffmpeg-image-transport-tools";
-  version = "1.0.1-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release/archive/release/jazzy/ffmpeg_image_transport_tools/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "ef84f138a2bbf8ce054b8fd2b92ca4760c4d603452b0fc73f7a56dc19c7836c5";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release/archive/release/jazzy/ffmpeg_image_transport_tools/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a2c032f099817ba46d9f36a504de9e66f4a9c7d36bdd3168dbfee5e312447bdd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg-image-transport ffmpeg-image-transport-msgs rclcpp rosbag2-cpp rosbag2-storage sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg-encoder-decoder ffmpeg-image-transport-msgs rclcpp rosbag2-cpp rosbag2-storage sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/jazzy/ffmpeg-image-transport/default.nix
+++ b/distros/jazzy/ffmpeg-image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, ffmpeg-image-transport-msgs, image-transport, libogg, opencv, pkg-config, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ffmpeg-image-transport";
-  version = "1.0.2-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/jazzy/ffmpeg_image_transport/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "c1c008f00379127d0ce08576ed8f32d567b8a427fec639e11ef12c08d8f0ffc5";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/jazzy/ffmpeg_image_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "0865436cc5fa02a64664c105454e3b143b95619752565461d82dddd09d7d6bce";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg ffmpeg-image-transport-msgs image-transport libogg opencv opencv.cxxdev pluginlib rclcpp rcutils sensor-msgs std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  propagatedBuildInputs = [ ffmpeg-encoder-decoder ffmpeg-image-transport-msgs image-transport pluginlib rclcpp rcutils sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {
     description = "ffmpeg_image_transport provides a plugin to image_transport for

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "a23e8f7e8478206a36cc5952f8dce2eb28d7371e900862e5a96be492739167f4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "6b1f9b94c9d2b051955ae70b7ff129b78b27b510de7984fe32076d6c1cb79413";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "f54bf5c63cbbf1cafa674dc5bff65987964f068028268474a760e7451bcd7d72";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "8326bf25dee6476324d01128942421d51ca3bd01ec573c71edd7ead5a2d50ba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -360,6 +360,10 @@ self: super: {
 
  clearpath-generator-common = self.callPackage ./clearpath-generator-common {};
 
+ clearpath-generator-gz = self.callPackage ./clearpath-generator-gz {};
+
+ clearpath-gz = self.callPackage ./clearpath-gz {};
+
  clearpath-manipulators = self.callPackage ./clearpath-manipulators {};
 
  clearpath-manipulators-description = self.callPackage ./clearpath-manipulators-description {};
@@ -381,6 +385,8 @@ self: super: {
  clearpath-ros2-socketcan-interface = self.callPackage ./clearpath-ros2-socketcan-interface {};
 
  clearpath-sensors-description = self.callPackage ./clearpath-sensors-description {};
+
+ clearpath-simulator = self.callPackage ./clearpath-simulator {};
 
  clearpath-tests = self.callPackage ./clearpath-tests {};
 
@@ -561,6 +567,8 @@ self: super: {
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
+
+ dynamixel-hardware-interface = self.callPackage ./dynamixel-hardware-interface {};
 
  dynamixel-interfaces = self.callPackage ./dynamixel-interfaces {};
 
@@ -1188,6 +1196,8 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ ld08-driver = self.callPackage ./ld08-driver {};
+
  lely-core-libraries = self.callPackage ./lely-core-libraries {};
 
  leo = self.callPackage ./leo {};
@@ -1561,6 +1571,10 @@ self: super: {
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
+
+ multisensor-calibration = self.callPackage ./multisensor-calibration {};
+
+ multisensor-calibration-interface = self.callPackage ./multisensor-calibration-interface {};
 
  mvsim = self.callPackage ./mvsim {};
 
@@ -2192,6 +2206,8 @@ self: super: {
 
  ros2-control = self.callPackage ./ros2-control {};
 
+ ros2-control-cmake = self.callPackage ./ros2-control-cmake {};
+
  ros2-control-test-assets = self.callPackage ./ros2-control-test-assets {};
 
  ros2-controllers = self.callPackage ./ros2-controllers {};
@@ -2621,6 +2637,8 @@ self: super: {
  smach-msgs = self.callPackage ./smach-msgs {};
 
  smach-ros = self.callPackage ./smach-ros {};
+
+ small-gicp-vendor = self.callPackage ./small-gicp-vendor {};
 
  smclib = self.callPackage ./smclib {};
 
@@ -3067,6 +3085,8 @@ self: super: {
  zbar-ros = self.callPackage ./zbar-ros {};
 
  zbar-ros-interfaces = self.callPackage ./zbar-ros-interfaces {};
+
+ zed-msgs = self.callPackage ./zed-msgs {};
 
  zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 

--- a/distros/jazzy/geometry-msgs/default.nix
+++ b/distros/jazzy/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-geometry-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/geometry_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "86f830a7e34d15268823a08cc40e33f15328667ba3ae7975fbd1207962fb0208";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/geometry_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "ffab29210d0200bfe93826915ee758b865a3108806fd6c3bf63179bbdcfa4cd4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "747e6425380f86879e60c6d1cc5c970c99f344181c5fb18d07dac2ebcb1cf335";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "06e2f179f7c6afc4e22a74b26fdd00478298839b0254f5296b2170b145aac432";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "e4bd3d86965eb8ce5813cf61f9e0aa0df853acb9f73baf3a1c2ea214496269dd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "91f68e1e21a44fa78bb265e2103020a5e69207dcef236d9e60323d0d4f4a54b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "aa97158015e88f93e9b19ab59d0a356d53822ab153c56747703f3d4025815e0b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "6de55996d6fffc7668c79041a7da87a3f43a645bc639b4dedc70750ae55b2ddc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "dc43a86a6df7c15762b5b9e1ccbfe52def740a2c7e40467c2316097744ac4ac0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "a70a0f3c7eaec39146cabee8a920f0c11e3d04310626c829a794e574d2db3454";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "f6d2ef7b56ecde0cbf1d41e4d6836ede7e70feff820661e06f158ef66e83fe7a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "aa636dcc13c94eec83eb317286141015b2904a1fbce1895bd672d4cf2f26842a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kinematics-interface-kdl/default.nix
+++ b/distros/jazzy/kinematics-interface-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, kdl-parser, kinematics-interface, pluginlib, ros2-control-test-assets, tf2-eigen-kdl }:
 buildRosPackage {
   pname = "ros-jazzy-kinematics-interface-kdl";
-  version = "1.2.1-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface_kdl/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "2d4a1a9b2442e047de2cab8c9f940f7f7580797da356870ad108dc72e10cb594";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface_kdl/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7559ec004ae3d56fdd359cfb0d334d64a56c9b7a63bd7a03ff387115aa403104";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kinematics-interface/default.nix
+++ b/distros/jazzy/kinematics-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-jazzy-kinematics-interface";
-  version = "1.2.1-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "0f72c880965707289380e712067d45c0c21d5517713c0b6d8fb9e3f88697035a";
+    url = "https://github.com/ros2-gbp/kinematics_interface-release/archive/release/jazzy/kinematics_interface/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "6dea9ec3c1537ce3c9ab2dae42a467a5dc4ce527e46ce21e06edbe55179c13db";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/kitti-metrics-eval/default.nix
+++ b/distros/jazzy/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-jazzy-kitti-metrics-eval";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "e4cca7f934114dea7dd6c2e3abca7a8bbef7c771d9173cb3f2394fbbb52d5f30";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/kitti_metrics_eval/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "e2abb57b1d70af7f223bc301f66bf7059453a798f5f7b4e6ea938ba0f7cdee08";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ld08-driver/default.nix
+++ b/distros/jazzy/ld08-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs, udev }:
+buildRosPackage {
+  pname = "ros-jazzy-ld08-driver";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/jazzy/ld08_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a1f0d545bc704941c69b1158c010ddb6d6d8392aa457025069481c298cc34f4f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ boost rclcpp sensor-msgs udev ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS package for LDS-02(LD08) Lidar.
+    The Lidar sensor sends data to the Host controller for the Simultaneous Localization And Mapping(SLAM).";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "72c8d5e378064bf9e79d1ceebf1c45f75870e7e165a9f959b3d82c54e50f8f70";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "ca7e43e86188a4b3427fc0d1a4f5760a38ce5547a1a0c121b8b4193f3f28b64d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/metavision-driver/default.nix
+++ b/distros/jazzy/metavision-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, event-camera-msgs, openeb-vendor, rclcpp, rclcpp-components, ros-environment, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-metavision-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/jazzy/metavision_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "87b533d50533969ccfc0289915150491c301db727b693f6d34d9030144ea901a";
+    url = "https://github.com/ros2-gbp/metavision_driver-release/archive/release/jazzy/metavision_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "301710ab2046177c473af359d6c212ed22a9ff377c36102ab13f432d7e6c2959";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-bridge-ros2/default.nix
+++ b/distros/jazzy/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-bridge-ros2";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "49f54780219f063a06be3bf4c288d7862917fd5346b8f1fce3b33d533df3b0b5";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_bridge_ros2/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "8a8ff98e2373101327a8e1a1b5b8fb934a984b9b83c6eeabf89912a68b2e43fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-demos/default.nix
+++ b/distros/jazzy/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-demos";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "fe84c40ea8bdf777fc237b0cd51b356ce487bbb979f4243da9e70c28d00e8e6f";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_demos/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "fa8cf79a3f8fe19750ea7f3cb3422f906b06c2d7ef5c98a0a041cfdfd36e0dcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-imu-preintegration/default.nix
+++ b/distros/jazzy/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-imu-preintegration";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "748b10b41db86f9f50aa0ba045c3b08c48ea7e7e1f43c558dc2c74486cd0b872";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_imu_preintegration/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "7ddf3f79fd1d27184a5474e453c488e68ef2a4f996ae7d14dd328e7099ec6dca";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-euroc-dataset/default.nix
+++ b/distros/jazzy/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-euroc-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "08d22aa801376fda04371e1188662d7ce421a014c937e5d4affa6066b7effd16";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_euroc_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "b4da611414a1d05a201e36926fb9862f5fdfcaf4156d6afee6daad94b1d1ea13";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "6c1b52488d8a0e4cb686fd7ad3da78149ef598e3f5899c424f82257fe38c1fad";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "f37cf82264d7e3ea97e338c8dd53bf3abad161f448a2f506d613c09c33db97b0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-kitti360-dataset/default.nix
+++ b/distros/jazzy/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-kitti360-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "ea2a26d7f44252b1d57d38aff805a0a3e49309a28894af39746e6374eb29aae3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_kitti360_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "96c65cbdb4bc4cd424defa213c32a4bfe17914aca9ec92fae96cf91a534b5712";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-mulran-dataset/default.nix
+++ b/distros/jazzy/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-mulran-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "6e9fd9771009494a865fbe441b0b01dd5b6f9e039d4655ec8a2438eb1582fef7";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_mulran_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "965aa3556f70f82c939d56ab9d25edd5e348df5fbeacb83ae6e5b1f5bc2c0150";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-paris-luco-dataset/default.nix
+++ b/distros/jazzy/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-paris-luco-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "ba7151f22fb7d42a9a69a162a1d56572e4d6c849e71f691ba78468af616518a3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_paris_luco_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "bc0e8d7adfda6bf88945e4268af70ba307556198f753c08a118eaae8bcc6a294";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rawlog/default.nix
+++ b/distros/jazzy/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rawlog";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "65c73ee590e63725abee437b48324053dbc9522f710de1767aa7d9d79be772c6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rawlog/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "3c2290cfe05f71b688e371c2e31709a1b082c5487520c05c85c80baf847ec7cd";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-input-rosbag2/default.nix
+++ b/distros/jazzy/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-jazzy-mola-input-rosbag2";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "03dabc68b33c8cb5fb657f68e115d283da113eedb25a27da541e90feaeb87b69";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_input_rosbag2/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "cfcd6b9a3bb277c55e39dcc84ba68ca4ce12a60670a41f25a119b1a7193b6145";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-kernel/default.nix
+++ b/distros/jazzy/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-kernel";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "1b76d9ee4bd80cc5115821efbfb8ce669654bd287cb1f094af7d8d6c9ff0578c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_kernel/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "095fc4446dd80be1728421b42ed91d93bb383d3d3159c43e2e0207385849a2d2";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-launcher/default.nix
+++ b/distros/jazzy/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-launcher";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "17352377c09d60f8568655615800e170607342c3f4dfca066cf9d21b4c32c6ee";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_launcher/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "d81dd4a31a6e426f32720ea971ba467e3cde3f855d741150f9a4e6d7a981fe6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-lidar-odometry/default.nix
+++ b/distros/jazzy/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-jazzy-mola-lidar-odometry";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "42d88cc0a535105e0771be3b7b0975e6835c723f2fc4f59d404a7b34a9976e2f";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/jazzy/mola_lidar_odometry/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "0f5948b62ac42a2843f70eacaf8c8e031c24a0d4c27d824708f4c8bb166beec6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-metric-maps/default.nix
+++ b/distros/jazzy/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-mola-metric-maps";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "f8327c311d2f975ad2d16d11302ebee43aab21bdb26ad86138d14a494236e6bf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_metric_maps/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "fd425041bd64acd6f8096fe1ab80e3b13b5b2132993385e4b6bcbb704916565a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-msgs/default.nix
+++ b/distros/jazzy/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-mola-msgs";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "284e5bb901a780dade92d7bf06538aefe457777be68ee20ed1942ff41a3dad86";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_msgs/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "94561523a647446923b139b748d2ef61c05b6efc50a8f130b2894fc5249b269a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-pose-list/default.nix
+++ b/distros/jazzy/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-pose-list";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "a9a704ef6f4da5f175c1704a123dfdabbe771f93b3577581793323ceb2459b04";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_pose_list/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "3638cae1a8893a17039cd6519c7c41f21d3108637693bddd0116fe754abe622c";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-relocalization/default.nix
+++ b/distros/jazzy/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-jazzy-mola-relocalization";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "af20c49ce7f351138dc4ddd1fb4d57d80920913367d85d7c266f2a52b0a27d5b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_relocalization/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "364bdccdd6078da5c51a55f13feee4416efaab4eaa44bbfc9057b8bca14e65d0";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-simple/default.nix
+++ b/distros/jazzy/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-simple";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "53e3fd7ffaaebb896cb76cd2d9af8f234f436d511e2e7261ce29a674d1c8656b";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_simple/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "2b8c729f2395fa2a66b5e4d91a9f1eb977c4c7c23d095e36cd72d16c748cf922";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation-smoother/default.nix
+++ b/distros/jazzy/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation-smoother";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "bb10b661e2d9fcc9d6474489f7135fad843817f38062d4cc8fb78b8aa066def7";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation_smoother/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "4e008931d924d8a9588fb6922e958601b3e47a8f16b2803766c3dbe213c50beb";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-state-estimation/default.nix
+++ b/distros/jazzy/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-jazzy-mola-state-estimation";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "072264aa0468da5742376292dd399c3d8e719cb792ad4b25f3c699ed8aaca428";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/jazzy/mola_state_estimation/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "317258d259a265d95a3ea88db2194a3eba03ab8461cb77f51fae746a767c60bd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mola-traj-tools/default.nix
+++ b/distros/jazzy/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-jazzy-mola-traj-tools";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "0e64f5fdad332b0838907b731a30e6b671067d70e2f87a5a93d187f5912f5a00";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_traj_tools/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "96d268f3c87592b500fd1209b9e25cf54372fa50b3a28dfbf2256035659bd003";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-viz/default.nix
+++ b/distros/jazzy/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-jazzy-mola-viz";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "10c53cd65ac34c20b68c35a7ea3756520818689f82cceae3ab3d2e23c91a8eb0";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_viz/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "8382f55ee885c8183af5e7957de879bd72ed7a5576db51449d382eddf2dfc76e";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola-yaml/default.nix
+++ b/distros/jazzy/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-jazzy-mola-yaml";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c72646d1b12aba989451757479f14539e112bd4a0edab797a128cf8930b04ed4";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola_yaml/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "ef328fb621a4fa90c10f3723d2fa592800dbcd4d23e0d78bd98a52290169f2e8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/mola/default.nix
+++ b/distros/jazzy/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-jazzy-mola";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "2d59c09b17d7dc228ea72a973b3c652f7a38a5a58d5c4f36eecf38d387be329c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/jazzy/mola/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "ca61d9583218c67c6068330fa6b5e672df3f29d790724e64adeca927e8a0d08e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/multisensor-calibration-interface/default.nix
+++ b/distros/jazzy/multisensor-calibration-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-multisensor-calibration-interface";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/multisensor_calibration_interface/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "916e849a4bd934f8b6d1a566c1487da5ff114a4554a179f9bdd85d26bb9b96ce";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Messages and service definitions for the multisensor_calibration package.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/multisensor-calibration/default.nix
+++ b/distros/jazzy/multisensor-calibration/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, geometry-msgs, image-transport, multisensor-calibration-interface, pcl-conversions, pcl-ros, qt5, rclcpp, rclcpp-components, rviz-common, sensor-msgs, small-gicp-vendor, std-msgs, tf2, tf2-ros, tinyxml-2, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-multisensor-calibration";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/multisensor_calibration/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4026bf469072fa416dc2b30230089f948a49bd050418fb3281a33e12c50f0d65";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-transport multisensor-calibration-interface pcl-conversions pcl-ros qt5.qtbase rclcpp rclcpp-components rviz-common sensor-msgs small-gicp-vendor std-msgs tf2 tf2-ros tinyxml-2 urdf visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Collection of methods and applications to calibrate multi-sensor-systems, e.g.
+    camera to LiDAR, LiDAR to LiDAR, and LiDAR to vehicle.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/nav-msgs/default.nix
+++ b/distros/jazzy/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-nav-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/nav_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "deab770c630923f180a951268963d16ab9c9f6c0a5cf102aa8d82cc91463b8c9";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/nav_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "57c5498bde4febd9ca5c30c4570c8b52edf1600ffef307e37b3a2fa5ef151a39";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-oem7-driver/default.nix
+++ b/distros/jazzy/novatel-oem7-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, geographiclib, git, gps-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, nmea-msgs, novatel-oem7-msgs, pluginlib, rclcpp, rclcpp-components, rclpy, rosbag2, rosidl-runtime-py, sensor-msgs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-oem7-driver";
-  version = "24.0.0-r1";
+  version = "24.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_driver/24.0.0-1.tar.gz";
-    name = "24.0.0-1.tar.gz";
-    sha256 = "188d01ed1555897506a96ee0b1b1ca9a4f40750a47acb37e0a04e30459626e83";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_driver/24.1.0-1.tar.gz";
+    name = "24.1.0-1.tar.gz";
+    sha256 = "7f5b6c58227e847ea37be785ec4159bab86ef64b60579c8d95eae80bfe1a4346";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/novatel-oem7-msgs/default.nix
+++ b/distros/jazzy/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-novatel-oem7-msgs";
-  version = "24.0.0-r1";
+  version = "24.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_msgs/24.0.0-1.tar.gz";
-    name = "24.0.0-1.tar.gz";
-    sha256 = "3e66b68d38d52a01c9e8a910f26c654f9618ee1b9437bac6d76e1965b4295428";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/jazzy/novatel_oem7_msgs/24.1.0-1.tar.gz";
+    name = "24.1.0-1.tar.gz";
+    sha256 = "d4ee5f0e2973ded03a15b85f2d483977c93fe30e18d8fda41fa4115c63f2f297";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "9bcdaeafe9a05943b9691d178f135d7eb95c118f69db95bd9e7d5761ee5c51e1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "5581f18584d0f2785760cec4c231f3a8ab910279deef3c9b3f6d3f6d2a1053b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/picknik-reset-fault-controller/default.nix
+++ b/distros/jazzy/picknik-reset-fault-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
 buildRosPackage {
   pname = "ros-jazzy-picknik-reset-fault-controller";
-  version = "0.0.3-r3";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/jazzy/picknik_reset_fault_controller/0.0.3-3.tar.gz";
-    name = "0.0.3-3.tar.gz";
-    sha256 = "f6b4abf56f34fc4fb6f910d3290465f43a79e5ebde291daa1216eea195d20f6b";
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/jazzy/picknik_reset_fault_controller/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "19012588afff8dd2c6e79e54ba941b748a60c45914e4ce05b21b71412a48a8ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/picknik-twist-controller/default.nix
+++ b/distros/jazzy/picknik-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
 buildRosPackage {
   pname = "ros-jazzy-picknik-twist-controller";
-  version = "0.0.3-r3";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/jazzy/picknik_twist_controller/0.0.3-3.tar.gz";
-    name = "0.0.3-3.tar.gz";
-    sha256 = "844a14e3633b58b4b4132d649ad9977a41a71b8c5584384c97d6054555498545";
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/jazzy/picknik_twist_controller/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "54809be69a9d7ad33568cc9375e75b8add15935e384c521d52e0ccd761a5a863";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "547c2cae6444feef19c02e9fc21e7aa7315a3b67e69eafa9e5d61a453145d61c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "0203c21d3b856e94d14ef74c052b823e97c21f18b65b10b369a712bb87396140";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "9ff302d6d805b0bec0588ae30c4dbeeca3fe473c1304c1738e28b8dbb46faf90";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "327d40022cb5e9a0a16591a90283e18c69dcc1883e6680566c4682a0cd10373a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "78ea27f0a0129435169b633f34bb37c6dc308a4a5c1e48fdd2799302b36ba4a6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "a9b86e2a9473cdf5e7f596a3b9338d99d03fe8bb5b727ab765b6b9f86003d88f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "7a529632046eaf01de11fd8a7f649872368f057d3bf48ab568c064ebc20106ed";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "84e7c8f95d6c28f1a9bfc80bed9e47dfa65e3bea363a13bf7c88c1d60780f805";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-connextdds-common/default.nix
+++ b/distros/jazzy/rmw-connextdds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, rti-connext-dds-cmake-module, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-connextdds-common";
-  version = "0.22.0-r2";
+  version = "0.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/jazzy/rmw_connextdds_common/0.22.0-2.tar.gz";
-    name = "0.22.0-2.tar.gz";
-    sha256 = "5d185fb4451868c2a404fd8e7a5bdfa1bea9c031e3a0375babba0a09686dd2de";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/jazzy/rmw_connextdds_common/0.22.1-1.tar.gz";
+    name = "0.22.1-1.tar.gz";
+    sha256 = "2257c11c6c57cccfefb87e17064414fe9992aefaff9a8946fbb5a61300774e0d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-connextdds/default.nix
+++ b/distros/jazzy/rmw-connextdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rmw-connextdds-common }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-connextdds";
-  version = "0.22.0-r2";
+  version = "0.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/jazzy/rmw_connextdds/0.22.0-2.tar.gz";
-    name = "0.22.0-2.tar.gz";
-    sha256 = "69a1a42df2705f561d35c43aca18dbc7a838b2974b6163d80ba05a0d759649fa";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/jazzy/rmw_connextdds/0.22.1-1.tar.gz";
+    name = "0.22.1-1.tar.gz";
+    sha256 = "bdd285dbe407d626e4178741a1984699f03c35867b3b4aab17f175a20cd4d6dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/jazzy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, iceoryx-binding-c, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-cyclonedds-cpp";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/jazzy/rmw_cyclonedds_cpp/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "295b9fef0647557ab8947f3eae0a595970972fac5ed0232744c8720f5d2a23e9";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/jazzy/rmw_cyclonedds_cpp/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "aba4244bf29f70eda772b65b53de06505f3009b1fd492ee765e45b596e0f13e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-desert/default.nix
+++ b/distros/jazzy/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-desert";
-  version = "2.0.0-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/jazzy/rmw_desert/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "8135a71d212e182576a81cf19db5f1073f8bac2cd4ee5f0a263c781dcb70c434";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/jazzy/rmw_desert/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "56fb1b0ac48823b05d4453ff16f9aeb41ac178373b84e32a7cfb2445a59f6676";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-fastrtps-cpp/default.nix
+++ b/distros/jazzy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-dynamic-typesupport, rosidl-dynamic-typesupport-fastrtps, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-fastrtps-cpp";
-  version = "8.4.1-r1";
+  version = "8.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_cpp/8.4.1-1.tar.gz";
-    name = "8.4.1-1.tar.gz";
-    sha256 = "0566a5e417152a672de18a153274029e6859900c27f8258811865d6985dce8d9";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_cpp/8.4.2-1.tar.gz";
+    name = "8.4.2-1.tar.gz";
+    sha256 = "c26c547bda7b7302e2dca20c391ba1b2f9b5a9466440e0c01ea5629dd12bec5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/jazzy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-fastrtps-dynamic-cpp";
-  version = "8.4.1-r1";
+  version = "8.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.1-1.tar.gz";
-    name = "8.4.1-1.tar.gz";
-    sha256 = "b387a3ef293d988c396c0958c310a461f9014a08655d82ae6e98914a81dd2651";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_dynamic_cpp/8.4.2-1.tar.gz";
+    name = "8.4.2-1.tar.gz";
+    sha256 = "008885d0a04363133d88779cffad0a6cd87caae6a3625599ef3ba538233ed3ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/jazzy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, tracetools }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-fastrtps-shared-cpp";
-  version = "8.4.1-r1";
+  version = "8.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_shared_cpp/8.4.1-1.tar.gz";
-    name = "8.4.1-1.tar.gz";
-    sha256 = "19c154a80e06bb7797b4e704aa642487099ad6abb3b5c54e904fbce8baf45689";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/jazzy/rmw_fastrtps_shared_cpp/8.4.2-1.tar.gz";
+    name = "8.4.2-1.tar.gz";
+    sha256 = "8e17e8b2f1c3ca7c6905a64d7b13cb5524c0b5b629da0bb9fd474c5cd1c2c61a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-implementation-cmake/default.nix
+++ b/distros/jazzy/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-implementation-cmake";
-  version = "7.3.1-r1";
+  version = "7.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/jazzy/rmw_implementation_cmake/7.3.1-1.tar.gz";
-    name = "7.3.1-1.tar.gz";
-    sha256 = "93f146dccb7fa4f634eb259da6f9cb35807e7f36b513deba4ab647d391b07f75";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/jazzy/rmw_implementation_cmake/7.3.2-1.tar.gz";
+    name = "7.3.2-1.tar.gz";
+    sha256 = "712e518d0ecc9f5b116101ee23a6e86c36db5c04e18cf330a9412c9e1b71fc38";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-implementation/default.nix
+++ b/distros/jazzy/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connextdds, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-fastrtps-dynamic-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-implementation";
-  version = "2.15.4-r1";
+  version = "2.15.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/jazzy/rmw_implementation/2.15.4-1.tar.gz";
-    name = "2.15.4-1.tar.gz";
-    sha256 = "298c7cd34169f2e4db73fe3054dd4a8e47da72a9791d430019e78f8528cbc0d9";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/jazzy/rmw_implementation/2.15.5-1.tar.gz";
+    name = "2.15.5-1.tar.gz";
+    sha256 = "e1166795fd697c9259b575972a524051d3625fabb5920c3f55332f93a346c115";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rmw-zenoh-cpp/default.nix
+++ b/distros/jazzy/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-rmw-zenoh-cpp";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "af0c94cc556bb9d01ff65cc8d786a2169dfebb90fefbde26e69b5a80882e86fc";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/rmw_zenoh_cpp/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "7b5a125d9fad52251274a75bae2d1efdf592d5380b95310ffdf9a04dc46927e5";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = "A ROS 2 middleware implementation using zenoh-cpp";
-    license = with lib.licenses; [ asl20 mit bsdOriginal ];
+    license = with lib.licenses; [ asl20 bsdOriginal ];
   };
 }

--- a/distros/jazzy/rmw/default.nix
+++ b/distros/jazzy/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-dynamic-typesupport, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-jazzy-rmw";
-  version = "7.3.1-r1";
+  version = "7.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/jazzy/rmw/7.3.1-1.tar.gz";
-    name = "7.3.1-1.tar.gz";
-    sha256 = "d252d9bf13327dc1fa036fc91d82dcb31175563a2337f20c818fbfef93374db3";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/jazzy/rmw/7.3.2-1.tar.gz";
+    name = "7.3.2-1.tar.gz";
+    sha256 = "53aa79e9c665d9098bd33ff4b668efbf9e2a6ded809865e4c58e187c35205401";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/robot-localization/default.nix
+++ b/distros/jazzy/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, message-filters, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-robot-localization";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/jazzy/robot_localization/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "2fe74fcdd9d88aeefccb182cccba424b76c2e0935749ec694937008372343a55";
+    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/jazzy/robot_localization/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "8d13f9b4e32e537d6f5e1d90af7144dabedc92446506dd98db1b9edace8c58b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-bridge/default.nix
+++ b/distros/jazzy/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-bridge";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_bridge/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1bb95fc32bb6c41663aaa2e46c60ba45b56bbfca3dcaa4c5eda5b60d7f1125bf";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_bridge/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "dc5ef7b56842a2d7812e08c358d5bdefb03f7df8d624f11ef23ff57908ab137c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-image/default.nix
+++ b/distros/jazzy/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-image";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_image/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1becd43d37149e9c248454c22b6704dd38b9009e0fe71a996cb3cbedbd80db98";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_image/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "06a9e8fd3f9c877fd9a11120ea15b5907914a6229efed28a401a4d28b262d92c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-interfaces/default.nix
+++ b/distros/jazzy/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-interfaces";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_interfaces/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "4d896face9384ada5469fabf80e3d4c41a1b1c781c071ccce193c1910098e5f4";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_interfaces/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "1af82b2dd80d3b6efb19a4cb85ff48280c046b8dcb82c9087b3d3204ec690d29";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-sim-demos/default.nix
+++ b/distros/jazzy/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz2, sdformat-urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-sim-demos";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim_demos/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "4ba1e7cbff66fc19522da72e46474994b64ea0dbea47e629126d82325ba7071b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim_demos/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "bc18d7674bb2bf15f8dd00a9d50db72cbbe909963c621402c979828825fa3dd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz-sim/default.nix
+++ b/distros/jazzy/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz-sim";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "ef016448d8ec1668e9a216e9b4083bee2b481db31fcf2725f7f4ef0be6b63e47";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz_sim/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "c7f8ef427bce0f85556165d0c0887bd77e65fc833cd5498520d94358c28c7440";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros-gz/default.nix
+++ b/distros/jazzy/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-jazzy-ros-gz";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0925bf0e76798f8bb77a40031c5f691bd3fce1f5eab4c31925f5272ba35aae39";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/ros_gz/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "3fcc9b95636a9efe87bd7c827014d2f87df9deee26ce0af5076309390e2154c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-control-cmake/default.nix
+++ b/distros/jazzy/ros2-control-cmake/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-jazzy-ros2-control-cmake";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/jazzy/ros2_control_cmake/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "74675b93d17b285334a7725693482cc5df69f23b21db988f15ea3985229b1099";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Provides CMake macros used by the ros2_control framework";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "e8ef45c7582979b2f1d20b60be5e1a04ca9943bf7c7103f3f9f071510faa5bff";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "f8ed548ce709100d4f6794011ad641329c7993f4f52ff0ec98c44931b82ff6d7";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "e4baf5c08e9e8cab65b14d31e138d010348cf980834495154e5d2fb760dd735a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "18145e85261b7ca6167948f537eaa02a0dfb5780cda617a15351f060935161d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "e112ffd8cbf13b1ef235d83f21629764f70e364e91f567df4b0588583ca08141";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "6246a8be8bfc609800aaee87f2a2ba583e79c6f4295b36358da591c2db0009f3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-robot-steering/default.nix
+++ b/distros/jazzy/rqt-robot-steering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, geometry-msgs, python-qt-binding, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-robot-steering";
-  version = "1.0.0-r6";
+  version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/jazzy/rqt_robot_steering/1.0.0-6.tar.gz";
-    name = "1.0.0-6.tar.gz";
-    sha256 = "eaf1c3f8bccd8e80c69eebc65e22e6c3223c2f16b7cc92f1d4befc7069b503ae";
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/jazzy/rqt_robot_steering/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "3e3c1e801dd7fe95b1e92e53cc31ff04796b5a308ab23bc1e540715cf7cad695";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rti-connext-dds-cmake-module/default.nix
+++ b/distros/jazzy/rti-connext-dds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-rti-connext-dds-cmake-module";
-  version = "0.22.0-r2";
+  version = "0.22.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/jazzy/rti_connext_dds_cmake_module/0.22.0-2.tar.gz";
-    name = "0.22.0-2.tar.gz";
-    sha256 = "bd08a7f489b831f2c2157bce24066ba7d998dd6aeb3d66617b0c516971036c7a";
+    url = "https://github.com/ros2-gbp/rmw_connextdds-release/archive/release/jazzy/rti_connext_dds_cmake_module/0.22.1-1.tar.gz";
+    name = "0.22.1-1.tar.gz";
+    sha256 = "814613941871e12ad818bbdd20385033707f12c00eb8e73a59a23656e5b5ff3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/sensor-msgs-py/default.nix
+++ b/distros/jazzy/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-sensor-msgs-py";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs_py/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "e4a35b1bc77d6227a414a70898f61f29fbf9c133128b6b739932984c4222221f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs_py/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "9e241162862085300d2177fec506efd4568f3f0fe2d3405c163cd7a51c3a196e";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/sensor-msgs/default.nix
+++ b/distros/jazzy/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-sensor-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "b2d2060bf86790b56038c96469f0034a6bb7c77a2c7b711705972b51dad94b34";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/sensor_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "26b170ca29756bfe184881772f6a99d0c5d6ae0627b5149ba54eff4fcbaecaf5";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/shape-msgs/default.nix
+++ b/distros/jazzy/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-shape-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/shape_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "264be19b6e4f7e095289a297caef69faf71408d6c20e0407060a92966e9d4a92";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/shape_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "c0769a50f2b2216a41882a25d408d9a091dc6371f90e1bfe403536e8101d92b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/small-gicp-vendor/default.nix
+++ b/distros/jazzy/small-gicp-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package }:
+buildRosPackage {
+  pname = "ros-jazzy-small-gicp-vendor";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/multisensor_calibration-release/archive/release/jazzy/small_gicp_vendor/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "81d951bca577266a886a698593b261eebab624038c5f6ace8eb5cdbd5b13a7d5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-vendor-package ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-vendor-package ];
+
+  meta = {
+    description = "Vendor package for small_gicp. This is just a wrapper to provide ExternalProject build";
+    license = with lib.licenses; [ mit "BSD3" ];
+  };
+}

--- a/distros/jazzy/std-msgs/default.nix
+++ b/distros/jazzy/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-std-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "c82eb233d12c096540156e0da4d45c6c30301df1f735b328c1bfe1e8ef6bb7d7";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "76b47a6cb5d93e9620dfc5d4b4514b3f2d7123fb2c640dc667a2b30c1c5e7019";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/std-srvs/default.nix
+++ b/distros/jazzy/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-std-srvs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_srvs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "97e185ddb5713ce1271ff927929be19b198c802c07691f837a1acd3a6ce827b8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/std_srvs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "961b36de7be584ae91d094150dcabca7b03df428e36c4ca62ea14d3fb7648ae1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "28d1f03000974cb5e38223c062c830ccca0ecd9307dcf30fea741bc146fce578";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "b8c993bdfa01eccc5537ae550854fe221102c4b85a912a7b0988d52bacc47a36";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/stereo-msgs/default.nix
+++ b/distros/jazzy/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-stereo-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/stereo_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "5d71e9abe1922ad5d10fde4b86327892116dbcf129846c0ec6b16d9316b7cbb1";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/stereo_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "c3a4168cf230fbe170bfb126ad3a84b31696b4ecad3af72228f7cc55937d5838";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/test-ros-gz-bridge/default.nix
+++ b/distros/jazzy/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-jazzy-test-ros-gz-bridge";
-  version = "1.0.9-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/test_ros_gz_bridge/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "fa9a0403f6b342c23b7659cc453d35f95fe4cfc1b90979c085af5926951a3b87";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/jazzy/test_ros_gz_bridge/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "c8e123e20398111b9c4eb89a727a2eabf4dacbf95be7de417f9eef02aa583242";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/trajectory-msgs/default.nix
+++ b/distros/jazzy/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-trajectory-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/trajectory_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "248189d8f00a8d75e5a2e147aac85dbd08db3a5cdd2a701f50f2cafe34276d02";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/trajectory_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "9f0675dbc1f06b035c75fb4583502444f52f4678afb3062b1b27f6260b1a60f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "efff6f3b5d6db7b25211354aca73a1c219b573fac689668a442865e31c63ca95";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "b7864f19c4a13cb99812890cd438d9bf40744ef583b2beadecd4fded978c0769";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "2fda1c6ea3c5d8448cec3f08c324e0e6713c3770e5041cd962b4ffbf98604405";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "734a4c18e6bf34eda8256d5ab9898bc90f2e97ef4caa355c01845eeb8ebc367b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-calibration/default.nix
+++ b/distros/jazzy/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-ur-calibration";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "2f223f0ba88f76488163089b36f6256ec796a4c18457c7497d01fa485bddb25a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "25ec21aee5dafd5c785d12ce9fe3f21dba263f54431b567494de403d5e4603bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-client-library/default.nix
+++ b/distros/jazzy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ur-client-library";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "c80594dcf5f8a9eac439e1614e7273d1d000c3583f8f9a366bdabe0dd88d2d31";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/jazzy/ur_client_library/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "8a7fcbe5b9bf76719e444591e27cb538009b330a7595a426e06ebed6970879b8";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/ur-controllers/default.nix
+++ b/distros/jazzy/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ur-controllers";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c38f638ec227eeca9400bd6527d4a147f8519231405e0c52cc368d6fc8488046";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "5b88e2df545c29e32db6836529a0adc192c868f8bb6cf7683e11d665acbecaee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-dashboard-msgs/default.nix
+++ b/distros/jazzy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-dashboard-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "a64eed0e5b724c753f0d629798ec09b283e75d3110b58694ce18d58322936e47";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "e6fcf3b36657368baebda63aa6c95e5c15574f471be66af6ef5b725640e63f7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-description/default.nix
+++ b/distros/jazzy/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-description";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/jazzy/ur_description/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "6687f696460f5b49af02ff5f0093b7a8465518d8cdbee9ead4af4158944e160c";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/jazzy/ur_description/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "c2319a8a444819fb9dc61e2cea39eb0fb20a37717696d0d22e6513d7eba1eb75";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-moveit-config/default.nix
+++ b/distros/jazzy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-moveit-config";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "3fc426a8e90cc80b430d68a21018eae1394a629a36b1b6b4c0c629c867815ebc";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "72f80f7942a707b0b146b74a0d5145caf7ea895d8272264b5526a346a562f762";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-msgs/default.nix
+++ b/distros/jazzy/ur-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/jazzy/ur_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ea7c29b87e92126e63c0239c134c116da9ad463d120763c92257c22d6820ac54";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/jazzy/ur_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a5a3919c014cb4e5675d139dd1250423fafc46102ab4cd63067bfd4786319f32";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/jazzy/ur-robot-driver/default.nix
+++ b/distros/jazzy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-robot-driver";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e8e6da6d088c66091e3b52f63905f6e8a5b50abea981d9bb963d04218cbb4691";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "9c0caf7c050ef89b41ce7ff5fb1571417519c9de0abef1343f94332d8ba152c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur/default.nix
+++ b/distros/jazzy/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-jazzy-ur";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "2db548bf9fd33ff51abf58ba9838280fb4b6eead8b1820bee12e23e8f2b67a43";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "3867e12759061d4f4f03c1ea134181d7220d92fb0355cbeeb43868947a1377b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "ea445bc6c7a8a6eb79420423bc915445987bacd07876d1e56e5a3aa4358ededf";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "c1ab7f81b2a23a784dbb43b22fe1a0452dc30a76187589b11e38eb3243ec4189";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/visualization-msgs/default.nix
+++ b/distros/jazzy/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-visualization-msgs";
-  version = "5.3.5-r1";
+  version = "5.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/visualization_msgs/5.3.5-1.tar.gz";
-    name = "5.3.5-1.tar.gz";
-    sha256 = "21d39878a5daf69ea51770acc4691f73739ed88e7ffc00633ca60915d30d2607";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/jazzy/visualization_msgs/5.3.6-1.tar.gz";
+    name = "5.3.6-1.tar.gz";
+    sha256 = "d3e42c3170cc80518232129a4e563e8c1e23e7e9475ab548a7efc7c87089899e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/xacro/default.nix
+++ b/distros/jazzy/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-xacro";
-  version = "2.0.11-r2";
+  version = "2.0.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/jazzy/xacro/2.0.11-2.tar.gz";
-    name = "2.0.11-2.tar.gz";
-    sha256 = "a0fcdf6884d34db999f66f4cdb941af7bae0486742e05a89ea6b8405abdf08c2";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/jazzy/xacro/2.0.13-1.tar.gz";
+    name = "2.0.13-1.tar.gz";
+    sha256 = "72103c4fece3e334514bef076ef7a063bc005c1b7729c9898b81fad42c0184f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/zed-msgs/default.nix
+++ b/distros/jazzy/zed-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-zed-msgs";
+  version = "4.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/zed-ros2-interfaces-release/archive/release/jazzy/zed_msgs/4.2.5-1.tar.gz";
+    name = "4.2.5-1.tar.gz";
+    sha256 = "b72bd5c9cdaac6a5ae0c19629ed62f9f8e2ccbf52782847a01b0bf3b37455395";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto builtin-interfaces rosidl-default-generators ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Contains message and service definitions used by the ZED ROS2 nodes.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/zenoh-cpp-vendor/default.nix
+++ b/distros/jazzy/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-jazzy-zenoh-cpp-vendor";
-  version = "0.2.2-r1";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "1e826d47fb9ab055ec58c23c411e3158cc5a0dd6fdbb6580c00ae1843f7a0ef5";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/jazzy/zenoh_cpp_vendor/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "0ac4e9e54aa1a0d106de074b0371101d05571ccb2a626c8ad0f0233855466ce0";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/cob-sound/default.nix
+++ b/distros/noetic/cob-sound/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsaOss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, alsa-oss, catkin, cob-srvs, diagnostic-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs, visualization-msgs, vlc }:
 buildRosPackage {
   pname = "ros-noetic-cob-sound";
   version = "0.7.17-r2";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ catkin message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs alsaOss cob-srvs diagnostic-msgs message-runtime roscpp rospy std-msgs std-srvs visualization-msgs vlc ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs alsa-oss cob-srvs diagnostic-msgs message-runtime roscpp rospy std-msgs std-srvs visualization-msgs vlc ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "d13970ed30d2c75b6b04f3c00cfa92dac436f3d3b524611e360a102e6e1ba571";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "54881c53641ef095127f193467281110c5a8b11ee358057ce0410957eb6f4964";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-bridge/default.nix
+++ b/distros/noetic/depthai-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-info-manager, catkin, cv-bridge, depthai, depthai-ros-msgs, image-transport, opencv, robot-state-publisher, ros-environment, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-geometry-msgs, tf2-ros, urdf, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-bridge";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "726173ef90bdea41437e23e4025860e3cebf76eb96d46c6931869f3156833fed";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_bridge/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "eb6b4d658598993c16f5ac6f322022e3c5b2d50304564ae45b7d90b3e467021e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-descriptions/default.nix
+++ b/distros/noetic/depthai-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-descriptions";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "97472f3f35e10daad0d617edc2ac65cb049c6540a8722ae36bb9b8bc14c53249";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_descriptions/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "0bfb0098a7f524c5dfe88cdde2bc919671785b73393cf743e48ed24430359e40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-examples/default.nix
+++ b/distros/noetic/depthai-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-image-proc, depthai, depthai-bridge, depthai-descriptions, depthai-ros-msgs, foxglove-msgs, image-transport, message-filters, nodelet, opencv, robot-state-publisher, ros-environment, roscpp, rospy, sensor-msgs, std-msgs, stereo-msgs, vision-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-depthai-examples";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "83ba8d04a946123922f8d7ca149e25da53266b5f5bb04fc0578ff1d5c49878d6";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_examples/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "1f53f0e0af7c837e35c456665c424fdddcedb4113dc642641f770f81b40c86bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-filters/default.nix
+++ b/distros/noetic/depthai-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, depthai-ros-msgs, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, opencv, roscpp, sensor-msgs, vision-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-filters";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "50573899a52fadb44450138c7696b25882873639c182c9843f54fa25d126ab38";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_filters/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "81a2684548d08c6d5b7e4d9888bfd8d59e1486c0e26ba1a57f0b223920bbb3ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-driver/default.nix
+++ b/distros/noetic/depthai-ros-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-ros-msgs, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, image-pipeline, image-transport, image-transport-plugins, message-filters, nodelet, pluginlib, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-driver";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "2dca0a740507291e5d25a18852c1004cc7d76a0ecd7f421ab156ddccc8fc75b2";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_driver/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "8fe288e72a3ab8041b991ad2dc8b49552dd294f56d3844737ad5e36d6d2a1805";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros-msgs/default.nix
+++ b/distros/noetic/depthai-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros-msgs";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "54c13c4a2e3468c7eb9a66f9c5b604342f86a9807dcc800e4e2ebe47dcc2bf77";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai_ros_msgs/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "b8931d0c8e89370360948da8e4c01bc57b835477ef88ac1ab89502d416cad21a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai-ros/default.nix
+++ b/distros/noetic/depthai-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depthai, depthai-bridge, depthai-descriptions, depthai-examples, depthai-filters, depthai-ros-driver, depthai-ros-msgs }:
 buildRosPackage {
   pname = "ros-noetic-depthai-ros";
-  version = "2.11.0-r1";
+  version = "2.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.11.0-1.tar.gz";
-    name = "2.11.0-1.tar.gz";
-    sha256 = "80c1eb3996212c3a22c8c25e2e4ed8cd36a94899875b13f9519e1553b2346b08";
+    url = "https://github.com/luxonis/depthai-ros-release/archive/release/noetic/depthai-ros/2.11.2-1.tar.gz";
+    name = "2.11.2-1.tar.gz";
+    sha256 = "7d29f716586e49e49bad790ab7b50a8f83f2031c8b43462b380474e86fc20090";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depthai/default.nix
+++ b/distros/noetic/depthai/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb1, nlohmann_json, opencv, ros-environment }:
 buildRosPackage {
   pname = "ros-noetic-depthai";
-  version = "2.29.0-r1";
+  version = "2.30.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.29.0-1.tar.gz";
-    name = "2.29.0-1.tar.gz";
-    sha256 = "48d30f83bb19daab803551fd8e6a3606c73f32f01b0056dc198aa22368323408";
+    url = "https://github.com/luxonis/depthai-core-release/archive/release/noetic/depthai/2.30.0-1.tar.gz";
+    name = "2.30.0-1.tar.gz";
+    sha256 = "9d4d44e075cd4d69b677b69ac5ffa21fb4d09955e3e7664f8317d3777734a77d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "e9b4fcc4fcdd8281d4e1ba194022d1d1eee458101a0c6f70230bec33ded18d74";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "dc49f0c43a886dab2a73c838f562af9a0cd174757ee068f426840f2889c97199";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "f4cd8ddd4bfd40f8700c1b69ed32905e53b95254c7e6ca12e39c989367d8d085";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "2a196509bed94291b036e62f04c8df08aef68585c5ee5ce1c3f5606945367355";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "9432ad5d041ec942afe02fa4adc92da606ae6749aaacb98a749a25bcabfebbbc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "9126d85bdd122f3ab56aa506079606ebed5ce293d5b4696acc4a3b61efce436b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "ddc22bd7d7bb5dda783b630e871fc88a5931d9b4fc651b1184fc65ae8a1d7f80";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "03c4ed30d6131a292359a8cbb7bfd44cc5a586f3291efd1c0adbd15dc6b4a022";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "4686af3bfd76845a44f1f3bdfa80410583af531dc892bdbe34cfce5ba476688d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "24c851551d3d97a3afb811655988a4fc6ece724e4ad8d3c03f21d3463de84a0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "c5f35f86a02a296a8f4e10b403d5c300f38d2d9b8f2f0c5293473537f3a442f4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "876ca0c00963cdc7a68995ca3374d515844001d412e8d03dc26b7a0d4e2d38dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, neonavigation-metrics-msgs, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "d608135e366c3a43b8e895d4e6550e644bb01019f8c8834dea3a4006745acccb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "b5b3794470767f513a7301824bcb79aac237abdc0a001f8383e4e1d3f32fef1f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "caba1028401352df34a29eaf3f0001099d8f17610c25b1474dca9bc21e89a561";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "58aada1859a710dbc6a2ee07e7de1220bf946300599f2e093897d039a2e5fdb3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "6cae05b1ccf150e0c737741ac70403209b191a75028443e8e0de812f5a20a6f3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "3eeddb2c295447f55ec24cc002c36f841dfba54291a7c1365a13b42fe0393ad2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.17.5-r1";
+  version = "0.17.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.5-1.tar.gz";
-    name = "0.17.5-1.tar.gz";
-    sha256 = "07d7d4eba4f5fddcb2f21fcd641ca14a28d20da570a354fd195861721f419184";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.17.6-1.tar.gz";
+    name = "0.17.6-1.tar.gz";
+    sha256 = "15449132b3ca49900885efaa3f85bfc422614e6585c16eb31c9bfc294beb004a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "5020d31c1f8af5babc87dd8ec2c1a73ef6faf55c2a4fd6c129832233f9964dfd";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "4e22a3596966e8e2562de000c55e5a9267f0e5a69b28915926a408570257c0eb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.19-r1";
+  version = "1.14.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.19-1.tar.gz";
-    name = "1.14.19-1.tar.gz";
-    sha256 = "f7b6fd75a3ad3112dd4d9314e370fa2220f8c2d6d0de5f8f91945b13a68d4d20";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.20-1.tar.gz";
+    name = "1.14.20-1.tar.gz";
+    sha256 = "b3a51916c9d26acf734446edd780d3b732be8e0ecaba3a592eb3826e12cc384c";
   };
 
   buildType = "catkin";

--- a/distros/rolling/ackermann-steering-controller/default.nix
+++ b/distros/rolling/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-ackermann-steering-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "fb927854fd3d04a77f92610cbbb837aafaddd29e35cd4f4f0e8343fba9a2b4dc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ackermann_steering_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "2f468eae8c8a3db18544e0d2ea889108149839a6795cbcedb668480a41b90323";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/actionlib-msgs/default.nix
+++ b/distros/rolling/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-actionlib-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "9bcb116acc12f5864f17616fc2132a9f45c65cfd93c233189f2c1b207f007b94";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/actionlib_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "3f3838b33e1216752ed51e76ff2c67bb63767c11d633dd8d28daabd7b849ca0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/admittance-controller/default.nix
+++ b/distros/rolling/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-admittance-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "300fde300b5e5122a6ff217a4ae7fc9dd6ce4a189fb895f633c2392972e3b4e4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/admittance_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "8951ecf243f3b32c28ad8fc44d262f99ea59c61602c3e92e69a2a73681fe84d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ament-cmake-ros-core/default.nix
+++ b/distros/rolling/ament-cmake-ros-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-dependencies, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-rolling-ament-cmake-ros-core";
+  version = "0.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros_core/0.14.0-1.tar.gz";
+    name = "0.14.0-1.tar.gz";
+    sha256 = "2866eb573f02845b78ba8b1a134f8604e16501e7702d9abdc2a72ed4bcfbf978";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-export-dependencies ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-core ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-export-dependencies ];
+
+  meta = {
+    description = "Core ROS specific CMake bits in the ament buildsystem.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/ament-cmake-ros/default.nix
+++ b/distros/rolling/ament-cmake-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, domain-coordinator }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros-core, ament-lint-auto, ament-lint-common, domain-coordinator }:
 buildRosPackage {
   pname = "ros-rolling-ament-cmake-ros";
-  version = "0.13.1-r1";
+  version = "0.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros/0.13.1-1.tar.gz";
-    name = "0.13.1-1.tar.gz";
-    sha256 = "1b0b47e774593f2c90ad66ee61950d2a930f4603ce380ae27b95ea707b7385de";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/ament_cmake_ros/0.14.0-1.tar.gz";
+    name = "0.14.0-1.tar.gz";
+    sha256 = "c44fab8862ef1ef8721b76f9576b3829ff87661a4687d20648d9e9a3edb3cb13";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest domain-coordinator ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ];
+  propagatedBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-cmake-ros-core domain-coordinator ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-cmake-ros-core ];
 
   meta = {
     description = "The ROS specific CMake bits in the ament buildsystem.";

--- a/distros/rolling/autoware-cmake/default.nix
+++ b/distros/rolling/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-autoware-cmake";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_cmake/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ce27a9ff153c27fb5a97d84bdcc06cf25b6da506a01e3ba7a83a0bd592102438";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_cmake/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "03218fe1ecbf19eff17afa6bc950d72e68ee52553ce29bc1071c67dafc74fafa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-lint-common/default.nix
+++ b/distros/rolling/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lint-common";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_lint_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e973988df988fb95e01241d43f30352a272cc7029a72ca816399d22bd6616898";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_lint_common/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9f058f35e7a5486f99d21df063a0d5fa4448ebcd3c5c6399764cbda33951d785";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/bicycle-steering-controller/default.nix
+++ b/distros/rolling/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-bicycle-steering-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "736309d5113b1fad8be53a298593675d10be8b0d1527c86b25b64498792f4016";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/bicycle_steering_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "0aa95a9900cad9af889076c5e398711bc6f2327a351a0ad4cc404d7646748466";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/common-interfaces/default.nix
+++ b/distros/rolling/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-common-interfaces";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "201f1953d17ec6126e1953caa70a91b10cad2497bf2b42043baf57d9f89d8a15";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/common_interfaces/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "807b9e5b5bcd5ef7d9b891ba3c18331ca5da0dc5050885f474bd84ff10978bd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diagnostic-msgs/default.nix
+++ b/distros/rolling/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diagnostic-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "3166fb42f8740c7d386c0213b78e6be0971a3ab80db1f73a73e310e5455ba5ca";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/diagnostic_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "61f34c1d15c8e55a5e8532c559077ba66bfe0792d8fb5566222df4279cf40a8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/diff-drive-controller/default.nix
+++ b/distros/rolling/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-diff-drive-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "2511b7cd69922996c4e1baeb81051a8a2c955e31516e2a1040f2ecc6d99cbd65";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/diff_drive_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "68f429ced84c44e0c2716002dccde534c80c3013d7eb452c31541d84dd9bddca";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/domain-coordinator/default.nix
+++ b/distros/rolling/domain-coordinator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-domain-coordinator";
-  version = "0.13.1-r1";
+  version = "0.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/domain_coordinator/0.13.1-1.tar.gz";
-    name = "0.13.1-1.tar.gz";
-    sha256 = "73631bbb0ee51dc7c94748216590c7bbe2201e532d839cead08fe015b4643edc";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/rolling/domain_coordinator/0.14.0-1.tar.gz";
+    name = "0.14.0-1.tar.gz";
+    sha256 = "c70310874e099207a01efd9daeab2989ac97cceaa716ec193c4d3053aa4421ff";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/dynamixel-hardware-interface/default.nix
+++ b/distros/rolling/dynamixel-hardware-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
+buildRosPackage {
+  pname = "ros-rolling-dynamixel-hardware-interface";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "d45d5fc9c9d4817f4078dea6e212f4b1f1277410d0ae71b83f18317328c90a78";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-interfaces dynamixel-sdk hardware-interface pluginlib rclcpp realtime-tools std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 package providing a hardware interface for controlling Dynamixel motors via the ROS 2 control framework.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/rolling/dynamixel-sdk-custom-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-sdk-custom-interfaces";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/rolling/dynamixel_sdk_custom_interfaces/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "fc9ea24f30df31d0cdecaa80c37b7d85b10d6132a83181e123764724ed0e4aa4";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/rolling/dynamixel_sdk_custom_interfaces/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "2fb9c3e6eb599a13674ea8e4be30f49e344f5beb32d6b20b547d2efaba732eef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dynamixel-sdk-examples/default.nix
+++ b/distros/rolling/dynamixel-sdk-examples/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-sdk-examples";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/rolling/dynamixel_sdk_examples/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "61c5437e62929204a9a57019fed5587d105ccc759630c82323ede73ecee0e224";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/rolling/dynamixel_sdk_examples/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "6bc5353a73ad009dc33d277912fb1d1813f7f55099aaa510a7e28fd68931ff99";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "ROS 2 examples using ROBOTIS DYNAMIXEL SDK";

--- a/distros/rolling/dynamixel-sdk/default.nix
+++ b/distros/rolling/dynamixel-sdk/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-sdk";
-  version = "3.8.1-r1";
+  version = "3.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/rolling/dynamixel_sdk/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "4628656a7c414fade90d35fa029221267e7987f129db82d8c666c9702ea6680c";
+    url = "https://github.com/ros2-gbp/dynamixel_sdk-release/archive/release/rolling/dynamixel_sdk/3.8.2-1.tar.gz";
+    name = "3.8.2-1.tar.gz";
+    sha256 = "45cd7d0165e13c3a4e4046edd5113d33b654de06f273b12132106b2e775f834b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = "This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.";

--- a/distros/rolling/dynamixel-workbench-toolbox/default.nix
+++ b/distros/rolling/dynamixel-workbench-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-workbench-toolbox";
-  version = "2.2.3-r4";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/rolling/dynamixel_workbench_toolbox/2.2.3-4.tar.gz";
-    name = "2.2.3-4.tar.gz";
-    sha256 = "e831e41ab84ba177af7ba56e1ce96bcbc588753c068d03f1da1eb335eefdeb3f";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/rolling/dynamixel_workbench_toolbox/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "b881a95b4d34f7bc5abb747d36c507748a4fd33bc760ee12bc0cc6a832df2477";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/dynamixel-workbench/default.nix
+++ b/distros/rolling/dynamixel-workbench/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-workbench-toolbox }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-workbench";
-  version = "2.2.3-r4";
+  version = "2.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/rolling/dynamixel_workbench/2.2.3-4.tar.gz";
-    name = "2.2.3-4.tar.gz";
-    sha256 = "caff858ba6ae1f73b5f7b22433b54d5604081ff416ff3647d4fc712262d3c727";
+    url = "https://github.com/ros2-gbp/dynamixel_workbench-release/archive/release/rolling/dynamixel_workbench/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "d51d143fa4d6c8473a9a762c63537dfe4e67603ce5c7e8c82bf6efd073a21ad1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/effort-controllers/default.nix
+++ b/distros/rolling/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-effort-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "f2674ce03a7b901f82e702fe193ea829bd0824fc33f5f2d7f806c8a16679a91e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/effort_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "df9e5d93bea21b98a2b87558565b59eb15190beeab0e4a94d72f091fec86545b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ffmpeg-encoder-decoder/default.nix
+++ b/distros/rolling/ffmpeg-encoder-decoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, opencv, pkg-config, rclcpp, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ffmpeg-encoder-decoder";
-  version = "1.0.1-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/rolling/ffmpeg_encoder_decoder/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d6adae78af221fb7fda9354ec8dfe27fa8d594bfa26a34662745f33022aab404";
+    url = "https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release/archive/release/rolling/ffmpeg_encoder_decoder/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d3c77b91be457bde2542a7338cdaf90a087e9e8160180f07a5882995bf49ee71";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ffmpeg-image-transport-tools/default.nix
+++ b/distros/rolling/ffmpeg-image-transport-tools/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg-image-transport, ffmpeg-image-transport-msgs, rclcpp, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, rclcpp, ros-environment, rosbag2-cpp, rosbag2-storage, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ffmpeg-image-transport-tools";
-  version = "1.0.1-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release/archive/release/rolling/ffmpeg_image_transport_tools/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "42a523c3961aae31515cfa634944e55efa7289042cb7bf5b021b24d3e3f76d20";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release/archive/release/rolling/ffmpeg_image_transport_tools/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "308a6980b28cac77e1aa69730db54838308f4030e1fae36ab94944ed15655642";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg-image-transport ffmpeg-image-transport-msgs rclcpp rosbag2-cpp rosbag2-storage sensor-msgs ];
+  propagatedBuildInputs = [ cv-bridge ffmpeg-encoder-decoder ffmpeg-image-transport-msgs rclcpp rosbag2-cpp rosbag2-storage sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {

--- a/distros/rolling/ffmpeg-image-transport/default.nix
+++ b/distros/rolling/ffmpeg-image-transport/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, cv-bridge, ffmpeg, ffmpeg-image-transport-msgs, image-transport, libogg, opencv, pkg-config, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-ros, ament-lint-auto, ament-lint-common, ffmpeg-encoder-decoder, ffmpeg-image-transport-msgs, image-transport, pluginlib, rclcpp, rcutils, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ffmpeg-image-transport";
-  version = "1.0.2-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/rolling/ffmpeg_image_transport/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "71e6c369c6c739528613ced0206c9d54877e7d9b488cca51eec57012fae0b9d1";
+    url = "https://github.com/ros2-gbp/ffmpeg_image_transport-release/archive/release/rolling/ffmpeg_image_transport/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f41ec659fe37c3c7dcf41d51d1f1222957935e363e0b74c2e6a5bfc73f78e99b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  buildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
   checkInputs = [ ament-cmake-clang-format ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge ffmpeg ffmpeg-image-transport-msgs image-transport libogg opencv opencv.cxxdev pluginlib rclcpp rcutils sensor-msgs std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-ros pkg-config ros-environment ];
+  propagatedBuildInputs = [ ffmpeg-encoder-decoder ffmpeg-image-transport-msgs image-transport pluginlib rclcpp rcutils sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-ros ros-environment ];
 
   meta = {
     description = "ffmpeg_image_transport provides a plugin to image_transport for

--- a/distros/rolling/force-torque-sensor-broadcaster/default.nix
+++ b/distros/rolling/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-force-torque-sensor-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "9db4831477e538cab74fc4846aa09b61b9a1f203c672e2eee8c15de241219ba6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/force_torque_sensor_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "b603c112b985cc3bec23239f7d212ec328c0f4e7c20dccafa6fa06d13a5bf5dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/forward-command-controller/default.nix
+++ b/distros/rolling/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-forward-command-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "8af0fb26f57896845ceaab39bff6d50695c964256541fcde6405d3298a192a81";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/forward_command_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "9afeef0c83ae9d812887ff9aa3855287ccc763538b4bfbbc1a6aa8bba578dd91";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -98,6 +98,8 @@ self: super: {
 
  ament-cmake-ros = self.callPackage ./ament-cmake-ros {};
 
+ ament-cmake-ros-core = self.callPackage ./ament-cmake-ros-core {};
+
  ament-cmake-target-dependencies = self.callPackage ./ament-cmake-target-dependencies {};
 
  ament-cmake-test = self.callPackage ./ament-cmake-test {};
@@ -427,6 +429,8 @@ self: super: {
  dummy-sensors = self.callPackage ./dummy-sensors {};
 
  dynamixel-hardware = self.callPackage ./dynamixel-hardware {};
+
+ dynamixel-hardware-interface = self.callPackage ./dynamixel-hardware-interface {};
 
  dynamixel-interfaces = self.callPackage ./dynamixel-interfaces {};
 
@@ -949,6 +953,8 @@ self: super: {
  launch-xml = self.callPackage ./launch-xml {};
 
  launch-yaml = self.callPackage ./launch-yaml {};
+
+ ld08-driver = self.callPackage ./ld08-driver {};
 
  lely-core-libraries = self.callPackage ./lely-core-libraries {};
 
@@ -1804,6 +1810,8 @@ self: super: {
 
  ros2-control = self.callPackage ./ros2-control {};
 
+ ros2-control-cmake = self.callPackage ./ros2-control-cmake {};
+
  ros2-control-test-assets = self.callPackage ./ros2-control-test-assets {};
 
  ros2-controllers = self.callPackage ./ros2-controllers {};
@@ -2573,6 +2581,8 @@ self: super: {
  zbar-ros = self.callPackage ./zbar-ros {};
 
  zbar-ros-interfaces = self.callPackage ./zbar-ros-interfaces {};
+
+ zed-msgs = self.callPackage ./zed-msgs {};
 
  zenoh-bridge-dds = self.callPackage ./zenoh-bridge-dds {};
 

--- a/distros/rolling/geometry-msgs/default.nix
+++ b/distros/rolling/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-geometry-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "0b553df9d4c07aed09a84189985d7d793bd2fbd537e9b188776777feb00b9ca9";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/geometry_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "53436f14d0b1316b5d72f403c0e04d2b9033f1e0953c989872db3c6125a24a75";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gpio-controllers/default.nix
+++ b/distros/rolling/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gpio-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "21764351a13df4728eaad39cf05bab958eeb64ba4ad3e035d9c96d522bbf4758";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gpio_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "7313cbf16c2f2918efe72e422f65d5dca029f43791c91ead821707b821bbde17";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/gripper-controllers/default.nix
+++ b/distros/rolling/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-gripper-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "3b3ceaec706f21f22254a64ddff18910dd4055626b5b3fe9024ebea92134dee0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/gripper_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "cf497f9a84b022868b2b6b9c0db878647c6c2151900cbc0c1d79956458814df2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hls-lfcd-lds-driver/default.nix
+++ b/distros/rolling/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-hls-lfcd-lds-driver";
-  version = "2.0.4-r5";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/rolling/hls_lfcd_lds_driver/2.0.4-5.tar.gz";
-    name = "2.0.4-5.tar.gz";
-    sha256 = "a1fa474dc6c60338dd9a069299244ae1568d27fe9c20ef070eae159039f74256";
+    url = "https://github.com/ros2-gbp/hls_lfcd_lds_driver-release/archive/release/rolling/hls_lfcd_lds_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "fdd68915a31e862cafe302e1a2169bd75965820baa7cb507d80f1c1c3ed1bff2";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ROS package for LDS(HLS-LFCD2).
+    description = "ROS package for LDS-01(HLS-LFCD2).
     The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.";
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/rolling/imu-sensor-broadcaster/default.nix
+++ b/distros/rolling/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-imu-sensor-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "7df358bea6ff2a79d1188685a78a5bebda0b4ab0961f29efe56ed8b5453d5c54";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/imu_sensor_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "56bc0db6e88fadab057753884a487cc747abebcb4008cbe192001173a817b9d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-state-broadcaster/default.nix
+++ b/distros/rolling/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-state-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "ba4b3642d0a2156b8baee0826eb6ef76e0355b84c431d9a8ebd4c61d068c7697";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_state_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "8ac9f9081e4821eae442f90b357d40c45d922b0e9ad33529a5027ff1b5d66820";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/joint-trajectory-controller/default.nix
+++ b/distros/rolling/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-rolling-joint-trajectory-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "cc0e4311048a91742aaf116b00ef988e22d4b20c6e02a9f37a8f08ad767c1f6b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/joint_trajectory_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "2c843a16b94b2a7ac4ab678e28e4421ff8c594e5f6de4ca2d143ea1809f81ccb";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/kitti-metrics-eval/default.nix
+++ b/distros/rolling/kitti-metrics-eval/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmath, mrpt-libposes, mrpt-libtclap }:
 buildRosPackage {
   pname = "ros-rolling-kitti-metrics-eval";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "de8238ab71b7a70380fc9c9a7ddf0738ee19e204851838d5b7477138ea80d614";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/kitti_metrics_eval/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "ef952b45c7cdde60b37f2c015a13e60ab28984a5af275000dad951056b2e5728";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ld08-driver/default.nix
+++ b/distros/rolling/ld08-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-ld08-driver";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/rolling/ld08_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8590ceb176a61c8edfce32f7857fe82346fbd696c1036aa36657e5e98bbc1800";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS package for LDS-02(LD08) Lidar.
+    The Lidar sensor sends data to the Host controller for the Simultaneous Localization And Mapping(SLAM).";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/mecanum-drive-controller/default.nix
+++ b/distros/rolling/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mecanum-drive-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "67daf72f1d4712e5b8270a16dada069060ee84940738cafea8d03842a6b31229";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/mecanum_drive_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "1dfa521019e0d99876d6ead3fa2392442864a3199b2e463d1f27c21568f3b90b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-bridge-ros2/default.nix
+++ b/distros/rolling/mola-bridge-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, geometry-msgs, mola-common, mola-kernel, mola-msgs, mrpt-libmaps, mrpt-libros-bridge, mrpt-nav-interfaces, nav-msgs, rclcpp, ros-environment, sensor-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-rolling-mola-bridge-ros2";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c6cd4a5ff25f588f94a751baf623fea08a08af05dc696b7daf128d256f7a2862";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_bridge_ros2/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "b6ccd1626f8efd6403445128c9e1112d86d5a6fe4ffc6c29a29486f6644dde9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-demos/default.nix
+++ b/distros/rolling/mola-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-demos";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "48ec79cc4374282a5f1b978b49eed6b4c1fc92c13319704320dc70b06219dc38";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_demos/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "ffa1db44fddc3014adb95b8106c371ed0320706c48d4db7ea697347300b74aec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-imu-preintegration/default.nix
+++ b/distros/rolling/mola-imu-preintegration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-imu-preintegration";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "6336fd926a7e0e3decc4a878a9f6e89caeddbdadeebde31ecce3e74b15a93815";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_imu_preintegration/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "0030975752abe9adf53fe766fd400409d8a0de6764e5a2a7875dc026bf1358c7";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-euroc-dataset/default.nix
+++ b/distros/rolling/mola-input-euroc-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmath, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-euroc-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "febfd9a9625138ba26b2cc0f6ca14ad68d81b5120d1e1a4a4f3c38f4d53a845d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_euroc_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "6cda7f89b6ad8c6a7734f1683c40adbcde5acc28c74e49a009bccfd694761225";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "13d50dfe160ff165bbdcb2c88d4bb27ce37255a672511ac6580f9a20d5ea6a0d";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "4821b2c3415229aef3bbd919d614ec15610861bd979f2d29069df5dab920201b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-kitti360-dataset/default.nix
+++ b/distros/rolling/mola-input-kitti360-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-kitti360-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c134737576f8b7f4fdb4a146c645a20f5aa74e74ca7dc3406077b80588f1d272";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_kitti360_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "7984dd98724ec355ccd3b5a3b9ab709448d69e1c76b83534b40cd1c543804a5c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-mulran-dataset/default.nix
+++ b/distros/rolling/mola-input-mulran-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-mulran-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c4d6902d154e8a427b847e09f6ffda8c0fe8d1942423305552ac3a8e92166f8b";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_mulran_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "350f6901446e9cce0750513a97487e87970c0f3e50d3f4f123e7418af6ef1c0a";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-paris-luco-dataset/default.nix
+++ b/distros/rolling/mola-input-paris-luco-dataset/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-kernel, mrpt-libmaps }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-paris-luco-dataset";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "c74ac35771bc3fe2b8c3a6d55ddc4a5ecab2ec011306ceaa2cc8b1b7516750ca";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_paris_luco_dataset/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "a36224ab1701066aa702edf75c5cda457774f9bd77e003f549b0a4b763432ac1";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rawlog/default.nix
+++ b/distros/rolling/mola-input-rawlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rawlog";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "5f1cde8cd5b36c2d31150869a9ae8698d38c3f099c28df2c088ad7ebfcff2acd";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rawlog/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "a27d30782e22519a689fe8b69a3d1ef400c8cee204beb8bbd6db899bdf5e16ad";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-input-rosbag2/default.nix
+++ b/distros/rolling/mola-input-rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cv-bridge, mola-kernel, mrpt-libobs, mrpt-libros-bridge, rosbag2-cpp, sensor-msgs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-mola-input-rosbag2";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "3a44ce6efdc6c60701c192d94a3ebbc95d81552ddf3901d72f34440bf4bae375";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_input_rosbag2/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "9cfbc28a4e27e29fa1f3c9ae51a3ad52c66d135655886d1b61666fa7144898e6";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-kernel/default.nix
+++ b/distros/rolling/mola-kernel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-yaml, mrpt-libgui, mrpt-libmaps, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-kernel";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "ede9ab46fdde2b1122892b243952a9fa731bff5207158b6747b20d95e4726133";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_kernel/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "8b235565907267f033d4d2e4af9ab3dfed703e130649bfec7904c77cb7c82670";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-launcher/default.nix
+++ b/distros/rolling/mola-launcher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-kernel, mrpt-libbase, mrpt-libtclap, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-launcher";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "73926fc2098ea77ddec7cc50b7cce0048862c7ccebe6d88d3da6e859eb3928ff";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_launcher/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "35bf4c80b079c82d69aa3b97ec3a4e3d3b554754c5565b23f815bf60b37c8948";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-lidar-odometry/default.nix
+++ b/distros/rolling/mola-lidar-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, cmake, mola-common, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-state-estimation-simple, mola-test-datasets, mola-viz, mp2p-icp, mrpt-libmaps, mrpt-libtclap, ros-environment, rosbag2-storage-mcap }:
 buildRosPackage {
   pname = "ros-rolling-mola-lidar-odometry";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "bd9b43288dc31b24bc2b13ad181b98ef09bf27305cc2cf252c2f18ad5d8e60dc";
+    url = "https://github.com/ros2-gbp/mola_lidar_odometry-release/archive/release/rolling/mola_lidar_odometry/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "1e7918029a5d98833101dfe61c58aa525c20a36fbadc8f598219fcdaf5ef634c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-metric-maps/default.nix
+++ b/distros/rolling/mola-metric-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, cmake, mola-common, mp2p-icp, mrpt-libmaps, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-mola-metric-maps";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "5fa0fcccdd698ea33ab143e7c9da314d9380eddf968325f036a7d8f7b1dc7cc6";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_metric_maps/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "e854260cc487f3e77ee5aa3f44d3ea754ad4b43396a18bff8648351c51a57ab3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-msgs/default.nix
+++ b/distros/rolling/mola-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, mrpt-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-mola-msgs";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "453b4880f8501274be5f6a4df5145048b2aa77496a70029f8d1a612b3ac12d8c";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_msgs/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "50bfaf8b82d7ec661ed4e77c58a31a9ccd605ad8e08b70bd7fda630d403eb56a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-pose-list/default.nix
+++ b/distros/rolling/mola-pose-list/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libmaps, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-pose-list";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "6d6d8c42341d4330ffe09a9ae73d11362150ac1a76f4526a7d4ce208b8bd3851";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_pose_list/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "e8ecd401f058ff91d4195ab6be1daa7ccdf94b8ce43aa7e6e320cb3460c96606";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-relocalization/default.nix
+++ b/distros/rolling/mola-relocalization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-pose-list, mola-test-datasets, mp2p-icp, mrpt-libmaps, mrpt-libobs, mrpt-libslam }:
 buildRosPackage {
   pname = "ros-rolling-mola-relocalization";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "db7dcb1a5cbdabe29bac3ca6a30d997ba621c9dff17763652de5e6e953d505f1";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_relocalization/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "82e3d8cc4b32c1147bcc0d730628a77675c4884c9bfcdb24518648d3453d7ff4";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-simple/default.nix
+++ b/distros/rolling/mola-state-estimation-simple/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-simple";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "c55de2e2be648bd38bfb965650162c3c027d3c3c83631d61cfba3e885a99a9d5";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_simple/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "46529ed4cd5e874432e76eff94207b23d098e8fb2adb925118e2b8cfaa6084e5";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation-smoother/default.nix
+++ b/distros/rolling/mola-state-estimation-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, gtsam, mola-common, mola-imu-preintegration, mola-kernel, mrpt-libobs }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation-smoother";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "1630b05996f28589a060edccb047f4185f67387ed413631a4c4b1f9a8d3bfe57";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation_smoother/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "50fdab6252213a717d39cf427e44b47f55e1dd72b1fef4f2c2c57e38227d3307";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-state-estimation/default.nix
+++ b/distros/rolling/mola-state-estimation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, mola-imu-preintegration, mola-state-estimation-simple, mola-state-estimation-smoother }:
 buildRosPackage {
   pname = "ros-rolling-mola-state-estimation";
-  version = "1.7.0-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.7.0-1.tar.gz";
-    name = "1.7.0-1.tar.gz";
-    sha256 = "67f61fbbe122da5103a29238d4ce4bc5c2b331cf9f1a80e2bcd9407400262e6a";
+    url = "https://github.com/ros2-gbp/mola_state_estimation-release/archive/release/rolling/mola_state_estimation/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "9c16040e049a3a4a2067a2d1d9a3607a62a440d09ff38fb0f4ec95be5cd62397";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/mola-traj-tools/default.nix
+++ b/distros/rolling/mola-traj-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libposes }:
 buildRosPackage {
   pname = "ros-rolling-mola-traj-tools";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "08c3b24471cf2f0d95b232a746eda773f08f77c934ac74ff56731c0135d1b2cf";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_traj_tools/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "d2eb49a6c027e80040ab256eb3207d70ac5f00fbda72b4ea1231473195f7ee4b";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-viz/default.nix
+++ b/distros/rolling/mola-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-kernel, mrpt-libgui, mrpt-libmaps, mrpt-libopengl }:
 buildRosPackage {
   pname = "ros-rolling-mola-viz";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "fddae7a61d060b2966ecb106f23be032a6283af969df6d99018fb293ae4502e3";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_viz/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "deeadd16cfe399539bd5d6931af2d0fa588e5e30a68ab09b4cc2cf494455d183";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola-yaml/default.nix
+++ b/distros/rolling/mola-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, mola-common, mrpt-libbase }:
 buildRosPackage {
   pname = "ros-rolling-mola-yaml";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "8215a672fbdbfb7d55a81db6fb8055c6e32446ca98b924e13847afd107b07569";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola_yaml/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "b0c80a1b3b907e3a51ecc995011ef860fc20fbfec41c1849059ddce1d7ddf28c";
   };
 
   buildType = "cmake";

--- a/distros/rolling/mola/default.nix
+++ b/distros/rolling/mola/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-cmake, kitti-metrics-eval, mola-bridge-ros2, mola-demos, mola-input-euroc-dataset, mola-input-kitti-dataset, mola-input-kitti360-dataset, mola-input-mulran-dataset, mola-input-paris-luco-dataset, mola-input-rawlog, mola-input-rosbag2, mola-kernel, mola-launcher, mola-metric-maps, mola-pose-list, mola-relocalization, mola-traj-tools, mola-viz, mola-yaml }:
 buildRosPackage {
   pname = "ros-rolling-mola";
-  version = "1.6.2-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.6.2-1.tar.gz";
-    name = "1.6.2-1.tar.gz";
-    sha256 = "4f55bebfa8c61ca2d2bb358194b6aaff7f826105f123a2bc7f7b0264443ada02";
+    url = "https://github.com/ros2-gbp/mola-release/archive/release/rolling/mola/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "323e760a708da0ba07a3807dd2ae9cdeac090c35870652784ee1bd130b25bd72";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/nav-msgs/default.nix
+++ b/distros/rolling/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-nav-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "ab405c79f69d2bac1aede9e0fa201e4e2d21d3e99a2ea07fbf707b41b8e3fd14";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/nav_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "aa19edb0deb1f2dba2859733cad6f4d371e6c330347529c123af803c418dd5ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/parallel-gripper-controller/default.nix
+++ b/distros/rolling/parallel-gripper-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-parallel-gripper-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "081fc3c0911f9f320554196e15cf17dc8152a4038144b07d235f7993426c9b8d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/parallel_gripper_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "11e704d7ca46e10a346ce7e75760c6a8809233a017ace768ead92a8312b63ba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/picknik-reset-fault-controller/default.nix
+++ b/distros/rolling/picknik-reset-fault-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
 buildRosPackage {
   pname = "ros-rolling-picknik-reset-fault-controller";
-  version = "0.0.3-r2";
+  version = "0.0.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/rolling/picknik_reset_fault_controller/0.0.3-2.tar.gz";
-    name = "0.0.3-2.tar.gz";
-    sha256 = "56aaba66f0c724280d69e3a0ed80d3416429a793ba215e3c57df55cfe2caf0e5";
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/rolling/picknik_reset_fault_controller/0.0.4-2.tar.gz";
+    name = "0.0.4-2.tar.gz";
+    sha256 = "4d0dc70b64f55a2d0323e85b90475783689323affc4b49f8bb2a3874826d2ea2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/picknik-twist-controller/default.nix
+++ b/distros/rolling/picknik-twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, controller-interface, example-interfaces, geometry-msgs, rclcpp, realtime-tools }:
 buildRosPackage {
   pname = "ros-rolling-picknik-twist-controller";
-  version = "0.0.3-r2";
+  version = "0.0.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/rolling/picknik_twist_controller/0.0.3-2.tar.gz";
-    name = "0.0.3-2.tar.gz";
-    sha256 = "1429ad50d5341cf861d962bc122327830ac57c637365b0989fabe21772ce38f5";
+    url = "https://github.com/ros2-gbp/picknik_controllers-release/archive/release/rolling/picknik_twist_controller/0.0.4-2.tar.gz";
+    name = "0.0.4-2.tar.gz";
+    sha256 = "749c9cf5fc1e93bba30fe3c189d12cc9e9dd6185e02b5db88f9aee98e83db268";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pid-controller/default.nix
+++ b/distros/rolling/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-pid-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "ed2cd91c44807b13454c9cc45547b5769a577bbc541ccdb01be7a7b797c50777";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pid_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "e335e113b2843c17b4c412f6ffb74809d01d715d8760a86b29403b9fe0c64aad";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pose-broadcaster/default.nix
+++ b/distros/rolling/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pose-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "310a14bf6d31a1d1674da5a4a44dc2dc24a064841ec24db1ef04909491d37a64";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/pose_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "b83cf8ba34da48ddb302a97b4a5fe75db6cef58c5bf0cb38db753515662d5323";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/position-controllers/default.nix
+++ b/distros/rolling/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-position-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "4e78bc5d24aef7a8295ef5cfc8992c227ada911c0188b8b0bcfa73550cbd5680";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/position_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "1814e78ef2e5e03604a5b45de5f472c4e7952b426b8163fad05a16be8ce9575d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/range-sensor-broadcaster/default.nix
+++ b/distros/rolling/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-range-sensor-broadcaster";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "438709f4980eb271032afecad707b140ead7f75be177c68f9f45512ef661ecc8";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/range_sensor_broadcaster/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "ce416ef82910313224120c202ae1887e8ac125dd2bced1fb027f0aa9ab9b7e5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-desert/default.nix
+++ b/distros/rolling/rmw-desert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-cmake, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-rolling-rmw-desert";
-  version = "2.0.0-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "c3d7beb6b5dd49058ae14820d280a2ecea25df22e9013e82b0e9bf114db447f7";
+    url = "https://github.com/ros2-gbp/rmw_desert-release/archive/release/rolling/rmw_desert/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "04ae305c71a316ef526449a2bd801f0e66d2d20255f9e40e41b5237fc57641e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rmw-zenoh-cpp/default.nix
+++ b/distros/rolling/rmw-zenoh-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, fastcdr, rcpputils, rcutils, rmw, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, tracetools, zenoh-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rmw-zenoh-cpp";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "25f5965261e683b326cab4d640f4c1160cecb154b43eb9011e7d5fa623e6b735";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/rmw_zenoh_cpp/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "9c9ea10eb2670bbf43a469e69ee5fbbc2515a643c6b967caa8581ac2755d99e1";
   };
 
   buildType = "ament_cmake";
@@ -21,6 +21,6 @@ buildRosPackage {
 
   meta = {
     description = "A ROS 2 middleware implementation using zenoh-cpp";
-    license = with lib.licenses; [ asl20 mit bsdOriginal ];
+    license = with lib.licenses; [ asl20 bsdOriginal ];
   };
 }

--- a/distros/rolling/robot-localization/default.nix
+++ b/distros/rolling/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geographiclib, geometry-msgs, launch-ros, launch-testing-ament-cmake, message-filters, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-robot-localization";
-  version = "3.9.1-r1";
+  version = "3.9.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.9.1-1.tar.gz";
-    name = "3.9.1-1.tar.gz";
-    sha256 = "2721e26781a78e70abfcf57bb665b6c11cbb24929535009ddfe2114d5ca7889e";
+    url = "https://github.com/ros2-gbp/robot_localization-release/archive/release/rolling/robot_localization/3.9.2-2.tar.gz";
+    name = "3.9.2-2.tar.gz";
+    sha256 = "2e39b5001047cc51a13ff4ba3944ce782892c77e82f2c7d6a0903af85423d16a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-bridge/default.nix
+++ b/distros/rolling/ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actuator-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-lint-auto, ament-lint-common, geometry-msgs, gps-msgs, gz-msgs-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rclcpp-components, ros-gz-interfaces, rosgraph-msgs, rosidl-pycommon, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs, vision-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-bridge";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "22900fdd6a91c5072c581638a78d8de684f33fb1d63aa5b0554affb252dec1f3";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_bridge/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "6d5be3dc8740e2cf81ebad8aa16eea8400928ccd25fe6f20d62cb427ba14444d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-image/default.nix
+++ b/distros/rolling/ros-gz-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-msgs-vendor, gz-transport-vendor, image-transport, pkg-config, rclcpp, ros-gz-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-image";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "b6ec9cf8215d87d09af12ca5f609b18241064d77b8373d153d4b1c978d3db17e";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_image/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "ce06e77aeb127946ddd53e450212714f915f481f1d6fc73fd134a39615bb406b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-interfaces/default.nix
+++ b/distros/rolling/ros-gz-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-interfaces";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "07384a6e5d4b01c91a5a5613b11851b32d6ad1a55791caede7d8a797e198672b";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_interfaces/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "3761c63c4f54500ad6facabd561f0d136e3a225df114a5a3230aaae96b3da220";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim-demos/default.nix
+++ b/distros/rolling/ros-gz-sim-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gz-sim-vendor, image-transport-plugins, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, rqt-image-view, rqt-plot, rqt-topic, rviz-imu-plugin, rviz2, sdformat-urdf, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim-demos";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "7597ce0f59294c6bf3ece7ade0b4bac4e1f6d91502dccb9ccc9f8a71165e0c96";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim_demos/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "c81467816af446f747a610e4c4b9c3ff448928a9b7a9d0bfb1d11ed05b878617";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz-sim/default.nix
+++ b/distros/rolling/ros-gz-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-index-python, ament-lint-auto, ament-lint-common, gflags, gz-math-vendor, gz-msgs-vendor, gz-sim-vendor, gz-transport-vendor, launch, launch-ros, launch-testing, launch-testing-ament-cmake, pkg-config, rclcpp, rclcpp-components, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz-sim";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "9c4df09395fcd76aa89ec54755cd000af92848b4d0427972d69a95a5bb6e97eb";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz_sim/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "f5c80b9ee631074f02a0cea85a036b8281500d44c5e0cc6b1d3ddc4fea18bd49";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros-gz/default.nix
+++ b/distros/rolling/ros-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros-gz-sim-demos }:
 buildRosPackage {
   pname = "ros-rolling-ros-gz";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "05f5bf9e5dd0203556e6fd606683b38944f888cd55c4af72f539f3c1683b3eed";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/ros_gz/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "10241a6364ccfb1ff3991d12cd0d3afbe8dbf55cc178a977eef41ec6e0e4ad8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ros2-control-cmake/default.nix
+++ b/distros/rolling/ros2-control-cmake/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-rolling-ros2-control-cmake";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control_cmake-release/archive/release/rolling/ros2_control_cmake/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "ed3d14b3372bc6cebaecffc9293250412213cb527c77e93d0ce0d9c639dd3ca1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Provides CMake macros used by the ros2_control framework";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/ros2-controllers-test-nodes/default.nix
+++ b/distros/rolling/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers-test-nodes";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "f949aa3dd4651fd2dfe70c4051ce67a7f8275b5b49e2d153df26a5a8ac6485f5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers_test_nodes/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "4674c8f0ae1ab5eb3cf899cb0ff50ed42520e1534bcc4277a098349c1dc1d840";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/ros2-controllers/default.nix
+++ b/distros/rolling/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-rolling-ros2-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "37d8a6cef747693392af481f30339d7a3706328104dafbe520761bb672db5abb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/ros2_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "ecc773b5a55ad0a3ee259f312e9d3e52cd5718b595aecbe8422b0ae26aa86f70";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rqt-joint-trajectory-controller/default.nix
+++ b/distros/rolling/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rqt-joint-trajectory-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "8c65c7771a0b19ee296face87b2b1076c6fb9d72493266b4c2925f14d351800c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/rqt_joint_trajectory_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "2f57f241e44d448ab70968219d77bd8aece16c266950cdfdd1ebf0a93abfd188";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rqt-robot-steering/default.nix
+++ b/distros/rolling/rqt-robot-steering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, geometry-msgs, python-qt-binding, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-rolling-rqt-robot-steering";
-  version = "1.0.0-r5";
+  version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/rolling/rqt_robot_steering/1.0.0-5.tar.gz";
-    name = "1.0.0-5.tar.gz";
-    sha256 = "6e0134f0f1456e6048d50682efb2cb1c9a5ee9ec4875b8c621ae2d40c26e095d";
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/rolling/rqt_robot_steering/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "529683f9f76f6677da4978b4ed1dbd13443aba384472e1ef0a5fa12e8bf49506";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/rviz-assimp-vendor/default.nix
+++ b/distros/rolling/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, assimp }:
 buildRosPackage {
   pname = "ros-rolling-rviz-assimp-vendor";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "a56acf0cac95056941834edd5dbfda1facc9b82c20d8419d56d1a23ed692f146";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_assimp_vendor/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "554ed3ec0c5986fa76d2afaf615996cc61d1356ab98640ea89f2f7ea2e6a0f26";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-common/default.nix
+++ b/distros/rolling/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, tinyxml2-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-common";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "b881d1c2664e76d9faa4e9211335bf6abe5b5e105332af6c0da8bdd5041e38b7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_common/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "40fe857976759793c30981d1dcebd9296faae92b132ed9c2e116fbbc46a23738";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-default-plugins/default.nix
+++ b/distros/rolling/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, geometry-msgs, gz-math-vendor, image-transport, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, point-cloud-transport, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz-default-plugins";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "d67789c951ca9b8661e200a8934523c043dbded66ef5909b6f3c396adfe486b7";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_default_plugins/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "af5c6392d9332107a5d6f2c7f4ebdceacd4c9fbd4b6a64d0d8d05735250d7da0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-ogre-vendor/default.nix
+++ b/distros/rolling/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, ament-cmake-xmllint, ament-lint-auto, freetype, libGL, libGLU, xorg }:
 buildRosPackage {
   pname = "ros-rolling-rviz-ogre-vendor";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "274b5005343f9235f0092f7943c4dab0e3ffb23e7c52e621152311bb241d9667";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_ogre_vendor/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "9f735a558024f420bdc040a1a0be61130a99c4c6197e4f239de26d2087f62c06";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering-tests/default.nix
+++ b/distros/rolling/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering-tests";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "b498377136ed6c40982c9a7f652d9c17b98c2eaf4daeec03c3df2d9eca42d478";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering_tests/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "7a8a147e1cb414228aa78d905d5d3a8723639e8a666d9ee1025e1c40e29194ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-rendering/default.nix
+++ b/distros/rolling/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-rolling-rviz-rendering";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "ddea9db88b67a2b3dcbb5bf4617e1c153f3f742b47ded9995d936b8f2856d783";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_rendering/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "83f98a7c8e873c35cea21aeec0843444ed2f2ec88d40a90c6c6474d2691b42da";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz-visual-testing-framework/default.nix
+++ b/distros/rolling/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, qt5, rclcpp, rcutils, rviz-common, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-rviz-visual-testing-framework";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "8b4e2bda4d47cc0f00420ee33e4886e77f052e6f2bb76bc9c204bf0458669236";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz_visual_testing_framework/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "bb6c4bfae292a34a6e064afd1d9fa288920614edebdab272acac61d6781e8b0b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rviz2/default.nix
+++ b/distros/rolling/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, python3, python3Packages, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rviz2";
-  version = "14.4.2-r1";
+  version = "14.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.2-1.tar.gz";
-    name = "14.4.2-1.tar.gz";
-    sha256 = "feb1a5bf610ac10a44678e62272f83a84f5e0360699bec08d8c1362bd15b6c8c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/rolling/rviz2/14.4.4-1.tar.gz";
+    name = "14.4.4-1.tar.gz";
+    sha256 = "391dee25743424aa1d555d040991314f62bf43c95273f9b77e49aac325d3e0be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/sensor-msgs-py/default.nix
+++ b/distros/rolling/sensor-msgs-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs-py";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "f1d6c815733200c25dfc98b4cd66a4f41105c4f9f9cbf5a7adab47312c0fd525";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs_py/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "7f542d3fde9e5a59e00b7dffebf37ae0342ff325ae98e4d3e84d06da9bb0aadb";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/sensor-msgs/default.nix
+++ b/distros/rolling/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-sensor-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "1df769ea771638b24643c10f200005c8f173215aad76f47f5f50c104f31e280b";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/sensor_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "231c6c76bacb49d2a4a035f1fd6c9eebb129745d5bba7a617b8fc0acd6fc8486";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/shape-msgs/default.nix
+++ b/distros/rolling/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-shape-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "bd36417ffeee4daf36a1fb9bde74dca4ef33b5714c2aff1cce99ca51e4d0289a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/shape_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "4d3eed88b05540cb37e83c3b2ee2dc7c975ba7425731c99de98d41320c50bb25";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-msgs/default.nix
+++ b/distros/rolling/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "42745e24e1407ab6c6da01173f87074757251f374af96fcfa079ecf4d29aa84e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "12572501e8f87c9c6f9f0e39dbaf7b264cab77a9f3bd8940780b0f1e8532503e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/std-srvs/default.nix
+++ b/distros/rolling/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-std-srvs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "4b7e0fac32c3f27ab34cdcc1d50339b009d771418c89521d0ea3361e53f5bc4e";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/std_srvs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "398caad07946d11cce8b6696fec8f20d7b190bda279d5eee60de12acf66ab6c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/steering-controllers-library/default.nix
+++ b/distros/rolling/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-steering-controllers-library";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "af6af746d15562b743c303bc4347dba2c5e68dc4e5f0aefda1a75af7ba745d1e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/steering_controllers_library/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "295646419ceaaf21180a2b411bcced57945a35d414cc7caf539447e21f3741a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/stereo-msgs/default.nix
+++ b/distros/rolling/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-stereo-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "b97caa9b4b245bc5c0fe4f233b2f7c0e55bffd1222ba028a300b57be76891dd6";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/stereo_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "6f804ff335fb7c33cc44747a5addee5a8284a8158766b780a0451a59112c1ec4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/test-ros-gz-bridge/default.nix
+++ b/distros/rolling/test-ros-gz-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, launch-ros, launch-testing, launch-testing-ament-cmake, ros-gz-bridge }:
 buildRosPackage {
   pname = "ros-rolling-test-ros-gz-bridge";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "40d377da21eb6eebcfde54891f97a7f914db93287e6f2e591532265f95cd9392";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/rolling/test_ros_gz_bridge/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "10431e56ea5cff296f42ac9779669b02e87ee11495af5293e7488a4235f0107e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/trajectory-msgs/default.nix
+++ b/distros/rolling/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-trajectory-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "bf99a8553b7df0ed28d81fbb4cea73c4d736ee98e9c23c9956cb52abb9837163";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/trajectory_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "6e1fccca8fec15336d97e7dce0bc99808ef52e06898feb55196bc7b29ad84567";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-controller/default.nix
+++ b/distros/rolling/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "a3312eb75826690f43d749c0001c2d27b09bf6c42024cd7d82afc58a9f746db5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "aee285a87a79d5e8a4c0aadc40b4af94760b12d7f6f7c4d909fb29a58d09abf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/tricycle-steering-controller/default.nix
+++ b/distros/rolling/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-rolling-tricycle-steering-controller";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "3acf45804cfdffc55fdcd044a6d5cf0affa813e9b41b2f273f82bff1ede2b9b5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/tricycle_steering_controller/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "2e431d99a0af28f5ce65b12a0dab7a37cfa4c52dfaca511b5ff05c7a02ff2690";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-calibration/default.nix
+++ b/distros/rolling/ur-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
 buildRosPackage {
   pname = "ros-rolling-ur-calibration";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "7abf40f9131c61591f74b5a8ffb2e51416da26c63517053eb4fc0258a6214bd1";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_calibration/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "9213621ee83b64f3c06a8ab36c15dd03082a06c52aff2a9ec06e0ccc3cc29bb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-client-library/default.nix
+++ b/distros/rolling/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-rolling-ur-client-library";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "38faebe1417d05274c111839e2aedcbf0800959c04334ce55ac7f9bb8be0fefd";
+    url = "https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/archive/release/rolling/ur_client_library/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "597bc5cb5a6b153ef2aae01c95117124af957ca157a824adcad22cf2d5dc2b17";
   };
 
   buildType = "cmake";

--- a/distros/rolling/ur-controllers/default.nix
+++ b/distros/rolling/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-rolling-ur-controllers";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "fc2aa1ab272f7e2d8edf25cc78de7abe77a21fd4e218be43a0fb288953ab5824";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_controllers/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "bcb35ba1928baffad4aa5b258a8774941b37d48b068acb4584ccae1418f6937b";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-dashboard-msgs/default.nix
+++ b/distros/rolling/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-dashboard-msgs";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "dc9b6cc85d0be68d4c3f965f5a878a1604b8c2ef11bb60a01d9d384417e9116a";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_dashboard_msgs/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "715e63b08668aab59d94e78bf1c0817d217699a1f7a74345b5a72974f7c9d63f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-description/default.nix
+++ b/distros/rolling/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, joint-state-publisher-gui, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, robot-state-publisher, rviz2, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-description";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "68f84c13812efcff8007f1ba80f8072c968c376e8901787a1e980f4cb29a9066";
+    url = "https://github.com/ros2-gbp/ur_description-release/archive/release/rolling/ur_description/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "eb7409e557885dec0f849c6dcaf1e5c37e54ede9c339d8c24c701fc94227e28f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-moveit-config/default.nix
+++ b/distros/rolling/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-moveit-config";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "28a5f3c6d95c929a35b5c2fc13a91aebf48a0acef0b0a1a06f400401d82edd3e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_moveit_config/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "ea7735329f155f921f0538dfbc1cb6007fce13d6281aac7a688a00ded6f60cd1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur-msgs/default.nix
+++ b/distros/rolling/ur-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-ur-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/rolling/ur_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "2705f72b7799321c14ca6a5205526cc63fd6fc53cb8f49de8976a86d72dc255d";
+    url = "https://github.com/ros2-gbp/ur_msgs-release/archive/release/rolling/ur_msgs/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e57c452891b6697147d9221c5da91a91f5ea0b1068c1fe3f031edff49a02e35a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces geometry-msgs rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/ur-robot-driver/default.nix
+++ b/distros/rolling/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-ur-robot-driver";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "990841d04e8d54a143a1687bf150627fea8c99054258d0397b52ed7a49f79c14";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur_robot_driver/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "33ea4313abd5134c8311243be7aa324528f56e48021115abf573165b1ba2a292";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/ur/default.nix
+++ b/distros/rolling/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-rolling-ur";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "df33f1e04f6536d5127ff8d84a5fd50c9cb48c2e603ece6383c7bd396c5c8a1e";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/rolling/ur/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "be4866ad586776ff6a18b3ba1f96d73daba62f5f7f268c4f88a99d72cf1c2732";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/velocity-controllers/default.nix
+++ b/distros/rolling/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-rolling-velocity-controllers";
-  version = "4.21.0-r1";
+  version = "4.22.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.21.0-1.tar.gz";
-    name = "4.21.0-1.tar.gz";
-    sha256 = "0916850682f1a9366e11af4cf8282b4aa55c1b1c26bd840c70749873d6f85475";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/rolling/velocity_controllers/4.22.0-1.tar.gz";
+    name = "4.22.0-1.tar.gz";
+    sha256 = "d003e6aa080cb863cdf0661c836ad73d212f30030248aab1d829cafef7ef7a47";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/visualization-msgs/default.nix
+++ b/distros/rolling/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-visualization-msgs";
-  version = "5.4.2-r1";
+  version = "5.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.4.2-1.tar.gz";
-    name = "5.4.2-1.tar.gz";
-    sha256 = "611ead7b92f80aee5da900b56d7eebd9d6acc3ef4b4b1e0654ece6c9ffe68966";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/rolling/visualization_msgs/5.5.0-1.tar.gz";
+    name = "5.5.0-1.tar.gz";
+    sha256 = "9976ba9e65b0d4deced47f8436bc4bf89262772da3cef589d62919f2410496ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/xacro/default.nix
+++ b/distros/rolling/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-xacro";
-  version = "2.0.12-r1";
+  version = "2.0.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/rolling/xacro/2.0.12-1.tar.gz";
-    name = "2.0.12-1.tar.gz";
-    sha256 = "2af6d5c8e0b645b62dbf7af0ea47676dcd70adf656bf9c9b6311b35bb2b8be81";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/rolling/xacro/2.0.13-1.tar.gz";
+    name = "2.0.13-1.tar.gz";
+    sha256 = "12d8ccd93e10c03abc8be9b0f956aff464bab6249e8ecdbb2a40246b97fadb69";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/zed-msgs/default.nix
+++ b/distros/rolling/zed-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-zed-msgs";
+  version = "4.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/zed-ros2-interfaces-release/archive/release/rolling/zed_msgs/4.2.5-1.tar.gz";
+    name = "4.2.5-1.tar.gz";
+    sha256 = "ebc4c1a392a8f578ab0f349c831d7efc5ace5d5c38f22e81f0122607164d76f3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-cmake-auto builtin-interfaces rosidl-default-generators ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Contains message and service definitions used by the ZED ROS2 nodes.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/zenoh-cpp-vendor/default.nix
+++ b/distros/rolling/zenoh-cpp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, cargo, clang, git }:
 buildRosPackage {
   pname = "ros-rolling-zenoh-cpp-vendor";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "f8a3750e8140906da727158d93b33db008ea8e73007c5afac7ed6eb50a1e0650";
+    url = "https://github.com/ros2-gbp/rmw_zenoh-release/archive/release/rolling/zenoh_cpp_vendor/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "6f6f7a848146e0e35c38d8eec29bbbc727f32a4c2812320a3361ec6d273f1a84";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit ab3c1b3b7c3eca52614b4fe9d7c05ddded5b94b1.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.42.1-r1 --> 2.43.0-r1*
* *actionlib-msgs 4.2.4-r1 --> 4.8.0-r1*
* *admittance-controller 2.42.1-r1 --> 2.43.0-r1*
* *ament-clang-format 0.12.11-r1 --> 0.12.12-r1*
* *ament-clang-tidy 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-clang-format 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-clang-tidy 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-copyright 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-cppcheck 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-cpplint 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-flake8 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-lint-cmake 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-mypy 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-pclint 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-pep257 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-pycodestyle 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-pyflakes 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-uncrustify 0.12.11-r1 --> 0.12.12-r1*
* *ament-cmake-xmllint 0.12.11-r1 --> 0.12.12-r1*
* *ament-copyright 0.12.11-r1 --> 0.12.12-r1*
* *ament-cppcheck 0.12.11-r1 --> 0.12.12-r1*
* *ament-cpplint 0.12.11-r1 --> 0.12.12-r1*
* *ament-flake8 0.12.11-r1 --> 0.12.12-r1*
* *ament-lint 0.12.11-r1 --> 0.12.12-r1*
* *ament-lint-auto 0.12.11-r1 --> 0.12.12-r1*
* *ament-lint-cmake 0.12.11-r1 --> 0.12.12-r1*
* *ament-lint-common 0.12.11-r1 --> 0.12.12-r1*
* *ament-mypy 0.12.11-r1 --> 0.12.12-r1*
* *ament-pclint 0.12.11-r1 --> 0.12.12-r1*
* *ament-pep257 0.12.11-r1 --> 0.12.12-r1*
* *ament-pycodestyle 0.12.11-r1 --> 0.12.12-r1*
* *ament-pyflakes 0.12.11-r1 --> 0.12.12-r1*
* *ament-uncrustify 0.12.11-r1 --> 0.12.12-r1*
* *ament-xmllint 0.12.11-r1 --> 0.12.12-r1*
* *autoware-cmake 1.0.0-r2 --> 1.0.1-r1*
* *autoware-lanelet2-extension 0.6.2-r1 --> 0.6.3-r1*
* *autoware-lanelet2-extension-python 0.6.2-r1 --> 0.6.3-r1*
* *autoware-lint-common 1.0.0-r2 --> 1.0.1-r1*
* *bicycle-steering-controller 2.42.1-r1 --> 2.43.0-r1*
* *clearpath-config 1.1.1-r1 --> 1.2.0-r1*
* *clearpath-config-live 1.0.0-r1 --> 1.2.0-r1*
* *clearpath-desktop 1.0.0-r1 --> 1.2.0-r1*
* *clearpath-viz 1.0.0-r1 --> 1.2.0-r1*
* *common-interfaces 4.2.4-r1 --> 4.8.0-r1*
* *control-msgs 4.7.0-r1 --> 4.8.0-r1*
* *controller-interface 2.48.0-r1 --> 2.49.0-r1*
* *controller-manager 2.48.0-r1 --> 2.49.0-r1*
* *controller-manager-msgs 2.48.0-r1 --> 2.49.0-r1*
* *depthai 2.29.0-r1 --> 2.30.0-r1*
* *depthai-bridge 2.11.0-r1 --> 2.11.2-r1*
* *depthai-descriptions 2.11.0-r1 --> 2.11.2-r1*
* *depthai-examples 2.11.0-r1 --> 2.11.2-r1*
* *depthai-filters 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros-driver 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros-msgs 2.11.0-r1 --> 2.11.2-r1*
* *diagnostic-msgs 4.2.4-r1 --> 4.8.0-r1*
* *diff-drive-controller 2.42.1-r1 --> 2.43.0-r1*
* *dynamixel-hardware-interface 1.3.0-r1 --> 1.4.0-r1*
* *dynamixel-sdk 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-sdk-custom-interfaces 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-sdk-examples 3.8.1-r1 --> 3.8.2-r1*
* *effort-controllers 2.42.1-r1 --> 2.43.0-r1*
* *ffmpeg-encoder-decoder 1.0.1-r2 --> 2.0.0-r1*
* *ffmpeg-image-transport 1.0.2-r1 --> 2.0.1-r1*
* *ffmpeg-image-transport-tools 1.1.0-r1 --> 2.1.1-r1*
* *force-torque-sensor-broadcaster 2.42.1-r1 --> 2.43.0-r1*
* *forward-command-controller 2.42.1-r1 --> 2.43.0-r1*
* *geometry-msgs 4.2.4-r1 --> 4.8.0-r1*
* *gpio-controllers 2.42.1-r1 --> 2.43.0-r1*
* *gripper-controllers 2.42.1-r1 --> 2.43.0-r1*
* *hardware-interface 2.48.0-r1 --> 2.49.0-r1*
* *hardware-interface-testing 2.48.0-r1 --> 2.49.0-r1*
* *imu-sensor-broadcaster 2.42.1-r1 --> 2.43.0-r1*
* *joint-limits 2.48.0-r1 --> 2.49.0-r1*
* *joint-state-broadcaster 2.42.1-r1 --> 2.43.0-r1*
* *joint-trajectory-controller 2.42.1-r1 --> 2.43.0-r1*
* *kitti-metrics-eval 1.6.2-r1 --> 1.6.3-r1*
* *launch 1.0.7-r1 --> 1.0.8-r1*
* *launch-pytest 1.0.7-r1 --> 1.0.8-r1*
* *launch-ros 0.19.8-r1 --> 0.19.9-r1*
* *launch-testing 1.0.7-r1 --> 1.0.8-r1*
* *launch-testing-ament-cmake 1.0.7-r1 --> 1.0.8-r1*
* *launch-testing-ros 0.19.8-r1 --> 0.19.9-r1*
* *launch-xml 1.0.7-r1 --> 1.0.8-r1*
* *launch-yaml 1.0.7-r1 --> 1.0.8-r1*
* *ld08-driver 1.1.1-r1*
* *libcurl-vendor 3.1.2-r1 --> 3.1.3-r1*
* *mcap-vendor 0.15.13-r1 --> 0.15.14-r1*
* *mecanum-drive-controller 2.43.0-r1*
* *message-filters 4.3.5-r1 --> 4.3.6-r1*
* *metavision-driver 2.0.0-r1 --> 2.0.1-r1*
* *mola 1.6.2-r1 --> 1.6.3-r1*
* *mola-bridge-ros2 1.6.2-r1 --> 1.6.3-r1*
* *mola-demos 1.6.2-r1 --> 1.6.3-r1*
* *mola-imu-preintegration 1.7.0-r1 --> 1.8.0-r1*
* *mola-input-euroc-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-kitti-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-kitti360-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-mulran-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-paris-luco-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-rawlog 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-rosbag2 1.6.2-r1 --> 1.6.3-r1*
* *mola-kernel 1.6.2-r1 --> 1.6.3-r1*
* *mola-launcher 1.6.2-r1 --> 1.6.3-r1*
* *mola-lidar-odometry 0.7.0-r1 --> 0.7.1-r1*
* *mola-metric-maps 1.6.2-r1 --> 1.6.3-r1*
* *mola-msgs 1.6.2-r1 --> 1.6.3-r1*
* *mola-pose-list 1.6.2-r1 --> 1.6.3-r1*
* *mola-relocalization 1.6.2-r1 --> 1.6.3-r1*
* *mola-state-estimation 1.7.0-r1 --> 1.8.0-r1*
* *mola-state-estimation-simple 1.7.0-r1 --> 1.8.0-r1*
* *mola-state-estimation-smoother 1.7.0-r1 --> 1.8.0-r1*
* *mola-traj-tools 1.6.2-r1 --> 1.6.3-r1*
* *mola-viz 1.6.2-r1 --> 1.6.3-r1*
* *mola-yaml 1.6.2-r1 --> 1.6.3-r1*
* *nav-msgs 4.2.4-r1 --> 4.8.0-r1*
* *novatel-oem7-driver 20.6.0-r1 --> 20.7.0-r1*
* *novatel-oem7-msgs 20.6.0-r1 --> 20.7.0-r1*
* *osrf-pycommon 2.1.4-r1 --> 2.1.6-r1*
* *pid-controller 2.42.1-r1 --> 2.43.0-r1*
* *pose-broadcaster 2.42.1-r1 --> 2.43.0-r1*
* *position-controllers 2.42.1-r1 --> 2.43.0-r1*
* *qt-dotgraph 2.2.3-r2 --> 2.2.4-r1*
* *qt-gui 2.2.3-r2 --> 2.2.4-r1*
* *qt-gui-app 2.2.3-r2 --> 2.2.4-r1*
* *qt-gui-core 2.2.3-r2 --> 2.2.4-r1*
* *qt-gui-cpp 2.2.3-r2 --> 2.2.4-r1*
* *qt-gui-py-common 2.2.3-r2 --> 2.2.4-r1*
* *range-sensor-broadcaster 2.42.1-r1 --> 2.43.0-r1*
* *rclcpp 16.0.11-r1 --> 16.0.12-r1*
* *rclcpp-action 16.0.11-r1 --> 16.0.12-r1*
* *rclcpp-components 16.0.11-r1 --> 16.0.12-r1*
* *rclcpp-lifecycle 16.0.11-r1 --> 16.0.12-r1*
* *rclpy 3.3.15-r1 --> 3.3.16-r1*
* *rcpputils 2.4.4-r1 --> 2.4.5-r1*
* *resource-retriever 3.1.2-r1 --> 3.1.3-r1*
* *rmw-desert 1.0.3-r1 --> 1.0.4-r1*
* *ros2-control 2.48.0-r1 --> 2.49.0-r1*
* *ros2-control-test-assets 2.48.0-r1 --> 2.49.0-r1*
* *ros2-controllers 2.42.1-r1 --> 2.43.0-r1*
* *ros2-controllers-test-nodes 2.42.1-r1 --> 2.43.0-r1*
* *ros2action 0.18.11-r1 --> 0.18.12-r1*
* *ros2bag 0.15.13-r1 --> 0.15.14-r1*
* *ros2cli 0.18.11-r1 --> 0.18.12-r1*
* *ros2cli-test-interfaces 0.18.11-r1 --> 0.18.12-r1*
* *ros2component 0.18.11-r1 --> 0.18.12-r1*
* *ros2controlcli 2.48.0-r1 --> 2.49.0-r1*
* *ros2doctor 0.18.11-r1 --> 0.18.12-r1*
* *ros2interface 0.18.11-r1 --> 0.18.12-r1*
* *ros2launch 0.19.8-r1 --> 0.19.9-r1*
* *ros2lifecycle 0.18.11-r1 --> 0.18.12-r1*
* *ros2lifecycle-test-fixtures 0.18.11-r1 --> 0.18.12-r1*
* *ros2multicast 0.18.11-r1 --> 0.18.12-r1*
* *ros2node 0.18.11-r1 --> 0.18.12-r1*
* *ros2param 0.18.11-r1 --> 0.18.12-r1*
* *ros2pkg 0.18.11-r1 --> 0.18.12-r1*
* *ros2run 0.18.11-r1 --> 0.18.12-r1*
* *ros2service 0.18.11-r1 --> 0.18.12-r1*
* *ros2topic 0.18.11-r1 --> 0.18.12-r1*
* *rosbag2 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-compression 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-compression-zstd 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-cpp 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-interfaces 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-performance-benchmarking 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-py 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-storage 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-storage-default-plugins 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-storage-mcap 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-storage-mcap-testdata 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-test-common 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-tests 0.15.13-r1 --> 0.15.14-r1*
* *rosbag2-transport 0.15.13-r1 --> 0.15.14-r1*
* *rqt-controller-manager 2.48.0-r1 --> 2.49.0-r1*
* *rqt-joint-trajectory-controller 2.42.1-r1 --> 2.43.0-r1*
* *rqt-plot 1.1.3-r1 --> 1.1.4-r1*
* *rqt-robot-steering 1.0.0-r4 --> 1.0.1-r1*
* *sensor-msgs 4.2.4-r1 --> 4.8.0-r1*
* *sensor-msgs-py 4.2.4-r1 --> 4.8.0-r1*
* *shape-msgs 4.2.4-r1 --> 4.8.0-r1*
* *shared-queues-vendor 0.15.13-r1 --> 0.15.14-r1*
* *sqlite3-vendor 0.15.13-r1 --> 0.15.14-r1*
* *sros2 0.10.5-r1 --> 0.10.6-r1*
* *sros2-cmake 0.10.5-r1 --> 0.10.6-r1*
* *std-msgs 4.2.4-r1 --> 4.8.0-r1*
* *std-srvs 4.2.4-r1 --> 4.8.0-r1*
* *steering-controllers-library 2.42.1-r1 --> 2.43.0-r1*
* *stereo-msgs 4.2.4-r1 --> 4.8.0-r1*
* *trajectory-msgs 4.2.4-r1 --> 4.8.0-r1*
* *transmission-interface 2.48.0-r1 --> 2.49.0-r1*
* *tricycle-controller 2.42.1-r1 --> 2.43.0-r1*
* *tricycle-steering-controller 2.42.1-r1 --> 2.43.0-r1*
* *turtlebot3 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-bringup 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-cartographer 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-description 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-example 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-navigation2 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-node 2.1.5-r1 --> 2.2.5-r1*
* *turtlebot3-teleop 2.1.5-r1 --> 2.2.5-r1*
* *ur 2.5.2-r1 --> 2.6.0-r1*
* *ur-bringup 2.5.2-r1 --> 2.6.0-r1*
* *ur-calibration 2.5.2-r1 --> 2.6.0-r1*
* *ur-client-library 1.7.1-r1 --> 1.8.0-r1*
* *ur-controllers 2.5.2-r1 --> 2.6.0-r1*
* *ur-dashboard-msgs 2.5.2-r1 --> 2.6.0-r1*
* *ur-description 2.1.10-r1 --> 2.1.11-r1*
* *ur-moveit-config 2.5.2-r1 --> 2.6.0-r1*
* *ur-msgs 2.1.0-r1 --> 2.2.0-r1*
* *ur-robot-driver 2.5.2-r1 --> 2.6.0-r1*
* *velocity-controllers 2.42.1-r1 --> 2.43.0-r1*
* *visualization-msgs 4.2.4-r1 --> 4.8.0-r1*
* *xacro 2.0.8-r1 --> 2.0.13-r1*
* *zed-msgs 4.2.2-r1 --> 4.2.5-r1*
* *zstd-vendor 0.15.13-r1 --> 0.15.14-r1*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.21.0-r1 --> 4.22.0-r1*
* *actionlib-msgs 5.3.5-r1 --> 5.3.6-r1*
* *admittance-controller 4.21.0-r1 --> 4.22.0-r1*
* *autoware-cmake 1.0.0-r1 --> 1.0.1-r1*
* *autoware-lint-common 1.0.0-r1 --> 1.0.1-r1*
* *bicycle-steering-controller 4.21.0-r1 --> 4.22.0-r1*
* *clearpath-bt-joy 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-common 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-config 2.1.1-r1 --> 2.2.2-r1*
* *clearpath-control 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-customization 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-description 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-generator-common 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-generator-gz 2.2.0-r1*
* *clearpath-gz 2.2.0-r1*
* *clearpath-manipulators 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-manipulators-description 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-motor-msgs 2.1.0-r1 --> 2.2.2-r1*
* *clearpath-mounts-description 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-msgs 2.1.0-r1 --> 2.2.2-r1*
* *clearpath-platform-description 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-platform-msgs 2.1.0-r1 --> 2.2.2-r1*
* *clearpath-sensors-description 2.1.0-r1 --> 2.2.0-r1*
* *clearpath-simulator 2.2.0-r1*
* *clearpath-tests 0.2.2-r1 --> 0.2.9-r1*
* *common-interfaces 5.3.5-r1 --> 5.3.6-r1*
* *control-msgs 5.3.0-r1 --> 5.4.0-r1*
* *depthai 2.29.0-r1 --> 2.30.0-r1*
* *depthai-bridge 2.11.0-r1 --> 2.11.2-r1*
* *depthai-descriptions 2.11.0-r1 --> 2.11.2-r1*
* *depthai-examples 2.11.0-r1 --> 2.11.2-r1*
* *depthai-filters 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros-driver 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros-msgs 2.11.0-r1 --> 2.11.2-r1*
* *diagnostic-msgs 5.3.5-r1 --> 5.3.6-r1*
* *diff-drive-controller 4.21.0-r1 --> 4.22.0-r1*
* *dynamixel-hardware-interface 1.4.0-r2*
* *dynamixel-sdk 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-sdk-custom-interfaces 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-sdk-examples 3.8.1-r1 --> 3.8.2-r1*
* *effort-controllers 4.21.0-r1 --> 4.22.0-r1*
* *ffmpeg-encoder-decoder 1.0.1-r1 --> 2.0.0-r1*
* *ffmpeg-image-transport 1.0.2-r1 --> 2.0.1-r1*
* *ffmpeg-image-transport-tools 1.0.1-r2 --> 2.1.1-r1*
* *force-torque-sensor-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *forward-command-controller 4.21.0-r1 --> 4.22.0-r1*
* *geometry-msgs 5.3.5-r1 --> 5.3.6-r1*
* *gpio-controllers 4.21.0-r1 --> 4.22.0-r1*
* *gripper-controllers 4.21.0-r1 --> 4.22.0-r1*
* *imu-sensor-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *joint-state-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *joint-trajectory-controller 4.21.0-r1 --> 4.22.0-r1*
* *kinematics-interface 1.2.1-r1 --> 1.3.0-r1*
* *kinematics-interface-kdl 1.2.1-r1 --> 1.3.0-r1*
* *kitti-metrics-eval 1.6.2-r1 --> 1.6.3-r1*
* *ld08-driver 1.1.1-r1*
* *mecanum-drive-controller 4.21.0-r1 --> 4.22.0-r1*
* *metavision-driver 2.0.0-r1 --> 2.0.1-r1*
* *mola 1.6.2-r1 --> 1.6.3-r1*
* *mola-bridge-ros2 1.6.2-r1 --> 1.6.3-r1*
* *mola-demos 1.6.2-r1 --> 1.6.3-r1*
* *mola-imu-preintegration 1.7.0-r1 --> 1.8.0-r1*
* *mola-input-euroc-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-kitti-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-kitti360-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-mulran-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-paris-luco-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-rawlog 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-rosbag2 1.6.2-r1 --> 1.6.3-r1*
* *mola-kernel 1.6.2-r1 --> 1.6.3-r1*
* *mola-launcher 1.6.2-r1 --> 1.6.3-r1*
* *mola-lidar-odometry 0.7.0-r1 --> 0.7.1-r1*
* *mola-metric-maps 1.6.2-r1 --> 1.6.3-r1*
* *mola-msgs 1.6.2-r1 --> 1.6.3-r1*
* *mola-pose-list 1.6.2-r1 --> 1.6.3-r1*
* *mola-relocalization 1.6.2-r1 --> 1.6.3-r1*
* *mola-state-estimation 1.7.0-r1 --> 1.8.0-r1*
* *mola-state-estimation-simple 1.7.0-r1 --> 1.8.0-r1*
* *mola-state-estimation-smoother 1.7.0-r1 --> 1.8.0-r1*
* *mola-traj-tools 1.6.2-r1 --> 1.6.3-r1*
* *mola-viz 1.6.2-r1 --> 1.6.3-r1*
* *mola-yaml 1.6.2-r1 --> 1.6.3-r1*
* *multisensor-calibration 2.0.2-r1*
* *multisensor-calibration-interface 2.0.2-r1*
* *nav-msgs 5.3.5-r1 --> 5.3.6-r1*
* *novatel-oem7-driver 24.0.0-r1 --> 24.1.0-r1*
* *novatel-oem7-msgs 24.0.0-r1 --> 24.1.0-r1*
* *parallel-gripper-controller 4.21.0-r1 --> 4.22.0-r1*
* *picknik-reset-fault-controller 0.0.3-r3 --> 0.0.4-r1*
* *picknik-twist-controller 0.0.3-r3 --> 0.0.4-r1*
* *pid-controller 4.21.0-r1 --> 4.22.0-r1*
* *pose-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *position-controllers 4.21.0-r1 --> 4.22.0-r1*
* *range-sensor-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *rmw 7.3.1-r1 --> 7.3.2-r1*
* *rmw-connextdds 0.22.0-r2 --> 0.22.1-r1*
* *rmw-connextdds-common 0.22.0-r2 --> 0.22.1-r1*
* *rmw-cyclonedds-cpp 2.2.2-r1 --> 2.2.3-r1*
* *rmw-desert 2.0.0-r1 --> 2.0.2-r1*
* *rmw-fastrtps-cpp 8.4.1-r1 --> 8.4.2-r1*
* *rmw-fastrtps-dynamic-cpp 8.4.1-r1 --> 8.4.2-r1*
* *rmw-fastrtps-shared-cpp 8.4.1-r1 --> 8.4.2-r1*
* *rmw-implementation 2.15.4-r1 --> 2.15.5-r1*
* *rmw-implementation-cmake 7.3.1-r1 --> 7.3.2-r1*
* *rmw-zenoh-cpp 0.2.2-r1 --> 0.2.3-r1*
* *robot-localization 3.8.1-r1 --> 3.8.2-r1*
* *ros-gz 1.0.9-r1 --> 1.0.11-r1*
* *ros-gz-bridge 1.0.9-r1 --> 1.0.11-r1*
* *ros-gz-image 1.0.9-r1 --> 1.0.11-r1*
* *ros-gz-interfaces 1.0.9-r1 --> 1.0.11-r1*
* *ros-gz-sim 1.0.9-r1 --> 1.0.11-r1*
* *ros-gz-sim-demos 1.0.9-r1 --> 1.0.11-r1*
* *ros2-control-cmake 0.1.1-r1*
* *ros2-controllers 4.21.0-r1 --> 4.22.0-r1*
* *ros2-controllers-test-nodes 4.21.0-r1 --> 4.22.0-r1*
* *rqt-joint-trajectory-controller 4.21.0-r1 --> 4.22.0-r1*
* *rqt-robot-steering 1.0.0-r6 --> 1.0.1-r2*
* *rti-connext-dds-cmake-module 0.22.0-r2 --> 0.22.1-r1*
* *sensor-msgs 5.3.5-r1 --> 5.3.6-r1*
* *sensor-msgs-py 5.3.5-r1 --> 5.3.6-r1*
* *shape-msgs 5.3.5-r1 --> 5.3.6-r1*
* *small-gicp-vendor 2.0.2-r1*
* *std-msgs 5.3.5-r1 --> 5.3.6-r1*
* *std-srvs 5.3.5-r1 --> 5.3.6-r1*
* *steering-controllers-library 4.21.0-r1 --> 4.22.0-r1*
* *stereo-msgs 5.3.5-r1 --> 5.3.6-r1*
* *test-ros-gz-bridge 1.0.9-r1 --> 1.0.11-r1*
* *trajectory-msgs 5.3.5-r1 --> 5.3.6-r1*
* *tricycle-controller 4.21.0-r1 --> 4.22.0-r1*
* *tricycle-steering-controller 4.21.0-r1 --> 4.22.0-r1*
* *ur 3.1.0-r1 --> 3.1.1-r1*
* *ur-calibration 3.1.0-r1 --> 3.1.1-r1*
* *ur-client-library 1.7.1-r1 --> 1.8.0-r1*
* *ur-controllers 3.1.0-r1 --> 3.1.1-r1*
* *ur-dashboard-msgs 3.1.0-r1 --> 3.1.1-r1*
* *ur-description 3.0.1-r1 --> 3.0.2-r1*
* *ur-moveit-config 3.1.0-r1 --> 3.1.1-r1*
* *ur-msgs 2.1.0-r1 --> 2.2.0-r1*
* *ur-robot-driver 3.1.0-r1 --> 3.1.1-r1*
* *velocity-controllers 4.21.0-r1 --> 4.22.0-r1*
* *visualization-msgs 5.3.5-r1 --> 5.3.6-r1*
* *xacro 2.0.11-r2 --> 2.0.13-r1*
* *zed-msgs 4.2.5-r1*
* *zenoh-cpp-vendor 0.2.2-r1 --> 0.2.3-r1*

Noetic Changes:
---------------
* *costmap-cspace 0.17.5-r1 --> 0.17.6-r1*
* *depthai 2.29.0-r1 --> 2.30.0-r1*
* *depthai-bridge 2.11.0-r1 --> 2.11.2-r1*
* *depthai-descriptions 2.11.0-r1 --> 2.11.2-r1*
* *depthai-examples 2.11.0-r1 --> 2.11.2-r1*
* *depthai-filters 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros-driver 2.11.0-r1 --> 2.11.2-r1*
* *depthai-ros-msgs 2.11.0-r1 --> 2.11.2-r1*
* *joystick-interrupt 0.17.5-r1 --> 0.17.6-r1*
* *map-organizer 0.17.5-r1 --> 0.17.6-r1*
* *neonavigation 0.17.5-r1 --> 0.17.6-r1*
* *neonavigation-common 0.17.5-r1 --> 0.17.6-r1*
* *neonavigation-launch 0.17.5-r1 --> 0.17.6-r1*
* *obj-to-pointcloud 0.17.5-r1 --> 0.17.6-r1*
* *planner-cspace 0.17.5-r1 --> 0.17.6-r1*
* *safety-limiter 0.17.5-r1 --> 0.17.6-r1*
* *track-odometry 0.17.5-r1 --> 0.17.6-r1*
* *trajectory-tracker 0.17.5-r1 --> 0.17.6-r1*
* *ur-client-library 1.7.1-r1 --> 1.8.0-r1*
* *xacro 1.14.19-r1 --> 1.14.20-r1*

Rolling Changes:
----------------
* *ackermann-steering-controller 4.21.0-r1 --> 4.22.0-r1*
* *actionlib-msgs 5.4.2-r1 --> 5.5.0-r1*
* *admittance-controller 4.21.0-r1 --> 4.22.0-r1*
* *ament-cmake-ros 0.13.1-r1 --> 0.14.0-r1*
* *ament-cmake-ros-core 0.14.0-r1*
* *autoware-cmake 1.0.0-r1 --> 1.0.1-r1*
* *autoware-lint-common 1.0.0-r1 --> 1.0.1-r1*
* *bicycle-steering-controller 4.21.0-r1 --> 4.22.0-r1*
* *common-interfaces 5.4.2-r1 --> 5.5.0-r1*
* *diagnostic-msgs 5.4.2-r1 --> 5.5.0-r1*
* *diff-drive-controller 4.21.0-r1 --> 4.22.0-r1*
* *domain-coordinator 0.13.1-r1 --> 0.14.0-r1*
* *dynamixel-hardware-interface 1.4.0-r1*
* *dynamixel-sdk 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-sdk-custom-interfaces 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-sdk-examples 3.8.1-r1 --> 3.8.2-r1*
* *dynamixel-workbench 2.2.3-r4 --> 2.2.4-r1*
* *dynamixel-workbench-toolbox 2.2.3-r4 --> 2.2.4-r1*
* *effort-controllers 4.21.0-r1 --> 4.22.0-r1*
* *ffmpeg-encoder-decoder 1.0.1-r1 --> 2.0.0-r1*
* *ffmpeg-image-transport 1.0.2-r1 --> 2.0.1-r1*
* *ffmpeg-image-transport-tools 1.0.1-r1 --> 2.1.1-r1*
* *force-torque-sensor-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *forward-command-controller 4.21.0-r1 --> 4.22.0-r1*
* *geometry-msgs 5.4.2-r1 --> 5.5.0-r1*
* *gpio-controllers 4.21.0-r1 --> 4.22.0-r1*
* *gripper-controllers 4.21.0-r1 --> 4.22.0-r1*
* *hls-lfcd-lds-driver 2.0.4-r5 --> 2.1.0-r1*
* *imu-sensor-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *joint-state-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *joint-trajectory-controller 4.21.0-r1 --> 4.22.0-r1*
* *kitti-metrics-eval 1.6.2-r1 --> 1.6.3-r1*
* *ld08-driver 1.1.0-r1*
* *mecanum-drive-controller 4.21.0-r1 --> 4.22.0-r1*
* *mola 1.6.2-r1 --> 1.6.3-r1*
* *mola-bridge-ros2 1.6.2-r1 --> 1.6.3-r1*
* *mola-demos 1.6.2-r1 --> 1.6.3-r1*
* *mola-imu-preintegration 1.7.0-r1 --> 1.8.0-r1*
* *mola-input-euroc-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-kitti-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-kitti360-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-mulran-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-paris-luco-dataset 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-rawlog 1.6.2-r1 --> 1.6.3-r1*
* *mola-input-rosbag2 1.6.2-r1 --> 1.6.3-r1*
* *mola-kernel 1.6.2-r1 --> 1.6.3-r1*
* *mola-launcher 1.6.2-r1 --> 1.6.3-r1*
* *mola-lidar-odometry 0.7.0-r1 --> 0.7.1-r1*
* *mola-metric-maps 1.6.2-r1 --> 1.6.3-r1*
* *mola-msgs 1.6.2-r1 --> 1.6.3-r1*
* *mola-pose-list 1.6.2-r1 --> 1.6.3-r1*
* *mola-relocalization 1.6.2-r1 --> 1.6.3-r1*
* *mola-state-estimation 1.7.0-r1 --> 1.8.0-r1*
* *mola-state-estimation-simple 1.7.0-r1 --> 1.8.0-r1*
* *mola-state-estimation-smoother 1.7.0-r1 --> 1.8.0-r1*
* *mola-traj-tools 1.6.2-r1 --> 1.6.3-r1*
* *mola-viz 1.6.2-r1 --> 1.6.3-r1*
* *mola-yaml 1.6.2-r1 --> 1.6.3-r1*
* *nav-msgs 5.4.2-r1 --> 5.5.0-r1*
* *parallel-gripper-controller 4.21.0-r1 --> 4.22.0-r1*
* *picknik-reset-fault-controller 0.0.3-r2 --> 0.0.4-r2*
* *picknik-twist-controller 0.0.3-r2 --> 0.0.4-r2*
* *pid-controller 4.21.0-r1 --> 4.22.0-r1*
* *pose-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *position-controllers 4.21.0-r1 --> 4.22.0-r1*
* *range-sensor-broadcaster 4.21.0-r1 --> 4.22.0-r1*
* *rmw-desert 2.0.0-r1 --> 3.0.0-r1*
* *rmw-zenoh-cpp 0.4.0-r1 --> 0.5.0-r1*
* *robot-localization 3.9.1-r1 --> 3.9.2-r2*
* *ros-gz 2.1.5-r1 --> 2.1.6-r1*
* *ros-gz-bridge 2.1.5-r1 --> 2.1.6-r1*
* *ros-gz-image 2.1.5-r1 --> 2.1.6-r1*
* *ros-gz-interfaces 2.1.5-r1 --> 2.1.6-r1*
* *ros-gz-sim 2.1.5-r1 --> 2.1.6-r1*
* *ros-gz-sim-demos 2.1.5-r1 --> 2.1.6-r1*
* *ros2-control-cmake 0.1.1-r1*
* *ros2-controllers 4.21.0-r1 --> 4.22.0-r1*
* *ros2-controllers-test-nodes 4.21.0-r1 --> 4.22.0-r1*
* *rqt-joint-trajectory-controller 4.21.0-r1 --> 4.22.0-r1*
* *rqt-robot-steering 1.0.0-r5 --> 1.0.1-r2*
* *rviz-assimp-vendor 14.4.2-r1 --> 14.4.4-r1*
* *rviz-common 14.4.2-r1 --> 14.4.4-r1*
* *rviz-default-plugins 14.4.2-r1 --> 14.4.4-r1*
* *rviz-ogre-vendor 14.4.2-r1 --> 14.4.4-r1*
* *rviz-rendering 14.4.2-r1 --> 14.4.4-r1*
* *rviz-rendering-tests 14.4.2-r1 --> 14.4.4-r1*
* *rviz-visual-testing-framework 14.4.2-r1 --> 14.4.4-r1*
* *rviz2 14.4.2-r1 --> 14.4.4-r1*
* *sensor-msgs 5.4.2-r1 --> 5.5.0-r1*
* *sensor-msgs-py 5.4.2-r1 --> 5.5.0-r1*
* *shape-msgs 5.4.2-r1 --> 5.5.0-r1*
* *std-msgs 5.4.2-r1 --> 5.5.0-r1*
* *std-srvs 5.4.2-r1 --> 5.5.0-r1*
* *steering-controllers-library 4.21.0-r1 --> 4.22.0-r1*
* *stereo-msgs 5.4.2-r1 --> 5.5.0-r1*
* *test-ros-gz-bridge 2.1.5-r1 --> 2.1.6-r1*
* *trajectory-msgs 5.4.2-r1 --> 5.5.0-r1*
* *tricycle-controller 4.21.0-r1 --> 4.22.0-r1*
* *tricycle-steering-controller 4.21.0-r1 --> 4.22.0-r1*
* *ur 3.1.0-r1 --> 3.1.1-r1*
* *ur-calibration 3.1.0-r1 --> 3.1.1-r1*
* *ur-client-library 1.7.1-r1 --> 1.8.0-r1*
* *ur-controllers 3.1.0-r1 --> 3.1.1-r1*
* *ur-dashboard-msgs 3.1.0-r1 --> 3.1.1-r1*
* *ur-description 3.0.1-r1 --> 3.0.2-r1*
* *ur-moveit-config 3.1.0-r1 --> 3.1.1-r1*
* *ur-msgs 2.1.0-r1 --> 2.2.0-r1*
* *ur-robot-driver 3.1.0-r1 --> 3.1.1-r1*
* *velocity-controllers 4.21.0-r1 --> 4.22.0-r1*
* *visualization-msgs 5.4.2-r1 --> 5.5.0-r1*
* *xacro 2.0.12-r1 --> 2.0.13-r1*
* *zed-msgs 4.2.5-r1*
* *zenoh-cpp-vendor 0.4.0-r1 --> 0.5.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] autoware_utils
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] fastrtps_cmake_module
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

