### PR TITLE
release.nix: Fix eval error when evaluating without arguments

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -14,8 +14,8 @@ in
 let
   pkgs = import nix-ros-overlay { inherit nixpkgs system; };
   inherit (pkgs.lib) isDerivation filterAttrs;
-  inherit (builtins) mapAttrs attrNames filter listToAttrs readDir;
-  cleanupDistro = (_: a: removeAttrs a [
+  inherit (builtins) mapAttrs attrNames filter listToAttrs readDir isAttrs;
+  cleanupDistro = (_: a: if !isAttrs a then a else removeAttrs a [
     "lib"
     "python"
     "python3"


### PR DESCRIPTION
Without this, when running `nix-eval-jobs release.nix`, the following error occurs early, preventing generating useful output:

    error:
       … while evaluating recurseForDerivations

       … while calling the 'removeAttrs' builtin
         at /home/wsh/src/ros/nix-ros-overlay/release.nix:18:26:
           17|   inherit (builtins) mapAttrs attrNames filter listToAttrs readDir;
           18|   cleanupDistro = (_: a: removeAttrs a [
             |                          ^
           19|     "lib"

       … while evaluating the first argument passed to builtins.removeAttrs

       error: expected a set but found a Boolean: true

With this change, `nix-eval-jobs release.nix` tries to evaluate all packages.