### PR TITLE
Update Turtlebot3-gazebo example to use Humble distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ nix-shell \
   --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=' \
   '<nix-ros-overlay/examples/turtlebot3-gazebo.nix>'
 # If not on NixOS, nixGL (https://github.com/guibou/nixGL) is needed for OpenGL support
-roslaunch turtlebot3_gazebo turtlebot3_world.launch
+ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
 # Spawn a new nix-shell in a new terminal and then:
-roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
+ros2 run turtlebot3_teleop teleop_keyboard
 ```
 
 ### Flakes

--- a/distros/humble/overrides.nix
+++ b/distros/humble/overrides.nix
@@ -4,6 +4,15 @@ self:
 rosSelf: rosSuper: let
   inherit (rosSelf) lib;
 in with lib; {
+  # Many packages fail to compile with Boost 1.87
+  boost = rosSelf.boost186;
+
+  # Apply the same override as in distro-overlay.nix
+  boost186 = self.boost186.override {
+    python = rosSelf.python;
+    enablePython = true;
+  };
+
   cyclonedds = rosSuper.cyclonedds.overrideAttrs ({
     patches ? [], ...
   }: {
@@ -29,6 +38,12 @@ in with lib; {
   };
 
   gazebo = self.gazebo_11;
+
+  gazebo-ros = rosSuper.gazebo-ros.overrideAttrs ({
+    nativeBuildInputs ? [], ...
+  }: {
+    nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.qtbase ];
+  });
 
   google-benchmark-vendor = lib.patchExternalProjectGit rosSuper.google-benchmark-vendor {
     url = "https://github.com/google/benchmark.git";

--- a/examples/turtlebot3-gazebo.nix
+++ b/examples/turtlebot3-gazebo.nix
@@ -1,22 +1,19 @@
 # Run:
-# roslaunch turtlebot3_gazebo turtlebot3_world.launch
-# roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
+# ros2 launch turtlebot3_gazebo turtlebot3_world.launch.py
+# ros2 run turtlebot3_teleop teleop_keyboard
 
 { pkgs ? import ../. {} }:
 with pkgs;
-with rosPackages.noetic;
+with rosPackages.humble;
 with pythonPackages;
 
 mkShell {
   buildInputs = [
     glibcLocales
     (buildEnv { paths = [
-      rosbash
-      turtlebot3-description
+      ros-base
       turtlebot3-teleop
       turtlebot3-gazebo
-      gazebo-plugins
-      xacro
     ]; })
   ];
 


### PR DESCRIPTION
We changed the distro from Noetic to Humble for the Turtlebot3-gazebo example. While doing that, we found an error related to boost and Qt5, which we fixed and tested.