### PR TITLE
noetic.xacro: Propagate distutils

### DIFF
--- a/distros/noetic/overrides.nix
+++ b/distros/noetic/overrides.nix
@@ -310,6 +310,12 @@ in {
     }) ];
   });
 
+  xacro = rosSuper.xacro.overrideAttrs ({
+    propagatedBuildInputs ? [], ...
+  } : {
+    propagatedBuildInputs = propagatedBuildInputs ++ [ rosSelf.python3Packages.distutils ];
+  });
+
 })
 # distutils was removed from standard library in Python 3.12, but many packages
 # still depend on it.


### PR DESCRIPTION
Without this, `examples/turtlebot3-gazebo.nix` fails to run.

Fixes #610.