### PR TITLE
rosdistro sync, Fri Apr 11 13:54:49 2025

### DIFF
--- a/distros/humble/autoware-cmake/default.nix
+++ b/distros/humble/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-autoware-cmake";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_cmake/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "208d48aaf1436c5f296d853b85ab24c4459b34e902d9776087bc32a469f8b37f";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_cmake/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "34fbd12867d9b1375b48e3990b37963e8b0f9cddc2584a2738dab26c4182c3a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-common-msgs/default.nix
+++ b/distros/humble/autoware-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-autoware-common-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_common_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "8d272c206485d63de20a8d056874021830c7baaad2b4fdb353d59fef35a51b0f";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_common_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "52f92eaa69eae32d2e75d687fe92c5204f3f6a8bdb5bc9871d8e85885f0aa7ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-control-msgs/default.nix
+++ b/distros/humble/autoware-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-autoware-control-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_control_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "c06824bb1bb8fda26ef3e22005a423adf6d1ca96b151be30116d4a357ae5ec89";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_control_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "a1a8269de0e6ab6c0a71aac142eed79c3353b37d8b3fa56f7b98b644a1ff8cf9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-debug-msgs/default.nix
+++ b/distros/humble/autoware-internal-debug-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-debug-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_debug_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "8e4cb11d5b5dd53f99980ded1e3d76af70395cb5550a5a8c45b86acce6cbff87";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_debug_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "2fb8a975d0af5c13a158a1d14ff6d4bc0f97fa32f2afd1ddc4512c37081d8d9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-metric-msgs/default.nix
+++ b/distros/humble/autoware-internal-metric-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-humble-autoware-internal-metric-msgs";
+  version = "1.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_metric_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "840eec0ffc13d9db321b745022a9954d8d0b4f09a972a0ba1687a750de8d5621";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The autoware_internal_metric_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/autoware-internal-msgs/default.nix
+++ b/distros/humble/autoware-internal-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-internal-debug-msgs, autoware-internal-metric-msgs, autoware-internal-perception-msgs, autoware-internal-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "88ebc11d84470dc3cc65c266aaf9e2f9a68f2e44a01faba9992b357dc49209fc";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "c01fba24528f6a523913bce84a3eb8d5b481f1de6f720e7af1556d332928c205";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ autoware-internal-debug-msgs autoware-internal-metric-msgs autoware-internal-perception-msgs autoware-internal-planning-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {

--- a/distros/humble/autoware-internal-perception-msgs/default.nix
+++ b/distros/humble/autoware-internal-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-perception-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_perception_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "8a5b0468138a3f3a87c988851f94af1583b724e49019df0669373ff6405900e2";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_perception_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "168b42e96144d35f77a6bc6f8874c88f63ebd9b5d1c7ffb46428e4a77d4c0f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-internal-planning-msgs/default.nix
+++ b/distros/humble/autoware-internal-planning-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-internal-planning-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_planning_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "366512c41404fff72a02f2258de75b57caf670b1476e0f6d6c0620f19002f992";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/humble/autoware_internal_planning_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "11929fd9f99bff0755e265c9b1c20b386f1931d11fa11d3ff807f0b883b1d56d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ autoware-perception-msgs autoware-planning-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
+  propagatedBuildInputs = [ autoware-common-msgs autoware-perception-msgs autoware-planning-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/humble/autoware-lanelet2-extension-python/default.nix
+++ b/distros/humble/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension-python";
-  version = "0.6.3-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "40c0c3c523b3a81357c8af4aeeda357c62920e00696685b3a378081d5a3e502e";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension_python/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "a4def111897ddc7e568cd54c14182d6f89afd069ca0ef25f54c72a6fb2947813";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-lanelet2-extension/default.nix
+++ b/distros/humble/autoware-lanelet2-extension/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-lanelet2-extension";
-  version = "0.6.3-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "15d740fc79e4ad09acd5ccfad7bda99c105a0705cb31562d69f0854c0ae51046";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/humble/autoware_lanelet2_extension/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "cc63e96736e943f9576aa87d73dbc5c26f65ffaeb6c6d35082617ce1759c3a1d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto autoware-cmake ];
   checkInputs = [ ament-cmake-ros ];
-  propagatedBuildInputs = [ autoware-map-msgs autoware-planning-msgs autoware-utils geographiclib geometry-msgs lanelet2-core lanelet2-io lanelet2-maps lanelet2-projection lanelet2-routing lanelet2-traffic-rules lanelet2-validation pugixml range-v3 rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ autoware-map-msgs autoware-planning-msgs geographiclib geometry-msgs lanelet2-core lanelet2-io lanelet2-maps lanelet2-projection lanelet2-routing lanelet2-traffic-rules lanelet2-validation pugixml range-v3 rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-auto autoware-cmake ];
 
   meta = {

--- a/distros/humble/autoware-lint-common/default.nix
+++ b/distros/humble/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-humble-autoware-lint-common";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_lint_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "06420aec748a3ca645b184a3547cf885089d0110da2efccfc5eff871d8a707b5";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/humble/autoware_lint_common/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "262b7889eb35ff70c0697741724a0cecd9aaf7d86820c004f9abbe5e814194c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-localization-msgs/default.nix
+++ b/distros/humble/autoware-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-localization-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_localization_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "e90a52eea644253509637ac9d0f5c1de90f770af20051cfaf929dd689be67663";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_localization_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "691865e285874dbdfc216c372b1280cfe71ca0c6df8329d772b0c8b4a3e7faa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-map-msgs/default.nix
+++ b/distros/humble/autoware-map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-map-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_map_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "483d1e2a04aaf6864a253e219cc2c7d98d9927c47fd7a5e5ae70e4387f52f97f";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_map_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "087faff3271a9d1b43e876edde728c5e747c1a2e120c26e70a380370a65589af";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-msgs/default.nix
+++ b/distros/humble/autoware-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, autoware-common-msgs, autoware-control-msgs, autoware-localization-msgs, autoware-map-msgs, autoware-perception-msgs, autoware-planning-msgs, autoware-sensing-msgs, autoware-system-msgs, autoware-v2x-msgs, autoware-vehicle-msgs }:
+buildRosPackage {
+  pname = "ros-humble-autoware-msgs";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "0f2cee255678e052a73f8c8eb2db911ddb27dedc9f95b448b4c54c8a957110bf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ autoware-common-msgs autoware-control-msgs autoware-localization-msgs autoware-map-msgs autoware-perception-msgs autoware-planning-msgs autoware-sensing-msgs autoware-system-msgs autoware-v2x-msgs autoware-vehicle-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Meta package for the autoware_msgs packages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/autoware-perception-msgs/default.nix
+++ b/distros/humble/autoware-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-perception-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_perception_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "6e5f8a0af5ed941ef2b566e5eaa7e6c1e85b1fa8fecf8bc38307772a0dff8056";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_perception_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "d934ef8c0f06383a8a10a81107eecd67e16e822f8635de837d78905040e836a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-planning-msgs/default.nix
+++ b/distros/humble/autoware-planning-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-planning-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_planning_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "5a5463d51042d54cb87a5bd95dc1ea42f312c3a51d28aa41a006cf4ef64c00ed";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_planning_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "f54d00989bc0a967985cc1ef93e2452f0c41036b488675e0eaf5598c9632686a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-sensing-msgs/default.nix
+++ b/distros/humble/autoware-sensing-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-sensing-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_sensing_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "8ec93d22be1db5cfff3f9a1ba7533c731fa3251fcf4f7794dcbfc9d59f41a6cd";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_sensing_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "914fd0196e5459dc2fdc3200b0f82c3ec8ee585b301e4b401feee9dc67939676";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-system-msgs/default.nix
+++ b/distros/humble/autoware-system-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-system-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_system_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f33b7e7af4d5c7056924d119f343d18b75e3a521d77287dc2f4e77c3403a7723";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_system_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "b8fbafe72f26329fb9ccb7f9d0a6076aff219892e0caaf360a96e63d94206764";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-v2x-msgs/default.nix
+++ b/distros/humble/autoware-v2x-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-autoware-v2x-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_v2x_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "3bf8a305d2834d953a59b91066d456e405a09833147f27ed4f72ddc77e792c28";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_v2x_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "527e16527259017ba10be0c3ea0ada56b5102242d8bde32486d5d1f78a262395";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/autoware-vehicle-msgs/default.nix
+++ b/distros/humble/autoware-vehicle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-autoware-vehicle-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_vehicle_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "445320670f2f92dae9f4bbae2539a3e11b52773d0239dec77ecc51e058abc074";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/humble/autoware_vehicle_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "d9d5fbbb760e09e7afc65112f7f400036f311b984e9d215624b0133da979f101";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-mecanum-drive-controller/default.nix
+++ b/distros/humble/clearpath-mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-clearpath-mecanum-drive-controller";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_mecanum_drive_controller-release/archive/release/humble/clearpath_mecanum_drive_controller/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "842b373d7ed0563c9f61a427c89c66e00a740c2d5d05fb282571e335e790b4c5";
+    url = "https://github.com/clearpath-gbp/clearpath_mecanum_drive_controller-release/archive/release/humble/clearpath_mecanum_drive_controller/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "5ff432cb169481e05fd76ca38b11f38788787804af3384a1989b04d4791b6cd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/clearpath-ros2-socketcan-interface/default.nix
+++ b/distros/humble/clearpath-ros2-socketcan-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-clearpath-ros2-socketcan-interface";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/humble/clearpath_ros2_socketcan_interface/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "8b641f43251021a58af334f3bec0ec87f78a4a67cbd7c3337a68c8e6c2cbb1f4";
+    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/humble/clearpath_ros2_socketcan_interface/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "084e0e3967469d17637de1003a8aba623330cb6ebad4c05a49d76451f23650b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/control-toolbox/default.nix
+++ b/distros/humble/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
 buildRosPackage {
   pname = "ros-humble-control-toolbox";
-  version = "3.6.0-r1";
+  version = "3.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "57bbb412b8afff177d6896ddcf5e9ded01467b3c14dd50419124f991604f1db9";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/humble/control_toolbox/3.6.1-1.tar.gz";
+    name = "3.6.1-1.tar.gz";
+    sha256 = "1d8bd6fe084f2ab1435e11792fc079fe71660737182ec35533c4b27b04634f45";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-aggregator/default.nix
+++ b/distros/humble/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-aggregator";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "d65e4b76fc963f735c1eadecd425a20e33f76c0009a1db68726effbf5bb063a8";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_aggregator/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "af5b3169c9e725a2b6009f6184781192fe1b4b825894865c7479046fcf202057";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-common-diagnostics/default.nix
+++ b/distros/humble/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-common-diagnostics";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_common_diagnostics/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "629ddc2e92b2d7f809953ed187c628759a4b51f4e8098801b6848c838eae1bf7";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_common_diagnostics/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "f3921f257465852aae3dc610b00dca7040af949fa815ccde2f8e702710f41fb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diagnostic-remote-logging/default.nix
+++ b/distros/humble/diagnostic-remote-logging/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-humble-diagnostic-remote-logging";
+  version = "4.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_remote_logging/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "b7853761f4d9645413a994e4674dbb7b448286edebab5cedfc9862e43a51cb70";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake curl diagnostic-msgs rclcpp-components ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "diagnostic_remote_logging";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/humble/diagnostic-updater/default.nix
+++ b/distros/humble/diagnostic-updater/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-diagnostic-updater";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "3572e730c63c96c8f77a3b15186fb0827746de3b998c0d7526940f89db5c9232";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostic_updater/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "7ca16b17301bb39458bcc2d10894b04d59566b3646e84c9762dfc2fc138552b3";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python ];
+  buildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ros python3Packages.pytest rclcpp-lifecycle ];
   propagatedBuildInputs = [ diagnostic-msgs rclcpp rclpy std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
     description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";

--- a/distros/humble/diagnostics/default.nix
+++ b/distros/humble/diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-humble-diagnostics";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostics/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "c68afe325eed915c3eaf0efc16635eae76ca7bb168e24f74c80bbcea76bfa564";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/diagnostics/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "e6d7a6bc2f453e989d0e165a3a9a2d9453a478ffef209b00905812a1db4b654c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-hardware-interface/default.nix
+++ b/distros/humble/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-hardware-interface";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "d5af16d709aacbf52fb3b3a562d015bb6d5efad1fcc2b0a573a798e5c39177ea";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "3d591f073fb40d3f041a7837082c4a1b725dd7725a424edfaf51e4f4cb2b140f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -306,6 +306,8 @@ self: super: {
 
  autoware-internal-debug-msgs = self.callPackage ./autoware-internal-debug-msgs {};
 
+ autoware-internal-metric-msgs = self.callPackage ./autoware-internal-metric-msgs {};
+
  autoware-internal-msgs = self.callPackage ./autoware-internal-msgs {};
 
  autoware-internal-perception-msgs = self.callPackage ./autoware-internal-perception-msgs {};
@@ -321,6 +323,8 @@ self: super: {
  autoware-localization-msgs = self.callPackage ./autoware-localization-msgs {};
 
  autoware-map-msgs = self.callPackage ./autoware-map-msgs {};
+
+ autoware-msgs = self.callPackage ./autoware-msgs {};
 
  autoware-perception-msgs = self.callPackage ./autoware-perception-msgs {};
 
@@ -679,6 +683,8 @@ self: super: {
  diagnostic-common-diagnostics = self.callPackage ./diagnostic-common-diagnostics {};
 
  diagnostic-msgs = self.callPackage ./diagnostic-msgs {};
+
+ diagnostic-remote-logging = self.callPackage ./diagnostic-remote-logging {};
 
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
 
@@ -1182,6 +1188,8 @@ self: super: {
 
  gtsam = self.callPackage ./gtsam {};
 
+ gz-ros2-control-demos = self.callPackage ./gz-ros2-control-demos {};
+
  gz-ros2-control-tests = self.callPackage ./gz-ros2-control-tests {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
@@ -1227,6 +1235,8 @@ self: super: {
  iceoryx-posh = self.callPackage ./iceoryx-posh {};
 
  ifm3d-core = self.callPackage ./ifm3d-core {};
+
+ ign-ros2-control = self.callPackage ./ign-ros2-control {};
 
  ign-ros2-control-demos = self.callPackage ./ign-ros2-control-demos {};
 

--- a/distros/humble/gz-ros2-control-demos/default.nix
+++ b/distros/humble/gz-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-humble-gz-ros2-control-demos";
+  version = "0.7.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_demos/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "06ac4d63168d2573b0de81ea574bc523e1df88e8774078f0047ef2049da0aecb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-action ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "gz_ros2_control_demos";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/gz-ros2-control-tests/default.nix
+++ b/distros/humble/gz-ros2-control-tests/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, geometry-msgs, hardware-interface, ign-ros2-control, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, python3Packages, rclcpp, rclcpp-action, robot-state-publisher, ros-ign-gazebo, ros2controlcli, ros2launch, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, controller-manager, gz-ros2-control-demos, ign-ros2-control-demos, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, ros2launch, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-humble-gz-ros2-control-tests";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "c03ebfd589eb2e6d0a4cee3ca0975862ddb1a1c6df2ea940c7f5a9d089284c54";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/gz_ros2_control_tests/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "996f966c0f1e4833d7c1e581ddabec70a056159d7e02b121a8a183f300d5399d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rclcpp-action ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs geometry-msgs hardware-interface ign-ros2-control joint-state-broadcaster joint-trajectory-controller launch launch-ros launch-testing-ament-cmake python3Packages.psutil python3Packages.pytest rclcpp robot-state-publisher ros-ign-gazebo ros2controlcli ros2launch xacro ];
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-index-python ament-lint-auto ament-lint-common controller-manager gz-ros2-control-demos ign-ros2-control-demos launch launch-ros launch-testing-ament-cmake launch-testing-ros python3Packages.psutil python3Packages.pytest rclpy ros2launch rosgraph-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ign-ros2-control-demos/default.nix
+++ b/distros/humble/ign-ros2-control-demos/default.nix
@@ -2,25 +2,24 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, hardware-interface, ign-ros2-control, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-ign-gazebo, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, gz-ros2-control-demos, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-humble-ign-ros2-control-demos";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "fe383495be64effd982f4298af675700e610444f6740d4f978aae49b4a600f33";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control_demos/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "a9071572da638fddcd5119d4ad86eb3427ea590f3cac6f1a71d1bff8b316d273";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake rclcpp-action ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs hardware-interface ign-ros2-control imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros-gz-bridge ros-ign-gazebo ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-index-cpp gz-ros2-control-demos launch launch-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ign_ros2_control_demos";
+    description = "Shim package for gz_ros2_control_demos";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/humble/ign-ros2-control/default.nix
+++ b/distros/humble/ign-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gz-ros2-control }:
+buildRosPackage {
+  pname = "ros-humble-ign-ros2-control";
+  version = "0.7.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/humble/ign_ros2_control/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "d319d97811551ca6c72e76e77ada41e791945016827b12b840f1b6346acb82a4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ gz-ros2-control ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Ignition ros2_control package allows to control simulated robots using ros2_control framework.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/message-filters/default.nix
+++ b/distros/humble/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, builtin-interfaces, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-message-filters";
-  version = "4.3.6-r1";
+  version = "4.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.6-1.tar.gz";
-    name = "4.3.6-1.tar.gz";
-    sha256 = "8a3b96aab1487fc648f82147a18481453841c63e8f5df84d178713d3f394aaec";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/humble/message_filters/4.3.7-1.tar.gz";
+    name = "4.3.7-1.tar.gz";
+    sha256 = "6f91aea441efdf24cf907d304159b3031870eaae1bd1e99e8347800df93d4acc";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-can/default.nix
+++ b/distros/humble/off-highway-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, can-msgs, diagnostic-updater, rclcpp, ros2-socketcan-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-can";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_can/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "200d8df11660d3c2a816481c619ae4eeeffdbefd7d3de2d91e110ccbcf79f3f0";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_can/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "06c48876c9b37bbeeafeaf51df08e610e2bda0f5c4e364d06810edc3167ba71f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-general-purpose-radar-msgs/default.nix
+++ b/distros/humble/off-highway-general-purpose-radar-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-general-purpose-radar-msgs";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_general_purpose_radar_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "0e5d33dff30c17a700aab2c9aa609c18a4058841b096a2682c52e1bd14da8780";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_general_purpose_radar_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "671c6ac79cfa51d960c18c0a3dab38dae2d0432c8ee84924604feb88310be61f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = "The off_highway_general_purpose_radar_msgs package";

--- a/distros/humble/off-highway-general-purpose-radar/default.nix
+++ b/distros/humble/off-highway-general-purpose-radar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-general-purpose-radar-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-general-purpose-radar";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_general_purpose_radar/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "54ea7a4e1e46252e24829ffbad19fdb18cfee11653654ead370d4801c49e66d7";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_general_purpose_radar/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ba407ba23ab2f2cc4f227bbb6d2b0dcc870da88f2750082bf37354966d961cc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-premium-radar-sample-msgs/default.nix
+++ b/distros/humble/off-highway-premium-radar-sample-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-premium-radar-sample-msgs";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_premium_radar_sample_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "6be0ff3c78c562327870830d5b76d5c5ed106aa6c12621a79ea71bb819421dae";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_premium_radar_sample_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "197d197565d82306e34dfb3c9c6c501dfee2e7f0d3e04bf71bea269fc5713b23";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = "The off_highway_premium_radar_sample_msgs package";

--- a/distros/humble/off-highway-premium-radar-sample/default.nix
+++ b/distros/humble/off-highway-premium-radar-sample/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, diagnostic-updater, io-context, off-highway-premium-radar-sample-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-premium-radar-sample";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_premium_radar_sample/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "82219fcd0232db6bcaabbde7bd23d6ab9c64fc67f883b6aab319b61b17aade54";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_premium_radar_sample/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "f52f57d9a9cee293dae7264cd5398bb3d0637d052d9bd8dba4e78d99ca2bae35";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-radar-msgs/default.nix
+++ b/distros/humble/off-highway-radar-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-radar-msgs";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_radar_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "a61807e5780820575bc01f8a79cf3e62b66553284c4c5f2286112238218ba66e";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_radar_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "059e193e50bcd296fa3c7bb216fcfdb567865e3bdbd79b4d2b9471532a5daba4";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = "The off_highway_radar_msgs package";

--- a/distros/humble/off-highway-radar/default.nix
+++ b/distros/humble/off-highway-radar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-radar-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-radar";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_radar/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "f9452a4a3b29cc660444945640f2c29686927c6f1fd91261f4f1fc4c46685c8b";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_radar/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "f081c867339d9ab788c46fb5633b262eda4bc2374adb476bdd3747352c337bb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-sensor-drivers-examples/default.nix
+++ b/distros/humble/off-highway-sensor-drivers-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, off-highway-premium-radar-sample, off-highway-radar, pcl-ros, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-humble-off-highway-sensor-drivers-examples";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_sensor_drivers_examples/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "913229ef57a4179a3b35ad164ecaacdf2c4b18b2cf500474d501cfb5574dd49d";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_sensor_drivers_examples/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ea8af72be111cac1d2890290122f596da9d39662e590a764ce976cc0224eab99";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-sensor-drivers/default.nix
+++ b/distros/humble/off-highway-sensor-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, off-highway-can, off-highway-general-purpose-radar, off-highway-general-purpose-radar-msgs, off-highway-premium-radar-sample, off-highway-premium-radar-sample-msgs, off-highway-radar, off-highway-radar-msgs, off-highway-uss, off-highway-uss-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-sensor-drivers";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_sensor_drivers/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "f9e470acee18251090a3285547f2c48316054e62fbefac6a4ef2f1359d0e286e";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_sensor_drivers/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "d4808f481bc7d2adbe74c909c278d08bcef43eb7aae603b412280d9176b8f79e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/off-highway-uss-msgs/default.nix
+++ b/distros/humble/off-highway-uss-msgs/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-uss-msgs";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_uss_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "7a5966779b3eba2d646183f0f1a5e224a2ff151a6d0c96ecb126a4be70afccfc";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_uss_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "34106784d7613704c4bb02430fa0dcc839aa7e397c43707338d1c6d433fb4ffb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = "The off_highway_uss_msgs package";

--- a/distros/humble/off-highway-uss/default.nix
+++ b/distros/humble/off-highway-uss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, off-highway-can, off-highway-uss-msgs, pcl, pcl-conversions, pcl-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-off-highway-uss";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_uss/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "b58d206bfc41d8a61c1bf315ae4dd2117774363e5e6f52be3fc661928109ae6d";
+    url = "https://github.com/ros2-gbp/off_highway_sensor_drivers-release/archive/release/humble/off_highway_uss/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "de21b431b882469c03d2c2aae4a1cee8fd95051ab5063e8972ad8aa079a47901";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/realtime-tools/default.nix
+++ b/distros/humble/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-humble-realtime-tools";
-  version = "2.12.0-r1";
+  version = "2.13.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "d26f45c4d0d3f90e1de029a160ec665529ea618dd3d7776af15a32b5873617c2";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/humble/realtime_tools/2.13.0-1.tar.gz";
+    name = "2.13.0-1.tar.gz";
+    sha256 = "3df80d238b3d45b947d980f5086885e71324a0342401ff9f213c45ac72f5300b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/self-test/default.nix
+++ b/distros/humble/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-humble-self-test";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "4cce81a95d741c6541761907cc0b3b04e686e8eb955b0cbda76de323d678942f";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/humble/self_test/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "9bcde7c177aa3ef11c1bb4f3a0788b3710fa1abf2cccb5cc4d3bf6161788c955";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ament-package/default.nix
+++ b/distros/jazzy/ament-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-ament-package";
-  version = "0.16.3-r3";
+  version = "0.16.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/jazzy/ament_package/0.16.3-3.tar.gz";
-    name = "0.16.3-3.tar.gz";
-    sha256 = "6ca31466dc402c4871c704a75464e75e05785b412b602eb140125de8459b576f";
+    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/jazzy/ament_package/0.16.4-1.tar.gz";
+    name = "0.16.4-1.tar.gz";
+    sha256 = "3a23086f1bcb638cdad1a5cb6ad0075b79e3a184e9898210e21fa0ef2fa16a5b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/autoware-cmake/default.nix
+++ b/distros/jazzy/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-cmake";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_cmake/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "68b384fafc2b4a9784e83c2fc9e8af0aa8fb0bd9c049b1c168083c39280c3c8b";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_cmake/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "01e7bcb39dc1bcad676fba3a83883097f2c9f234e5f15302a85afed9bcccb9da";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-common-msgs/default.nix
+++ b/distros/jazzy/autoware-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-common-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_common_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "83e53486770f468f652e003fabd9b564d1ce033cd2bc6d8541a28570c0289f84";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_common_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "0228951d546ea85d33f31e2440e1585f90569266d43f0ee3d8bb4da830119034";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-control-msgs/default.nix
+++ b/distros/jazzy/autoware-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-control-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_control_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ae2ddd705b67733f3a876e814e8dec1949176e38634b786349c60d620d804cab";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_control_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "b147b36c1a2384c7664fd2d31a6af81e8802d0ac2c84313f18bf7b59e73c45f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-debug-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-debug-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-debug-msgs";
-  version = "1.5.0-r2";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_debug_msgs/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "6d923e50d4af5ce8caaeb1192062620410da314517b7dfa9711b5723f44407ec";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_debug_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "543e8587e50e0c72967f7a9a32b338d2e3051ee8a2408cbda347adf048969885";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-metric-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-metric-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-autoware-internal-metric-msgs";
+  version = "1.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_metric_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "91377b43cfca74a30b262b2dea5e748a333f6f47a43dfd953898b77ff1f1c757";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The autoware_internal_metric_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/autoware-internal-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-internal-debug-msgs, autoware-internal-metric-msgs, autoware-internal-perception-msgs, autoware-internal-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-msgs";
-  version = "1.5.0-r2";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_msgs/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "41491c13605b61ff28a881c5fbc6612951d390291c02ab5a4bc036bbae132622";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "8b47a29d9b176eefc601d4173ef08991cdc2839fc8f018bab065057cfbb79bce";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ autoware-internal-debug-msgs autoware-internal-metric-msgs autoware-internal-perception-msgs autoware-internal-planning-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {

--- a/distros/jazzy/autoware-internal-perception-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-perception-msgs";
-  version = "1.5.0-r2";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_perception_msgs/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "6226b46307420b1619d77e58588d9c72cbdf6cad1a77c51b7341b5799a4933a0";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_perception_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "df6d2631d17f932b8c8f64d9f07c29a208d098e576c60a87984e3dafcedce979";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-internal-planning-msgs/default.nix
+++ b/distros/jazzy/autoware-internal-planning-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-internal-planning-msgs";
-  version = "1.5.0-r2";
+  version = "1.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_planning_msgs/1.5.0-2.tar.gz";
-    name = "1.5.0-2.tar.gz";
-    sha256 = "6f3d73c10813a7036d1d2bf80318f088b9e801e74fbfe24eaafc566c13682bd2";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/jazzy/autoware_internal_planning_msgs/1.8.1-1.tar.gz";
+    name = "1.8.1-1.tar.gz";
+    sha256 = "55618a02b1d458fdba3f0108746740357d0ef578cc35df31dab7bb424a67abe7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ autoware-perception-msgs autoware-planning-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
+  propagatedBuildInputs = [ autoware-common-msgs autoware-perception-msgs autoware-planning-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/jazzy/autoware-lanelet2-extension-python/default.nix
+++ b/distros/jazzy/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lanelet2-extension-python";
-  version = "0.6.2-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension_python/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "3d1c51026183ec312c1c082f6e225fd54f9bf2598889e67f8ab90e088f506324";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension_python/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "d506c1a66342fb51d2e866927401a25609ccbc4d3635017228bb6f4880f6adff";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-lanelet2-extension/default.nix
+++ b/distros/jazzy/autoware-lanelet2-extension/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lanelet2-extension";
-  version = "0.6.2-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "e810dfee5461a99f731c6e3998b8538bdf7223c0ccffe76398838ce302f9528b";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/jazzy/autoware_lanelet2_extension/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "38c9a39c686cbb298efb1220e78f28a521b758c83228259319aff321e6415db0";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto autoware-cmake ];
   checkInputs = [ ament-cmake-ros ];
-  propagatedBuildInputs = [ autoware-map-msgs autoware-planning-msgs autoware-utils geographiclib geometry-msgs lanelet2-core lanelet2-io lanelet2-maps lanelet2-projection lanelet2-routing lanelet2-traffic-rules lanelet2-validation pugixml range-v3 rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ autoware-map-msgs autoware-planning-msgs geographiclib geometry-msgs lanelet2-core lanelet2-io lanelet2-maps lanelet2-projection lanelet2-routing lanelet2-traffic-rules lanelet2-validation pugixml range-v3 rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-auto autoware-cmake ];
 
   meta = {

--- a/distros/jazzy/autoware-lint-common/default.nix
+++ b/distros/jazzy/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-lint-common";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_lint_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "8a8e36cc9fb338341aaca34724f1965e07869431ae98bb49686565ef7217c358";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/jazzy/autoware_lint_common/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "7eaa57ae240f43f86a197125e51e0503edf0c2966a42cf919b9cc53c3df615ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-localization-msgs/default.nix
+++ b/distros/jazzy/autoware-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-localization-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_localization_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "25e9a3a836902250c8e06b0971ea2d4bc4e4cf52b4d1b76f6cf45a724eff92f9";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_localization_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "9b1911a90ceefdc805d66b9edd96fc355eadaf7e13a013931bdeba0eba665b80";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-map-msgs/default.nix
+++ b/distros/jazzy/autoware-map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-map-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_map_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "42b2d522afd9f0b8b85c4e361d19ecbbed8b402ca3ea6e3d6ad6128bd30dd02e";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_map_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "c7d6ddf8689d681a4f0b681458c0628a5e2bf60cf283c08bd5df2da2c1bd201f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-msgs/default.nix
+++ b/distros/jazzy/autoware-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, autoware-common-msgs, autoware-control-msgs, autoware-localization-msgs, autoware-map-msgs, autoware-perception-msgs, autoware-planning-msgs, autoware-sensing-msgs, autoware-system-msgs, autoware-v2x-msgs, autoware-vehicle-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-autoware-msgs";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "6c44956bab5e34168dbad41f6a0264846ddd2ece8011fa2e09a7a37246a24209";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ autoware-common-msgs autoware-control-msgs autoware-localization-msgs autoware-map-msgs autoware-perception-msgs autoware-planning-msgs autoware-sensing-msgs autoware-system-msgs autoware-v2x-msgs autoware-vehicle-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Meta package for the autoware_msgs packages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/autoware-perception-msgs/default.nix
+++ b/distros/jazzy/autoware-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-perception-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_perception_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "9faec675f48b65f0264a3701d15695408fa3d7b77ac190a289880c541d04da34";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_perception_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "46df1227589e14484c8e6485bf61112cda1525641eeda41f5c67f416560cefe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-planning-msgs/default.nix
+++ b/distros/jazzy/autoware-planning-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-planning-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_planning_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "199ee1bec9a164f7ee018150c6eb34b465d1872ba7d776c94d13b07ded6e0c03";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_planning_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "65ddc058d846910449f4efa39913456bf9b4d37016c23a7fca5a5e6e7eddd3c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-sensing-msgs/default.nix
+++ b/distros/jazzy/autoware-sensing-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-sensing-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_sensing_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "21d1995f6ea237382bfb1a3502a9a1410e58a50fee379aa9d13b929d14cee25c";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_sensing_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "b509f1781271e8fff2bafe257ea29a62fc3f863c8e68f64b5726f559bcadf98f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-system-msgs/default.nix
+++ b/distros/jazzy/autoware-system-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-system-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_system_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "5588918b3707c696f586ca6b1908724b15efc6d45baf43a512b301a763e633a1";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_system_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "2bc85f87fa7d3e6cc34a333c2d94ad2d6de9b35e309b91ea04cdfb341f95544d";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-v2x-msgs/default.nix
+++ b/distros/jazzy/autoware-v2x-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-v2x-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_v2x_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "705f77af1504d7d2cfbbd7d312b76bc4173d6619ea60fde8b8a90a2f2de40695";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_v2x_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "b281faba965ce995a230c9421528aae9b6ed61c6fb1aefd360d3ca5745592f84";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/autoware-vehicle-msgs/default.nix
+++ b/distros/jazzy/autoware-vehicle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-autoware-vehicle-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_vehicle_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "b7b3b15278a07c230ed285332066f9fff0f9c1694e7ff1096ca422ac60b1124b";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/jazzy/autoware_vehicle_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "ec8332c771e1fc1a05539a78b6f1ecae324614310d4ec11179567dae1faa1fee";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/camera-calibration-parsers/default.nix
+++ b/distros/jazzy/camera-calibration-parsers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-camera-calibration-parsers";
-  version = "5.1.5-r1";
+  version = "5.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_calibration_parsers/5.1.5-1.tar.gz";
-    name = "5.1.5-1.tar.gz";
-    sha256 = "4bb91c757ab42de1b30104f29b4e2a366b173b94838a16c202a3954a5abe8fd4";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_calibration_parsers/5.1.6-1.tar.gz";
+    name = "5.1.6-1.tar.gz";
+    sha256 = "a5194fbf4af7b3d24e74b731b999fa3fc7e2549490e2dad3fb19a3ddc71f3221";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/camera-info-manager-py/default.nix
+++ b/distros/jazzy/camera-info-manager-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, python3Packages, rclpy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-info-manager-py";
-  version = "5.1.5-r1";
+  version = "5.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager_py/5.1.5-1.tar.gz";
-    name = "5.1.5-1.tar.gz";
-    sha256 = "b60c5cb07b54818a8dcca4c0aad36bc38790a1496405990e3f3c54fc85ac7882";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager_py/5.1.6-1.tar.gz";
+    name = "5.1.6-1.tar.gz";
+    sha256 = "d72957c2899b0d5ca05590aa111b0d14de63f3729aaf9c9064f45344bb906b60";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/camera-info-manager/default.nix
+++ b/distros/jazzy/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, camera-calibration-parsers, rclcpp, rclcpp-lifecycle, rcpputils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-camera-info-manager";
-  version = "5.1.5-r1";
+  version = "5.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager/5.1.5-1.tar.gz";
-    name = "5.1.5-1.tar.gz";
-    sha256 = "11a4db7ac93ea393b21594ef41f2e6c66dc8729c4c1507f168dfc9381f3ebf19";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/camera_info_manager/5.1.6-1.tar.gz";
+    name = "5.1.6-1.tar.gz";
+    sha256 = "9412a0a6956d5d3931743e8d5157f83603f373daf4a97a310b4ba03498e10bdd";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0a23f4f6a42494d9bb5bdda2780516a67bca7354ebeaeab09eb42a4109a2a6e7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "b84c7026ab9d3f69d873e4faa61709c9495baf5071be17ca6d53500de51facf8";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "65e382490c67d7a9f2dee673ad00160511227c150f69ad2ccb94be94f5ccdc2a";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "4173afa194f60318f569c450c585e2d5cff9ee62ee7734297b15999ba28ebaa8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "1eaa4a9ff5399ca72eafba9e9d210809ce5300c1e585c672c5fe7f358eab2274";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "2d26d9f580d4a81f9906c7adbe1ad29388a3c3542871c73840f0fe53be00c79c";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "1cf55170cce77537aa49be4af2c58cee6e798dd66660efe793f2ddde59dd9b10";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "de8fe147526a32e1e2f4ec1b202074d244802d121c0fc5dde158b897f5e60ff7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "41f0fd564cd77fc8029b7bfc5cd346aa8b2411253fa7a5fa4cd5906b8763a5b2";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "471e82da63bf4357fcf1b9adf69b9609674207bb7585cb423f9ded95f31956a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d90e67ffd511465f6eaeeadfd9f56cd5f3c0ced86932e1f619ed760e8597551e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "34a051c579948557c564a312c562c2042f7f24aa079b1f6cf8e3664238ec2f91";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "37183d2359f2120d86e0b9b54a6ef0d2b99f61fb5bba1561ec85d3c14d0f5489";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "a099dd638bfa923690e02670e3e29d34a02f446bb249c701693372af649da150";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a2ea3c29c0d2f5b2fea6e5a44fbb73f7e526128d59b6702c806eba3ec8311bb3";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "1b2cb0b426d9974fef828156395b31c84925c1fcf2276006e43cfa419db2c967";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "731734d0b909d7d04b7c04aaedcbfb4b65d0ce305387ed69ba55fe9706500c1e";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "356dc8ba62795532d2ff25a5cf1cf1a8fb2d0d3c7f5dfe0f23b755aa4ed20595";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "7879f731495683b6b7f63f6e3ab27f6f9786f8cb651bdf9b02ef6042a8c0c640";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "394eec59e07e710c75454a3165a52cbddbab8651f125f9ba7635919bacf63b60";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-ros2-socketcan-interface/default.nix
+++ b/distros/jazzy/clearpath-ros2-socketcan-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, can-msgs, iproute2, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-ros2-socketcan-interface";
-  version = "2.1.0-r1";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/jazzy/clearpath_ros2_socketcan_interface/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "58e54d6f5ab78356fc6cd754c3ff211ca1217f24a5ab1376d37a61521749173d";
+    url = "https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release/archive/release/jazzy/clearpath_ros2_socketcan_interface/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "54f19c1ee7c6d9bc1b7f5525873a4b27b225e4026f06131f3b7e3dd490de351b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.2.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "119bf02902011b53299b259fdb2be2ed1455908c8b7be806ff182884f5ea2e12";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "2b72d8eb6810647a8d65b080ab53a94f19532a61b5bb0ea4b235b0bbfb6c63f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-tests/default.nix
+++ b/distros/jazzy/clearpath-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, can-utils, clearpath-config, clearpath-generator-common, clearpath-motor-msgs, clearpath-platform-msgs, diagnostic-msgs, geometry-msgs, nav-msgs, rclpy, sensor-msgs, simple-term-menu-vendor, std-msgs, stress, tf-transformations, tf2-geometry-msgs, tf2-msgs, wireless-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-tests";
-  version = "0.2.9-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/0.2.9-1.tar.gz";
-    name = "0.2.9-1.tar.gz";
-    sha256 = "bb7b9c6c62326967f57f8a9417bce2198291cca047a3548e15dfdb83a02d2e4c";
+    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "480675486ac01065213ea5c9e1d2440e525afb319154dabe1356d749c5a28ee1";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/control-toolbox/default.nix
+++ b/distros/jazzy/control-toolbox/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-control-toolbox";
-  version = "4.0.1-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "d8127cbca82e54888b3e08666a553ffe4b30513c88f3a4a4aef8060c869e9f29";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/jazzy/control_toolbox/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "c59b035083e7f115756e54bdf47ff2f3af99aec876632571a5c60b508f5c198c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest rclcpp-lifecycle ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock rclcpp-lifecycle ];
   propagatedBuildInputs = [ control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/diagnostic-aggregator/default.nix
+++ b/distros/jazzy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-pytest, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rcl-interfaces, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-aggregator";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_aggregator/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "20da3a2fcda11977e224b2b31738c9d19cf40e4d09f51803836e38ef26451a8b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_aggregator/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "d06f7bdf082b3cbe66649890b84df1ac967a4aef8277fee7777b5c9d20ba5d34";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diagnostic-common-diagnostics/default.nix
+++ b/distros/jazzy/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-pytest, ament-cmake-python, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, launch-testing-ament-cmake, lm_sensors, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-common-diagnostics";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_common_diagnostics/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "d8a715bce992e033627c35d9a9323c17f027fb365e02da4141811fab6e484975";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_common_diagnostics/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "fa78b7063941dc72a2ea8cf56df77b9d65c711de3987171a507bf93f3e820cd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/diagnostic-remote-logging/default.nix
+++ b/distros/jazzy/diagnostic-remote-logging/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, curl, diagnostic-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-jazzy-diagnostic-remote-logging";
+  version = "4.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_remote_logging/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "347121c90cc6fc61d2d9b2e349bfe1f1c268de342bf9bd2a681079dddad81810";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake curl diagnostic-msgs rclcpp-components ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "diagnostic_remote_logging";
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/distros/jazzy/diagnostic-updater/default.nix
+++ b/distros/jazzy/diagnostic-updater/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch, launch-testing, launch-testing-ros, python3Packages, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostic-updater";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_updater/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "a672945e52024daf6e8ae01b76a6065fac346ed10dd9a67e891e50eecbed7fbc";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostic_updater/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "6a40833d4d3d825e7790971adda3d2c3e00bd4269dc20afdad86d292d0d88d62";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-python ];
+  buildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ros python3Packages.pytest rclcpp-lifecycle ];
   propagatedBuildInputs = [ diagnostic-msgs rclcpp rclpy std-msgs ];
-  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ament-cmake-ros ];
 
   meta = {
     description = "diagnostic_updater contains tools for easily updating diagnostics. it is commonly used in device drivers to keep track of the status of output topics, device status, etc.";

--- a/distros/jazzy/diagnostics/default.nix
+++ b/distros/jazzy/diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-aggregator, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-jazzy-diagnostics";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostics/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "ca9c25a87cc3fb5cbdc8477a5fb2a42de9dd83d7f4f28ee5df88d21ba4205349";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/diagnostics/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "94d21058a7f2d8c5a8db5bd12a4337565794f6e71c8b68b4e91796d6df8203cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/dynamixel-hardware-interface/default.nix
+++ b/distros/jazzy/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-hardware-interface";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "6f58ecc7682cee4a9eab191959ce0053239ad16248dd1c4ab78cd5a2549cbed2";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "235d063cdc83c90d315964781866eaf684b48cb83427f6061c72c848a9f729d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -210,11 +210,15 @@ self: super: {
 
  autoware-internal-debug-msgs = self.callPackage ./autoware-internal-debug-msgs {};
 
+ autoware-internal-metric-msgs = self.callPackage ./autoware-internal-metric-msgs {};
+
  autoware-internal-msgs = self.callPackage ./autoware-internal-msgs {};
 
  autoware-internal-perception-msgs = self.callPackage ./autoware-internal-perception-msgs {};
 
  autoware-internal-planning-msgs = self.callPackage ./autoware-internal-planning-msgs {};
+
+ autoware-lanelet2-extension = self.callPackage ./autoware-lanelet2-extension {};
 
  autoware-lanelet2-extension-python = self.callPackage ./autoware-lanelet2-extension-python {};
 
@@ -223,6 +227,8 @@ self: super: {
  autoware-localization-msgs = self.callPackage ./autoware-localization-msgs {};
 
  autoware-map-msgs = self.callPackage ./autoware-map-msgs {};
+
+ autoware-msgs = self.callPackage ./autoware-msgs {};
 
  autoware-perception-msgs = self.callPackage ./autoware-perception-msgs {};
 
@@ -521,6 +527,8 @@ self: super: {
  diagnostic-common-diagnostics = self.callPackage ./diagnostic-common-diagnostics {};
 
  diagnostic-msgs = self.callPackage ./diagnostic-msgs {};
+
+ diagnostic-remote-logging = self.callPackage ./diagnostic-remote-logging {};
 
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
 
@@ -1018,6 +1026,8 @@ self: super: {
 
  hash-library-vendor = self.callPackage ./hash-library-vendor {};
 
+ hatchbed-common = self.callPackage ./hatchbed-common {};
+
  heaphook = self.callPackage ./heaphook {};
 
  hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
@@ -1174,6 +1184,8 @@ self: super: {
 
  laser-proc = self.callPackage ./laser-proc {};
 
+ laser-segmentation = self.callPackage ./laser-segmentation {};
+
  launch = self.callPackage ./launch {};
 
  launch-param-builder = self.callPackage ./launch-param-builder {};
@@ -1263,6 +1275,8 @@ self: super: {
  lifecycle-py = self.callPackage ./lifecycle-py {};
 
  linux-isolate-process = self.callPackage ./linux-isolate-process {};
+
+ log-view = self.callPackage ./log-view {};
 
  logging-demo = self.callPackage ./logging-demo {};
 

--- a/distros/jazzy/gz-ros2-control-demos/default.nix
+++ b/distros/jazzy/gz-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control-demos";
-  version = "1.2.11-r1";
+  version = "1.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.11-1.tar.gz";
-    name = "1.2.11-1.tar.gz";
-    sha256 = "e3001448c7c9b18b42e9f4ef4cd5e3ae771c0c7190321458629a386ff349379b";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control_demos/1.2.12-1.tar.gz";
+    name = "1.2.12-1.tar.gz";
+    sha256 = "ed9e79ec809e22e3dbb4e1166a96a78931cb2c748aa055e5dbb24cd6815b6c3f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/gz-ros2-control/default.nix
+++ b/distros/jazzy/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-gz-ros2-control";
-  version = "1.2.11-r1";
+  version = "1.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.11-1.tar.gz";
-    name = "1.2.11-1.tar.gz";
-    sha256 = "f1f59f6bca12705f79cf4947707fd44907dbadfc0bf08eff0c2e4a52440136ac";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/jazzy/gz_ros2_control/1.2.12-1.tar.gz";
+    name = "1.2.12-1.tar.gz";
+    sha256 = "18194de8e2ee780cb5b81bee44f966f34a42d0fb1c0db2fbfe15c0ee038c0890";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/hatchbed-common/default.nix
+++ b/distros/jazzy/hatchbed-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
+buildRosPackage {
+  pname = "ros-jazzy-hatchbed-common";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/hatchbed_common-release/archive/release/jazzy/hatchbed_common/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "bb530931876fb9a5aaca45025671e3468ecfb9c852eeeabedd61390d8a15a482";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Common Hatchbed C++ utility code for ROS, such registering and handling updates to ros parameters.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/image-common/default.nix
+++ b/distros/jazzy/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, camera-info-manager, image-transport }:
 buildRosPackage {
   pname = "ros-jazzy-image-common";
-  version = "5.1.5-r1";
+  version = "5.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_common/5.1.5-1.tar.gz";
-    name = "5.1.5-1.tar.gz";
-    sha256 = "e48290e46adcefe898aea159574d6841344447476e9623bef857fcd8debef46c";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_common/5.1.6-1.tar.gz";
+    name = "5.1.6-1.tar.gz";
+    sha256 = "1d5dc2ad0e001c8111e1757f19c60c6200b67e1e66d63fbc83bc93a36abec580";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/image-transport/default.nix
+++ b/distros/jazzy/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-image-transport";
-  version = "5.1.5-r1";
+  version = "5.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_transport/5.1.5-1.tar.gz";
-    name = "5.1.5-1.tar.gz";
-    sha256 = "46de2bc5d05d427847e11cf952ce455823d3bff754c78ef7bf1df883e04304b8";
+    url = "https://github.com/ros2-gbp/image_common-release/archive/release/jazzy/image_transport/5.1.6-1.tar.gz";
+    name = "5.1.6-1.tar.gz";
+    sha256 = "4425bae8086c4a79cab3a69e39a5c798f69a5ed5216ec9924763eb9a61babb08";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/laser-segmentation/default.nix
+++ b/distros/jazzy/laser-segmentation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, slg-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-laser-segmentation";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/laser_segmentation-release/archive/release/jazzy/laser_segmentation/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "7afa9eef0378d70a976724e7136e4d792f057cc27feecdf94cb4dae1b973b88d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs slg-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Implementation of algorithms for segmentation of laserscans.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/libcurl-vendor/default.nix
+++ b/distros/jazzy/libcurl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-vendor-package, curl, file, pkg-config }:
 buildRosPackage {
   pname = "ros-jazzy-libcurl-vendor";
-  version = "3.4.3-r1";
+  version = "3.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/jazzy/libcurl_vendor/3.4.3-1.tar.gz";
-    name = "3.4.3-1.tar.gz";
-    sha256 = "45541f14c0f47e3d463162e99b41d3ebb693d5c9cad02bb6f7e62d0b9bf0fbc1";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/jazzy/libcurl_vendor/3.4.4-1.tar.gz";
+    name = "3.4.4-1.tar.gz";
+    sha256 = "0db91a33f56f91824cc5f76f91a3c01598593e9bc65354825489b6eacfc078e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/log-view/default.nix
+++ b/distros/jazzy/log-view/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ncurses, rcl-interfaces, rclcpp, xclip }:
+buildRosPackage {
+  pname = "ros-jazzy-log-view";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/log_view-release/archive/release/jazzy/log_view/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "9effcbe235a12a10560ce76d9fe804c7258bef8fb4b296413c44a0dae7730969";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ncurses rcl-interfaces rclcpp xclip ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The log_view package provides a ncurses based terminal GUI for
+    viewing and filtering published ROS log messages.
+
+    This is an alternative to rqt_console and swri_console that doesn't depend
+    on qt and can be run directly in a terminal.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/mp2p-icp/default.nix
+++ b/distros/jazzy/mp2p-icp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, mola-common, mrpt-libbase, mrpt-libgui, mrpt-libmaps, mrpt-libobs, mrpt-libposes, mrpt-libtclap, ros-environment, tbb_2021_11 }:
 buildRosPackage {
   pname = "ros-jazzy-mp2p-icp";
-  version = "1.6.6-r1";
+  version = "1.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.6-1.tar.gz";
-    name = "1.6.6-1.tar.gz";
-    sha256 = "4970463f7c44e12138d2cb23481ae72efcb7fca0cbd1828456468aff6e450563";
+    url = "https://github.com/ros2-gbp/mp2p_icp-release/archive/release/jazzy/mp2p_icp/1.6.7-1.tar.gz";
+    name = "1.6.7-1.tar.gz";
+    sha256 = "c7a43bad2457a351d3e5748e477717009949697e4aace035c3ce7b0c5febb1d5";
   };
 
   buildType = "cmake";

--- a/distros/jazzy/osrf-pycommon/default.nix
+++ b/distros/jazzy/osrf-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-osrf-pycommon";
-  version = "2.1.5-r1";
+  version = "2.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/jazzy/osrf_pycommon/2.1.5-1.tar.gz";
-    name = "2.1.5-1.tar.gz";
-    sha256 = "1fecd245ff189e8c0867f804593f7c1ed1e31714f25491949e3a403dd1c77fbf";
+    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/jazzy/osrf_pycommon/2.1.6-1.tar.gz";
+    name = "2.1.6-1.tar.gz";
+    sha256 = "28204dc7a7a9329cbe0f3c55361754f5d39aeaf7c3fb62de7ed2529e79ebe5fe";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/point-cloud-transport-py/default.nix
+++ b/distros/jazzy/point-cloud-transport-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, pluginlib, point-cloud-transport, pybind11-vendor, python-cmake-module, rclcpp, rpyutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-point-cloud-transport-py";
-  version = "4.0.3-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport_py/4.0.3-1.tar.gz";
-    name = "4.0.3-1.tar.gz";
-    sha256 = "31df9c16f7936a4729cb8285443b5e6fa7a216f22e4bc780f6164d16c594dfa4";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport_py/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "5372cd25040b39a93b09add1fe054edd2109194265b66fd29af81148b3543091";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/point-cloud-transport/default.nix
+++ b/distros/jazzy/point-cloud-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, message-filters, pluginlib, rclcpp, rclcpp-components, rcpputils, rmw, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-point-cloud-transport";
-  version = "4.0.3-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport/4.0.3-1.tar.gz";
-    name = "4.0.3-1.tar.gz";
-    sha256 = "c4c6587fe5d858da79fb7849fe36080ae8ff0fab59821882c69fa9b14aee64b3";
+    url = "https://github.com/ros2-gbp/point_cloud_transport-release/archive/release/jazzy/point_cloud_transport/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "eeffd10ff5ace78fa0fd1f6c7700e5f4a9d12839a2c2853a18a2c8c84e42fcb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/realtime-tools/default.nix
+++ b/distros/jazzy/realtime-tools/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-realtime-tools";
-  version = "3.4.0-r1";
+  version = "3.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "ca810261195c529bcdb17775fae3feb39dd5ad1f22dfded51adf2c8bfcb1be2b";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/jazzy/realtime_tools/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "7838391c616c0bddee4a989edb57113ec6ec4a8a80fe998dad2488b8e5e88315";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock lifecycle-msgs rclcpp-lifecycle test-msgs ];
   propagatedBuildInputs = [ ament-cmake boost libcap rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/resource-retriever/default.nix
+++ b/distros/jazzy/resource-retriever/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, libcurl-vendor, python-cmake-module, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-resource-retriever";
-  version = "3.4.3-r1";
+  version = "3.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/jazzy/resource_retriever/3.4.3-1.tar.gz";
-    name = "3.4.3-1.tar.gz";
-    sha256 = "207b90e62b2a8c8f42a73f07a1d84a11192009fe03f8db5ae7a1af9ba9e3ab7c";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/jazzy/resource_retriever/3.4.4-1.tar.gz";
+    name = "3.4.4-1.tar.gz";
+    sha256 = "a9cae73b48692d434e92160943351510e6f8b451f1d2aca4768e4ab6b50627ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/self-test/default.nix
+++ b/distros/jazzy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, ros-environment }:
 buildRosPackage {
   pname = "ros-jazzy-self-test";
-  version = "4.2.2-r1";
+  version = "4.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/self_test/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "1a6390665c94f66879a2bdd7dd3a67ae7386fb033e5fc1df7e5ecaa7b3baa5ba";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/jazzy/self_test/4.2.3-1.tar.gz";
+    name = "4.2.3-1.tar.gz";
+    sha256 = "1cec7ca69d86e76fde08cca730ff5f4648ec25d4238f2040b259389e54b57f28";
   };
 
   buildType = "ament_cmake";

--- a/distros/noetic/abb-crb15000-support/default.nix
+++ b/distros/noetic/abb-crb15000-support/default.nix
@@ -1,0 +1,59 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-crb15000-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_crb15000_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "18f4a0bcab3e0ded3b06e9ed52f54beab5a8f63c768ada140af37c8d3fc4e6c5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB GoFa CRB 15000 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB GoFa CRB 15000 manipulators. This currently includes the
+      CRB 15000-5/0.95 and CRB 15000-12/1.27 variants.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <em>ABB CRB 15000 Datasheet</em>, document ID: <em>TODO, Feb 2021</em> for
+      the CRB 15000-5/0.95. For CRB 15000-12/1.27, they are based on the
+      information in <em>ABB CRB 15000 Product manual</em>, document ID:
+      <em>3HAC077389-001, Rev. P</em>.
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Note 1: the CRB 15000-5/0.95 is an early conversion from CAD data
+      downloaded from ABB's library with geometry and kinematics partially
+      based on the GoFa datasheet.
+      There may be conversion errors and other deviations from the real robot.
+    </p>
+    <p>
+      Note 2: this support package does not currently include launch files for
+      loading a driver, as no driver has been tested with OmniCore controllers
+      and/or CRB 15000 robots yet.
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb120-support/default.nix
+++ b/distros/noetic/abb-irb120-support/default.nix
@@ -1,0 +1,51 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb120-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb120_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b15721b4c15a109c3db1454d1815115c57c91d25a3ea5927caf73c925974c872";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 120 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 120 manipulators. This includes the base model (120) and
+      the 120T.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"http://new.abb.com/products/robotics/industrial-robots/irb-120/irb-120-data\">
+      ABB IRB 120 technical data sheet</a> (Version: ROB0149EN_D, May 2012).
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Inertial and mass properties were calculated using 3D modelling software, based on the 
+      supplied <a href=\"http://new.abb.com/products/robotics/industrial-robots/irb-120/irb-120-cad\">
+      ABB IRB 120 CAD model</a>.
+    </p> 
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb1200-support/default.nix
+++ b/distros/noetic/abb-irb1200-support/default.nix
@@ -1,0 +1,58 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb1200-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb1200_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "02839d4dc3e844cb4f0740159691a5577eca8cf213a9b348efb47c56b8c6b422";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 1200 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 1200 manipulators. This currently includes the IRB 1200-5/0.9
+      and the IRB 1200-7/0.7 variants.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <em>ABB IRB 1200 Datasheet</em>, document ID: <em>ROB0275EN_A, Sept 2016</em>.
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Note 1: inertial and dynamics values for the 5/0.9 variant were calculated
+      from the meshes using <em>Meshlab</em>, assuming constant density.
+      As the datasheet only provides the mass of the entire robot,
+      the mass of each link was estimated based on its volume, assuming
+      constant density for the entire robot.
+    </p>
+    <p>
+      Note 2: maximum joint effort values for the 5/0.9 variant do not
+      correspond to real world limits of the robot. The current values were
+      chosen to accomodate Gazebo simulations of this specific variant but
+      are fictional values.
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb1600-support/default.nix
+++ b/distros/noetic/abb-irb1600-support/default.nix
@@ -1,0 +1,46 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb1600-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb1600_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ff1da3591bac5aa59ade9d5ebe1e5883bbff28df87943e81ff9ae5022964a335";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 1600 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 1600 manipulators. This package includes the 6kg 1.2m
+      and the 8kg and 10kg 1.45m versions.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in
+      <em>ABB Product specification - IRB 1600/1660ID</em>, document ID:
+      <em>3HAC023604-001, Rev AQ</em>.
+      All URDFs / XACROs are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb2400-support/default.nix
+++ b/distros/noetic/abb-irb2400-support/default.nix
@@ -1,0 +1,48 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb2400-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb2400_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "22d18010c93e1f7bdcc14ce6f17fce5eaa13af8bb715a322fd50ad96dfc36c0f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 2400 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 2400 manipulators. This currently includes the base model.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in
+      the ABB data sheets.  All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p>
+      The unqualified IRB 2400 model will be removed in ROS-Lunar, please
+      use the IRB 2400-12/1.55 as a replacement.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb2600-support/default.nix
+++ b/distros/noetic/abb-irb2600-support/default.nix
@@ -1,0 +1,49 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb2600-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb2600_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "53b294470d914329e633b8213e28f3ab056931893821f0bde93746c35d1503b6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 2600 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 2600 manipulators. This currently includes the IRB 2600-12/1.65
+      (20/1.65) and the IRB 2600-12/1.85. Variants listed in parenthesis may use
+      the files of the preceding model.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"http://new.abb.com/products/robotics/industrial-robots/irb-2600/irb-2600-data\">
+      ABB IRB 2600 technical data sheet</a> (Version: ROB0142EN_B, October
+      2010) and the <em>ABB Product specification IRB 2600</em>, document ID:
+      <em>3HAC035959-001, Rev. AE</em> for the IRB 2600-12/1.85 variant.
+      All urdfs / xacros are based on the default motion and joint
+      velocity limits, unless noted otherwise (ie: no support for high speed
+      joints, extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb4400-support/default.nix
+++ b/distros/noetic/abb-irb4400-support/default.nix
@@ -1,0 +1,45 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb4400-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb4400_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "a86b98d720cc36325f064fb0ca4c48a04567dbd3121a3e260e51f7da70887798";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 4400 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 4400 manipulators. This currently includes the L30.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"http://www05.abb.com/global/scot/scot352.nsf/veritydisplay/c90b98aaa057bd6ec12576cb00528ef6/$file/Product%20specification%204400%20M99%20BWOS3.2.pdf\">
+      ABB IRB 4400 product specification document</a> (Article No: 3HAC 8770-1).
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb4600-support/default.nix
+++ b/distros/noetic/abb-irb4600-support/default.nix
@@ -1,0 +1,45 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb4600-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb4600_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "bfbcaa8cc3bb21937364d1bf6f6e35e13ff127886c1300170ff560e642d92f85";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 4600 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 4600 manipulators. This currently includes the 20/2.50, the
+      40/2.55 and the 60/2.05 variants.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <em>ABB IRB 4600 Product Specification</em>, <em>3HAC032885-001, Rev Z</em>.
+      All urdfs / xacros are based on the default motion and joint velocity
+      limits, unless noted otherwise (ie: no support for high speed joints,
+      extended / limited motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb52-support/default.nix
+++ b/distros/noetic/abb-irb52-support/default.nix
@@ -1,0 +1,46 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb52-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb52_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "840ff489cf48be41b9e403cbdbbe51a4b0d170d7b95d6c129952345b65739ae5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 52 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 52 manipulators. This currently includes the 7/1.2 and
+      7/1.45 variants.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"https://library.e.abb.com/public/2acc052fe4720ff9c12576ef002a2fe5/IRB%2052%20Datasheet.pdf\">
+      ABB IRB 52 product specification document</a> All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb5400-support/default.nix
+++ b/distros/noetic/abb-irb5400-support/default.nix
@@ -1,0 +1,44 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb5400-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb5400_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "1cc2e5864e7e171f27e3becad5be7e4b8ef3614a89ecb819ce8967e818c37da1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 5400 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 5400 manipulators. This currently includes the base model.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in
+      the ABB data sheets.  All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb6600-support/default.nix
+++ b/distros/noetic/abb-irb6600-support/default.nix
@@ -1,0 +1,48 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb6600-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb6600_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "a13de49f18d1f0316afb786d97c6a73c517a77f1e77a976dbf02eee755c98ff1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 6600 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 6600 manipulators. This currently includes the base model.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in
+      the ABB data sheets.  All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>
+    <p>
+      The unqualified IRB 6400 model will be removed in ROS-Lunar, please
+      use the abb_irb6640_support as a replacement.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb6640-support/default.nix
+++ b/distros/noetic/abb-irb6640-support/default.nix
@@ -1,0 +1,46 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb6640-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb6640_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c5f85c9325a6a412a0e05057e64fa246e0ebaf7ba95c629d3a4129f3449875b7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 6640 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 6640 manipulators. This currently includes the
+      IRB 6640-185/2.8m (6640-185) only.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"http://www.abbrobots.co.uk/en/3HAC028284-en.pdf\">ABB IRB 6640
+      technical data sheet</a> (Version: 3HAC 028284-001 Rev. N). All urdfs /
+      xacros are based on the default motion and joint velocity limits, unless
+      noted otherwise (ie: no support for high speed joints, extended / limited
+      motion ranges or other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb6650s-support/default.nix
+++ b/distros/noetic/abb-irb6650s-support/default.nix
@@ -1,0 +1,45 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb6650s-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb6650s_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "23050720767aaee7ea8ac336da5417f6fb161db591c8924180b20f0f277bde9c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB_6650S (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB_6650S manipulators. This currently includes the base model.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"https://library.e.abb.com/public/9fcf15f419454768823fccb5fa26df11/3HAC030822-en.pdf\">
+      ABB IRB 6650S product specification document</a> All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb6700-support/default.nix
+++ b/distros/noetic/abb-irb6700-support/default.nix
@@ -1,0 +1,46 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb6700-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb6700_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "5685949d4c198f3cf82d3aea711ff38b76e3c6d21465ae577f043185effacaf7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 6700 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 6700 manipulators. This currently includes the 200/2.60 and
+      235/2.65 variants.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"https://library.e.abb.com/public/f69fdf358ddc4264b2d86c02b019ec0e/3HAC044265%20PS%20IRB%206700-en.pdf\">
+      ABB IRB 6700 product specification document</a> All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-irb7600-support/default.nix
+++ b/distros/noetic/abb-irb7600-support/default.nix
@@ -1,0 +1,46 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-driver, abb-resources, catkin, industrial-robot-client, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-abb-irb7600-support";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_irb7600_support/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e643f13703a2b392bbb610a0f14f98bb8db7bdaafbc9f26e1b083c3fad90a9fd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ abb-driver abb-resources industrial-robot-client joint-state-publisher-gui robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      ROS-Industrial support for the ABB IRB 7600 (and variants).
+    </p>
+    <p>
+      This package contains configuration data, 3D models and launch files
+      for ABB IRB 7600 manipulators. This currently includes the 150/3.50
+      variant only.
+    </p>
+    <p>
+      Joint limits and max joint velocities are based on the information in the
+      <a href=\"https://library.e.abb.com/public/10b88af5de1b4396a3337e734869f364/PR10074_EN_R11_HR.pdf\">
+      ABB IRB 7600 product specification document</a>. All URDFs / XACROs are based on the
+      default motion and joint velocity limits, unless noted otherwise (ie:
+      no support for high speed joints, extended / limited motion ranges or
+      other options).
+    </p>
+    <p>
+      Before using any of the configuration files and / or meshes included
+      in this package, be sure to check they are correct for the particular
+      robot model and configuration you intend to use them with.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb-resources/default.nix
+++ b/distros/noetic/abb-resources/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-abb-resources";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb_resources/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "0c015c5433b419b0f00e4e29383d394b1950cdf8ded034445e1ca7cbce232828";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "<p>
+      Shared configuration data for ABB manipulators.
+    </p>
+    <p>
+      This package contains common urdf / xacro resources used by
+      ABB related packages.
+    </p>";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/abb/default.nix
+++ b/distros/noetic/abb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, abb-crb15000-support, abb-driver, abb-irb120-support, abb-irb1200-support, abb-irb1600-support, abb-irb2400-support, abb-irb2600-support, abb-irb4400-support, abb-irb4600-support, abb-irb52-support, abb-irb5400-support, abb-irb6600-support, abb-irb6640-support, abb-irb6650s-support, abb-irb6700-support, abb-irb7600-support, abb-resources, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-abb";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/abb-release/archive/release/noetic/abb/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "02c5e07e4ab89585cdc18e6f3d1e00bd5551c4c3a5ff8276a805b84ab776e564";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ abb-crb15000-support abb-driver abb-irb120-support abb-irb1200-support abb-irb1600-support abb-irb2400-support abb-irb2600-support abb-irb4400-support abb-irb4600-support abb-irb52-support abb-irb5400-support abb-irb6600-support abb-irb6640-support abb-irb6650s-support abb-irb6700-support abb-irb7600-support abb-resources ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "ROS-Industrial support for ABB manipulators (metapackage).";
+    license = with lib.licenses; [ bsd3 asl20 ];
+  };
+}

--- a/distros/noetic/actionlib-tools/default.nix
+++ b/distros/noetic/actionlib-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, python3Packages, roslib, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-actionlib-tools";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/actionlib-release/archive/release/noetic/actionlib_tools/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "cb6b03293d18061e310738bd3aa2f7c3a2114879c5b653969f55770579f878ef";
+    url = "https://github.com/ros-gbp/actionlib-release/archive/release/noetic/actionlib_tools/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "7634b0137a2afaaa03a117108b8315ffdc2211750eb9edd78bf6619a7d135ba1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/actionlib/default.nix
+++ b/distros/noetic/actionlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, boost, catkin, message-generation, message-runtime, roscpp, rosnode, rospy, rostest, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-actionlib";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/actionlib-release/archive/release/noetic/actionlib/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "cc2f1a34e4fc117f845a8ee44102ac3e2bfeb7d9de2a448d741641f6923cb203";
+    url = "https://github.com/ros-gbp/actionlib-release/archive/release/noetic/actionlib/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "7176a73d832c6828fd6ae08ffac0837360c4436b539336d1e107a13a009feb8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/angles/default.nix
+++ b/distros/noetic/angles/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-angles";
-  version = "1.9.13-r1";
+  version = "1.9.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_angles_utils-release/archive/release/noetic/angles/1.9.13-1.tar.gz";
-    name = "1.9.13-1.tar.gz";
-    sha256 = "bd33e903e57fce8b8cfc4444924e684088609475b61cdd8343e80be60a4861ea";
+    url = "https://github.com/ros-gbp/geometry_angles_utils-release/archive/release/noetic/angles/1.9.14-1.tar.gz";
+    name = "1.9.14-1.tar.gz";
+    sha256 = "a34880d681ee68ee08234bc5cda436ff23fd513713558bb54c6fba8ba77d7b11";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   checkInputs = [ rosunit ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "This package provides a set of simple math utilities to work

--- a/distros/noetic/camera-calibration-parsers/default.nix
+++ b/distros/noetic/camera-calibration-parsers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, pkg-config, rosbash, rosconsole, roscpp, roscpp-serialization, rosunit, sensor-msgs, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, rosbash, rosconsole, roscpp, roscpp-serialization, rosunit, sensor-msgs, yaml-cpp }:
 buildRosPackage {
   pname = "ros-noetic-camera-calibration-parsers";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/camera_calibration_parsers/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "9a61cdd6c7c363a7edb9e58315680826f1fccd4ed43418b4a3ff02c5fad30503";
+    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/camera_calibration_parsers/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "40beed2aa97e6f5c09b7f675d5f2bc98dc987d9626c8c55d54ff824af8560ba0";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin pkg-config rosconsole ];
+  buildInputs = [ catkin rosconsole ];
   checkInputs = [ rosbash rosunit ];
   propagatedBuildInputs = [ boost roscpp roscpp-serialization sensor-msgs yaml-cpp ];
   nativeBuildInputs = [ catkin ];

--- a/distros/noetic/camera-info-manager/default.nix
+++ b/distros/noetic/camera-info-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, gtest, image-transport, roscpp, roslib, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-camera-info-manager";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/camera_info_manager/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "665ff2dc8fd366d67b1fd535bbf3bae4eca13f43e622b8ec4232afc0b8844c51";
+    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/camera_info_manager/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "eb6fbebb3802f05a602af88f612bba442eb59c3a37a39da64cd12397673511b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/catkin/default.nix
+++ b/distros/noetic/catkin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtest, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-catkin";
-  version = "0.8.10-r1";
+  version = "0.8.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.10-1.tar.gz";
-    name = "0.8.10-1.tar.gz";
-    sha256 = "08401b37f85d0a6b153e00408b6e51fdf7b0fd0d485da6ccb808aba401a5518f";
+    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.11-1.tar.gz";
+    name = "0.8.11-1.tar.gz";
+    sha256 = "03c3a455f3b44252f1da0b886a3e88f0e7b8af0e85202400edebeac410c7f660";
   };
 
   buildType = "catkin";

--- a/distros/noetic/class-loader/default.nix
+++ b/distros/noetic/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, console-bridge, poco }:
 buildRosPackage {
   pname = "ros-noetic-class-loader";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/class_loader-release/archive/release/noetic/class_loader/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "7c1c002eac68d9c1b8bb82ea68004a444955fb844e444b806b1639501644de1b";
+    url = "https://github.com/ros-gbp/class_loader-release/archive/release/noetic/class_loader/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "7657a7db4650dda3bf66e2c407f6ab64716e26cc6f29718efd3dbec553339e34";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cmake-modules/default.nix
+++ b/distros/noetic/cmake-modules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-cmake-modules";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/cmake_modules-release/archive/release/noetic/cmake_modules/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "dfeaf30ec1bc678393abb6429ee19d99582a6df73cdfdf5d8a165bd408ebc46b";
+    url = "https://github.com/ros-gbp/cmake_modules-release/archive/release/noetic/cmake_modules/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "91d4137c9f9be6fe30be4b0095d454333f1637eba80282b2d5ed6a37f9a3a311";
   };
 
   buildType = "catkin";

--- a/distros/noetic/depth-obstacle-detect-ros-msgs/default.nix
+++ b/distros/noetic/depth-obstacle-detect-ros-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-depth-obstacle-detect-ros-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/anilsripadarao/depth-obstacle-detect-ros-release/archive/release/noetic/depth_obstacle_detect_ros_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c62efa28f241a7c3ddf297136729e05a0506e3df039ba9ca583d2e6781185809";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "The obstacle_msg package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/depth-obstacle-detect-ros/default.nix
+++ b/distros/noetic/depth-obstacle-detect-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, depth-obstacle-detect-ros-msgs, image-transport, nodelet, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-depth-obstacle-detect-ros";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/anilsripadarao/depth-obstacle-detect-ros-release/archive/release/noetic/depth_obstacle_detect_ros/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "32f645d44fc193b5a2d73fe50674d1e4c3b9f2fd8ba636529027ee8f74db65ea";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge depth-obstacle-detect-ros-msgs image-transport nodelet roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "A depth based obstacle detection package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dynamic-reconfigure/default.nix
+++ b/distros/noetic/dynamic-reconfigure/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, roscpp, roscpp-serialization, roslib, rospy, rosservice, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, rosbash, roscpp, roscpp-serialization, roslib, rospy, rosservice, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-reconfigure";
-  version = "1.7.3-r1";
+  version = "1.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/noetic/dynamic_reconfigure/1.7.3-1.tar.gz";
-    name = "1.7.3-1.tar.gz";
-    sha256 = "bb4e9834fe4b0da8a503c8060a5f4780ac29f4192b0f889a07be6362176b41f4";
+    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/noetic/dynamic_reconfigure/1.7.4-1.tar.gz";
+    name = "1.7.4-1.tar.gz";
+    sha256 = "68aa23459061d514f4995bb87b404c1fad65692dbdfcc318b56a62c2762754f3";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin cpp-common message-generation roscpp-serialization rostest ];
+  checkInputs = [ rosbash ];
   propagatedBuildInputs = [ boost message-runtime roscpp roslib rospy rosservice std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/eigen-conversions/default.nix
+++ b/distros/noetic/eigen-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, orocos-kdl, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-eigen-conversions";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/eigen_conversions/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "e6d86b7c9644726e18547a077a21715f90186140f3b9fd6dd11bc1baa4e0656f";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/eigen_conversions/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "764c4a03393892afd39db05fda619f289f29d2097646c3f8a4fabdb6a9c498b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/filters/default.nix
+++ b/distros/noetic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-filters";
-  version = "1.9.2-r1";
+  version = "1.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/noetic/filters/1.9.2-1.tar.gz";
-    name = "1.9.2-1.tar.gz";
-    sha256 = "7cfca50e56f78921bf185fd6dd7d3fe614b2daee6e326a96307776ad3aad8fe6";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/noetic/filters/1.9.3-1.tar.gz";
+    name = "1.9.3-1.tar.gz";
+    sha256 = "7c1bd71c345ebb62b97501f49e89682b798dcc9a639b47f3fbe0a42446675969";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gencpp/default.nix
+++ b/distros/noetic/gencpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-gencpp";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gencpp-release/archive/release/noetic/gencpp/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "3cd1676629c01895c386837a4c0ed2a3fec51386f96749a8f8a160cb8493f82d";
+    url = "https://github.com/ros-gbp/gencpp-release/archive/release/noetic/gencpp/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "197538d2bce13e399ebd6af742e8f08dd848f2f3fad81a8eae23e79740a67470";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -4,13 +4,47 @@
 
 self: super: {
 
+ abb = self.callPackage ./abb {};
+
+ abb-crb15000-support = self.callPackage ./abb-crb15000-support {};
+
  abb-driver = self.callPackage ./abb-driver {};
 
  abb-egm-msgs = self.callPackage ./abb-egm-msgs {};
 
+ abb-irb1200-support = self.callPackage ./abb-irb1200-support {};
+
+ abb-irb120-support = self.callPackage ./abb-irb120-support {};
+
+ abb-irb1600-support = self.callPackage ./abb-irb1600-support {};
+
+ abb-irb2400-support = self.callPackage ./abb-irb2400-support {};
+
+ abb-irb2600-support = self.callPackage ./abb-irb2600-support {};
+
+ abb-irb4400-support = self.callPackage ./abb-irb4400-support {};
+
+ abb-irb4600-support = self.callPackage ./abb-irb4600-support {};
+
+ abb-irb52-support = self.callPackage ./abb-irb52-support {};
+
+ abb-irb5400-support = self.callPackage ./abb-irb5400-support {};
+
+ abb-irb6600-support = self.callPackage ./abb-irb6600-support {};
+
+ abb-irb6640-support = self.callPackage ./abb-irb6640-support {};
+
+ abb-irb6650s-support = self.callPackage ./abb-irb6650s-support {};
+
+ abb-irb6700-support = self.callPackage ./abb-irb6700-support {};
+
+ abb-irb7600-support = self.callPackage ./abb-irb7600-support {};
+
  abb-rapid-msgs = self.callPackage ./abb-rapid-msgs {};
 
  abb-rapid-sm-addin-msgs = self.callPackage ./abb-rapid-sm-addin-msgs {};
+
+ abb-resources = self.callPackage ./abb-resources {};
 
  abb-robot-msgs = self.callPackage ./abb-robot-msgs {};
 
@@ -659,6 +693,10 @@ self: super: {
  delphi-srr-msgs = self.callPackage ./delphi-srr-msgs {};
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
+
+ depth-obstacle-detect-ros = self.callPackage ./depth-obstacle-detect-ros {};
+
+ depth-obstacle-detect-ros-msgs = self.callPackage ./depth-obstacle-detect-ros-msgs {};
 
  depthai = self.callPackage ./depthai {};
 
@@ -3934,6 +3972,8 @@ self: super: {
 
  ur10e-moveit-config = self.callPackage ./ur10e-moveit-config {};
 
+ ur12e-moveit-config = self.callPackage ./ur12e-moveit-config {};
+
  ur16e-moveit-config = self.callPackage ./ur16e-moveit-config {};
 
  ur20-moveit-config = self.callPackage ./ur20-moveit-config {};
@@ -3947,6 +3987,8 @@ self: super: {
  ur5-moveit-config = self.callPackage ./ur5-moveit-config {};
 
  ur5e-moveit-config = self.callPackage ./ur5e-moveit-config {};
+
+ ur7e-moveit-config = self.callPackage ./ur7e-moveit-config {};
 
  ur-calibration = self.callPackage ./ur-calibration {};
 

--- a/distros/noetic/genmsg/default.nix
+++ b/distros/noetic/genmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-genmsg";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genmsg-release/archive/release/noetic/genmsg/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "64ea7374aff61084f36ed781a20e44dbccecbf5ff24a3d6c6f9218e57fbfaa9e";
+    url = "https://github.com/ros-gbp/genmsg-release/archive/release/noetic/genmsg/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "9029cac5c2aa0532829debfa16cbb3810580acaa11bc315894df9cfe1d04f8ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/genpy/default.nix
+++ b/distros/noetic/genpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-genpy";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "6ff427b4dba67d28eb6c39e3c43c3ab5a011e9fc0d3b5c4c39828476f5ea2746";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "8ec57c55393f20da7f7fb079a9b6572777fa80fa378a679822dab4b12d628c13";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geometry-tutorials/default.nix
+++ b/distros/noetic/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, turtle-tf, turtle-tf2 }:
 buildRosPackage {
   pname = "ros-noetic-geometry-tutorials";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/noetic/geometry_tutorials/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "58b0ecb64acf567e9bc62efb6252452443c399d98701edc9bbbb295d9999ecb4";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/noetic/geometry_tutorials/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "bb880af229bf7a5fc494d4cbfb8b9eba0156f11defb5bb9ecf993121da1622b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geometry/default.nix
+++ b/distros/noetic/geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, eigen-conversions, kdl-conversions, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-geometry";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/geometry/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "45d3dd1724ca4416f16efbc51f6bb9e8fd1eb72db66cd0b7392b83d7d6eb9e1f";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/geometry/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "6830ebedcd61263e4044ccc5d09a68754bb6670b284c1e1f15dd1afa11166020";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geometry2/default.nix
+++ b/distros/noetic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-noetic-geometry2";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/geometry2/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "5f7a757fc5e98a8b13bfb77d855ab40c70882f265be7a5536e1623c0f10c804c";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/geometry2/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "a9f52a88b20bdc17df5dc2c04979850339e416fcbe5717ac17ab61345b9ea828";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gl-dependency/default.nix
+++ b/distros/noetic/gl-dependency/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-gl-dependency";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gl_dependency-release/archive/release/noetic/gl_dependency/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "0dd1355fce88a9e67f0ee0f2c223511f7686e5a07bbabaecb7663a732452daf3";
+    url = "https://github.com/ros-gbp/gl_dependency-release/archive/release/noetic/gl_dependency/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "cbda6475567788aeaafdbd24a853944ef0a42b3dabf8a011df089bfd081d36a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-common/default.nix
+++ b/distros/noetic/image-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, camera-info-manager, catkin, image-transport, polled-camera }:
 buildRosPackage {
   pname = "ros-noetic-image-common";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/image_common/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "697fe0a393f7b4d08c2dc1168a7479344b4997a1920d233138c07232d90f5d7a";
+    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/image_common/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "7158d40215f9252a9523f62b41ae687a5e94ed4c732f245c64e7bbe9e855dff3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/image-transport/default.nix
+++ b/distros/noetic/image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, pluginlib, rosconsole, roscpp, roslib, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-image-transport";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/image_transport/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "22806dd3683201412ecd38f44e40255a7736221fe13f1bc06c660c83eddf3692";
+    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/image_transport/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "76bde3dd7c5f21ee19ef60116ac6de068529552601e2bb0dfb670b16052afc2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/interactive-marker-tutorials/default.nix
+++ b/distros/noetic/interactive-marker-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, roscpp, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-interactive-marker-tutorials";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/interactive_marker_tutorials/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "aeb1dd43c1cc86c20755d73500ee277b9bbe9355d6a5cae09427bbbbc47f5dcb";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/interactive_marker_tutorials/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "dae59c68ac8133827a1b442c85a67b55f9a1fac9466d7df0642b4159c088574c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/interactive-markers/default.nix
+++ b/distros/noetic/interactive-markers/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosconsole, roscpp, rospy, rostest, std-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosconsole, roscpp, rospy, rostest, std-msgs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-interactive-markers";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/interactive_markers-release/archive/release/noetic/interactive_markers/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "d4a8ca9eb762c228712bd9479147db3a73b0cafcf526c926fb406a2bc523ce87";
+    url = "https://github.com/ros-gbp/interactive_markers-release/archive/release/noetic/interactive_markers/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "0b7993123eb4ed27cfe20b8e249acb3725982e61bc4b7f9de2dc89baba1eb533";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ rosconsole roscpp rospy rostest std-msgs tf2-geometry-msgs tf2-ros visualization-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "3D interactive marker communication library for RViz and similar tools.";

--- a/distros/noetic/joint-state-publisher-gui/default.nix
+++ b/distros/noetic/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, python-qt-binding, rospy }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-publisher-gui";
-  version = "1.15.1-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher_gui/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "0a285a9ff411a8dc5944e4540fade94f52a067f70fe79656ae40061938f8dc34";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher_gui/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "ed8bd7878ad29dd30ea25fc4192db25e97eae1a50cce4c0b8223750342772010";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-publisher/default.nix
+++ b/distros/noetic/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-publisher";
-  version = "1.15.1-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "e12c52894f255b6b5682d14ebe3a12c0d865a72d92455992987a31e51922115a";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/noetic/joint_state_publisher/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "aae43d5818ec452e464bf1156b1449b291ce25f76e3de8f4d9666065ceada8f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/kdl-conversions/default.nix
+++ b/distros/noetic/kdl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl }:
 buildRosPackage {
   pname = "ros-noetic-kdl-conversions";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/kdl_conversions/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "8bf8790de2b08b6274348c68c23337dc16e4ca2b4a1ca4028d5555cb53094a5f";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/kdl_conversions/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "abbe6eb2d3e7b5142ffcd7f54ca72b7fb993036a19886a6d4caf7c76438361c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-geometry/default.nix
+++ b/distros/noetic/laser-geometry/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, python3Packages, roscpp, rosunit, sensor-msgs, tf, tf2, tf2-geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, python3Packages, roscpp, rostest, rosunit, sensor-msgs, tf, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-geometry";
-  version = "1.6.7-r1";
+  version = "1.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/noetic/laser_geometry/1.6.7-1.tar.gz";
-    name = "1.6.7-1.tar.gz";
-    sha256 = "81c363c1ab9719c59cf41d01c0624af2307259f711a2de85ef3287137c0794e5";
+    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/noetic/laser_geometry/1.6.8-1.tar.gz";
+    name = "1.6.8-1.tar.gz";
+    sha256 = "62de824e97364108be9f63407bceb417149d89f6f29b6161b8877826667f960d";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin tf2-geometry-msgs ];
+  buildInputs = [ catkin rostest ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ angles boost eigen python3Packages.numpy roscpp sensor-msgs tf tf2 ];
+  propagatedBuildInputs = [ angles boost eigen python3Packages.numpy roscpp sensor-msgs tf tf2 tf2-geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/librviz-tutorial/default.nix
+++ b/distros/noetic/librviz-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-librviz-tutorial";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/librviz_tutorial/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "0a090780b1304627cff505805fafb7ed99b4ba1bb3e99fb1a40516be84bfa951";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/librviz_tutorial/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "f6c9d24390b03b2647ea7f82c2dd7e00153a78f02a038c162b6cbc6e8a5d27bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mk/default.nix
+++ b/distros/noetic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-noetic-mk";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "6e570970ed335eace1b1b4ed1f2cdf9b079c31a1a61bd6e73fe794f53ca17bdc";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "29ca455a3c5c62f5135c16282d42347bfd923899937ae7f1bd013087c67feed8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pluginlib/default.nix
+++ b/distros/noetic/pluginlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, class-loader, cmake-modules, rosconsole, roslib, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-pluginlib";
-  version = "1.13.0-r1";
+  version = "1.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/pluginlib-release/archive/release/noetic/pluginlib/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "0601378fa3e4471c7e995df4d4ccfc0e03fece47661e15df6ae83ce4fb62d74f";
+    url = "https://github.com/ros-gbp/pluginlib-release/archive/release/noetic/pluginlib/1.13.1-1.tar.gz";
+    name = "1.13.1-1.tar.gz";
+    sha256 = "e6893821b8ab839fcd004f064019f8a59f187dd6ad5a0e9dee57de25fd01b63c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/polled-camera/default.nix
+++ b/distros/noetic/polled-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, image-transport, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-polled-camera";
-  version = "1.12.0-r1";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/polled_camera/1.12.0-1.tar.gz";
-    name = "1.12.0-1.tar.gz";
-    sha256 = "ef7758bb4a5e8e9cde9fb84846474e2df5ed0051eb17913f901f7d7c7889973e";
+    url = "https://github.com/ros-gbp/image_common-release/archive/release/noetic/polled_camera/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "a7173b8bd8266ff81dc35d7ab2e56ea06078a7c02c73b5690af835135d226a35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/python-qt-binding/default.nix
+++ b/distros/noetic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-noetic-python-qt-binding";
-  version = "0.4.4-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.4-1.tar.gz";
-    name = "0.4.4-1.tar.gz";
-    sha256 = "d4db9983e7df47036a7afa16aac5db9e5c3de0de0c9a203fd0a2419456d035a7";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "115bde8b7e22780710df63d47cc7b0652668198f75d1f44fd5953ed9dd488151";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-dotgraph/default.nix
+++ b/distros/noetic/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-qt-dotgraph";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_dotgraph/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "a879051a9279d88ee26a6468b3ce27816868bb3c56c1b80a6eadaa8e2745630a";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_dotgraph/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "6b0c41bee3c81dfcd1c733681e3d6294395df19b71946cc6c3d0ac73fb21199d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-app/default.nix
+++ b/distros/noetic/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, qt-gui }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-app";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_app/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "ac27afd75d8effd07b6654b7b6e6d71eba0c4b8d171f01516db07cbccee5f5a7";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_app/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "14766b231fc6ae2757e5cc8aa88c480b45c6eacbd4f6422cea9b50314789e096";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-core/default.nix
+++ b/distros/noetic/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-core";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_core/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "7a166499737a330456941515965c0357b715c1d145c9cc331e6ce6d338b543d9";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_core/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "bd6c6b557b05586a6d492d2098e596164bc05e411b55676e5c0b55948afacf35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-cpp/default.nix
+++ b/distros/noetic/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, python3Packages, qt-gui, qt5, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-cpp";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_cpp/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "4673918813e1660f1c5b05e49e7ad869fd9c91507972f38262efa79665d10fbe";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_cpp/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "6c155334aa32f1a42698dc77616dfb5bc7de62c98419e6aa7e4ee7f00d8056cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-py-common/default.nix
+++ b/distros/noetic/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-py-common";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_py_common/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "fa7d2b35a2513e6a10353cde91a8cbb1ad8e9eafee2f25d59b69c2f2187edd61";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_py_common/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "ba059608502cca1e88b2f840f4ec990a342dbf768b21c226932af6b77006d198";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui/default.nix
+++ b/distros/noetic/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "b565d65a2049bb96f1ce7cd81aa9e95f510e36ab8fede8a8ca4e959bfe84d10a";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "3d1c1c878e7ad6fa462648aa7b82b2938e70f49de571d60ef3bcd3989ad3f0b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/resource-retriever/default.nix
+++ b/distros/noetic/resource-retriever/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, python3Packages, rosconsole, roslib }:
 buildRosPackage {
   pname = "ros-noetic-resource-retriever";
-  version = "1.12.8-r1";
+  version = "1.12.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/resource_retriever-release/archive/release/noetic/resource_retriever/1.12.8-1.tar.gz";
-    name = "1.12.8-1.tar.gz";
-    sha256 = "53548be2b97095493c7e587b62f3f049b0cdf02424823d3fabb31b7ac896cfb2";
+    url = "https://github.com/ros-gbp/resource_retriever-release/archive/release/noetic/resource_retriever/1.12.9-1.tar.gz";
+    name = "1.12.9-1.tar.gz";
+    sha256 = "277cc94e09241ee224dd8363a7f7941f92bc242d59d39455eda5a2ec385464ae";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ boost curl python3Packages.rospkg rosconsole roslib ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "This package retrieves data from url-format files such as http://,

--- a/distros/noetic/robot-state-publisher/default.nix
+++ b/distros/noetic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, kdl-parser, orocos-kdl, rosbag, rosconsole, roscpp, rostest, rostime, sensor-msgs, tf, tf2-kdl, tf2-ros, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-publisher";
-  version = "1.15.2-r1";
+  version = "1.15.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/noetic/robot_state_publisher/1.15.2-1.tar.gz";
-    name = "1.15.2-1.tar.gz";
-    sha256 = "9939e39eb22755515c60d7d1941f9775c44725dbd10e79c18fc558c4a5b6af94";
+    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/noetic/robot_state_publisher/1.15.3-1.tar.gz";
+    name = "1.15.3-1.tar.gz";
+    sha256 = "e4240240cc0a2b870ca03f5c1628389ca7b717322682adf803ee4c4194da325f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-tutorials/default.nix
+++ b/distros/noetic/ros-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp-tutorials, rospy-tutorials, turtlesim }:
 buildRosPackage {
   pname = "ros-noetic-ros-tutorials";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/ros_tutorials/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "a0c6ae6566e4b340c27826cef30b0706d1d24ac101884b1f3948a26281b23f5e";
+    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/ros_tutorials/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "5d2210ba31ebc201323264749901d90478792bd41323be34d637a382ffd3c16c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros/default.nix
+++ b/distros/noetic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-ros";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "84a51b386e543407cdf8fe3e318adc5dbffeebd7ec9f1eda709b7d64d3ead11f";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "5e4cf2015f02111c42def612881475a1ff67757c11b051ed463bc2a173b8998e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-migration-rule/default.nix
+++ b/distros/noetic/rosbag-migration-rule/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-migration-rule";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_migration_rule-release/archive/release/noetic/rosbag_migration_rule/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "4a014649acb782d64beee309a200e9043582ac3f27492568afe600873a2de41a";
+    url = "https://github.com/ros-gbp/rosbag_migration_rule-release/archive/release/noetic/rosbag_migration_rule/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "c3b1cf23e3470dd151c3422f0f26e3f364cfcb5ab36b5d7a027fbea7f8ea5ffc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbash/default.nix
+++ b/distros/noetic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-noetic-rosbash";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "9e29d79829b5a974db4142d1d8f1bc5ed0e412d85694cf707316c503bce81af5";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "f0231b7403be022793b2af49970c6a797af94e7cbdc4027ebeceab2c4dea33f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "7560041d65a39dc786a1202318395c866af0b7b17a5eb8839e4c485f7679c7eb";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "42c36635eddf4a3d49380b02a64e3a25e8a667f0b9356dde9dbb6491c395fe44";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbuild/default.nix
+++ b/distros/noetic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-rosbuild";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "0c84f212ce86cdfe61726e3bfd304ca257c1ae4d113bd0524c8f9d7dd6529c43";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "5b02dfbef96adf7b4c5c4a01a70cf14c1bd7c18a2273c864abceb6e67a4dfab4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "6ce03bce22e1009aa43f3f74f99efd6026702e7d775aac15a1800c7305857086";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "653b85cca8a7fdde3fd89c89ee95c8a0bdc053bb197c88e162e53d9c3d2daa7d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosconsole-bridge/default.nix
+++ b/distros/noetic/rosconsole-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, console-bridge, cpp-common, rosconsole }:
 buildRosPackage {
   pname = "ros-noetic-rosconsole-bridge";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosconsole_bridge-release/archive/release/noetic/rosconsole_bridge/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "5531266ba03ccb439a2191abdfa26ef735e7c58e647c4fc44f880b31a5d921ae";
+    url = "https://github.com/ros-gbp/rosconsole_bridge-release/archive/release/noetic/rosconsole_bridge/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "69da97d7a98b8de418315bfa1edaf04691c46497137384c5a5056964d1829e2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosconsole/default.nix
+++ b/distros/noetic/rosconsole/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apr, boost, catkin, cpp-common, log4cxx, rosbuild, rostime, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-rosconsole";
-  version = "1.14.3-r1";
+  version = "1.14.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosconsole-release/archive/release/noetic/rosconsole/1.14.3-1.tar.gz";
-    name = "1.14.3-1.tar.gz";
-    sha256 = "8b0e2f4ebe5f8ca194b7a5ced20ff304746c6041800b891ae88f9a76a898a0eb";
+    url = "https://github.com/ros-gbp/rosconsole-release/archive/release/noetic/rosconsole/1.14.4-1.tar.gz";
+    name = "1.14.4-1.tar.gz";
+    sha256 = "717f7668b34e1e7cdd017b7a8474623c6b54ed33739ed8763ec8acd041d7c437";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-tutorials/default.nix
+++ b/distros/noetic/roscpp-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, message-generation, message-runtime, rosconsole, roscpp, roscpp-serialization, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-tutorials";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/roscpp_tutorials/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "061c038b00f6b75cf509199821f166e5c6a9a1e13041de1151dd5c69948c4ff5";
+    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/roscpp_tutorials/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "30ca51776bffdb20824afe180b4cc32eee79528debc2340c8882a4c46348ec40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "0cd12e40b3e5c68ccd1576f6b0f34be6fa0d98744105bb545d26f41b738d5ca6";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "44ab1f867a176462ff2e750f591bef9b8a0c91b1d65c997f6fc4d2a709e8f403";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosgraph-msgs/default.nix
+++ b/distros/noetic/rosgraph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosgraph-msgs";
-  version = "1.11.3-r1";
+  version = "1.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm_msgs-release/archive/release/noetic/rosgraph_msgs/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "770d46f9bf622ba92bdc426ba49d80229c0324500aea8f50f8a1b947eba42997";
+    url = "https://github.com/ros-gbp/ros_comm_msgs-release/archive/release/noetic/rosgraph_msgs/1.11.4-1.tar.gz";
+    name = "1.11.4-1.tar.gz";
+    sha256 = "38418eecbfb37cf3f9906d8ed328b250dd5efef8cba6de64617a85f9be5faab9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslang/default.nix
+++ b/distros/noetic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-noetic-roslang";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "920854f983ee43f4eda52a44e2e318f1db47ffd36f74af6cd43c9139c0d5f053";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "4f596ac011719b6de6b682f7cb1afced7cebedf1a6ae57f60c921e4adbac97b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, python3Packages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "5842542a7518a694e1e339fb3d59d4807bf15382d0393c4dab077d67f1458148";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "2c52e7a295ff448b49af94a3103365f70c0dec77d42269cb89663fd404c5c5ea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "03ed121f2231478045cdb983ccbca247f214322acf67d9553d78f78a558c3ffb";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "eb8d470383a5c74f477fce26264563336c42ab19e868feffda81cb4eed254f87";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospack/default.nix
+++ b/distros/noetic/rospack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, gtest, pkg-config, python3, python3Packages, ros-environment, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-rospack";
-  version = "2.6.2-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rospack-release/archive/release/noetic/rospack/2.6.2-1.tar.gz";
-    name = "2.6.2-1.tar.gz";
-    sha256 = "1d74ca071fa02049d6f9739aa0e2624afbeef4100c2f8ca76db4fc1c9e13c390";
+    url = "https://github.com/ros-gbp/rospack-release/archive/release/noetic/rospack/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "60484b89cc155a3f80957bf6fbab7659175ef55af2ed44115d0ebb7b13b132c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy-tutorials/default.nix
+++ b/distros/noetic/rospy-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp-tutorials, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-tutorials";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/rospy_tutorials/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "2f1bd789def2a6591abe28b2497304681f1ccba3748b2044cf724e6552fcd11b";
+    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/rospy_tutorials/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "166095612d7d039ea65e88e1e100f23670f96d5083af1ec7ee11aecf948c22ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
-  version = "1.15.8-r1";
+  version = "1.15.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.8-1.tar.gz";
-    name = "1.15.8-1.tar.gz";
-    sha256 = "8a8a32d9a5b42badd7cae613892b2db4a72035923a4e2a369e34e1877b2fa433";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.9-1.tar.gz";
+    name = "1.15.9-1.tar.gz";
+    sha256 = "94e08641c46a08b8e988771876786b937c513b7584a2eb3dbc1e9077d7a36b28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-action/default.nix
+++ b/distros/noetic/rqt-action/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rospy, rqt-msg, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy, rqt-msg, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-action";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_action-release/archive/release/noetic/rqt_action/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "86d32021ce58ab1d2624157c728e664bcb7345bb055b1388f0d2f4b9045af03b";
+    url = "https://github.com/ros-gbp/rqt_action-release/archive/release/noetic/rqt_action/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "294d156bbc984cb8a48349235f0f54bc19bbf1f3f8901a81b961173bc9e222d8";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ rospy rqt-msg rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_action provides a feature to introspect all available ROS

--- a/distros/noetic/rqt-bag-plugins/default.nix
+++ b/distros/noetic/rqt-bag-plugins/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag-plugins";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "b6bfae17347d4d64fa1b40bc3663d4cb4a8fef9de8aa2b1e3138c4394561b6cb";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "a0bd28227e467da76e1ba14eb9ac4c5228824765258fd70d6f1e2be974e784c8";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ geometry-msgs python3Packages.pillow python3Packages.pycairo rosbag roslib rospy rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.";

--- a/distros/noetic/rqt-bag/default.nix
+++ b/distros/noetic/rqt-bag/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "864c0851f8c2a470246555831630a5d7108ad76bde6e9fd5775113b35e722e8d";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "73b8698ca226a02295d7bcbab08e6fcb12da51d3bba55d3e67e7cd4afbabcd12";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg rosbag rosgraph-msgs roslib rosnode rospy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_bag provides a GUI plugin for displaying and replaying ROS bag files.";

--- a/distros/noetic/rqt-common-plugins/default.nix
+++ b/distros/noetic/rqt-common-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rqt-action, rqt-bag, rqt-bag-plugins, rqt-console, rqt-dep, rqt-graph, rqt-image-view, rqt-launch, rqt-logger-level, rqt-msg, rqt-plot, rqt-publisher, rqt-py-common, rqt-py-console, rqt-reconfigure, rqt-service-caller, rqt-shell, rqt-srv, rqt-top, rqt-topic, rqt-web }:
 buildRosPackage {
   pname = "ros-noetic-rqt-common-plugins";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_common_plugins-release/archive/release/noetic/rqt_common_plugins/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "76c6b6eef42e7935e220d53c6d52edea82550b947b0dbc0a0526d690bc169a9f";
+    url = "https://github.com/ros-gbp/rqt_common_plugins-release/archive/release/noetic/rqt_common_plugins/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "ee6876a8859201f73788dbe8f7b345d7745709d4dbc9e2a1cc9ae7b825afd378";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-console/default.nix
+++ b/distros/noetic/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-logger-level, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-console";
-  version = "0.4.12-r1";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/noetic/rqt_console/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "9d28654f41fb82fc298140b8ea5b7041b15d5ade3bccc467b01f7b1763be1c36";
+    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/noetic/rqt_console/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "5de46819ef0b0989a67c5a4e8e8afc2ee95f410479d474fbd78a2e1c32cd55ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-dep/default.nix
+++ b/distros/noetic/rqt-dep/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, qt-gui, qt-gui-py-common, rqt-graph, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-dep";
-  version = "0.4.12-r1";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "173543b28fd652b17aa90d4be483382b1fb6a2c7cc842fa58c3151293eccc445";
+    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "aaa895456e4924a03f73120be8f4346df822c08e5f3a69a7bb0abf87cb22636a";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   checkInputs = [ python3Packages.mock ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-dotgraph qt-gui qt-gui-py-common rqt-graph rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_dep provides a GUI plugin for visualizing the ROS dependency graph.";

--- a/distros/noetic/rqt-graph/default.nix
+++ b/distros/noetic/rqt-graph/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rosgraph, rosgraph-msgs, roslib, rosnode, rospy, rosservice, rostopic, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-graph";
-  version = "0.4.14-r1";
+  version = "0.4.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_graph-release/archive/release/noetic/rqt_graph/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "f9aaccd3cd5c2fced10194e48880281ada1f61ad9bea14db7e7fa1c5c85ed8c9";
+    url = "https://github.com/ros-gbp/rqt_graph-release/archive/release/noetic/rqt_graph/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "77e3e3daed66e7905e4905db3e69a4197fbb4bd83df674483a5d2ed2fcbbf030";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-dotgraph rosgraph rosgraph-msgs roslib rosnode rospy rosservice rostopic rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_graph provides a GUI plugin for visualizing the ROS

--- a/distros/noetic/rqt-gui-cpp/default.nix
+++ b/distros/noetic/rqt-gui-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, nodelet, qt-gui, qt-gui-cpp, qt5, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, python3Packages, qt-gui, qt-gui-cpp, qt5, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-rqt-gui-cpp";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_gui_cpp/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "1b87265e422398938561fb938fc66f820ff63f28f5c8da4b198410b3eeb2f5cf";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_gui_cpp/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "e6e742622dcf6d09df6275e042d52539efef6f7eeb0b164108b24d9c25bb4d5a";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin qt5.qtbase ];
+  buildInputs = [ catkin python3Packages.setuptools qt5.qtbase ];
   propagatedBuildInputs = [ nodelet qt-gui qt-gui-cpp roscpp ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_gui_cpp enables GUI plugins to use the C++ client library for ROS.";

--- a/distros/noetic/rqt-gui-py/default.nix
+++ b/distros/noetic/rqt-gui-py/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qt-gui, rospy, rqt-gui }:
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, qt-gui, rospy, rqt-gui }:
 buildRosPackage {
   pname = "ros-noetic-rqt-gui-py";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_gui_py/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "3a72b9cf0c411dabdeab3f8299e64d7926eb1e8f51403f1019acd8b0bf9f9b27";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_gui_py/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "f8ef25e81dcdc4fb9eb11377be28701a653cfe8502b93883de8456bc86f2f2e7";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ qt-gui rospy rqt-gui ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_gui_py enables GUI plugins to use the Python client library for ROS.";

--- a/distros/noetic/rqt-gui/default.nix
+++ b/distros/noetic/rqt-gui/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rqt-gui";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_gui/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "aa55a946456a86035c97ea159bd9c71d8a410e8e069fc3df1cd585649b78308d";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_gui/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "2afa87478b8c8a693d688700456e15ff1cad5f548bed92d7625eae624c412e23";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui rospy ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_gui provides the main to start an instance of the ROS integrated graphical user interface provided by qt_gui.";

--- a/distros/noetic/rqt-image-view/default.nix
+++ b/distros/noetic/rqt-image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, python3Packages, qt5, rqt-gui, rqt-gui-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-image-view";
-  version = "0.4.17-r1";
+  version = "0.4.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_image_view-release/archive/release/noetic/rqt_image_view/0.4.17-1.tar.gz";
-    name = "0.4.17-1.tar.gz";
-    sha256 = "a7919c7d7bed79836ccb9a64264145cc0d3faa78f84f252404c6ab3df70426ab";
+    url = "https://github.com/ros-gbp/rqt_image_view-release/archive/release/noetic/rqt_image_view/0.4.18-1.tar.gz";
+    name = "0.4.18-1.tar.gz";
+    sha256 = "9ca72bbe2358330b14178b1f8503a22758393e4a5561e8faaa1ff9d56bbc1e2c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-msg/default.nix
+++ b/distros/noetic/rqt-msg/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, roslib, rosmsg, rospy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-msg";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_msg-release/archive/release/noetic/rqt_msg/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "a9afbaff68d9f0ffa209152355c1511010b312e04d7c8244068f460f165b9f9c";
+    url = "https://github.com/ros-gbp/rqt_msg-release/archive/release/noetic/rqt_msg/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "ab27a5271265afacfc3bd64b1b21a8b2a3662de1bc2d03689c27c8599ed0c908";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg roslib rosmsg rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "A Python GUI plugin for introspecting available ROS message types.

--- a/distros/noetic/rqt-plot/default.nix
+++ b/distros/noetic/rqt-plot/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-plot";
-  version = "0.4.13-r2";
+  version = "0.4.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.13-2.tar.gz";
-    name = "0.4.13-2.tar.gz";
-    sha256 = "f39e892b46c2c4997bababc291468d8da129d8d766a55a0875bf13ff6ffb98ce";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "e530d7c8b9f5bd43c2fa5ce1d7098cc6f5d354397b6b9f1c3650edb4b447d0a5";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.matplotlib python3Packages.numpy python3Packages.rospkg qt-gui-py-common qwt-dependency rosgraph rostopic rqt-gui rqt-gui-py rqt-py-common std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_plot provides a GUI plugin visualizing numeric values in a 2D plot using different plotting backends.";

--- a/distros/noetic/rqt-pose-view/default.nix
+++ b/distros/noetic/rqt-pose-view/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gl-dependency, python-qt-binding, python3Packages, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, tf }:
 buildRosPackage {
   pname = "ros-noetic-rqt-pose-view";
-  version = "0.5.11-r1";
+  version = "0.5.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_pose_view-release/archive/release/noetic/rqt_pose_view/0.5.11-1.tar.gz";
-    name = "0.5.11-1.tar.gz";
-    sha256 = "cf7dbeba319b1a3b934ea9e89457dbe292d07e7fb7a01946adb802eb232acb61";
+    url = "https://github.com/ros-gbp/rqt_pose_view-release/archive/release/noetic/rqt_pose_view/0.5.12-1.tar.gz";
+    name = "0.5.12-1.tar.gz";
+    sha256 = "eea690c28149187f59e175a29bb0f58d5133965ae7dced44d4dbfa8ce7d6c88f";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ geometry-msgs gl-dependency python-qt-binding python3Packages.pyopengl python3Packages.rospkg rospy rostopic rqt-gui rqt-gui-py rqt-py-common tf ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_pose_view provides a GUI plugin for visualizing 3D poses.";

--- a/distros/noetic/rqt-pr2-dashboard/default.nix
+++ b/distros/noetic/rqt-pr2-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-msgs, pr2-power-board, python3Packages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-robot-dashboard, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-pr2-dashboard";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_pr2_dashboard-release/archive/release/noetic/rqt_pr2_dashboard/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "699918f513dcffcd7924aa8ab7660844c55b4158dc3f2d71ca9a4e007b5a37e1";
+    url = "https://github.com/ros-gbp/rqt_pr2_dashboard-release/archive/release/noetic/rqt_pr2_dashboard/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "3826a38110940ff6e51a6c42243ae8f3fa670b186df64d7d8cd2c2aef7918e05";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-publisher/default.nix
+++ b/distros/noetic/rqt-publisher/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, roslib, rosmsg, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-publisher";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_publisher-release/archive/release/noetic/rqt_publisher/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "5cbe23d13ab2d2c4286bb3e6d6b2e56396845732c3bf6574e6a129cedc642c07";
+    url = "https://github.com/ros-gbp/rqt_publisher-release/archive/release/noetic/rqt_publisher/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "d20b202fd6fe568d1cf3322e81f077f2a07262647691aecd90b5ef2ce0b00c02";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui-py-common roslib rosmsg rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_publisher provides a GUI plugin for publishing arbitrary messages with fixed or computed field values.";

--- a/distros/noetic/rqt-py-common/default.nix
+++ b/distros/noetic/rqt-py-common/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, genmsg, genpy, python-qt-binding, qt-gui, rosbag, roslib, rospy, rostopic, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, genmsg, genpy, python-qt-binding, python3Packages, qt-gui, rosbag, roslib, rospy, rostopic, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-py-common";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_py_common/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "021bd4579dd2ebf73b589a08345ba476ec96bc042466d345e41f760ca6eae06a";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt_py_common/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "aa0842f562dc7dcaafaa827bec51e2d8a2676fd9fd184ac50985d062ab424913";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin genmsg std-msgs ];
+  buildInputs = [ catkin genmsg python3Packages.setuptools std-msgs ];
   propagatedBuildInputs = [ actionlib genpy python-qt-binding qt-gui rosbag roslib rospy rostopic ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_py_common provides common functionality for rqt plugins written in Python.

--- a/distros/noetic/rqt-py-console/default.nix
+++ b/distros/noetic/rqt-py-console/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-py-console";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_py_console-release/archive/release/noetic/rqt_py_console/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "daf9be587966164b916b8a33de9d10d4e78db010228c6fc50ee63f511190874c";
+    url = "https://github.com/ros-gbp/rqt_py_console-release/archive/release/noetic/rqt_py_console/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "92d000a466050c0e87e17c77af2cdb699d93bba1b9f6fba037b32e7fad29cad3";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui qt-gui-py-common rospy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_py_console is a Python GUI plugin providing an interactive Python console.";

--- a/distros/noetic/rqt-reconfigure/default.nix
+++ b/distros/noetic/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python-qt-binding, python3Packages, roslint, rospy, rostest, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-reconfigure";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/noetic/rqt_reconfigure/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "95c072cfd3f2b997083601645e510482b268af1aabb4b0163e697a3cc15a4d94";
+    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/noetic/rqt_reconfigure/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "73b683d7e6fee94c1b24fa65b3b29da55760805805d6ab86f5962f9863053298";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-robot-steering/default.nix
+++ b/distros/noetic/rqt-robot-steering/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python-qt-binding, python3Packages, rostopic, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-robot-steering";
-  version = "0.5.12-r1";
+  version = "0.5.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_robot_steering-release/archive/release/noetic/rqt_robot_steering/0.5.12-1.tar.gz";
-    name = "0.5.12-1.tar.gz";
-    sha256 = "6cb57401673fd0d5d16dcead9fc27e2820d55760883578afc4b7dccb857b5d1e";
+    url = "https://github.com/ros-gbp/rqt_robot_steering-release/archive/release/noetic/rqt_robot_steering/0.5.13-1.tar.gz";
+    name = "0.5.13-1.tar.gz";
+    sha256 = "fac18ca09687c28905f56000a283176be6208851483a3e18fda78504429a65f4";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ geometry-msgs python-qt-binding python3Packages.rospkg rostopic rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_robot_steering provides a GUI plugin for steering a robot using Twist messages.";

--- a/distros/noetic/rqt-rviz/default.nix
+++ b/distros/noetic/rqt-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, class-loader, pluginlib, qt5, rqt-gui, rqt-gui-cpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rqt-rviz";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_rviz-release/archive/release/noetic/rqt_rviz/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "a654c09013c36efb408a635700dbd62bf8c37da8f9a5c53aaefe790a49fc7ad7";
+    url = "https://github.com/ros-gbp/rqt_rviz-release/archive/release/noetic/rqt_rviz/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "10f6557efe52f4a0ba3713f584a23bb713424459c3283485267b7f0ea2ed2023";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-service-caller/default.nix
+++ b/distros/noetic/rqt-service-caller/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosservice, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-service-caller";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_service_caller-release/archive/release/noetic/rqt_service_caller/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "dbf87bc996e161a0512b4f0627caa1d66ae00bfcbf28ef8ab6fa58de2fa4d9f5";
+    url = "https://github.com/ros-gbp/rqt_service_caller-release/archive/release/noetic/rqt_service_caller/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "79dcc49d59bbe8c79564675bb8d1ec97c46b5f265066d62de99c6af3a9121ac6";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python3Packages.rospkg rosservice rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_service_caller provides a GUI plugin for calling arbitrary services.";

--- a/distros/noetic/rqt-srv/default.nix
+++ b/distros/noetic/rqt-srv/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosmsg, rospy, rqt-gui, rqt-gui-py, rqt-msg }:
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosmsg, rospy, rqt-gui, rqt-gui-py, rqt-msg }:
 buildRosPackage {
   pname = "ros-noetic-rqt-srv";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_srv-release/archive/release/noetic/rqt_srv/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "a6bf6dba3326ed7d75d4f4ac1cedb2e162714721b7bba6141bf27dea2086ebcb";
+    url = "https://github.com/ros-gbp/rqt_srv-release/archive/release/noetic/rqt_srv/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "30cdc2f1e4a6db48a5eaa3b4a96007850b691c2e1ab80049fd8971f34dfee704";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ rosmsg rospy rqt-gui rqt-gui-py rqt-msg ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "A Python GUI plugin for introspecting available ROS message types.

--- a/distros/noetic/rqt-top/default.nix
+++ b/distros/noetic/rqt-top/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-top";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_top-release/archive/release/noetic/rqt_top/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "4bc9f4bfb79ee30f00faf53fc48c2914c179c51782dab97d625a07d5834d7a2b";
+    url = "https://github.com/ros-gbp/rqt_top-release/archive/release/noetic/rqt_top/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "67360350d8a9fc3844dcf3c8eea9510d1ae3316cc1b5f4778285c4412edb2e2f";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.psutil rospy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "RQT plugin for monitoring ROS processes.";

--- a/distros/noetic/rqt-topic/default.nix
+++ b/distros/noetic/rqt-topic/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rostopic, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-topic";
-  version = "0.4.13-r1";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_topic-release/archive/release/noetic/rqt_topic/0.4.13-1.tar.gz";
-    name = "0.4.13-1.tar.gz";
-    sha256 = "71b19f1b04cac8826e67b6cea1759cd4ede002eadbfeae9421a675e1bcdba30e";
+    url = "https://github.com/ros-gbp/rqt_topic-release/archive/release/noetic/rqt_topic/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "812424972731209ebad755720d22d6d062f8caccda6656b2de5f265666340986";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg rostopic rqt-gui rqt-gui-py std-msgs ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_topic provides a GUI plugin for displaying debug information about ROS topics including publishers, subscribers, publishing rate, and ROS Messages.";

--- a/distros/noetic/rqt-web/default.nix
+++ b/distros/noetic/rqt-web/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, webkit-dependency }:
 buildRosPackage {
   pname = "ros-noetic-rqt-web";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_web-release/archive/release/noetic/rqt_web/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "ab966db5d643bc5912b5f915bd2849ea8d4563b59f44bff9cd25c42ecba61e8c";
+    url = "https://github.com/ros-gbp/rqt_web-release/archive/release/noetic/rqt_web/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "efb50ef4af4df584ac3f2d1a5698df46bfcbf71d6a8df81158793b6edb9a9903";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
+  buildInputs = [ catkin python3Packages.setuptools ];
   propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py webkit-dependency ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
     description = "rqt_web is a simple web content viewer for rqt. Users can show web content in Qt-based window by specifying its URL.";

--- a/distros/noetic/rqt/default.nix
+++ b/distros/noetic/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rqt-gui, rqt-gui-cpp, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "59d56c82e343c8dd90174fe2318b1c7245f76807c6d594cb834df9be769b44f0";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/noetic/rqt/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "74b276cd851621eef3037c058558844ba7eba4a4d79cf4a50aaa04fd833803fe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz-plugin-tutorials/default.nix
+++ b/distros/noetic/rviz-plugin-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rviz-plugin-tutorials";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/rviz_plugin_tutorials/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "2a8d6d52961928fd5da2cf8203bfbf658ec2df5df6f9ec3c0f055a4358f05e0e";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/rviz_plugin_tutorials/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "e3d5576f1ef6b477f59c4512184e2fd54f670f84dad799c434f3502502721293";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz-python-tutorial/default.nix
+++ b/distros/noetic/rviz-python-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rviz-python-tutorial";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/rviz_python_tutorial/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "a6973338e5b84132cb2d445288ec8c6d84b81964c28e72be3c7010379e8ea599";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/rviz_python_tutorial/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "4e26cfa674bd4700044ea3d4c6e9ffda030e43d840c2b332a8f812ae81e2130a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/std-msgs/default.nix
+++ b/distros/noetic/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-std-msgs";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/std_msgs-release/archive/release/noetic/std_msgs/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "3739ca3b5da2427b549056936fb36dddc712e910aeb2b3c5afaa61ab0df48bf3";
+    url = "https://github.com/ros-gbp/std_msgs-release/archive/release/noetic/std_msgs/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "5b3e8cd3e4cad78c208160849b0781770e0b138a542e396bda1e92666f5c2905";
   };
 
   buildType = "catkin";

--- a/distros/noetic/std-srvs/default.nix
+++ b/distros/noetic/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-std-srvs";
-  version = "1.11.3-r1";
+  version = "1.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm_msgs-release/archive/release/noetic/std_srvs/1.11.3-1.tar.gz";
-    name = "1.11.3-1.tar.gz";
-    sha256 = "32f4449a495c1d4ca4da3a02eaea03a665d85ae83bd713fe5652d6a9170f66c1";
+    url = "https://github.com/ros-gbp/ros_comm_msgs-release/archive/release/noetic/std_srvs/1.11.4-1.tar.gz";
+    name = "1.11.4-1.tar.gz";
+    sha256 = "1a2c9d3e1eb7b74dcf47cf82b2f263f8fbd95f4d0861c292d181358da98f5ba4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf-conversions/default.nix
+++ b/distros/noetic/tf-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, kdl-conversions, orocos-kdl, python3Packages, tf }:
 buildRosPackage {
   pname = "ros-noetic-tf-conversions";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/tf_conversions/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "812795f7af1b22c8e82405f9832587653abcc3250b4606e910df0f0c38b304d6";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/tf_conversions/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "ee90e8b54280b000356b076083f76fa035f748e690c07dc8a6285387b48f946f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf/default.nix
+++ b/distros/noetic/tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geometry-msgs, graphviz, message-filters, message-generation, message-runtime, rosconsole, roscpp, rostest, rostime, rosunit, roswtf, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/tf/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "e80444520026246b20a25f86f897cac53af73b3019b478d0abacaae5c46f480d";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/tf/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "1ffeba83971b4b1fae35616dcb11da3a99a8a5f6603c3ee6b9aef2fe697e4147";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-bullet/default.nix
+++ b/distros/noetic/tf2-bullet/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bullet, catkin, geometry-msgs, pkg-config, tf2 }:
+{ lib, buildRosPackage, fetchurl, bullet, catkin, geometry-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-bullet";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_bullet/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "60c9dc1e9743218c4c012819b3f09a5caeedcddab2ee41e5e95cd6bbcd541aea";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_bullet/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "3724e9a8b2fa0ac7b123d4238b9bfc0b4d98f22a08ba56a00510b305f24091d3";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin pkg-config ];
+  buildInputs = [ catkin ];
   propagatedBuildInputs = [ bullet geometry-msgs tf2 ];
-  nativeBuildInputs = [ catkin pkg-config ];
+  nativeBuildInputs = [ catkin ];
 
   meta = {
     description = "tf2_bullet";

--- a/distros/noetic/tf2-eigen/default.nix
+++ b/distros/noetic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-eigen";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_eigen/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "6758c100e693708ebb0b0a5566fb9dda5bdb66581e831d0a0bedf813a947bf8e";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_eigen/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "40299e5e82f3ab4d2bc069e8241b4bfec3791f5e74b32a4b308675c6ff4b7e14";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-geometry-msgs/default.nix
+++ b/distros/noetic/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl, python3Packages, ros-environment, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-geometry-msgs";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_geometry_msgs/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "65ee0f2b31f4a7e00a00e10645c72a9eb82d16bf7b3652b2512f124014a5b8ca";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_geometry_msgs/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "3e926c82ad818deb974a5b2f3302aff716bc1a79a9379b89e9741b20652ee0fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-kdl/default.nix
+++ b/distros/noetic/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, orocos-kdl, ros-environment, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-kdl";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_kdl/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "f706d2ab7d6be921dc85a10c0d7eb656d60d00b00332a0b4388c470b5dbe9818";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_kdl/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "aa8b92456abd908c634a76abe0d41c1aed37418d9c42b2eec57e6c4289b62d28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-msgs/default.nix
+++ b/distros/noetic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation }:
 buildRosPackage {
   pname = "ros-noetic-tf2-msgs";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_msgs/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "90186a27936fab807993a65b9cd37f0d75cb6ac5f94ec42a20b6b0647a5025b9";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_msgs/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "6175b6b143e93d6e481d04adfc1d649bdcea0aba6612fc8d908818a28a4ff0d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-py/default.nix
+++ b/distros/noetic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-py";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_py/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "85116cfca21a47310aa075f5b9a3c718b5a5c4bf55f8310eff90d9249ba219ea";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_py/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "651d4eb98faea1190b46faaa8fde245edfdc943cea5cfad0307338a5d8304a2e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-ros/default.nix
+++ b/distros/noetic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-filters, roscpp, rosgraph, rospy, rostest, std-msgs, tf2, tf2-msgs, tf2-py, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-tf2-ros";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_ros/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "15a92e64deab87ec27986b6d16d690bef7979cefbe2346a0fc1e37090acb3881";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_ros/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "8bcef4c019f02cd7cde89b34e4cce97ff5363bf68d6e2d17d0342b9ca4fb2f8a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-sensor-msgs/default.nix
+++ b/distros/noetic/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, python3Packages, rospy, rostest, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-sensor-msgs";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_sensor_msgs/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "9abd5230feb17b73b983cfbee8f19c0cbda9b9fce4aefa94d4f1960956180d87";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_sensor_msgs/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "afe1f9c5e768c373b892418407b21d58ad8098480aff8f97acc1f1faa559c780";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-tools/default.nix
+++ b/distros/noetic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-tools";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_tools/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "5240dc9950b1e8f042cfbd49fa0043985ef02677d247099bcb4ca6dfa3f645a9";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_tools/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "c4bc8943c756d92c359b7ee22cb4465d98092e261603f726e22eda19b38edf6e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2/default.nix
+++ b/distros/noetic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, console-bridge, geometry-msgs, rostime, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-tf2";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "92205cf32422e07d31a0c849cc8a93ec7bdabee88b80fa425d683b4a12efb135";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "da4198c85c396e9aaa749ce462243235d81ba0aea65a14c3533797080cb7d1fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtle-tf/default.nix
+++ b/distros/noetic/turtle-tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, rospy, std-msgs, tf, turtlesim }:
 buildRosPackage {
   pname = "ros-noetic-turtle-tf";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/noetic/turtle_tf/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "647812c3fbed1534f79012e4c22e5701fe2d1b8dc0e3f838e96420e803fc313f";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/noetic/turtle_tf/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "ee931e975a975648eeecfb48fa880dfaee3151bd043d491b857a986dc67a1637";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtle-tf2/default.nix
+++ b/distros/noetic/turtle-tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, rospy, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-noetic-turtle-tf2";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/noetic/turtle_tf2/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "540a3c37186add6323b4c91fe7baff1671158b1b70edd2ed7f57e3903265e362";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/noetic/turtle_tf2/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "e7f9178181a4c15c8b9f5b44fb916ec3f9d394d74125efda9b3a7d51eeb6a0b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlesim/default.nix
+++ b/distros/noetic/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, qt5, rosconsole, roscpp, roscpp-serialization, roslib, rostime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-turtlesim";
-  version = "0.10.2-r1";
+  version = "0.10.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/turtlesim/0.10.2-1.tar.gz";
-    name = "0.10.2-1.tar.gz";
-    sha256 = "f5e1c21ee45163443ccc76bdae473e39b1f1015e2289ab13e6a7391c59bd33fb";
+    url = "https://github.com/ros-gbp/ros_tutorials-release/archive/release/noetic/turtlesim/0.10.3-1.tar.gz";
+    name = "0.10.3-1.tar.gz";
+    sha256 = "0f07b73276f9d0830bcf2392733f3500027568bb0d9019c464b49616d6b200bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/universal-robots/default.nix
+++ b/distros/noetic/universal-robots/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ur-description, ur-gazebo, ur10-moveit-config, ur10e-moveit-config, ur16e-moveit-config, ur20-moveit-config, ur3-moveit-config, ur30-moveit-config, ur3e-moveit-config, ur5-moveit-config, ur5e-moveit-config }:
+{ lib, buildRosPackage, fetchurl, catkin, ur-description, ur-gazebo, ur10-moveit-config, ur10e-moveit-config, ur12e-moveit-config, ur16e-moveit-config, ur20-moveit-config, ur3-moveit-config, ur30-moveit-config, ur3e-moveit-config, ur5-moveit-config, ur5e-moveit-config, ur7e-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-universal-robots";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/universal_robots/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "121c3dbe823e3235a573def84b447bae2547bd7c373b0f71307892fb3e2871f3";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/universal_robots/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "0b32ed7d23fb190e177cd217f755f02e58904524781c441818cc525e7309bb71";
   };
 
   buildType = "catkin";
   buildInputs = [ catkin ];
-  propagatedBuildInputs = [ ur-description ur-gazebo ur10-moveit-config ur10e-moveit-config ur16e-moveit-config ur20-moveit-config ur3-moveit-config ur30-moveit-config ur3e-moveit-config ur5-moveit-config ur5e-moveit-config ];
+  propagatedBuildInputs = [ ur-description ur-gazebo ur10-moveit-config ur10e-moveit-config ur12e-moveit-config ur16e-moveit-config ur20-moveit-config ur3-moveit-config ur30-moveit-config ur3e-moveit-config ur5-moveit-config ur5e-moveit-config ur7e-moveit-config ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ur-description/default.nix
+++ b/distros/noetic/ur-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur-description";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_description/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "27695dd079d7b005f3e0ed09ac2b3604af7df1c531ba7c22a795659af3784ba9";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_description/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "1b0b6af27fdadc1bd47b32c130f12605176e46b67ea44c2811614f6436d9ee22";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-gazebo/default.nix
+++ b/distros/noetic/ur-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, effort-controllers, gazebo-ros, gazebo-ros-control, joint-state-controller, joint-trajectory-controller, position-controllers, robot-state-publisher, roslaunch, ur-description }:
 buildRosPackage {
   pname = "ros-noetic-ur-gazebo";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_gazebo/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "55217f5a8a222feb7798e9d5be15609d533c3c8effd32eeb83c1e5a5d6c63f72";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur_gazebo/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "ef330f9b4b4844630e361a27946cf20912a1c9664a861d22950a6b2b45339005";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur10-moveit-config/default.nix
+++ b/distros/noetic/ur10-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur10-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "1662543b514e7b0677cae3a24c69c036ff7d372e8f597a9baca4811621ab3297";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "00eba66cee67c4ec0c2fd658d85148fd5e3c83dc2be87dbf0b33ece8a0fbdcf2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur10e-moveit-config/default.nix
+++ b/distros/noetic/ur10e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur10e-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10e_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "88cfe6a084835c3e33de3b4849fa6b88baf530d502ea7cd0738e9abcdca3e7b7";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur10e_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "5eb824462b1fe656724976b061b8934581cf431fcfd398810e28137ab9f6624f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur12e-moveit-config/default.nix
+++ b/distros/noetic/ur12e-moveit-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-ur12e-moveit-config";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur12e_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "74aa92763a5d5bbea34f24442dc1bddf05adc80ba3d50fc23c518c356a1b6e1f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-fake-controller-manager moveit-planners-ompl moveit-ros-benchmarks moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz tf2-ros trac-ik-kinematics-plugin ur-description warehouse-ros-mongo xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the ur12e with the MoveIt Motion Planning Framework";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ur16e-moveit-config/default.nix
+++ b/distros/noetic/ur16e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur16e-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur16e_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "3208e6aea2292592a82025704cfc6edd6022880c68c3e5627113f4dd90b0e2b8";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur16e_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "477946f8898926416d00c36d5de56bb7a03a82d0d1a2a6e340afb40715d19c7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur20-moveit-config/default.nix
+++ b/distros/noetic/ur20-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur20-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur20_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "3ceb7472473cc25ca1ec42692ce7664b038fc59b8fac7698d81ff4c3dccba06f";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur20_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "96dbfe1286581a468dfbf9081b723d857dc77ffe0e98835adaac74d2d379e077";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur3-moveit-config/default.nix
+++ b/distros/noetic/ur3-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur3-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "8746b956ca182345f66e0f9a19038a480a24c6cc889f53f47e034c36de310c7e";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "010a1704c181076b2f6363b4b13766a4f6b64335f0a942bd1b3a88bf3c15da1d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur30-moveit-config/default.nix
+++ b/distros/noetic/ur30-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur30-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur30_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "a68bcdc970c5dc2d94eed8091d85d3a296b83ed7989fda668b9a8e7aa967ce52";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur30_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "e3843178f23a4c5bb635985caba6a5e7e287f9f475a8aa75d861112151a71295";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur3e-moveit-config/default.nix
+++ b/distros/noetic/ur3e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur3e-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3e_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "5a4ea71067c0a6fa69b203ff9be2a169c904964e73069251a6f9c794bf1f9946";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur3e_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "132024a6e2bb744ad1eebdfef0b435d4b7a55b4c8e158a50319c49d9ae159470";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur5-moveit-config/default.nix
+++ b/distros/noetic/ur5-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur5-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "07604a2f515aad5055031008c425ac8b1f6b1578e6f4b9e3fafd8c98543eec1a";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "94515aa28ea80f0266c2898c55742369ee97e8e871ba20a745eac7b9efa5c030";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur5e-moveit-config/default.nix
+++ b/distros/noetic/ur5e-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ur5e-moveit-config";
-  version = "1.3.3-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5e_moveit_config/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "fdee6c6a3b6576ad5514321db3bcb7714ed12a39e9d0d30be99661569b3cf92d";
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur5e_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "619c0ed379b22dd0914507d1a88cb52e7490a640bd9cec96fb1aff3b748618b9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur7e-moveit-config/default.nix
+++ b/distros/noetic/ur7e-moveit-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-fake-controller-manager, moveit-planners-ompl, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rviz, tf2-ros, trac-ik-kinematics-plugin, ur-description, warehouse-ros-mongo, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-ur7e-moveit-config";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/universal_robot-release/archive/release/noetic/ur7e_moveit_config/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "4f80cf7ff3b6e5cd54ff1a104113031e9e54b718fba309b9a10635e8076ebe78";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ catkin ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-fake-controller-manager moveit-planners-ompl moveit-ros-benchmarks moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager robot-state-publisher rviz tf2-ros trac-ik-kinematics-plugin ur-description warehouse-ros-mongo xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the ur7e with the MoveIt Motion Planning Framework";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/urdf-parser-plugin/default.nix
+++ b/distros/noetic/urdf-parser-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-noetic-urdf-parser-plugin";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdf-release/archive/release/noetic/urdf_parser_plugin/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "dbcd40e7d574614908247854c7e3819cc0de375257f7e9e375596d6829e50603";
+    url = "https://github.com/ros-gbp/urdf-release/archive/release/noetic/urdf_parser_plugin/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "e7e6fcf185ebec3a04897bf7fbfd97342c56155829ee58a1eb4a012dd75d072a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urdf/default.nix
+++ b/distros/noetic/urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pluginlib, rosconsole-bridge, roscpp, rostest, tinyxml, tinyxml-2, urdf-parser-plugin, urdfdom, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-noetic-urdf";
-  version = "1.13.2-r1";
+  version = "1.13.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdf-release/archive/release/noetic/urdf/1.13.2-1.tar.gz";
-    name = "1.13.2-1.tar.gz";
-    sha256 = "4ea6bd9d92f2a2a0f25a41409d4b38b90d2fd137fa1fabbad4462a9af9a94588";
+    url = "https://github.com/ros-gbp/urdf-release/archive/release/noetic/urdf/1.13.3-1.tar.gz";
+    name = "1.13.3-1.tar.gz";
+    sha256 = "74d0244a95ed139cbc22a7e1b1f1172d06b895774c87d64ed6883c47563c7130";
   };
 
   buildType = "catkin";

--- a/distros/noetic/visualization-marker-tutorials/default.nix
+++ b/distros/noetic/visualization-marker-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-visualization-marker-tutorials";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/visualization_marker_tutorials/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "403a4658fd70b1faa9b6650839f28751383d1cd57fd7787fc4bee4bf7171fe1c";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/visualization_marker_tutorials/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "4643aa30e98522f7ab8458add9c6a409a7b97e64565639798ccf6f0d00671a86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/visualization-tutorials/default.nix
+++ b/distros/noetic/visualization-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-marker-tutorials, librviz-tutorial, rviz-plugin-tutorials, rviz-python-tutorial, visualization-marker-tutorials }:
 buildRosPackage {
   pname = "ros-noetic-visualization-tutorials";
-  version = "0.11.0-r1";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/visualization_tutorials/0.11.0-1.tar.gz";
-    name = "0.11.0-1.tar.gz";
-    sha256 = "595fcd50bd39b8cfa6ddcafd6e3365d6ed515d8a0cebbeb05603c29400c62cb9";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/noetic/visualization_tutorials/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "69cfb74ad79efe78f89a20303bf623157e804cdc1843b502c1157b2fda0e637c";
   };
 
   buildType = "catkin";

--- a/distros/rolling/autoware-cmake/default.nix
+++ b/distros/rolling/autoware-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, autoware-lint-common, ros-environment }:
 buildRosPackage {
   pname = "ros-rolling-autoware-cmake";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_cmake/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "03218fe1ecbf19eff17afa6bc950d72e68ee52553ce29bc1071c67dafc74fafa";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_cmake/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "c9c0cc75ef2aba6b0c496c6e303c91c93b33f430a2150d350efa95f5283d2247";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-common-msgs/default.nix
+++ b/distros/rolling/autoware-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-autoware-common-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_common_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "73a05e510dc4d7b1640859b70351e1708d7d5e6741b80463d3d0f9b66df3514e";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_common_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "0db5dd7e62aa83823635c01b9966ba85f3da14fa0bcce13f07f6f768729a60aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-control-msgs/default.nix
+++ b/distros/rolling/autoware-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-autoware-control-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_control_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "862d8dc742c03048113177a20d991041da41d0e4174caac93db120fbf275a21e";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_control_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "e275ce6c666d207492fa885f15dea817b6ee4f35888e0b6d0e120d86ecdb2115";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-debug-msgs/default.nix
+++ b/distros/rolling/autoware-internal-debug-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-debug-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_debug_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "4b9c18a7e12e7737d52e2f7814718365f32d9fbb095bb0734ca2767f084032d1";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_debug_msgs/1.8.1-2.tar.gz";
+    name = "1.8.1-2.tar.gz";
+    sha256 = "26ececf0e31067313fb28dbdb2ffda2aa9d17fb0cd16badf05ac676cfda08c20";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-metric-msgs/default.nix
+++ b/distros/rolling/autoware-internal-metric-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-rolling-autoware-internal-metric-msgs";
+  version = "1.8.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_metric_msgs/1.8.1-2.tar.gz";
+    name = "1.8.1-2.tar.gz";
+    sha256 = "689cd2f7447715ecc72c43676bb87bd93016095b5bc6b84f10c701ebd5120393";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = "The autoware_internal_metric_msgs package";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/autoware-internal-msgs/default.nix
+++ b/distros/rolling/autoware-internal-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-internal-debug-msgs, autoware-internal-metric-msgs, autoware-internal-perception-msgs, autoware-internal-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "62a401d026e6f52bc0c1c32ac010ceeae28a92d2065deb89708fea439b453aa0";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_msgs/1.8.1-2.tar.gz";
+    name = "1.8.1-2.tar.gz";
+    sha256 = "bf4a907e56832edc81335cd4620bdf886fca9610006979965fcf6354442b4ffe";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  propagatedBuildInputs = [ autoware-internal-debug-msgs autoware-internal-metric-msgs autoware-internal-perception-msgs autoware-internal-planning-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {

--- a/distros/rolling/autoware-internal-perception-msgs/default.nix
+++ b/distros/rolling/autoware-internal-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-perception-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_perception_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "2ac3d2720c626d7c8ede6db17920ef125d643f291071e37cd4f601e2dc266fa1";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_perception_msgs/1.8.1-2.tar.gz";
+    name = "1.8.1-2.tar.gz";
+    sha256 = "a6eb51588cdcab162d606196bc62b4db0dfad725b447d69fffbb92f29f63878a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-internal-planning-msgs/default.nix
+++ b/distros/rolling/autoware-internal-planning-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-common-msgs, autoware-perception-msgs, autoware-planning-msgs, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-internal-planning-msgs";
-  version = "1.5.0-r1";
+  version = "1.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_planning_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "1f3ea1d54768c34274390bb453f2ca8c19ff22e511b0839cdd71273745f294ff";
+    url = "https://github.com/ros2-gbp/autoware_internal_msgs-release/archive/release/rolling/autoware_internal_planning_msgs/1.8.1-2.tar.gz";
+    name = "1.8.1-2.tar.gz";
+    sha256 = "59391dc3f1b9fa435a21a3fa3d8a0f211d0538d42f7f22e2201cfcf4e4769d8d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto rosidl-default-generators ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ autoware-perception-msgs autoware-planning-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
+  propagatedBuildInputs = [ autoware-common-msgs autoware-perception-msgs autoware-planning-msgs builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/rolling/autoware-lanelet2-extension-python/default.nix
+++ b/distros/rolling/autoware-lanelet2-extension-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-lanelet2-extension, boost, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, python-cmake-module, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lanelet2-extension-python";
-  version = "0.6.2-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension_python/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "e5a181002a9b70586aa3de90d6b61d722ea7c6c734c334a1bea88071424953c8";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension_python/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "ecd2eb59571fb05ad3e274a1c9c6225a5273e5e72e99be81d90473b5bbe6dd05";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-lanelet2-extension/default.nix
+++ b/distros/rolling/autoware-lanelet2-extension/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, autoware-utils, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, autoware-cmake, autoware-map-msgs, autoware-planning-msgs, geographiclib, geometry-msgs, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, pugixml, range-v3, rclcpp, tf2, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lanelet2-extension";
-  version = "0.6.2-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "c00cdcd19b8a84a78bfc1e2203de0fe7e896199f3cef813806072a1cea1f319f";
+    url = "https://github.com/ros2-gbp/autoware_lanelet2_extension-release/archive/release/rolling/autoware_lanelet2_extension/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "26c848451624ee22d4076fc654821aa1def50abc28077709fac13dcfb2b4fb33";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake-auto autoware-cmake ];
   checkInputs = [ ament-cmake-ros ];
-  propagatedBuildInputs = [ autoware-map-msgs autoware-planning-msgs autoware-utils geographiclib geometry-msgs lanelet2-core lanelet2-io lanelet2-maps lanelet2-projection lanelet2-routing lanelet2-traffic-rules lanelet2-validation pugixml range-v3 rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ autoware-map-msgs autoware-planning-msgs geographiclib geometry-msgs lanelet2-core lanelet2-io lanelet2-maps lanelet2-projection lanelet2-routing lanelet2-traffic-rules lanelet2-validation pugixml range-v3 rclcpp tf2 tf2-geometry-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake-auto autoware-cmake ];
 
   meta = {

--- a/distros/rolling/autoware-lint-common/default.nix
+++ b/distros/rolling/autoware-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-export-dependencies, ament-cmake-lint-cmake, ament-cmake-test, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-rolling-autoware-lint-common";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_lint_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "9f058f35e7a5486f99d21df063a0d5fa4448ebcd3c5c6399764cbda33951d785";
+    url = "https://github.com/ros2-gbp/autoware_cmake-release/archive/release/rolling/autoware_lint_common/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "52b163666f5b6fb81a854eafe5e4443ad63d843159da911fec27e19baaabeb9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-localization-msgs/default.nix
+++ b/distros/rolling/autoware-localization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-localization-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_localization_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "27abf34bdc8a4e91a1d45509cfa5a3bee117b1bb30af8756a47895bb91b33e0e";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_localization_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "417e7cea82dc58e42a76d4890ccbc3b3c1c0ffa0a3e68efcf482986c7ac86079";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-map-msgs/default.nix
+++ b/distros/rolling/autoware-map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-map-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_map_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ceeeb6a944fe537dc0e63f7b5a3588339612a01b4c657ad0a38fc3b5198828c4";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_map_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "80b0f684540d37a497c65544f05f7c19056df236491e35ac504d441f211765d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-msgs/default.nix
+++ b/distros/rolling/autoware-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, autoware-common-msgs, autoware-control-msgs, autoware-localization-msgs, autoware-map-msgs, autoware-perception-msgs, autoware-planning-msgs, autoware-sensing-msgs, autoware-system-msgs, autoware-v2x-msgs, autoware-vehicle-msgs }:
+buildRosPackage {
+  pname = "ros-rolling-autoware-msgs";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "9732068f81d173f2b175748178b072bfcac378463605256c5b8c057aca0d2855";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ autoware-common-msgs autoware-control-msgs autoware-localization-msgs autoware-map-msgs autoware-perception-msgs autoware-planning-msgs autoware-sensing-msgs autoware-system-msgs autoware-v2x-msgs autoware-vehicle-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Meta package for the autoware_msgs packages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/rolling/autoware-perception-msgs/default.nix
+++ b/distros/rolling/autoware-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-perception-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_perception_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "e01c9e9e7c649c3cfbb8a875b1c63c1d4cc81fb5a9204158334a57fd8c90dca2";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_perception_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "7fb5a2f9c49e490e3347b1eac7c716083d9d8a77788a217aec6a7d9aa6f4fe15";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-planning-msgs/default.nix
+++ b/distros/rolling/autoware-planning-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-planning-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_planning_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "15487743ae2a8cdbce79ced2c000df86083ef2b39814e9a2fc6465431be39d4d";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_planning_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "e81cdf956c5437ab04ecddee66fa460c3f629ca8324e6db71d59b63e20984f35";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-sensing-msgs/default.nix
+++ b/distros/rolling/autoware-sensing-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-sensing-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_sensing_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2de433925a5265a5a9652ce716c5990d6008337260360e02b93846e7972d7084";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_sensing_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "567abce9f9425fc70e484b295385d6da06875cb02fa6a76bd0bcfafa1aea7f72";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-system-msgs/default.nix
+++ b/distros/rolling/autoware-system-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-system-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_system_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "63cbdadd34eb074ac2771d2d6d1cd0611420033c71d10968c7fc169dedcdcf62";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_system_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "41a84b19ded67c61159813d8c74f764222d082155cf79254559a668259d3303d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-v2x-msgs/default.nix
+++ b/distros/rolling/autoware-v2x-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-rolling-autoware-v2x-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_v2x_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "61317bd134be7cfcae41deef0bcff84cd1f794afdcc44be6d1eb72c031f885c8";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_v2x_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "14ea42986c686875e04293c41961a87f38305c4a1346c4af465476ec13da6a13";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/autoware-vehicle-msgs/default.nix
+++ b/distros/rolling/autoware-vehicle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, autoware-planning-msgs, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-autoware-vehicle-msgs";
-  version = "1.4.0-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_vehicle_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "4f8f3965dc575105d2b55b18f2af626204a0e1eacf28eef3c72d727e8851a2f8";
+    url = "https://github.com/ros2-gbp/autoware_msgs-release/archive/release/rolling/autoware_vehicle_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "9c73c97c25838eb5800bb2844a660e8a509cdfa9aa9d30fdaec332f250a74fc7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/control-toolbox/default.nix
+++ b/distros/rolling/control-toolbox/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, eigen, filters, generate-parameter-library, geometry-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake }:
 buildRosPackage {
   pname = "ros-rolling-control-toolbox";
-  version = "5.0.0-r1";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.0.0-1.tar.gz";
-    name = "5.0.0-1.tar.gz";
-    sha256 = "ca5e5df2e6b44b04983aa63c14202a6478e0f44552e33f52acbf15d2f880fd76";
+    url = "https://github.com/ros2-gbp/control_toolbox-release/archive/release/rolling/control_toolbox/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "dd7c7760e06190557caa3ec7a134ae6c749bfa6525448158e773caba1c7c86dd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock rclcpp-lifecycle ];
   propagatedBuildInputs = [ control-msgs eigen filters generate-parameter-library geometry-msgs pluginlib rclcpp rcutils realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/rolling/dynamixel-hardware-interface/default.nix
+++ b/distros/rolling/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-rolling-dynamixel-hardware-interface";
-  version = "1.4.1-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "06c3adf1839b43e2fd8e735f58d7cc23a6462eba73ae873ed72dcac4a912b55e";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/rolling/dynamixel_hardware_interface/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "be1f87faf9cca65d1b97c107381a4ca309a59a2f66da3702c56263dea12a0f4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/fastdds/default.nix
+++ b/distros/rolling/fastdds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, python3, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-rolling-fastdds";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "9b83f8ae395af1d873c607ee18cde5edd9c51a005f361f609296e40444425414";
+    url = "https://github.com/ros2-gbp/fastdds-release/archive/release/rolling/fastdds/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "ceed57d33eb6cde4a4eac96696a79cdbad0fc86057ad208bf3b7c8377d5e5f11";
   };
 
   buildType = "cmake";

--- a/distros/rolling/generated.nix
+++ b/distros/rolling/generated.nix
@@ -210,11 +210,15 @@ self: super: {
 
  autoware-internal-debug-msgs = self.callPackage ./autoware-internal-debug-msgs {};
 
+ autoware-internal-metric-msgs = self.callPackage ./autoware-internal-metric-msgs {};
+
  autoware-internal-msgs = self.callPackage ./autoware-internal-msgs {};
 
  autoware-internal-perception-msgs = self.callPackage ./autoware-internal-perception-msgs {};
 
  autoware-internal-planning-msgs = self.callPackage ./autoware-internal-planning-msgs {};
+
+ autoware-lanelet2-extension = self.callPackage ./autoware-lanelet2-extension {};
 
  autoware-lanelet2-extension-python = self.callPackage ./autoware-lanelet2-extension-python {};
 
@@ -223,6 +227,8 @@ self: super: {
  autoware-localization-msgs = self.callPackage ./autoware-localization-msgs {};
 
  autoware-map-msgs = self.callPackage ./autoware-map-msgs {};
+
+ autoware-msgs = self.callPackage ./autoware-msgs {};
 
  autoware-perception-msgs = self.callPackage ./autoware-perception-msgs {};
 

--- a/distros/rolling/gz-ros2-control-demos/default.nix
+++ b/distros/rolling/gz-ros2-control-demos/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, diff-drive-controller, effort-controllers, geometry-msgs, gz-ros2-control, hardware-interface, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, launch, launch-ros, mecanum-drive-controller, rclcpp, rclcpp-action, robot-state-publisher, ros-gz-bridge, ros-gz-sim, ros2controlcli, ros2launch, std-msgs, tricycle-controller, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control-demos";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "18338cc69d1d0b0623a912779c7306c7be7882f5d02713b7be8999dfd6f7faf3";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control_demos/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "f253fae181c63690f67172f0dedaa8a8b086811ba7ab3a50de2b03b40e30f69e";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-action ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ackermann-steering-controller ament-index-python control-msgs diff-drive-controller effort-controllers geometry-msgs gz-ros2-control hardware-interface imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller launch launch-ros mecanum-drive-controller rclcpp robot-state-publisher ros-gz-bridge ros-gz-sim ros2controlcli ros2launch std-msgs tricycle-controller velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/rolling/gz-ros2-control/default.nix
+++ b/distros/rolling/gz-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-manager, gz-plugin-vendor, gz-sim-vendor, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-rolling-gz-ros2-control";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "7d499ad8176268be7b30507c7cd95646df4fb124bd3c3ab2caf5e3daa2675326";
+    url = "https://github.com/ros2-gbp/ign_ros2_control-release/archive/release/rolling/gz_ros2_control/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "1c0b56f620adcd1cf43b8458826ba597bc47735481f2af95325b69b891035209";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/hatchbed-common/default.nix
+++ b/distros/rolling/hatchbed-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-hatchbed-common";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/hatchbed_common-release/archive/release/rolling/hatchbed_common/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "68fae62c52b1a7b47bcfd3b72c6f316ce2e53113623e5e6e7d788c5a165f2c62";
+    url = "https://github.com/ros2-gbp/hatchbed_common-release/archive/release/rolling/hatchbed_common/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "8f572ed0b5f21eecf0e6c73f1565b95ff055d34ff0f974a7bfe80eeed119f7a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libcamera/default.nix
+++ b/distros/rolling/libcamera/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, libyaml, meson, openssl, pkg-config, python3, python3Packages, udev }:
+{ lib, buildRosPackage, fetchurl, git, libyaml, meson, openssl, pkg-config, python3, python3Packages, udev }:
 buildRosPackage {
   pname = "ros-rolling-libcamera";
-  version = "0.4.0-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1ad70b2ba2e938443c408e2d678d0e70b55c849d8270706196774b91574fc7d0";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "6f28dc9215efe170c7f242c5f52a4ebfd7a9819744703392db5130dd562da4a6";
   };
 
   buildType = "meson";
-  buildInputs = [ meson pkg-config python3Packages.jinja2 python3Packages.ply python3Packages.pybind11 python3Packages.pyyaml ];
+  buildInputs = [ git meson pkg-config python3Packages.jinja2 python3Packages.ply python3Packages.pybind11 python3Packages.pyyaml ];
   propagatedBuildInputs = [ libyaml openssl python3 udev ];
-  nativeBuildInputs = [ meson ];
+  nativeBuildInputs = [ git meson pkg-config ];
 
   meta = {
     description = "An open source camera stack and framework for Linux, Android, and ChromeOS";

--- a/distros/rolling/message-filters/default.nix
+++ b/distros/rolling/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rclcpp, rclcpp-lifecycle, rclpy, rcutils, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-message-filters";
-  version = "7.0.2-r1";
+  version = "7.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.0.2-1.tar.gz";
-    name = "7.0.2-1.tar.gz";
-    sha256 = "0fb7b6913b1bc6c7f472087df189d3046f27c41c323cf06c11dcd442cf6fcebd";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/rolling/message_filters/7.1.0-1.tar.gz";
+    name = "7.1.0-1.tar.gz";
+    sha256 = "4a0e41d0579a68c7a6230637b196ad9482e05cf3b30a4ba748a898c50813c089";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pcl-conversions/default.nix
+++ b/distros/rolling/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, message-filters, pcl, pcl-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-pcl-conversions";
-  version = "2.6.1-r3";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_conversions/2.6.1-3.tar.gz";
-    name = "2.6.1-3.tar.gz";
-    sha256 = "973f39705df732aeb8d5157f66fd48bd77252acf868780a73c98bc3840a70d12";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_conversions/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "a69aa08cc9a44d757a276b76a23f4f57fc91d2a7db4dcf7c7919d5779932be4f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pcl-ros/default.nix
+++ b/distros/rolling/pcl-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, eigen, geometry-msgs, launch, launch-ros, launch-testing, launch-testing-ros, pcl, pcl-conversions, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-pcl-ros";
-  version = "2.6.1-r3";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_ros/2.6.1-3.tar.gz";
-    name = "2.6.1-3.tar.gz";
-    sha256 = "8a6bd01caa897348dca161fb12b6fcc655e2b18a2700865509f1ae29c1a17dcf";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/pcl_ros/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "416282dd02cd549c186af779644be16f23a60cb1bccf6016acb83537e4ab3cdd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ros sensor-msgs ];
-  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs pcl pcl-conversions rclcpp rclcpp-components sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/rolling/perception-pcl/default.nix
+++ b/distros/rolling/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-rolling-perception-pcl";
-  version = "2.6.1-r3";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/perception_pcl/2.6.1-3.tar.gz";
-    name = "2.6.1-3.tar.gz";
-    sha256 = "701adce1a8c15dc1f8b71fabb56c26d6b954571257ec73ca31231599cdde85e7";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/rolling/perception_pcl/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "f492a84ad3710112a43a6041c5df1c9d68af85f5558234efdb23442e9880cd67";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-action/default.nix
+++ b/distros/rolling/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rcl-action";
-  version = "10.0.2-r1";
+  version = "10.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.0.2-1.tar.gz";
-    name = "10.0.2-1.tar.gz";
-    sha256 = "e5ca785441e7c93fa61160f31758fc97a064e4c414ad5284ab7d5160ff0bdcbf";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_action/10.1.0-1.tar.gz";
+    name = "10.1.0-1.tar.gz";
+    sha256 = "2549e8846b55b9e7072fb1f143677c2dd08fce6169a96f50487a1069b438a198";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-lifecycle/default.nix
+++ b/distros/rolling/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rcl-lifecycle";
-  version = "10.0.2-r1";
+  version = "10.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.0.2-1.tar.gz";
-    name = "10.0.2-1.tar.gz";
-    sha256 = "90aabd2c737bca5a7b803f86484ad6c8b72464e365aba40eb37d5110899dde8a";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_lifecycle/10.1.0-1.tar.gz";
+    name = "10.1.0-1.tar.gz";
+    sha256 = "6950d095bb0196ca19c72a030b2e6e83e5b1001b8391b396552be873ec6c5831";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl-yaml-param-parser/default.nix
+++ b/distros/rolling/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-rolling-rcl-yaml-param-parser";
-  version = "10.0.2-r1";
+  version = "10.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.0.2-1.tar.gz";
-    name = "10.0.2-1.tar.gz";
-    sha256 = "5ce2ad9399f6d1f6619abd2f4008dba3a653168bd936db598b87166aed825405";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl_yaml_param_parser/10.1.0-1.tar.gz";
+    name = "10.1.0-1.tar.gz";
+    sha256 = "08a9aec94f0cc8b7e124af4f6ed16f5726c2f0d5cf42fbae95f39766af2fb56a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rcl/default.nix
+++ b/distros/rolling/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-interface, rcl-logging-spdlog, rcl-yaml-param-parser, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, rosidl-runtime-cpp, service-msgs, test-msgs, tracetools, type-description-interfaces }:
 buildRosPackage {
   pname = "ros-rolling-rcl";
-  version = "10.0.2-r1";
+  version = "10.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.0.2-1.tar.gz";
-    name = "10.0.2-1.tar.gz";
-    sha256 = "ee153c741e8df229a34847c6378d131b6895a6de69ab4be257e296dbc862331b";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/rolling/rcl/10.1.0-1.tar.gz";
+    name = "10.1.0-1.tar.gz";
+    sha256 = "02d7e03afe705975b26d17a066948bd43c82aab6781eaa91b3ae7daebec3295e";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-action/default.nix
+++ b/distros/rolling/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl, rcl-action, rclcpp, rcpputils, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-action";
-  version = "29.3.0-r1";
+  version = "29.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/29.3.0-1.tar.gz";
-    name = "29.3.0-1.tar.gz";
-    sha256 = "c249f4b8ac153ce065ff6c93a2d6051fa8d487d36537632ce7e40c5e29f15413";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_action/29.4.0-1.tar.gz";
+    name = "29.4.0-1.tar.gz";
+    sha256 = "5fa1d984dff0eaa299220029b86c90bb53e1e46ab6fd6aafc828c646dd1a9573";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-components/default.nix
+++ b/distros/rolling/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-components";
-  version = "29.3.0-r1";
+  version = "29.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/29.3.0-1.tar.gz";
-    name = "29.3.0-1.tar.gz";
-    sha256 = "6f8c97b6baff1939d38c1776586e5ccfb6c8865e3ecee894d37a6001f93027ff";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_components/29.4.0-1.tar.gz";
+    name = "29.4.0-1.tar.gz";
+    sha256 = "4c5ff66d5e02fa3f28d4b3a39eccbc96ac5e1e9bb9a1bf85bad52efe11c30851";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp-lifecycle/default.nix
+++ b/distros/rolling/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-lifecycle, rclcpp, rcpputils, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp-lifecycle";
-  version = "29.3.0-r1";
+  version = "29.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/29.3.0-1.tar.gz";
-    name = "29.3.0-1.tar.gz";
-    sha256 = "aa734d2c4346e4d39c3a555077d227c5c465a47df66228024eccf5cd363fbdbf";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp_lifecycle/29.4.0-1.tar.gz";
+    name = "29.4.0-1.tar.gz";
+    sha256 = "1e8db2b29f0c6c150658fe34b1ecd1c8cb25b30d14e14e4ed152ce546f4c7bfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/rclcpp/default.nix
+++ b/distros/rolling/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, python3, rcl, rcl-interfaces, rcl-logging-interface, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-dynamic-typesupport, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-rolling-rclcpp";
-  version = "29.3.0-r1";
+  version = "29.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/29.3.0-1.tar.gz";
-    name = "29.3.0-1.tar.gz";
-    sha256 = "50e8a09274e5fc7f4a1c7a8fd2e0f051a2e4feaffb74ae0838c3e0acb4290633";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/rolling/rclcpp/29.4.0-1.tar.gz";
+    name = "29.4.0-1.tar.gz";
+    sha256 = "674b770b28e6562a90cc0a0839a56aff15afcc61b65bf2e8c0a113eda6e1c86d";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/realtime-tools/default.nix
+++ b/distros/rolling/realtime-tools/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, boost, libcap, lifecycle-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2-control-cmake, test-msgs }:
 buildRosPackage {
   pname = "ros-rolling-realtime-tools";
-  version = "4.1.0-r1";
+  version = "4.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "bbd3ffd8db645604a4199db9ad13206e32323ca4c3c9a8c1d71baf70a5b22425";
+    url = "https://github.com/ros2-gbp/realtime_tools-release/archive/release/rolling/realtime_tools/4.2.0-1.tar.gz";
+    name = "4.2.0-1.tar.gz";
+    sha256 = "3a839d51801d87372a4123f1964afc27a8e4049576a4f26be6c49906d107bfa6";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock lifecycle-msgs rclcpp-lifecycle test-msgs ];
   propagatedBuildInputs = [ ament-cmake boost libcap rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 215f4895bf988ca94d2ccd09c9bd5d0971f9fcb9.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *autoware-cmake 1.0.1-r1 --> 1.0.2-r1*
* *autoware-common-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-control-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-internal-debug-msgs 1.5.0-r1 --> 1.8.1-r1*
* *autoware-internal-metric-msgs 1.8.1-r1*
* *autoware-internal-msgs 1.5.0-r1 --> 1.8.1-r1*
* *autoware-internal-perception-msgs 1.5.0-r1 --> 1.8.1-r1*
* *autoware-internal-planning-msgs 1.5.0-r1 --> 1.8.1-r1*
* *autoware-lanelet2-extension 0.6.3-r1 --> 0.7.0-r1*
* *autoware-lanelet2-extension-python 0.6.3-r1 --> 0.7.0-r1*
* *autoware-lint-common 1.0.1-r1 --> 1.0.2-r1*
* *autoware-localization-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-map-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-msgs 1.6.0-r1*
* *autoware-perception-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-planning-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-sensing-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-system-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-v2x-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-vehicle-msgs 1.4.0-r1 --> 1.6.0-r1*
* *clearpath-mecanum-drive-controller 0.1.0-r1 --> 0.1.1-r1*
* *clearpath-ros2-socketcan-interface 1.0.1-r2 --> 1.0.2-r1*
* *control-toolbox 3.6.0-r1 --> 3.6.1-r1*
* *diagnostic-aggregator 4.0.2-r1 --> 4.0.3-r1*
* *diagnostic-common-diagnostics 4.0.2-r1 --> 4.0.3-r1*
* *diagnostic-remote-logging 4.0.3-r1*
* *diagnostic-updater 4.0.2-r1 --> 4.0.3-r1*
* *diagnostics 4.0.2-r1 --> 4.0.3-r1*
* *dynamixel-hardware-interface 1.4.1-r1 --> 1.4.2-r1*
* *gz-ros2-control-demos 0.7.13-r1*
* *gz-ros2-control-tests 0.7.12-r1 --> 0.7.13-r1*
* *ign-ros2-control 0.7.13-r1*
* *ign-ros2-control-demos 0.7.12-r1 --> 0.7.13-r1*
* *message-filters 4.3.6-r1 --> 4.3.7-r1*
* *off-highway-can 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-general-purpose-radar 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-general-purpose-radar-msgs 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-premium-radar-sample 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-premium-radar-sample-msgs 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-radar 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-radar-msgs 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-sensor-drivers 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-sensor-drivers-examples 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-uss 0.7.0-r1 --> 0.8.0-r1*
* *off-highway-uss-msgs 0.7.0-r1 --> 0.8.0-r1*
* *realtime-tools 2.12.0-r1 --> 2.13.0-r1*
* *self-test 4.0.2-r1 --> 4.0.3-r1*

Jazzy Changes:
--------------
* *ament-package 0.16.3-r3 --> 0.16.4-r1*
* *autoware-cmake 1.0.1-r1 --> 1.0.2-r1*
* *autoware-common-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-control-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-internal-debug-msgs 1.5.0-r2 --> 1.8.1-r1*
* *autoware-internal-metric-msgs 1.8.1-r1*
* *autoware-internal-msgs 1.5.0-r2 --> 1.8.1-r1*
* *autoware-internal-perception-msgs 1.5.0-r2 --> 1.8.1-r1*
* *autoware-internal-planning-msgs 1.5.0-r2 --> 1.8.1-r1*
* *autoware-lanelet2-extension 0.6.2-r1 --> 0.7.0-r1*
* *autoware-lanelet2-extension-python 0.6.2-r1 --> 0.7.0-r1*
* *autoware-lint-common 1.0.1-r1 --> 1.0.2-r1*
* *autoware-localization-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-map-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-msgs 1.6.0-r1*
* *autoware-perception-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-planning-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-sensing-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-system-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-v2x-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-vehicle-msgs 1.4.0-r1 --> 1.6.0-r1*
* *camera-calibration-parsers 5.1.5-r1 --> 5.1.6-r1*
* *camera-info-manager 5.1.5-r1 --> 5.1.6-r1*
* *camera-info-manager-py 5.1.5-r1 --> 5.1.6-r1*
* *clearpath-bt-joy 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-common 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-control 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-customization 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-description 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-generator-common 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-manipulators 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-manipulators-description 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-mounts-description 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-platform-description 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-ros2-socketcan-interface 2.1.0-r1 --> 2.1.1-r2*
* *clearpath-sensors-description 2.2.0-r1 --> 2.2.2-r1*
* *clearpath-tests 0.2.9-r1 --> 2.3.0-r1*
* *control-toolbox 4.0.1-r1 --> 4.1.0-r1*
* *diagnostic-aggregator 4.2.2-r1 --> 4.2.3-r1*
* *diagnostic-common-diagnostics 4.2.2-r1 --> 4.2.3-r1*
* *diagnostic-remote-logging 4.2.3-r1*
* *diagnostic-updater 4.2.2-r1 --> 4.2.3-r1*
* *diagnostics 4.2.2-r1 --> 4.2.3-r1*
* *dynamixel-hardware-interface 1.4.1-r1 --> 1.4.2-r1*
* *gz-ros2-control 1.2.11-r1 --> 1.2.12-r1*
* *gz-ros2-control-demos 1.2.11-r1 --> 1.2.12-r1*
* *hatchbed-common 0.1.2-r1*
* *image-common 5.1.5-r1 --> 5.1.6-r1*
* *image-transport 5.1.5-r1 --> 5.1.6-r1*
* *laser-segmentation 3.0.4-r1*
* *libcurl-vendor 3.4.3-r1 --> 3.4.4-r1*
* *log-view 0.2.5-r1*
* *mp2p-icp 1.6.6-r1 --> 1.6.7-r1*
* *osrf-pycommon 2.1.5-r1 --> 2.1.6-r1*
* *point-cloud-transport 4.0.3-r1 --> 4.0.4-r1*
* *point-cloud-transport-py 4.0.3-r1 --> 4.0.4-r1*
* *realtime-tools 3.4.0-r1 --> 3.5.0-r1*
* *resource-retriever 3.4.3-r1 --> 3.4.4-r1*
* *self-test 4.2.2-r1 --> 4.2.3-r1*

Noetic Changes:
---------------
* *abb 1.5.0-r1*
* *abb-crb15000-support 1.5.0-r1*
* *abb-irb120-support 1.5.0-r1*
* *abb-irb1200-support 1.5.0-r1*
* *abb-irb1600-support 1.5.0-r1*
* *abb-irb2400-support 1.5.0-r1*
* *abb-irb2600-support 1.5.0-r1*
* *abb-irb4400-support 1.5.0-r1*
* *abb-irb4600-support 1.5.0-r1*
* *abb-irb52-support 1.5.0-r1*
* *abb-irb5400-support 1.5.0-r1*
* *abb-irb6600-support 1.5.0-r1*
* *abb-irb6640-support 1.5.0-r1*
* *abb-irb6650s-support 1.5.0-r1*
* *abb-irb6700-support 1.5.0-r1*
* *abb-irb7600-support 1.5.0-r1*
* *abb-resources 1.5.0-r1*
* *actionlib 1.14.0-r1 --> 1.14.1-r1*
* *actionlib-tools 1.14.0-r1 --> 1.14.1-r1*
* *angles 1.9.13-r1 --> 1.9.14-r1*
* *camera-calibration-parsers 1.12.0-r1 --> 1.12.1-r1*
* *camera-info-manager 1.12.0-r1 --> 1.12.1-r1*
* *catkin 0.8.10-r1 --> 0.8.11-r1*
* *class-loader 0.5.0-r1 --> 0.5.1-r1*
* *cmake-modules 0.5.0-r1 --> 0.5.1-r1*
* *depth-obstacle-detect-ros 1.0.0-r1*
* *depth-obstacle-detect-ros-msgs 1.0.0-r1*
* *dynamic-reconfigure 1.7.3-r1 --> 1.7.4-r1*
* *eigen-conversions 1.13.2-r1 --> 1.13.3-r1*
* *filters 1.9.2-r1 --> 1.9.3-r1*
* *gencpp 0.7.0-r1 --> 0.7.1-r1*
* *genmsg 0.6.0-r1 --> 0.6.1-r1*
* *genpy 0.6.15-r1 --> 0.6.17-r1*
* *geometry 1.13.2-r1 --> 1.13.3-r1*
* *geometry-tutorials 0.2.3-r1 --> 0.2.4-r1*
* *geometry2 0.7.7-r1 --> 0.7.8-r1*
* *gl-dependency 1.1.2-r1 --> 1.1.3-r1*
* *image-common 1.12.0-r1 --> 1.12.1-r1*
* *image-transport 1.12.0-r1 --> 1.12.1-r1*
* *interactive-marker-tutorials 0.11.0-r1 --> 0.11.1-r1*
* *interactive-markers 1.12.0-r1 --> 1.12.1-r1*
* *joint-state-publisher 1.15.1-r1 --> 1.15.2-r1*
* *joint-state-publisher-gui 1.15.1-r1 --> 1.15.2-r1*
* *kdl-conversions 1.13.2-r1 --> 1.13.3-r1*
* *laser-geometry 1.6.7-r1 --> 1.6.8-r1*
* *librviz-tutorial 0.11.0-r1 --> 0.11.1-r1*
* *mk 1.15.8-r1 --> 1.15.9-r1*
* *pluginlib 1.13.0-r1 --> 1.13.1-r1*
* *polled-camera 1.12.0-r1 --> 1.12.1-r1*
* *python-qt-binding 0.4.4-r1 --> 0.4.5-r1*
* *qt-dotgraph 0.4.2-r1 --> 0.4.3-r1*
* *qt-gui 0.4.2-r1 --> 0.4.3-r1*
* *qt-gui-app 0.4.2-r1 --> 0.4.3-r1*
* *qt-gui-core 0.4.2-r1 --> 0.4.3-r1*
* *qt-gui-cpp 0.4.2-r1 --> 0.4.3-r1*
* *qt-gui-py-common 0.4.2-r1 --> 0.4.3-r1*
* *resource-retriever 1.12.8-r1 --> 1.12.9-r1*
* *robot-state-publisher 1.15.2-r1 --> 1.15.3-r1*
* *ros 1.15.8-r1 --> 1.15.9-r1*
* *ros-tutorials 0.10.2-r1 --> 0.10.3-r1*
* *rosbag-migration-rule 1.0.1-r1 --> 1.0.2-r1*
* *rosbash 1.15.8-r1 --> 1.15.9-r1*
* *rosboost-cfg 1.15.8-r1 --> 1.15.9-r1*
* *rosbuild 1.15.8-r1 --> 1.15.9-r1*
* *rosclean 1.15.8-r1 --> 1.15.9-r1*
* *rosconsole 1.14.3-r1 --> 1.14.4-r1*
* *rosconsole-bridge 0.5.4-r1 --> 0.5.5-r1*
* *roscpp-tutorials 0.10.2-r1 --> 0.10.3-r1*
* *roscreate 1.15.8-r1 --> 1.15.9-r1*
* *rosgraph-msgs 1.11.3-r1 --> 1.11.4-r1*
* *roslang 1.15.8-r1 --> 1.15.9-r1*
* *roslib 1.15.8-r1 --> 1.15.9-r1*
* *rosmake 1.15.8-r1 --> 1.15.9-r1*
* *rospack 2.6.2-r1 --> 2.6.3-r1*
* *rospy-tutorials 0.10.2-r1 --> 0.10.3-r1*
* *rosunit 1.15.8-r1 --> 1.15.9-r1*
* *rqt 0.5.3-r1 --> 0.5.4-r1*
* *rqt-action 0.4.9-r1 --> 0.4.10-r1*
* *rqt-bag 0.5.1-r1 --> 0.5.2-r1*
* *rqt-bag-plugins 0.5.1-r1 --> 0.5.2-r1*
* *rqt-common-plugins 0.4.9-r1 --> 0.4.10-r1*
* *rqt-console 0.4.12-r1 --> 0.4.13-r1*
* *rqt-dep 0.4.12-r1 --> 0.4.13-r1*
* *rqt-graph 0.4.14-r1 --> 0.4.15-r1*
* *rqt-gui 0.5.3-r1 --> 0.5.4-r1*
* *rqt-gui-cpp 0.5.3-r1 --> 0.5.4-r1*
* *rqt-gui-py 0.5.3-r1 --> 0.5.4-r1*
* *rqt-image-view 0.4.17-r1 --> 0.4.18-r1*
* *rqt-msg 0.4.10-r1 --> 0.4.11-r1*
* *rqt-plot 0.4.13-r2 --> 0.4.15-r1*
* *rqt-pose-view 0.5.11-r1 --> 0.5.12-r1*
* *rqt-pr2-dashboard 0.4.1-r1 --> 0.4.2-r1*
* *rqt-publisher 0.4.10-r1 --> 0.4.11-r1*
* *rqt-py-common 0.5.3-r1 --> 0.5.4-r1*
* *rqt-py-console 0.4.10-r1 --> 0.4.11-r1*
* *rqt-reconfigure 0.5.5-r1 --> 0.5.6-r1*
* *rqt-robot-steering 0.5.12-r1 --> 0.5.13-r1*
* *rqt-rviz 0.7.0-r1 --> 0.7.1-r1*
* *rqt-service-caller 0.4.10-r1 --> 0.4.11-r1*
* *rqt-srv 0.4.9-r1 --> 0.4.10-r1*
* *rqt-top 0.4.10-r1 --> 0.4.11-r1*
* *rqt-topic 0.4.13-r1 --> 0.4.14-r1*
* *rqt-web 0.4.10-r1 --> 0.4.11-r1*
* *rviz-plugin-tutorials 0.11.0-r1 --> 0.11.1-r1*
* *rviz-python-tutorial 0.11.0-r1 --> 0.11.1-r1*
* *std-msgs 0.5.13-r1 --> 0.5.14-r1*
* *std-srvs 1.11.3-r1 --> 1.11.4-r1*
* *tf 1.13.2-r1 --> 1.13.3-r1*
* *tf-conversions 1.13.2-r1 --> 1.13.3-r1*
* *tf2 0.7.7-r1 --> 0.7.8-r1*
* *tf2-bullet 0.7.7-r1 --> 0.7.8-r1*
* *tf2-eigen 0.7.7-r1 --> 0.7.8-r1*
* *tf2-geometry-msgs 0.7.7-r1 --> 0.7.8-r1*
* *tf2-kdl 0.7.7-r1 --> 0.7.8-r1*
* *tf2-msgs 0.7.7-r1 --> 0.7.8-r1*
* *tf2-py 0.7.7-r1 --> 0.7.8-r1*
* *tf2-ros 0.7.7-r1 --> 0.7.8-r1*
* *tf2-sensor-msgs 0.7.7-r1 --> 0.7.8-r1*
* *tf2-tools 0.7.7-r1 --> 0.7.8-r1*
* *turtle-tf 0.2.3-r1 --> 0.2.4-r1*
* *turtle-tf2 0.2.3-r1 --> 0.2.4-r1*
* *turtlesim 0.10.2-r1 --> 0.10.3-r1*
* *universal-robots 1.3.3-r1 --> 1.4.0-r1*
* *ur-description 1.3.3-r1 --> 1.4.0-r1*
* *ur-gazebo 1.3.3-r1 --> 1.4.0-r1*
* *ur10-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur10e-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur12e-moveit-config 1.4.0-r1*
* *ur16e-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur20-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur3-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur30-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur3e-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur5-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur5e-moveit-config 1.3.3-r1 --> 1.4.0-r1*
* *ur7e-moveit-config 1.4.0-r1*
* *urdf 1.13.2-r1 --> 1.13.3-r1*
* *urdf-parser-plugin 1.13.2-r1 --> 1.13.3-r1*
* *visualization-marker-tutorials 0.11.0-r1 --> 0.11.1-r1*
* *visualization-tutorials 0.11.0-r1 --> 0.11.1-r1*

Rolling Changes:
----------------
* *autoware-cmake 1.0.1-r1 --> 1.0.2-r1*
* *autoware-common-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-control-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-internal-debug-msgs 1.5.0-r1 --> 1.8.1-r2*
* *autoware-internal-metric-msgs 1.8.1-r2*
* *autoware-internal-msgs 1.5.0-r1 --> 1.8.1-r2*
* *autoware-internal-perception-msgs 1.5.0-r1 --> 1.8.1-r2*
* *autoware-internal-planning-msgs 1.5.0-r1 --> 1.8.1-r2*
* *autoware-lanelet2-extension 0.6.2-r1 --> 0.7.0-r1*
* *autoware-lanelet2-extension-python 0.6.2-r1 --> 0.7.0-r1*
* *autoware-lint-common 1.0.1-r1 --> 1.0.2-r1*
* *autoware-localization-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-map-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-msgs 1.6.0-r1*
* *autoware-perception-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-planning-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-sensing-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-system-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-v2x-msgs 1.4.0-r1 --> 1.6.0-r1*
* *autoware-vehicle-msgs 1.4.0-r1 --> 1.6.0-r1*
* *control-toolbox 5.0.0-r1 --> 5.1.0-r1*
* *dynamixel-hardware-interface 1.4.1-r1 --> 1.4.2-r1*
* *fastdds 3.2.0-r1 --> 3.2.1-r1*
* *gz-ros2-control 2.0.6-r1 --> 2.0.7-r1*
* *gz-ros2-control-demos 2.0.6-r1 --> 2.0.7-r1*
* *hatchbed-common 0.1.1-r1 --> 0.1.2-r1*
* *libcamera 0.4.0-r1 --> 0.5.0-r2*
* *message-filters 7.0.2-r1 --> 7.1.0-r1*
* *pcl-conversions 2.6.1-r3 --> 2.6.3-r1*
* *pcl-ros 2.6.1-r3 --> 2.6.3-r1*
* *perception-pcl 2.6.1-r3 --> 2.6.3-r1*
* *rcl 10.0.2-r1 --> 10.1.0-r1*
* *rcl-action 10.0.2-r1 --> 10.1.0-r1*
* *rcl-lifecycle 10.0.2-r1 --> 10.1.0-r1*
* *rcl-yaml-param-parser 10.0.2-r1 --> 10.1.0-r1*
* *rclcpp 29.3.0-r1 --> 29.4.0-r1*
* *rclcpp-action 29.3.0-r1 --> 29.4.0-r1*
* *rclcpp-components 29.3.0-r1 --> 29.4.0-r1*
* *rclcpp-lifecycle 29.3.0-r1 --> 29.4.0-r1*
* *realtime-tools 4.1.0-r1 --> 4.2.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote

