### PR TITLE
rosdistro sync, Fri Apr 18 16:04:30 2025

### DIFF
--- a/distros/humble/ackermann-steering-controller/default.nix
+++ b/distros/humble/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-ackermann-steering-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "aa82d5f13068cae4ba3e704e0c2b0077959214806dda3c73b6a1662e06b276e2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ackermann_steering_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "dddff46171737e7f2bd16a0228068710c354b4e073305f7675d4cfae9a2aafa2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/admittance-controller/default.nix
+++ b/distros/humble/admittance-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-admittance-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "6a74551fe29f4a35b2ce4cec4efe72e6c04a461175492b7372f258ec750a7c0b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/admittance_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "e37a4c8b8064c4618548bba73e75a7d74ab7ecce2cfea086420bcc9cb0aa44f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/bicycle-steering-controller/default.nix
+++ b/distros/humble/bicycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-bicycle-steering-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "c3cb7cf7057a815b9fbddc2c15a8af47a017f7218f97c50a2585dde3ff876451";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/bicycle_steering_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "60c29783ee2d7b3ce29b541b5884d34e4af63ff7623dc2733d5609dc7553d584";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-interface/default.nix
+++ b/distros/humble/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-interface";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "763809855f6b0b32f69ebea189db1c6227e67a9f6e9fec9a91d47513e53e224d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_interface/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "9e254d6802f497b59c8b129aea1d063602c709239dd13982dc6862916c86c762";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager-msgs/default.nix
+++ b/distros/humble/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-controller-manager-msgs";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "4d85428613a9e469f0583465e43892b133563cc11da18a12e5a0b11c7107eef4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager_msgs/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "ff67a9a84b3859cd49ff971019b06749177e1b021b793cf252180549aac8dea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/controller-manager/default.nix
+++ b/distros/humble/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, ament-index-cpp, backward-ros, controller-interface, controller-manager-msgs, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-controller-manager";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "4eb56a818bf7d04c74809600d73cbf3d99657ceb75e47962373251b4a3a3b49f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/controller_manager/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "484b024096a78fb1901ae29933484b96fd006b97dbe1c12591ceacb97f3d8e04";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/diff-drive-controller/default.nix
+++ b/distros/humble/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-diff-drive-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "22135b7b52eb4ef5ca2e9c4596dad7ecd1d574e907df95b0dc4b179ae5d62efb";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/diff_drive_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "d94063da6a4b4b8491289aef46c329d09f918189ebdec05672bff5d745fc239b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/dynamixel-hardware-interface/default.nix
+++ b/distros/humble/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-dynamixel-hardware-interface";
-  version = "1.4.2-r1";
+  version = "1.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "3d591f073fb40d3f041a7837082c4a1b725dd7725a424edfaf51e4f4cb2b140f";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/humble/dynamixel_hardware_interface/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "b703d688a971b9539615af3ee82852de9de9672bd330cef56edb45b5afd1bba2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/effort-controllers/default.nix
+++ b/distros/humble/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-effort-controllers";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "1c75bb52bc0214fdb4c6cb88a0a69b505fcf63837c0af5927625dca4271b05a5";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/effort_controllers/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "e254e9e78063c8ca3878ac1bf8ca976e8cf36de737f78287347f12e2df5bc8d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/fkie-message-filters/default.nix
+++ b/distros/humble/fkie-message-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, sensor-msgs, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-humble-fkie-message-filters";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/humble/fkie_message_filters/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "1695320d44d10ba245f348ece974bc7c25ea9965e4efd9704d8e4c759aee702d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros std-msgs ];
+  propagatedBuildInputs = [ image-transport rclcpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Improved ROS message filters";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/force-torque-sensor-broadcaster/default.nix
+++ b/distros/humble/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-force-torque-sensor-broadcaster";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "e90030ce1e0fc4d4f4085402f4f2d00127746c8ff23bc7f03d1a91006d13fed1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/force_torque_sensor_broadcaster/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "467241b3e20d44e34e04824d2a3cda2653d1a3c7f4aac19227d8d82194384468";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/forward-command-controller/default.nix
+++ b/distros/humble/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-humble-forward-command-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "dc3ae677e109790259f77930458f0a02c5447fbe9ecb2f64630cfcdd6f7dcc21";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/forward_command_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "e5c95149cdba42777182e231bd3663063941cbcc3a11dbfa18f32fb55e99c53a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/franka-inria-inverse-dynamics-solver/default.nix
+++ b/distros/humble/franka-inria-inverse-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, franka-description, inverse-dynamics-solver, pluginlib }:
+buildRosPackage {
+  pname = "ros-humble-franka-inria-inverse-dynamics-solver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/franka_inria_inverse_dynamics_solver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ad5b99d5d91901203724c6bdee88e3645680440ddb530170944b72c732325355";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen franka-description inverse-dynamics-solver pluginlib ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A C++ library implementing the inverse dynamics solver for the Franka Emika Panda (FER) real robot.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/generated.nix
+++ b/distros/humble/generated.nix
@@ -978,6 +978,8 @@ self: super: {
 
  find-object-2d = self.callPackage ./find-object-2d {};
 
+ fkie-message-filters = self.callPackage ./fkie-message-filters {};
+
  flex-sync = self.callPackage ./flex-sync {};
 
  flexbe-behavior-engine = self.callPackage ./flexbe-behavior-engine {};
@@ -1049,6 +1051,8 @@ self: super: {
  franka-gripper = self.callPackage ./franka-gripper {};
 
  franka-hardware = self.callPackage ./franka-hardware {};
+
+ franka-inria-inverse-dynamics-solver = self.callPackage ./franka-inria-inverse-dynamics-solver {};
 
  franka-msgs = self.callPackage ./franka-msgs {};
 
@@ -1288,6 +1292,8 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ inverse-dynamics-solver = self.callPackage ./inverse-dynamics-solver {};
+
  io-context = self.callPackage ./io-context {};
 
  irobot-create-common-bringup = self.callPackage ./irobot-create-common-bringup {};
@@ -1337,6 +1343,8 @@ self: super: {
  joy-tester = self.callPackage ./joy-tester {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
+
+ kdl-inverse-dynamics-solver = self.callPackage ./kdl-inverse-dynamics-solver {};
 
  kdl-parser = self.callPackage ./kdl-parser {};
 
@@ -2079,6 +2087,18 @@ self: super: {
  omni-base-simulation = self.callPackage ./omni-base-simulation {};
 
  ompl = self.callPackage ./ompl {};
+
+ open-manipulator = self.callPackage ./open-manipulator {};
+
+ open-manipulator-x-bringup = self.callPackage ./open-manipulator-x-bringup {};
+
+ open-manipulator-x-description = self.callPackage ./open-manipulator-x-description {};
+
+ open-manipulator-x-gui = self.callPackage ./open-manipulator-x-gui {};
+
+ open-manipulator-x-playground = self.callPackage ./open-manipulator-x-playground {};
+
+ open-manipulator-x-teleop = self.callPackage ./open-manipulator-x-teleop {};
 
  openeb-vendor = self.callPackage ./openeb-vendor {};
 
@@ -3467,6 +3487,8 @@ self: super: {
  unitree-ros = self.callPackage ./unitree-ros {};
 
  ur = self.callPackage ./ur {};
+
+ ur10-inverse-dynamics-solver = self.callPackage ./ur10-inverse-dynamics-solver {};
 
  ur-bringup = self.callPackage ./ur-bringup {};
 

--- a/distros/humble/gpio-controllers/default.nix
+++ b/distros/humble/gpio-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gpio-controllers";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "1ae9a435114641f1e573bf34c3bf59220265478e047b5ec6657fbab57b795a80";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gpio_controllers/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "01be071a81153371ff8a1bbeeed8466897a99a8ffd84dcd006dc26a8c68444f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/gripper-controllers/default.nix
+++ b/distros/humble/gripper-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-gripper-controllers";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "3c931e2c833e6f88e054626b3a5055fcb7039940f7d1403070181e17bb751a7e";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/gripper_controllers/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "e921986629ec898702b6fbae1b21e7bce75486e4d03936984709f7cf0e3b8070";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface-testing/default.nix
+++ b/distros/humble/hardware-interface-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface-testing";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "2e4e54100be8b03eba9a4cde27a7bd62624e2e0f60631d993e7f594d24b95acb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface_testing/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "771411fb98fa6890a3f6fcb3203e3ce8b4497c1677ddc924311397e2f4d7414d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/hardware-interface/default.nix
+++ b/distros/humble/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, control-msgs, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-humble-hardware-interface";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "b5020d09755cea18ebbd40ba8ee7a91d7e8afad274fb9d08cf08b96797651090";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/hardware_interface/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "b032ad5c5a6f249cc7a5c9418b4727cb6d4190f08c71519e2c6e7d6a93d3f1bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/imu-sensor-broadcaster/default.nix
+++ b/distros/humble/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-imu-sensor-broadcaster";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "70926ca4d557ae3eabe5a3c8f3c72ededf5a50cb9f515992b740b33c7d3ac741";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/imu_sensor_broadcaster/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "093a8b0100b797de0214650411e85a04dc98d3134158d5a1dcbc42469fe99aa6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/inverse-dynamics-solver/default.nix
+++ b/distros/humble/inverse-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, pluginlib, rclcpp, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, sensor-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-humble-inverse-dynamics-solver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/inverse_dynamics_solver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "89e0feed7751a1bbcfa1729f7e2b8ab48ae8ce795435a0f90caee1d5c6218879";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen pluginlib rclcpp rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins sensor-msgs urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A library implementing an inverse dynamics solver for serial manipulators.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/joint-limits/default.nix
+++ b/distros/humble/joint-limits/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, launch-ros, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gtest, launch-ros, launch-testing-ament-cmake, rclcpp, rclcpp-lifecycle, urdf }:
 buildRosPackage {
   pname = "ros-humble-joint-limits";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "16368ea7305707e7bba8a203edaba22b4cdc7fb700e85237eb0ffea3310a7b70";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/joint_limits/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "b61e069a282ded0429fea87635658c1d28e2b271bcf375b503a0062cb664f443";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
   checkInputs = [ ament-cmake-gtest launch-ros launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ];
+  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {

--- a/distros/humble/joint-state-broadcaster/default.nix
+++ b/distros/humble/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-state-broadcaster";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "08eceb2c22009b1745a29bbddcf55d9cf77abeb2b4abd88ad45a3d970bea0652";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_state_broadcaster/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "4939583c11f14f21097db6a713cff56c9eb97a475c6824b72b0a312e1006d5a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/joint-trajectory-controller/default.nix
+++ b/distros/humble/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-joint-trajectory-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "fcf0c13bd685cb7f7215f7dd02b246a5ec5b4a9f830db25a23a71a745f850f0c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/joint_trajectory_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "f4792d45c27871d14e671cb0e91f49acb997bbbbd12e4abd96413c816d5bdba3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/kdl-inverse-dynamics-solver/default.nix
+++ b/distros/humble/kdl-inverse-dynamics-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, franka-description, inverse-dynamics-solver, kdl-parser, pluginlib, rclcpp, ros-testing, ur-description }:
+buildRosPackage {
+  pname = "ros-humble-kdl-inverse-dynamics-solver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/kdl_inverse_dynamics_solver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0cc8b791369446bfc84d139ba94f025848db8ee0af0961d6ed67350f8490cba7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp ros-testing ];
+  propagatedBuildInputs = [ franka-description inverse-dynamics-solver kdl-parser pluginlib ur-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A KDL-based library implementing an inverse dynamics solver for simulated robots.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/ld08-driver/default.nix
+++ b/distros/humble/ld08-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs, udev }:
 buildRosPackage {
   pname = "ros-humble-ld08-driver";
-  version = "1.1.1-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/humble/ld08_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6b4c03d37736cb345dcc0890e745e26e50e7c35e27cf7f523a5d4c85998234df";
+    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/humble/ld08_driver/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "2fe59ab1ec5203caed2ba1efa45a27d664a6e0376720701f179f61bf6ffe6c65";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-description/default.nix
+++ b/distros/humble/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-description";
-  version = "1.2.4-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "5db57530f37c1bd4594a712da74434822176d346aa7a71f7d5ce5e228d6ffb25";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_description/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "12f8cb6df42469994de637b0a8a6a8fd25ddd7757ea909eecb2fc48b39b3b956";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-gz-bringup/default.nix
+++ b/distros/humble/leo-gz-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, leo-description, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-humble-leo-gz-bringup";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_bringup/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4cb0a44d0d17915992d1e66f41af1904ab4b035ba29160c349f42620c840556c";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_bringup/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "3d6d57a0cfa8c28652224ae22f3d46062aeb77bc3bb219b90d4f36fd10f60bfd";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-gz-worlds/default.nix
+++ b/distros/humble/leo-gz-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-humble-leo-gz-worlds";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_worlds/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "179a2fd729a70b326f1147b4c9c015c60fe316de236309f8347b6d618ff6c14f";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_gz_worlds/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "2916cbf350bdd982e7ed42b1584be2c3441a71c3acbde3b3d82a94eae587617d";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-msgs/default.nix
+++ b/distros/humble/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-leo-msgs";
-  version = "1.2.4-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e746c7ec1d9489786270b74013cd05579439ce8cf0d71fe2d57c2ccfbb9c82ad";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "6484dc967dde2127751b1c0f7121aabaf3678fb6378045fbe8aa9efe9865a119";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-simulator/default.nix
+++ b/distros/humble/leo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, leo-gz-bringup, leo-gz-plugins, leo-gz-worlds }:
 buildRosPackage {
   pname = "ros-humble-leo-simulator";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_simulator/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4814956b0bfee5810a9f4ef1a1f14a548eeed57237bde83dd2214a4e72f63986";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/humble/leo_simulator/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c63804e7c69a9aa4732e0ecf97ff45b6f4d3a69f54be811ffa009282cf129303";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo-teleop/default.nix
+++ b/distros/humble/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-humble-leo-teleop";
-  version = "1.2.4-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e1ea96ae69be9c56ab2dec65272752a61ef406b7db1cd97cb2b87d525735916e";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo_teleop/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "2ce43911fffcb22e7cad8c7778afa1ff70f79aa3c8a49328deef98358c0c0ae5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/leo/default.nix
+++ b/distros/humble/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-humble-leo";
-  version = "1.2.4-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "db9463ea2c575db337d4317928b1bea25155b7d89c8665b3f74b3df03d444e97";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/humble/leo/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "a36b916a5e16c3c15677cc018d39055df647d36a8e8a7bb9aac02a1eb9699be7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/libcaer-driver/default.nix
+++ b/distros/humble/libcaer-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, camera-info-manager, event-camera-msgs, image-transport, libcaer-vendor, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-libcaer-driver";
-  version = "1.1.3-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcaer_driver-release/archive/release/humble/libcaer_driver/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b7433859e6f1d7f854a70cdfd8f44a4eaf5ea532f7e34d02d85b15545670b575";
+    url = "https://github.com/ros2-gbp/libcaer_driver-release/archive/release/humble/libcaer_driver/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c68f175f3647ede0d01c4dc9405ecf5dab841da4d4683ed712e7a9373a0d615b";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/mecanum-drive-controller/default.nix
+++ b/distros/humble/mecanum-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-mecanum-drive-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "c8c1af7fab0d211f6ec8d3a9c688073bcba2c34dcc16c680b369cd69680fbf08";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/mecanum_drive_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "2205a1e9da8db2a25e58a36584c59703fa193330cfc3fe0cb18730b591a806b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/open-manipulator-x-bringup/default.nix
+++ b/distros/humble/open-manipulator-x-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros, gripper-controllers, open-manipulator-x-description, robot-state-publisher, ros2-control, ros2-controllers, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-humble-open-manipulator-x-bringup";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/humble/open_manipulator_x_bringup/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "5e81d3c8507d1d441d10abce22084c76999e0d50aeaa203074e6a8ebe5e9239a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ gazebo-ros gripper-controllers open-manipulator-x-description robot-state-publisher ros2-control ros2-controllers rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "OpenMANIPULATOR-X bringup ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/open-manipulator-x-description/default.nix
+++ b/distros/humble/open-manipulator-x-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2 }:
+buildRosPackage {
+  pname = "ros-humble-open-manipulator-x-description";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/humble/open_manipulator_x_description/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "26a00621dde7694d9fb9691d6e3cd45891289289ebc31f5b07df5b23ab931994";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "open_manipulator_x_description ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/open-manipulator-x-gui/default.nix
+++ b/distros/humble/open-manipulator-x-gui/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, geometry-msgs, moveit-core, moveit-msgs, moveit-ros-planning, moveit-ros-planning-interface, qt5, rclcpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-humble-open-manipulator-x-gui";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/humble/open_manipulator_x_gui/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "7a9355886586f029278a7f49beeb7be51ab38d08b7906fb817684e8fedce9a4f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen3-cmake-module geometry-msgs moveit-core moveit-msgs moveit-ros-planning moveit-ros-planning-interface qt5.qtbase rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The OpenMANIPULATOR-X GUI ROS 2 package enables users to explore Joint Space,
+    Task Space, and even work with the Task Constructor functionality.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/open-manipulator-x-playground/default.nix
+++ b/distros/humble/open-manipulator-x-playground/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-planning-interface, rclcpp }:
+buildRosPackage {
+  pname = "ros-humble-open-manipulator-x-playground";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/humble/open_manipulator_x_playground/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "112a68dc674fb3c605d79f220e33061e10ca46c0a9ba81021be8ed3946136f8f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ moveit-ros-planning-interface rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides an example for utilizing the MoveIt API with the OpenMANIPULATOR-X,
+    allowing users to practice and experiment freely.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/open-manipulator-x-teleop/default.nix
+++ b/distros/humble/open-manipulator-x-teleop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, geometry-msgs, nav-msgs, open-manipulator-x-bringup, open-manipulator-x-description, open-manipulator-x-moveit-config, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-humble-open-manipulator-x-teleop";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/humble/open_manipulator_x_teleop/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "8c256869f9f423bff60c442494518dfdc7acec9bf162d17a897435b9a91222b3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ control-msgs geometry-msgs nav-msgs open-manipulator-x-bringup open-manipulator-x-description open-manipulator-x-moveit-config rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "OpenMANIPULATOR-X teleop ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/open-manipulator/default.nix
+++ b/distros/humble/open-manipulator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, open-manipulator-x-bringup, open-manipulator-x-description, open-manipulator-x-gui, open-manipulator-x-moveit-config, open-manipulator-x-playground, open-manipulator-x-teleop }:
+buildRosPackage {
+  pname = "ros-humble-open-manipulator";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/humble/open_manipulator/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "412e7d5e348a4fe195267b215ccaea8b2de03b572535ac56e827720564ea2581";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ open-manipulator-x-bringup open-manipulator-x-description open-manipulator-x-gui open-manipulator-x-moveit-config open-manipulator-x-playground open-manipulator-x-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "OpenMANIPULATOR-X meta ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/humble/pid-controller/default.nix
+++ b/distros/humble/pid-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-pid-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "29d612165530aab65c766325724d972c768a8dbbc38fa93728cfcd5bd0b4bc35";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pid_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "4b1146e524c5563b5218022a48a3cb054a319fa4d8de2f072f688c7c9a4b6349";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/pose-broadcaster/default.nix
+++ b/distros/humble/pose-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-pose-broadcaster";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "dbd894f581a0ea63e817dc64638fc78c36b905e5265c49821098aa36f6dc5cac";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/pose_broadcaster/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "6adabcfc9d747e1e54d771dcb2e72402eba72e4b7da46089d817359dfb8ccd75";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/position-controllers/default.nix
+++ b/distros/humble/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-position-controllers";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "7a274d9f95a67772fd7a3a6cbe1b4011bc824cad2195d5f708083e8e80f29b1f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/position_controllers/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "17c404d16d39436b94f2b91497f6b801196d75bad6f051fe39c74f2288b86745";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/range-sensor-broadcaster/default.nix
+++ b/distros/humble/range-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-humble-range-sensor-broadcaster";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "fef477b524f16718f08507844e7f0a9dfecc703257102a040315e53c3af99fb7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/range_sensor_broadcaster/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "b2a28d880cbc3a4e1291a6d4341dccc5c89beb0557ca32f85fbfaf26db93f227";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control-test-assets/default.nix
+++ b/distros/humble/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-ros2-control-test-assets";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "44ad3ed0b86c00fc843d648f88834a0d885efcebbe79828c9340bcf735b1a26e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control_test_assets/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "6df230a489067da92e1a00bf7302a4cc4fcf0863a974a93290a5b0b5b2d14f95";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-control/default.nix
+++ b/distros/humble/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-humble-ros2-control";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "f4058c69e77e8ad63ddf1311d97e09b40aa04c1656d9ee6bbd2dda5326bbef2b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2_control/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "91cc3982ba982dd58ed8936423a6b39bbee633c51f4a544b7210e9c4f5339565";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2-controllers-test-nodes/default.nix
+++ b/distros/humble/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers-test-nodes";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "4f077a7fad776eddc8fdd9e0689abb00c034c25365ba8b98d97f7c1551d08ad0";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers_test_nodes/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "e92f01598ee522ca298d179f56a8f90c98f2fb5a3449491f253300f83d053185";
   };
 
   buildType = "ament_python";

--- a/distros/humble/ros2-controllers/default.nix
+++ b/distros/humble/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-humble-ros2-controllers";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "7cfbbc5ea4ba59f1c9d6154d5d08f8a0d7d988c24ef9065fbf5dac40cdce002f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/ros2_controllers/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "9e47ea8e2a9355a83a7e66dd3a18eb5d23c8910f79d58fb1bb00265a2c4c9a9e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ros2controlcli/default.nix
+++ b/distros/humble/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-humble-ros2controlcli";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "30740e7102bda6d781e9a2ab593966e11b2bb8dfc5e5b43460cdf3af51f50d6b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/ros2controlcli/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "f934bf8fda6289373b2630a689a9fcc7e02a91b9729801331de88221a55310d2";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-controller-manager/default.nix
+++ b/distros/humble/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-humble-rqt-controller-manager";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "dcfc2210b355b4da7d0a71ba79398f8ccb32aa47864f77f1130c42da4c8df45b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/rqt_controller_manager/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "423bee16420bdfd0a53d5ab12bea607c5d2b30172cc0e2478adf13a61966333d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/rqt-joint-trajectory-controller/default.nix
+++ b/distros/humble/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-humble-rqt-joint-trajectory-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "0efc8501a15882ac2f8c5e6359bf1505a0c2fb8ca7dbeb37e7643d41d3866cb7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/rqt_joint_trajectory_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "83a40727b3fff82e29c26ef1bf081e5a432091fd61ebd960270a7820006fb924";
   };
 
   buildType = "ament_python";

--- a/distros/humble/steering-controllers-library/default.nix
+++ b/distros/humble/steering-controllers-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-steering-controllers-library";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "e71b6f56768c38d7e2dfdb6b30c966d3401688f8a73651f7fe64e9797b125001";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/steering_controllers_library/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "6a50544dcdb6e73142fe6276e68fde69688562907cf52186a2e896c2afda83e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-cli-tools/default.nix
+++ b/distros/humble/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-humble-swri-cli-tools";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "4ca57c79207a4bd2244755ce1e05925f249191f3b806f291c34ab4044890957b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_cli_tools/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "9fc4b429f0a49d6cf3bd975be1c264fbc2c94b8919fa500245ce2f4d62d56c1e";
   };
 
   buildType = "ament_python";

--- a/distros/humble/swri-console-util/default.nix
+++ b/distros/humble/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-console-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "db0309134c0d3363e16cb311ed5c7b086654e60146bfba504a39ccd9410bceca";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_console_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "8dc3a9ba381e055867fbef53b84a4243b3fa08c952363df89921ba3424f8ff7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-dbw-interface/default.nix
+++ b/distros/humble/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-humble-swri-dbw-interface";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "0eac606756d55c1d7ece2caa10a22227d90fe21960fc3524d6841c181be88bba";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_dbw_interface/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "2e943ca020fa9e4ac28abe8bde4763449b96cd8963ae2185977d151b03bada85";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-geometry-util/default.nix
+++ b/distros/humble/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-geometry-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "6af022490ac83049913306a2f27cdfdcf3db235ed14d46410b020545f9ba46cd";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_geometry_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "44da7612dc725cc7a7e87fa584e86449590f6bde16493bab1f6c3b298cb318d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-image-util/default.nix
+++ b/distros/humble/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-humble-swri-image-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "76cc9c8b1f7cd6ea84906130a3e20d7274c3c76c0add79877c0b24de77c4b2e8";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_image_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "06cbf2a1e1c9036dc9e413541a5c48596c5d1c1c4565f04508c6fdf84695b108";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-math-util/default.nix
+++ b/distros/humble/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-math-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "f500af58c3f6252061cb38a3611f07383835565f66a4612317929af918a2d3b5";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_math_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "563eb8826fe3f63a47678528da41c2b0c5ed5337df5cea88de419b4f14c4a8bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-opencv-util/default.nix
+++ b/distros/humble/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-humble-swri-opencv-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "06847e6af10d1b54eeb4b666bf687ca562c80c114c748b81a15d7b4105339a4c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_opencv_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "5957bdecbe5a89c5380b2150308cf724fcac49044807a78f230ddc323cfe4c62";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-roscpp/default.nix
+++ b/distros/humble/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-humble-swri-roscpp";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "30a48227da7a7f39006951f35239a42fb6cbaad00b4130e3263d29ae11104a5a";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_roscpp/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "ef72fd1b532f6a216c78e14816712aa85f285c25e40512649ca5d6eb9e92bfec";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-route-util/default.nix
+++ b/distros/humble/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-swri-route-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "3047d90b34e2e6d274491395b0cd618434bbb3ad9d8b92cf18aab374a75ddf98";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_route_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "b26f519f6cb1c8a9f39d793d55ee070181b2994a68753142d44bd7707fd11716";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-serial-util/default.nix
+++ b/distros/humble/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-humble-swri-serial-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "551ac664f73d4b745d2afad139bd83e52363c12001ebfb16310b047a39bfcb77";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_serial_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "5d2d8c29fabafd88631abda7174708a9306c818d70b25f259dbedeef31dab876";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-system-util/default.nix
+++ b/distros/humble/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-humble-swri-system-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_system_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "1c0e5748461c0f68206460418a22c41ec67e5f0e358775dcc6b2e5e865bf863d";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_system_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "1bbfc705a98147bfac2048195f780be9b9184bf9535a394bb94cc5a644892de6";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/swri-transform-util/default.nix
+++ b/distros/humble/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-humble-swri-transform-util";
-  version = "3.7.3-r2";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.7.3-2.tar.gz";
-    name = "3.7.3-2.tar.gz";
-    sha256 = "4c072ed751f0eb3d942bb078c490173f99de122f3acd28ffbd44a565ece75aab";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/humble/swri_transform_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "259f39fdeabf568addbf856299d07d5b070b2c36ad3d9bab5d6e80ac26a4f4f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/transmission-interface/default.nix
+++ b/distros/humble/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib }:
 buildRosPackage {
   pname = "ros-humble-transmission-interface";
-  version = "2.49.0-r1";
+  version = "2.50.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.49.0-1.tar.gz";
-    name = "2.49.0-1.tar.gz";
-    sha256 = "cf79dda4921826ab7962bddbd2a0efbc18e0c070c80f14ad4b98b7c37a7488d7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/humble/transmission_interface/2.50.0-1.tar.gz";
+    name = "2.50.0-1.tar.gz";
+    sha256 = "7b17cfd9bf2b816ba8efa2ddc307cf56fe048d78ae8f868f1eec9c6cc5f8516c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-controller/default.nix
+++ b/distros/humble/tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-humble-tricycle-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "7836871be7c7d25aa2110769d36353027401b722a198912441d68e109073ec87";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "6eff5a5540a77c262106995c95da156c645f844fcb4bebb88c8cab4b30267625";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/tricycle-steering-controller/default.nix
+++ b/distros/humble/tricycle-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-humble-tricycle-steering-controller";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "6194a1859784e337e4fa5878aa52fa5d87f15abcdaa86c670b9c8fee94c9e3a3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/tricycle_steering_controller/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "9535ac590e4056f8ebc829e85a632a406f555c69b523db7b6f21998e2b6c42b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-bringup/default.nix
+++ b/distros/humble/turtlebot3-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, hls-lfcd-lds-driver, robot-state-publisher, rviz2, turtlebot3-description, turtlebot3-node }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-bringup";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_bringup/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "514640e62b77d89335d14059ea6aeb659fcc2e4d4aa1d1f228e2b944f33202e6";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_bringup/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "67ec05fbc3190bd820b33eb2a34319278aa537584737ae91ed533f7347032f64";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-cartographer/default.nix
+++ b/distros/humble/turtlebot3-cartographer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer-ros }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-cartographer";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_cartographer/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "14e5593d2124db9933e71e5d2dd2020b886b6e0ebc5826f29f61343f0f080176";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_cartographer/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "036144df598b77e5f013450a7e11823a6d4f137a1cac6a862c6e089aac84ce29";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-description/default.nix
+++ b/distros/humble/turtlebot3-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-description";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_description/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "04d1faafcace3fd4f832faaaf7c326fddc4ef32550b278be1e02ebc9c414b7c5";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_description/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "33f7dc81a2e22d5eb85f25cce41d3a7483a0173667452350417197e1f908276c";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-example/default.nix
+++ b/distros/humble/turtlebot3-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, tf-transformations, turtlebot3-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-example";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_example/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "044ea9eb8fc8f6c2051092cf83ebd7a79c18cb2e5355d0293a3fdcb5176e29a0";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_example/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "2f371e5666e3e32db7aedfc01fa621f1d6dea84145c59409ce341edc825f2825";
   };
 
   buildType = "ament_python";

--- a/distros/humble/turtlebot3-navigation2/default.nix
+++ b/distros/humble/turtlebot3-navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-navigation2";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_navigation2/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "ad4b53fefab373db28e60ff73586e1cc5344b5fed253602c385b081720bdf012";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_navigation2/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "927ca34b30c293e6db0fe38523ee0e9383e7119ffe92e6a746120092e51adc1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-node/default.nix
+++ b/distros/humble/turtlebot3-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, geometry-msgs, message-filters, nav-msgs, rclcpp, rcutils, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-node";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_node/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "5354e3d03f495ffb650cac0aa652eb2d560ffed502a27be4d4787639d3e50dfc";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_node/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "9dcc7ab8804b7aa05b775ae5076b0be4659854882a551bad4c2da03904dd70d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/turtlebot3-teleop/default.nix
+++ b/distros/humble/turtlebot3-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, rclpy }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3-teleop";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3_teleop/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "11de2ce0d403ecf24024e6563eeacd388cbe0484d3b709dd13249d09bef0cb65";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3_teleop/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "37a3f93717e087b4f771c52cff3fffaac5ac325f16f4bc829f6767158edef58d";
   };
 
   buildType = "ament_python";

--- a/distros/humble/turtlebot3/default.nix
+++ b/distros/humble/turtlebot3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-bringup, turtlebot3-cartographer, turtlebot3-description, turtlebot3-example, turtlebot3-navigation2, turtlebot3-node, turtlebot3-teleop }:
 buildRosPackage {
   pname = "ros-humble-turtlebot3";
-  version = "2.2.6-r1";
+  version = "2.2.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/humble/turtlebot3/2.2.6-1.tar.gz";
-    name = "2.2.6-1.tar.gz";
-    sha256 = "ad008799ba93de050e7ac73da2261f8162b07b596d337892b25971cc33875a7a";
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/humble/turtlebot3/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "3c5f56c13a2deb94ebbd3ed4bc4e0da4ff60064d5f27eb9d2e3410aca567ccca";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-bringup/default.nix
+++ b/distros/humble/ur-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, controller-manager, force-torque-sensor-broadcaster, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, position-controllers, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, ur-controllers, ur-description, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-bringup";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "32b35d21ffd31e41de75cf5f9c08171c8230b62aa4056cfb27ae86d181693a67";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_bringup/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "3d2f36baf4f4a2157cb8a9f02eeeb147d435f3c8706619edbd5acb9b442e5465";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-calibration/default.nix
+++ b/distros/humble/ur-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-humble-ur-calibration";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "5f9ba617549f308c3b2c09653b85eda0dfd279fa1bd030c3cc34eb8a4a6c362c";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_calibration/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "8cd72bcc679a6f69d250fcd44734a0f089276e75e2d4ed918846b96cc04706e2";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp ];
+  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/humble/ur-controllers/default.nix
+++ b/distros/humble/ur-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-humble-ur-controllers";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "05d3a4d6a853eb1d43fb0b288232923eb90ffa0ff403a6d925d8c4abc4f2c555";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_controllers/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "47bb9acadf2a7f05ea15e6430394932ab131211e2654b51490a094a66947edbe";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-dashboard-msgs/default.nix
+++ b/distros/humble/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-humble-ur-dashboard-msgs";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "79410cc2a05c4e8018fec1c21c77500b05faccbc75d9cc4f51e85f30ad940210";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_dashboard_msgs/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "df708c4d9afd646028e76536fab4d5d2daeecc8323f82fb406a2b7f3cb88f306";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-moveit-config/default.nix
+++ b/distros/humble/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, launch, launch-ros, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, rviz2, ur-description, urdf, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-moveit-config";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "587372f9d2b94eaddbe9c9e07efa7c0d95e28c8ec293bef4fd6a199586359f48";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_moveit_config/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "1edc454cc9571fead83d973d3269be7d74ab2295ad1901ea42eb56c97c257e5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-robot-driver/default.nix
+++ b/distros/humble/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-robot-driver";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "48b011942de11b8867580aeece58ab4e7d86d32978d0080e8da2ba8a670c6181";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur_robot_driver/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "879f4656cec279979ec10cf56fcfa2b3e29c0ca3704c7966f8a6316c79896005";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur-simulation-gz/default.nix
+++ b/distros/humble/ur-simulation-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ign-ros2-control, joint-state-publisher, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, ros-gz-bridge, ros-gz-sim, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, xacro }:
 buildRosPackage {
   pname = "ros-humble-ur-simulation-gz";
-  version = "0.1.1-r2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/humble/ur_simulation_gz/0.1.1-2.tar.gz";
-    name = "0.1.1-2.tar.gz";
-    sha256 = "1fa453dceb341dc4e944b92c9bd6c46d83a1bdc7f3c0c202aefceaf64ca24cbb";
+    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/humble/ur_simulation_gz/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "229cafdc3752713838bd26eb9d49760db58630bfa561604520c946c47dfa9cbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur/default.nix
+++ b/distros/humble/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-humble-ur";
-  version = "2.6.0-r1";
+  version = "2.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "4280f73858b98d683d6e0c81c4e31de98dce2e58412b18356ca3950db958e506";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/humble/ur/2.7.0-1.tar.gz";
+    name = "2.7.0-1.tar.gz";
+    sha256 = "979e28458b62138157e4e052db3290d5efa1e36ec62bd06b03ad1221c7afe582";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/ur10-inverse-dynamics-solver/default.nix
+++ b/distros/humble/ur10-inverse-dynamics-solver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, inverse-dynamics-solver, pluginlib, rclcpp, ros-testing, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, trajectory-msgs, ur-description }:
+buildRosPackage {
+  pname = "ros-humble-ur10-inverse-dynamics-solver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/inverse_dynamics_solver-release/archive/release/humble/ur10_inverse_dynamics_solver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "65f8357031d05f889a6b9344e23db9fe6080acf50ed5a47697493fb214eefb5a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp ros-testing rosbag2-cpp rosbag2-storage rosbag2-storage-default-plugins trajectory-msgs ];
+  propagatedBuildInputs = [ inverse-dynamics-solver pluginlib ur-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "A C++ library implementing the inverse dynamics solver for the UR10 real robot.";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/humble/velocity-controllers/default.nix
+++ b/distros/humble/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-humble-velocity-controllers";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "6d6f51600d9303d103155d7da44e84e4f73139b1abd89797f56536351a34fb63";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/humble/velocity_controllers/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "6510d81fc4ec33265de289df6c191251399556dc088c5ef397c7a4dd2733c8af";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/yasmin-demos/default.nix
+++ b/distros/humble/yasmin-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, example-interfaces, nav-msgs, python3Packages, rclcpp, rclpy, ros-environment, yasmin, yasmin-ros, yasmin-viewer }:
 buildRosPackage {
   pname = "ros-humble-yasmin-demos";
-  version = "3.1.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_demos/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e870c1dd15b49f829412bdc57d42c114bbe30a1f5cb5f86784f9277df0ca1602";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_demos/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "81af58c06f2c999b5eb2b50ee9b8217f2cffef7dd768815844ec7e0d91017843";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/yasmin-msgs/default.nix
+++ b/distros/humble/yasmin-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-humble-yasmin-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "eac9d3312e0ad360984ffc8ef39134c8005efa299e5508a60d5145e0f1fd3297";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_msgs/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "a244a7cb188a4610dae831bf972c8256b2e359c67665a325b6d578e682d0a87e";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/yasmin-ros/default.nix
+++ b/distros/humble/yasmin-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclcpp, rclcpp-action, rclpy, ros-environment, yasmin }:
 buildRosPackage {
   pname = "ros-humble-yasmin-ros";
-  version = "3.1.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_ros/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "51e024b17ced206921b068d3412606b1e34ab0a956c96f2a5d30516172ca85f5";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_ros/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "1acbf9d056816a4f2c124d864510ef3fe19c8620cfa319dbf10aae6647903cc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/humble/yasmin-viewer/default.nix
+++ b/distros/humble/yasmin-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclcpp, rclpy, yasmin, yasmin-msgs, yasmin-ros }:
 buildRosPackage {
   pname = "ros-humble-yasmin-viewer";
-  version = "3.1.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_viewer/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "7a0f4b11f686e4a0453c1d95d9a7fe0690b18a71a4a7b53eb3164377edb108d2";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin_viewer/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "02a00520c037c57096518be01dd67fd86080f0ed825073fbfc6c5a89d007c90c";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "TODO: Package description";
-    license = with lib.licenses; [ "TODO-License-declaration" ];
+    description = "YASMIN viewer for FSM";
+    license = with lib.licenses; [ gpl3 ];
   };
 }

--- a/distros/humble/yasmin/default.nix
+++ b/distros/humble/yasmin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-humble-yasmin";
-  version = "3.1.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "b246e13e32c512062c3840eeaca9c0451481fb53f87fff9eae0eb835c0a26dc5";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/humble/yasmin/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "b812ccedec913fa6288215f249238a329fac50f337affd3785c7e9625314b3f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ackermann-steering-controller/default.nix
+++ b/distros/jazzy/ackermann-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-ackermann-steering-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "b4043eec8df8ecf2e5f6586e64c21a33940eb8a867ec2707fb36d27ec4205f71";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ackermann_steering_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "6afb2bb44a13ab67d77a2a292f86379396eb433dbb88f5218b34f386bca8c6c5";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/admittance-controller/default.nix
+++ b/distros/jazzy/admittance-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, kinematics-interface, kinematics-interface-kdl, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-admittance-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "7134bfad29508548ddb99a1b263aa7121536749d58b576c7fee6f07d3a38626c";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/admittance_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "9ed5fe17d878ce2f59255ccae7edf08ac54596e5cf94f45466815acbafc851f4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing kinematics-interface-kdl ros2-control-test-assets ];
   propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library geometry-msgs hardware-interface kinematics-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/bicycle-steering-controller/default.nix
+++ b/distros/jazzy/bicycle-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-bicycle-steering-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "4b798a9b2b00b60ac42e21c3da75e4f90bada431229aadb84aaf3226b4075128";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/bicycle_steering_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "20e49ce06f9502271fa95c0a67a81500d2f9280bf004a12a7acda7b3e1cd21be";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/clearpath-bt-joy/default.nix
+++ b/distros/jazzy/clearpath-bt-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, bluez, joy-linux, python3Packages, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-bt-joy";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "b84c7026ab9d3f69d873e4faa61709c9495baf5071be17ca6d53500de51facf8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_bt_joy/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "f3336b42f3afe6231d34349182a305df018ebe195680cb539a75ed40532f511b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-common/default.nix
+++ b/distros/jazzy/clearpath-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-control, clearpath-description, clearpath-generator-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-common";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "4173afa194f60318f569c450c585e2d5cff9ee62ee7734297b15999ba28ebaa8";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_common/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e439083474c011d126ab7207269d1cc4162181cf4ee3edd96a1f88a0364baab1";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-config/default.nix
+++ b/distros/jazzy/clearpath-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-config";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "6756e687a2f868e36c4293109d15b40e2cdd2a653a8740e53a37e851690eb25b";
+    url = "https://github.com/clearpath-gbp/clearpath_config-release/archive/release/jazzy/clearpath_config/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e36f2c529746277508c5ef510b8dfebe1de67c6283e29d464afd6191b3125936";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/clearpath-control/default.nix
+++ b/distros/jazzy/clearpath-control/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, clearpath-bt-joy, controller-manager, diff-drive-controller, imu-filter-madgwick, interactive-marker-twist-server, joint-state-broadcaster, joint-trajectory-controller, joy-linux, mecanum-drive-controller, robot-localization, robot-state-publisher, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-control";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "2d26d9f580d4a81f9906c7adbe1ad29388a3c3542871c73840f0fe53be00c79c";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_control/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "baf1e86a8459e529da9376965b554fe279ed7ecb7f66ba9bdad67956e2332a5d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ clearpath-bt-joy controller-manager diff-drive-controller imu-filter-madgwick interactive-marker-twist-server joint-state-broadcaster joint-trajectory-controller joy-linux robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
+  propagatedBuildInputs = [ clearpath-bt-joy controller-manager diff-drive-controller imu-filter-madgwick interactive-marker-twist-server joint-state-broadcaster joint-trajectory-controller joy-linux mecanum-drive-controller robot-localization robot-state-publisher teleop-twist-joy twist-mux ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/clearpath-customization/default.nix
+++ b/distros/jazzy/clearpath-customization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-customization";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "de8fe147526a32e1e2f4ec1b202074d244802d121c0fc5dde158b897f5e60ff7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_customization/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a50722602d707a543790f540bd98967310d2b60b07127c8a38c85f8b1f9e51ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-description/default.nix
+++ b/distros/jazzy/clearpath-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, clearpath-mounts-description, clearpath-platform-description, clearpath-sensors-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-description";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "471e82da63bf4357fcf1b9adf69b9609674207bb7585cb423f9ded95f31956a7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "7b54ea2581375e62cb4f6ff5c408ea46d3b8aeb29311288fff287ddd4770a5cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-common/default.nix
+++ b/distros/jazzy/clearpath-generator-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-control, clearpath-description, clearpath-manipulators, moveit-setup-srdf-plugins }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-common";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "34a051c579948557c564a312c562c2042f7f24aa079b1f6cf8e3664238ec2f91";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_generator_common/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "8225d29c6ef951a064c2534f825e9ab43236d30ee982311cb8c0c5f008837d14";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-generator-gz/default.nix
+++ b/distros/jazzy/clearpath-generator-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-config, clearpath-generator-common, cv-bridge, ptz-action-server-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-generator-gz";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d20fe91f56290d7826c2c70fed90266593f58b1d43aa912c85afa3e6fa8f9ff9";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_generator_gz/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3a74e312db2d7bbe207a802a25dc28e2939cc9fec572c86accdd8238eaed5985";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-gz/default.nix
+++ b/distros/jazzy/clearpath-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-common, clearpath-generator-gz, clearpath-viz, gz-ros2-control, ros-gz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-gz";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "91dbbdafdd0d815809d0b091ccbb31dc4ae88f44d7ec1fca86fc3c9b4eba1dbe";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_gz/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "547d6103267c8e099dde22b7368ed895ab990be4e01fe0c9d01cf3957f50632e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators-description/default.nix
+++ b/distros/jazzy/clearpath-manipulators-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, robotiq-description, ur-description, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators-description";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "a099dd638bfa923690e02670e3e29d34a02f446bb249c701693372af649da150";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "844cc357efa3bffc4ab2a44271a041e59775b15f1f2540321c529f3caa5803e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-manipulators/default.nix
+++ b/distros/jazzy/clearpath-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-manipulators-description, gripper-controllers, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-warehouse, moveit-simple-controller-manager, position-controllers, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-manipulators";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "1b2cb0b426d9974fef828156395b31c84925c1fcf2276006e43cfa419db2c967";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_manipulators/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3458f5adb413a302ab1ba6a0ab3292090e22d41c8aae683bbfab6d1617bf86f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-motor-msgs/default.nix
+++ b/distros/jazzy/clearpath-motor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-motor-msgs";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "f1245b099d30decf99d26642e85da96667c6b5ec0995ec070ca81dc7e021f729";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_motor_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "4a5dc03964978518606a537a893537ba7580631012eeba626789b1a540750f61";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-mounts-description/default.nix
+++ b/distros/jazzy/clearpath-mounts-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-mounts-description";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "356dc8ba62795532d2ff25a5cf1cf1a8fb2d0d3c7f5dfe0f23b755aa4ed20595";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_mounts_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "24de78725b170adc6d4a16af2693aa7ddd929499c345bd09916f3fc76762a627";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-msgs/default.nix
+++ b/distros/jazzy/clearpath-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, clearpath-motor-msgs, clearpath-platform-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-msgs";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "98f7a26d7c6f19dd3f5f304a22f6306e5703ea6fa38293a169d5ac79022e7891";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "0f6c7df39503f3b4c6121be20b748b0174f52f5215a955e8426cea6fcbb07743";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-description/default.nix
+++ b/distros/jazzy/clearpath-platform-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-description";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "394eec59e07e710c75454a3165a52cbddbab8651f125f9ba7635919bacf63b60";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_platform_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a7818ed3aad0310695051e4c362a0244378b450db6e7f3c06e2a8444d7b0de51";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-platform-msgs/default.nix
+++ b/distros/jazzy/clearpath-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-platform-msgs";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "e7b84cd5c1d800c4329d94b77b9af259c4cc2c1eaf619dd6e77d710ca80614fe";
+    url = "https://github.com/clearpath-gbp/clearpath_msgs-release/archive/release/jazzy/clearpath_platform_msgs/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "82368ac325babbb86b1183e8ac0c641e70312017105672a6e40b33ebb29e1cca";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-sensors-description/default.nix
+++ b/distros/jazzy/clearpath-sensors-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, axis-description, microstrain-inertial-description, realsense2-description, velodyne-description }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-sensors-description";
-  version = "2.2.2-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "2b72d8eb6810647a8d65b080ab53a94f19532a61b5bb0ea4b235b0bbfb6c63f7";
+    url = "https://github.com/clearpath-gbp/clearpath_common-release/archive/release/jazzy/clearpath_sensors_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "8cdfd9e9ef04aef90f3623cf8f5c410a179a0e5edca1047af9361f0269fd0e5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-simulator/default.nix
+++ b/distros/jazzy/clearpath-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, clearpath-generator-gz, clearpath-gz }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-simulator";
-  version = "2.2.0-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "944163c7defcc3a8fd91c9fa8a42a4184c19f38e633bde0cc65ac501b3c5c8ba";
+    url = "https://github.com/clearpath-gbp/clearpath_simulator-release/archive/release/jazzy/clearpath_simulator/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "8ac53585f163dad3833162797a8e5cbcfeb00439b24bede8cbeedafc8d117147";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/clearpath-tests/default.nix
+++ b/distros/jazzy/clearpath-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, can-utils, clearpath-config, clearpath-generator-common, clearpath-motor-msgs, clearpath-platform-msgs, diagnostic-msgs, geometry-msgs, nav-msgs, rclpy, sensor-msgs, simple-term-menu-vendor, std-msgs, stress, tf-transformations, tf2-geometry-msgs, tf2-msgs, wireless-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-clearpath-tests";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "480675486ac01065213ea5c9e1d2440e525afb319154dabe1356d749c5a28ee1";
+    url = "https://github.com/clearpath-gbp/clearpath_tests-release/archive/release/jazzy/clearpath_tests/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "e3c34705d30092558c9585bff7c12df41dbd501d3f0fbf9493959b63daa33115";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/controller-interface/default.nix
+++ b/distros/jazzy/controller-interface/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, geometry-msgs, hardware-interface, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-interface";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "b91eadb90d0dc325992d83e60ef5f7a2c8d337a87bca1aca2e0412c78ef003ff";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_interface/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "ca11f12075c27cdc40a693634f5a16272e1795eff90733b58d3da4e22e7d8aa8";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h sensor-msgs ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ros2-control-cmake sensor-msgs ];
   checkInputs = [ ament-cmake-gmock geometry-msgs ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
-    description = "Description of controller_interface";
+    description = "Base classes for controllers and syntax cookies for supporting common sensor types in controllers and broadcasters";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/controller-manager-msgs/default.nix
+++ b/distros/jazzy/controller-manager-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, lifecycle-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager-msgs";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "a055ad0473d61bfaa07a3400052ef9acc37ea2b4a6a1ed8a4552685ddcc1136d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager_msgs/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "d6868851d29efb7b8a3c2a4945721cf310cb9905f965e7870137e4dcdb291c6c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rosidl-default-generators ];
   checkInputs = [ ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime ];
+  propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/jazzy/controller-manager/default.nix
+++ b/distros/jazzy/controller-manager/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-pytest, ament-cmake-python, backward-ros, controller-interface, controller-manager-msgs, diagnostic-updater, example-interfaces, generate-parameter-library, hardware-interface, hardware-interface-testing, launch, launch-ros, launch-testing, launch-testing-ros, libstatistics-collector, pluginlib, python3Packages, rclcpp, rclpy, rcpputils, realtime-tools, robot-state-publisher, ros2-control-cmake, ros2-control-test-assets, ros2param, ros2run, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-controller-manager";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "2b456e2c4b71c01c75d667c467b55c26f0bbfff482d82122b4bfaa98b80dea33";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/controller_manager/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "4a31a401b270d4cec8a5d386582d07e6e326c07c15e0847e78f13ed1fcce420e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-pytest example-interfaces hardware-interface-testing launch launch-testing launch-testing-ros python3Packages.coverage rclpy robot-state-publisher ros2-control-test-assets sensor-msgs ];
   propagatedBuildInputs = [ backward-ros controller-interface controller-manager-msgs diagnostic-updater generate-parameter-library hardware-interface launch launch-ros libstatistics-collector pluginlib rclcpp rcpputils realtime-tools ros2-control-test-assets ros2param ros2run std-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ament-cmake-python ];
 
   meta = {
-    description = "Description of controller_manager";
+    description = "The main runnable entrypoint of ros2_control and home of controller management and resource management.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/depth-obstacle-detect-ros-msgs/default.nix
+++ b/distros/jazzy/depth-obstacle-detect-ros-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-depth-obstacle-detect-ros-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/depth_obstacle_detect_ros-release/archive/release/jazzy/depth_obstacle_detect_ros_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "0eedd5929013c4b33a237f524186072c4ac0ecd8af85d3b40198dc0d9b6c5e04";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = "A message package for depth_obstacle_detect_ros package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/depth-obstacle-detect-ros/default.nix
+++ b/distros/jazzy/depth-obstacle-detect-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, depth-obstacle-detect-ros-msgs, image-transport, rclcpp, rclcpp-components, rclpy, ros2launch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-depth-obstacle-detect-ros";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/depth_obstacle_detect_ros-release/archive/release/jazzy/depth_obstacle_detect_ros/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "2e401610a2c8bd67ec49d40f7b7dd30452b8bebdb7f4e7fca8c74d8104298f2d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cv-bridge depth-obstacle-detect-ros-msgs image-transport rclcpp rclcpp-components rclpy ros2launch sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The depth based obstacle detection package";
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/jazzy/diff-drive-controller/default.nix
+++ b/distros/jazzy/diff-drive-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-toolbox, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-diff-drive-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "fc92fe1b5b6088e0b4abe2e04c9ba35f81509657fab668d719097b1ecb8b45c9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/diff_drive_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "d7ee518a1bde9f3bef194ec5dce5287e853f5dbf62c217e658bd2a2338689a4e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-toolbox controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/dynamixel-hardware-interface/default.nix
+++ b/distros/jazzy/dynamixel-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-interfaces, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-dynamixel-hardware-interface";
-  version = "1.4.2-r1";
+  version = "1.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "235d063cdc83c90d315964781866eaf684b48cb83427f6061c72c848a9f729d7";
+    url = "https://github.com/ros2-gbp/dynamixel_hardware_interface-release/archive/release/jazzy/dynamixel_hardware_interface/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "6f806a8c40002bffe474ff6cb5a78e6f7cf2d1be4e7654a8824bb72d0460efc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/effort-controllers/default.nix
+++ b/distros/jazzy/effort-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-effort-controllers";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "1924427b23a6928c949498ca9ec372abade625577b81c0eab23e593d2c9ce9e3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/effort_controllers/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "a76e4c0677ca041f505b27c441d9238c89be03354f3994c0c903739bd5cb1db7";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/fkie-message-filters/default.nix
+++ b/distros/jazzy/fkie-message-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, image-transport, rclcpp, sensor-msgs, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-jazzy-fkie-message-filters";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/fkie_message_filters-release/archive/release/jazzy/fkie_message_filters/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "f295f5a6af999295616176422b1d57e6aa3b62deb40ecc1ca3de19e84e456c47";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-ros std-msgs ];
+  propagatedBuildInputs = [ image-transport rclcpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Improved ROS message filters";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/jazzy/force-torque-sensor-broadcaster/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-force-torque-sensor-broadcaster";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "6b1f9b94c9d2b051955ae70b7ff129b78b27b510de7984fe32076d6c1cb79413";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/force_torque_sensor_broadcaster/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "55c8e9778ac57e15da448991297e6d7e78ba3292e007cf6344f2ab43e5196934";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/forward-command-controller/default.nix
+++ b/distros/jazzy/forward-command-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-forward-command-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "8326bf25dee6476324d01128942421d51ca3bd01ec573c71edd7ead5a2d50ba3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/forward_command_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "480dcd34b0dcf1095628fed59e26f1bcd3af9ad6e45c6cec7af1091e2e6aca24";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/generated.nix
+++ b/distros/jazzy/generated.nix
@@ -498,6 +498,10 @@ self: super: {
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
+ depth-obstacle-detect-ros = self.callPackage ./depth-obstacle-detect-ros {};
+
+ depth-obstacle-detect-ros-msgs = self.callPackage ./depth-obstacle-detect-ros-msgs {};
+
  depthai = self.callPackage ./depthai {};
 
  depthai-ros = self.callPackage ./depthai-ros {};
@@ -814,6 +818,8 @@ self: super: {
 
  find-object-2d = self.callPackage ./find-object-2d {};
 
+ fkie-message-filters = self.callPackage ./fkie-message-filters {};
+
  flex-sync = self.callPackage ./flex-sync {};
 
  flexbe-behavior-engine = self.callPackage ./flexbe-behavior-engine {};
@@ -929,6 +935,8 @@ self: super: {
  gpio-controllers = self.callPackage ./gpio-controllers {};
 
  gps-msgs = self.callPackage ./gps-msgs {};
+
+ gps-sensor-broadcaster = self.callPackage ./gps-sensor-broadcaster {};
 
  gps-tools = self.callPackage ./gps-tools {};
 
@@ -1744,7 +1752,33 @@ self: super: {
 
  odri-master-board-sdk = self.callPackage ./odri-master-board-sdk {};
 
+ om-gravity-compensation-controller = self.callPackage ./om-gravity-compensation-controller {};
+
+ om-joint-trajectory-command-broadcaster = self.callPackage ./om-joint-trajectory-command-broadcaster {};
+
+ om-spring-actuator-controller = self.callPackage ./om-spring-actuator-controller {};
+
  ompl = self.callPackage ./ompl {};
+
+ open-manipulator = self.callPackage ./open-manipulator {};
+
+ open-manipulator-bringup = self.callPackage ./open-manipulator-bringup {};
+
+ open-manipulator-description = self.callPackage ./open-manipulator-description {};
+
+ open-manipulator-gui = self.callPackage ./open-manipulator-gui {};
+
+ open-manipulator-moveit-config = self.callPackage ./open-manipulator-moveit-config {};
+
+ open-manipulator-playground = self.callPackage ./open-manipulator-playground {};
+
+ open-manipulator-teleop = self.callPackage ./open-manipulator-teleop {};
+
+ open-sound-control = self.callPackage ./open-sound-control {};
+
+ open-sound-control-bridge = self.callPackage ./open-sound-control-bridge {};
+
+ open-sound-control-msgs = self.callPackage ./open-sound-control-msgs {};
 
  openeb-vendor = self.callPackage ./openeb-vendor {};
 
@@ -2866,13 +2900,29 @@ self: super: {
 
  turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
 
+ turtlebot3 = self.callPackage ./turtlebot3 {};
+
+ turtlebot3-bringup = self.callPackage ./turtlebot3-bringup {};
+
+ turtlebot3-cartographer = self.callPackage ./turtlebot3-cartographer {};
+
+ turtlebot3-description = self.callPackage ./turtlebot3-description {};
+
+ turtlebot3-example = self.callPackage ./turtlebot3-example {};
+
  turtlebot3-fake-node = self.callPackage ./turtlebot3-fake-node {};
 
  turtlebot3-gazebo = self.callPackage ./turtlebot3-gazebo {};
 
  turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
 
+ turtlebot3-navigation2 = self.callPackage ./turtlebot3-navigation2 {};
+
+ turtlebot3-node = self.callPackage ./turtlebot3-node {};
+
  turtlebot3-simulations = self.callPackage ./turtlebot3-simulations {};
+
+ turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
  turtlebot4-base = self.callPackage ./turtlebot4-base {};
 

--- a/distros/jazzy/gpio-controllers/default.nix
+++ b/distros/jazzy/gpio-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gpio-controllers";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "06e2f179f7c6afc4e22a74b26fdd00478298839b0254f5296b2170b145aac432";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gpio_controllers/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "b103c41a0b43a5edc73ce9ee3852b3c4be2182488291260e65b77040e6c1da06";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake pluginlib ];
+  buildInputs = [ ament-cmake pluginlib ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface generate-parameter-library hardware-interface rclcpp rclcpp-lifecycle realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/gps-sensor-broadcaster/default.nix
+++ b/distros/jazzy/gps-sensor-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-gps-sensor-broadcaster";
+  version = "4.23.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gps_sensor_broadcaster/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "79db23cef965f8921cbf8118772ff40362b26ea9b7f6e16329818380b8404f2d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller to publish readings of GPS sensors.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/gripper-controllers/default.nix
+++ b/distros/jazzy/gripper-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-gripper-controllers";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "91f68e1e21a44fa78bb265e2103020a5e69207dcef236d9e60323d0d4f4a54b7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/gripper_controllers/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "a4b9df1632cb0a858081b0924017e0571aec53ebce69af9fe974fa5a97b7b0fd";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/hardware-interface-testing/default.nix
+++ b/distros/jazzy/hardware-interface-testing/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, hardware-interface, lifecycle-msgs, pluginlib, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface-testing";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "c556d8fe1cf91dd9d2da9d83916f03a1f2f1b9f1447c64ed37af0a7c2c14f5ff";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface_testing/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "a278f783de36bf7274fa84f8a5eb7d591e4759e8fad5f58c87a904f4f129e7f9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ];
   propagatedBuildInputs = [ control-msgs hardware-interface lifecycle-msgs pluginlib rclcpp-lifecycle ros2-control-test-assets ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "ros2_control hardware interface testing";
+    description = "Commonly used test fixtures for the ros2_control framework";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/hardware-interface/default.nix
+++ b/distros/jazzy/hardware-interface/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, control-msgs, joint-limits, lifecycle-msgs, pal-statistics, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sdformat-urdf, tinyxml2-vendor, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-hardware-interface";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "ff0e0ebcb5232645948b8a1bb95782630fd300443af5254afa47ee60d9e76b66";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/hardware_interface/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "45b383672afd54843053546fa3be75f4f82f0f38c2c100bd404326a8dee485f6";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs joint-limits lifecycle-msgs pal-statistics pluginlib rclcpp-lifecycle rcpputils rcutils realtime-tools sdformat-urdf tinyxml2-vendor urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
-    description = "ros2_control hardware interface";
+    description = "Base classes for hardware abstraction and tooling for them";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/imu-sensor-broadcaster/default.nix
+++ b/distros/jazzy/imu-sensor-broadcaster/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-imu-sensor-broadcaster";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "6de55996d6fffc7668c79041a7da87a3f43a645bc639b4dedc70750ae55b2ddc";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/imu_sensor_broadcaster/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "2437b6bdd7dcce91cc69291387065232b55f4c7ff40ba56ba4c56232fbfa6fb9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/joint-limits/default.nix
+++ b/distros/jazzy/joint-limits/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, ament-cmake-gtest, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, trajectory-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, backward-ros, generate-parameter-library, launch-ros, launch-testing-ament-cmake, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-limits";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "d3371c06f30844b20e308311c86bc9781d824a327aaaa106ccd09ebf704f264c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/joint_limits/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "e47549f8e691e9fc8c5d218fa1312baba8ce98bf40540f2dc43979e194ae4938";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest generate-parameter-library launch-ros launch-testing-ament-cmake ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock generate-parameter-library launch-ros launch-testing-ament-cmake ];
   propagatedBuildInputs = [ backward-ros pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs urdf ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 

--- a/distros/jazzy/joint-state-broadcaster/default.nix
+++ b/distros/jazzy/joint-state-broadcaster/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-state-broadcaster";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "a70a0f3c7eaec39146cabee8a920f0c11e3d04310626c829a794e574d2db3454";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_state_broadcaster/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "51d6dabd91d7478c2b94210517df6fc890a907692b6ba2612f5901766bf852be";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
-  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing rclcpp ros2-control-test-assets ];
-  propagatedBuildInputs = [ backward-ros builtin-interfaces control-msgs controller-interface generate-parameter-library pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs urdf ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros builtin-interfaces control-msgs controller-interface generate-parameter-library pluginlib rclcpp rclcpp-lifecycle rcutils realtime-tools sensor-msgs urdf ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/joint-trajectory-controller/default.nix
+++ b/distros/jazzy/joint-trajectory-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, rsl, tl-expected, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-jazzy-joint-trajectory-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "aa636dcc13c94eec83eb317286141015b2904a1fbce1895bd672d4cf2f26842a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/joint_trajectory_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "a315b961282524eaa5a4b58f70707552439b3f93f9fb57d2a85cdbe0793ef44d";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl tl-expected trajectory-msgs urdf ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/ld08-driver/default.nix
+++ b/distros/jazzy/ld08-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs, udev }:
 buildRosPackage {
   pname = "ros-jazzy-ld08-driver";
-  version = "1.1.1-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/jazzy/ld08_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a1f0d545bc704941c69b1158c010ddb6d6d8392aa457025069481c298cc34f4f";
+    url = "https://github.com/ros2-gbp/ld08_driver-release/archive/release/jazzy/ld08_driver/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "ebc6fb0991c246fb9d2b1a860c63a862de33adaf1b58c320ccc7f7f4838adcf9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-description/default.nix
+++ b/distros/jazzy/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-leo-description";
-  version = "3.0.4-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "258c6da71458ea110973fc1ee1dd643e1663f6aec6cf797da789609f6fd5ebf5";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_description/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "f49a283b31877787085d2bef9b7ad937bd2b302363b239fc0ecbdaf3f641459a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-gz-bringup/default.nix
+++ b/distros/jazzy/leo-gz-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-black, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-xmllint, ament-index-python, ament-lint-auto, launch, launch-ros, leo-description, leo-gz-plugins, leo-gz-worlds, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-leo-gz-bringup";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_bringup/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "121a740b71a07a0303853fa6f7e92050fbb980976e32bcedb492caa0bfca0c11";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_bringup/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e6cf34a203aa52dc649f292e8277fe18efb66bcff82fd51542bdaf6e99e8e17a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-gz-plugins/default.nix
+++ b/distros/jazzy/leo-gz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, gz-plugin-vendor, gz-sim-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-leo-gz-plugins";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_plugins/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "803a5a36e65eb4c4146e20ff1a02c17bb225f4fe81327103d5db85f0b0dfb6b9";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e143431d4daa1c7494032176386f5d4c7c909152dd65c25ed6ba094942be1a47";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-gz-worlds/default.nix
+++ b/distros/jazzy/leo-gz-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-jazzy-leo-gz-worlds";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_worlds/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c8cb302cae63523497f9a4ee0213556a695355105050afec8e22f1f54be5f57a";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_gz_worlds/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "b23f6125a1492c15a8032cb0e17d2cffe61750aa308fca9ab613239936569a80";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-msgs/default.nix
+++ b/distros/jazzy/leo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-leo-msgs";
-  version = "3.0.4-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_msgs/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "b582607982f13ec9088e52977c283e44b25da60a963da97986b57ab39b20d941";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "1b090464fce57599bafcf457dd051eb13e1590b471652b6406d311e8790bbe48";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-simulator/default.nix
+++ b/distros/jazzy/leo-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, leo-gz-bringup, leo-gz-plugins, leo-gz-worlds }:
 buildRosPackage {
   pname = "ros-jazzy-leo-simulator";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_simulator/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "82c0ebcab09e7f310d408f99cb4fa005548ad06d798f6191b441e8d07b030f61";
+    url = "https://github.com/ros2-gbp/leo_simulator-release/archive/release/jazzy/leo_simulator/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "704ea56f7d43aeddf2611baba963a2a3fa0a5989ce5d41cad5d599576f857185";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo-teleop/default.nix
+++ b/distros/jazzy/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-lint-cmake, ament-cmake-xmllint, ament-lint-auto, joy-linux, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-jazzy-leo-teleop";
-  version = "3.0.4-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_teleop/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4bb641298a6aa0fb83d2215443024fea0dbe4f23d69bc875f1d845899ef6bd69";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo_teleop/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "59ace5efa5098d4e983aee260292f3a52b3afc0f78f376f891b3c4a8ec1915e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/leo/default.nix
+++ b/distros/jazzy/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, leo-description, leo-msgs, leo-teleop }:
 buildRosPackage {
   pname = "ros-jazzy-leo";
-  version = "3.0.4-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4c156ae9962c3958c249386da3adb48b527948cfd3adfe6c203a57cb6020f9f4";
+    url = "https://github.com/ros2-gbp/leo_common-release/archive/release/jazzy/leo/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8ced250845270728d9fc3634a749ccf848f93e26fe4514c1d2a55fbe1eb9e160";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/libcaer-driver/default.nix
+++ b/distros/jazzy/libcaer-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-ros, ament-cmake-xmllint, camera-info-manager, event-camera-msgs, image-transport, libcaer-vendor, rclcpp, rclcpp-components, ros-environment, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-libcaer-driver";
-  version = "1.3.3-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcaer_driver-release/archive/release/jazzy/libcaer_driver/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "bdc7c114b8bb6ecec6030393cdd303fcd08386c5c31c3be5730014a5635eb8f3";
+    url = "https://github.com/ros2-gbp/libcaer_driver-release/archive/release/jazzy/libcaer_driver/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "01f1a93001514da8eadbd4bf3a9afad1ca696ee8cff28a7105f3fe96572fdeed";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/mecanum-drive-controller/default.nix
+++ b/distros/jazzy/mecanum-drive-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-mecanum-drive-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "ca7e43e86188a4b3427fc0d1a4f5760a38ce5547a1a0c121b8b4193f3f28b64d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/mecanum_drive_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "83d1ab14fabb6d4c57fc17b6a9f753f1eec89c62345547648a571cdc6aaf9345";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/om-gravity-compensation-controller/default.nix
+++ b/distros/jazzy/om-gravity-compensation-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-om-gravity-compensation-controller";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_gravity_compensation_controller/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "2838bc932fea616dd06c934cfcf6d2d1b998c08eaedd4e516764107c86db35d5";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl tl-expected urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Controller for compensating for gravity on a group of joints";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/om-joint-trajectory-command-broadcaster/default.nix
+++ b/distros/jazzy/om-joint-trajectory-command-broadcaster/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, sensor-msgs, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-om-joint-trajectory-command-broadcaster";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_joint_trajectory_command_broadcaster/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "b6f9ecb50e9ef5813bb740ed7dd6473c2b4e20863b8d72c698646feea9f84324";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing rclcpp ros2-control-test-assets ];
+  propagatedBuildInputs = [ backward-ros builtin-interfaces control-msgs controller-interface generate-parameter-library pluginlib rclcpp-lifecycle rcutils realtime-tools sensor-msgs trajectory-msgs urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Joint Trajectory Command Broadcaster ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/om-spring-actuator-controller/default.nix
+++ b/distros/jazzy/om-spring-actuator-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, rsl, tl-expected, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-om-spring-actuator-controller";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/om_spring_actuator_controller/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "532eedc1759271f919593eee1e1e9af40724a81ed2c80efd7240ab0fecf24a39";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
+  propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools rsl tl-expected urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Spring Actuator Controller ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator-bringup/default.nix
+++ b/distros/jazzy/open-manipulator-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gripper-controllers, gz-ros2-control, open-manipulator-description, robot-state-publisher, ros-gz-bridge, ros-gz-image, ros-gz-sim, ros2-control, ros2-controllers, rviz2, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator-bringup";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_bringup/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a6471b028894761b2231c9636170c362d79f4163f5140cee1fad9e823386a07e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ gripper-controllers gz-ros2-control open-manipulator-description robot-state-publisher ros-gz-bridge ros-gz-image ros-gz-sim ros2-control ros2-controllers rviz2 xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "OpenMANIPULATOR bringup ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator-description/default.nix
+++ b/distros/jazzy/open-manipulator-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, rviz2 }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator-description";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "350f97cb1158a89f52965279e991b84f70e924034f7f18eb562085528670defc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "open_manipulator_description ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator-gui/default.nix
+++ b/distros/jazzy/open-manipulator-gui/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, geometry-msgs, moveit-core, moveit-msgs, moveit-ros-planning, moveit-ros-planning-interface, qt5, rclcpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator-gui";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_gui/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "6ae07d4cf29a7e1b82ed9aa0f48d873a4468133d91e226ce87cf595a01d29517";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ eigen3-cmake-module geometry-msgs moveit-core moveit-msgs moveit-ros-planning moveit-ros-planning-interface qt5.qtbase rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "The OpenMANIPULATOR-X GUI ROS 2 package enables users to explore Joint Space,
+    Task Space, and even work with the Task Constructor functionality.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator-moveit-config/default.nix
+++ b/distros/jazzy/open-manipulator-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-manager, joint-state-publisher, joint-state-publisher-gui, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-ros-move-group, moveit-ros-visualization, moveit-ros-warehouse, moveit-setup-assistant, moveit-simple-controller-manager, open-manipulator-description, robot-state-publisher, rviz-common, rviz-default-plugins, rviz2, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator-moveit-config";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_moveit_config/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "7fe332176a32738fc9f6a9718f52684753a5b4bdbed9eba4dd0562636f4b7494";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ controller-manager joint-state-publisher joint-state-publisher-gui moveit-configs-utils moveit-kinematics moveit-planners moveit-ros-move-group moveit-ros-visualization moveit-ros-warehouse moveit-setup-assistant moveit-simple-controller-manager open-manipulator-description robot-state-publisher rviz-common rviz-default-plugins rviz2 tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "An automatically generated package with all the configuration and launch files for using the open_manipulator_x with the MoveIt Motion Planning Framework";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator-playground/default.nix
+++ b/distros/jazzy/open-manipulator-playground/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-ros-planning-interface, rclcpp, rclpy, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator-playground";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_playground/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "45e2f9ffb758ead43e18fe99bba759629fabfb09e331599859b5f1c17ce2409e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ control-msgs moveit-ros-planning-interface rclcpp rclpy sensor-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides an example for utilizing the MoveIt API with the OpenMANIPULATOR-X,
+    allowing users to practice and experiment freely.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator-teleop/default.nix
+++ b/distros/jazzy/open-manipulator-teleop/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclpy }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator-teleop";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator_teleop/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "4a6cb6c21459474bb63a0e52a72b587db3d7e4ee58f0d4eb8798485582291594";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "OpenMANIPULATOR teleop ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-manipulator/default.nix
+++ b/distros/jazzy/open-manipulator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, om-gravity-compensation-controller, om-joint-trajectory-command-broadcaster, om-spring-actuator-controller, open-manipulator-bringup, open-manipulator-description, open-manipulator-gui, open-manipulator-moveit-config, open-manipulator-playground, open-manipulator-teleop }:
+buildRosPackage {
+  pname = "ros-jazzy-open-manipulator";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_manipulator-release/archive/release/jazzy/open_manipulator/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "af06d95da0e90c6e40d6899509e049fbbf27cc05f1dcb8e123113e74192dc896";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ om-gravity-compensation-controller om-joint-trajectory-command-broadcaster om-spring-actuator-controller open-manipulator-bringup open-manipulator-description open-manipulator-gui open-manipulator-moveit-config open-manipulator-playground open-manipulator-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "OpenMANIPULATOR meta ROS 2 package.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-sound-control-bridge/default.nix
+++ b/distros/jazzy/open-sound-control-bridge/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, open-sound-control-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-open-sound-control-bridge";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_sound_control-release/archive/release/jazzy/open_sound_control_bridge/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "1ccecfd8fa5b09a57e340cb1bdb779ee163cb705b59586c0cf0eb14b8aa52507";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ open-sound-control-msgs std-msgs ];
+
+  meta = {
+    description = "Bridge node for converting between OSC and ROS messages";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-sound-control-msgs/default.nix
+++ b/distros/jazzy/open-sound-control-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-jazzy-open-sound-control-msgs";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_sound_control-release/archive/release/jazzy/open_sound_control_msgs/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3f843d61fb5e3a18dc5156332e66fb99868219a3a6a9546cefc5880f8b36c401";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rosidl-default-generators ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Open Sound Control messages for ROS 2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/open-sound-control/default.nix
+++ b/distros/jazzy/open-sound-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, open-sound-control-bridge, open-sound-control-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-open-sound-control";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/open_sound_control-release/archive/release/jazzy/open_sound_control/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "30c7d62dee20ab49a9a5d2e3f97db4922be7d5826ae9635b8cc0836c663dc5f8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ open-sound-control-bridge open-sound-control-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "Metapackage for ROS/Open Sound Control bridge";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/parallel-gripper-controller/default.nix
+++ b/distros/jazzy/parallel-gripper-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-parallel-gripper-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "5581f18584d0f2785760cec4c231f3a8ab910279deef3c9b3f6d3f6d2a1053b1";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/parallel_gripper_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "54eced8b918b838c74e26ce9c3d3e4079b9e5305f4c860fd99ee013a7dcc6a84";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs control-toolbox controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/pid-controller/default.nix
+++ b/distros/jazzy/pid-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-srvs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, angles, backward-ros, control-msgs, control-toolbox, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, parameter-traits, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-pid-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "0203c21d3b856e94d14ef74c052b823e97c21f18b65b10b369a712bb87396140";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pid_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "bdae17fda7ba51959c36b3f9c51308f70b2fd6b023d0084e23145f48b991c3a3";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ angles backward-ros control-msgs control-toolbox controller-interface hardware-interface parameter-traits pluginlib rclcpp rclcpp-lifecycle realtime-tools std-srvs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/pose-broadcaster/default.nix
+++ b/distros/jazzy/pose-broadcaster/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-pose-broadcaster";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "327d40022cb5e9a0a16591a90283e18c69dcc1883e6680566c4682a0cd10373a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/pose_broadcaster/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "ffc5ea2a1050ae9688f7e036472f2d1b204708a41c03b9c07cedbb1aa425ddbf";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library geometry-msgs pluginlib rclcpp rclcpp-lifecycle realtime-tools tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/position-controllers/default.nix
+++ b/distros/jazzy/position-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-position-controllers";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "a9b86e2a9473cdf5e7f596a3b9338d99d03fe8bb5b727ab765b6b9f86003d88f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/position_controllers/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "6622cf8a725faf43350235dd987e758bbaabdfff7be12852e973f03b6aa870e9";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/range-sensor-broadcaster/default.nix
+++ b/distros/jazzy/range-sensor-broadcaster/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-cmake, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-range-sensor-broadcaster";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "84e7c8f95d6c28f1a9bfc80bed9e47dfa65e3bea363a13bf7c88c1d60780f805";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/range_sensor_broadcaster/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "83c4dfaaccf8f6d0cfa4d2c2fbe3cfd604dd70a40a05521d045c93067574750b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros controller-interface generate-parameter-library hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/ros2-control-test-assets/default.nix
+++ b/distros/jazzy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control-test-assets";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "b82601e88d15ad1670510778212914c8b7512a9eabc1b2fb06dddcdf0e969ded";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control_test_assets/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "5da8969075ae207f2bc9680e5a9ea77e60bcede559158dd90da58f2ed31c450a";
   };
 
   buildType = "ament_cmake";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = "The package provides shared test resources for ros2_control stack";
+    description = "Shared test resources for ros2_control stack";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/ros2-control/default.nix
+++ b/distros/jazzy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits, ros2-control-test-assets, ros2controlcli, transmission-interface }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-control";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "71c99c26dbca64b13af5a68be4900f46af3c56cb87d0427a2c7b4ed0f2289d39";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2_control/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "9826f917faa136eaac8dd34ed8d4bb11e80a2f7da6a427c0f5570fb1b109630e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ros2-controllers-test-nodes/default.nix
+++ b/distros/jazzy/ros2-controllers-test-nodes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch-ros, launch-testing-ros, python3Packages, rclpy, sensor-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers-test-nodes";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "f8ed548ce709100d4f6794011ad641329c7993f4f52ff0ec98c44931b82ff6d7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers_test_nodes/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "7dca5d131b3be8034418532954880d56a0d08d00c2fd2e2c1005014b7d67d737";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/ros2-controllers/default.nix
+++ b/distros/jazzy/ros2-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, admittance-controller, ament-cmake, bicycle-steering-controller, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, gpio-controllers, gps-sensor-broadcaster, gripper-controllers, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, mecanum-drive-controller, parallel-gripper-controller, pid-controller, pose-broadcaster, position-controllers, range-sensor-broadcaster, steering-controllers-library, tricycle-controller, tricycle-steering-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-jazzy-ros2-controllers";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "18145e85261b7ca6167948f537eaa02a0dfb5780cda617a15351f060935161d6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/ros2_controllers/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "e78d4a0f15bdb84f60d7bd496bd30a64a711a52e96795943154b303ddc02aabd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller gpio-controllers gripper-controllers imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller mecanum-drive-controller parallel-gripper-controller pid-controller pose-broadcaster position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller admittance-controller bicycle-steering-controller diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller gpio-controllers gps-sensor-broadcaster gripper-controllers imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller mecanum-drive-controller parallel-gripper-controller pid-controller pose-broadcaster position-controllers range-sensor-broadcaster steering-controllers-library tricycle-controller tricycle-steering-controller velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/ros2controlcli/default.nix
+++ b/distros/jazzy/ros2controlcli/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-jazzy-ros2controlcli";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "54c2087c3edbbff0874b311fafe75fd28d7d3e98e1a84d6d5ece3ffcd69bc963";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/ros2controlcli/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "53da6b55007801bf2e75e94cabb19b37c909aa68268c1aaa3982fc90d6435379";
   };
 
   buildType = "ament_python";
   propagatedBuildInputs = [ controller-manager controller-manager-msgs python3Packages.pygraphviz rcl-interfaces rclpy ros2cli ros2node ros2param rosidl-runtime-py ];
 
   meta = {
-    description = "The ROS 2 command line tools for ROS2 Control.";
+    description = "The ROS 2 command line tools for ros2_control.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/rqt-controller-manager/default.nix
+++ b/distros/jazzy/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, controller-manager, controller-manager-msgs, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-controller-manager";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "ce75bc86d1f1e3f38ac0a348c5b4c255932e6a74f4f063e718f7e379ededf960";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/rqt_controller_manager/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "a2425703a63bcdf8953d308160c692037552bd74df218dc473bb72c46723ae5b";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/rqt-joint-trajectory-controller/default.nix
+++ b/distros/jazzy/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-rqt-joint-trajectory-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "6246a8be8bfc609800aaee87f2a2ba583e79c6f4295b36358da591c2db0009f3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/rqt_joint_trajectory_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "c5f0a8d631ff54339341a70129682b7b1a1a83a046f0c7fdf3be23cfe3267b90";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/steering-controllers-library/default.nix
+++ b/distros/jazzy/steering-controllers-library/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-steering-controllers-library";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "b8c993bdfa01eccc5537ae550854fe221102c4b85a912a7b0988d52bacc47a36";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/steering_controllers_library/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "625172353f28c778d530b1fc3767139b9d95befeff555ce86b0b757924157133";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ ackermann-msgs backward-ros control-msgs controller-interface generate-parameter-library geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-geometry-msgs tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/swri-cli-tools/default.nix
+++ b/distros/jazzy/swri-cli-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, marti-introspection-msgs, python3Packages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2param, ros2topic }:
 buildRosPackage {
   pname = "ros-jazzy-swri-cli-tools";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_cli_tools/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "f0bdb9763335b1601d72cdf15ded2d321832dd8f77c57f1283c9783ce06fa8de";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_cli_tools/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "f8ac62ab7d821edaac3bfc2592e771d604305894ec50dc53c9cd66bb5edb82a3";
   };
 
   buildType = "ament_python";

--- a/distros/jazzy/swri-console-util/default.nix
+++ b/distros/jazzy/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-swri-console-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_console_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "df5c64568e2f6959710e3ff0f2a40fca793008ca92b66e7e5eea6cb25c8ca25b";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_console_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "5e826ddcaf7a0de51883dc5d8650f9449efdea15b339ea3a3a0dc5824b785e14";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-dbw-interface/default.nix
+++ b/distros/jazzy/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-jazzy-swri-dbw-interface";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_dbw_interface/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "78e993c4f55d3a93d6e9e3d81e16e622398c95a86856df9b62d40774ca903453";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_dbw_interface/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "ef1afd758103d01531e11a7ee1b07d0e96f21baf0e65c56b17c2eac116091057";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-geometry-util/default.nix
+++ b/distros/jazzy/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-swri-geometry-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_geometry_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "00fd5e7c4992f2438cc61eca023a4105835a718160cc7f59bbc95b9b9c9ed194";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_geometry_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "360eac381b0ab601346b2016a7e060bdd79411e52fa4dcc17548e9a16b88bf7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-image-util/default.nix
+++ b/distros/jazzy/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-jazzy-swri-image-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_image_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "511eb6ea244395d0a377cab44ec8bc3b24a0f71f1cfee5906f95e05a45732a3e";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_image_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "7e6d1897ec6f67b505733a4d6d8c987da1bf88845429f1d39205351546f98ea3";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-math-util/default.nix
+++ b/distros/jazzy/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-swri-math-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_math_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "0deda611e16ecf90d8c4aa92dd66c36025be6fe8a49425becdd4bb012982361c";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_math_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "dc1a63b8fc5aeff1bea26464e30fc65f1f4b38076d9a4dfdbb2573e95d5d1427";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-opencv-util/default.nix
+++ b/distros/jazzy/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-jazzy-swri-opencv-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_opencv_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "794b462a1897f1d5adc5b72b53932ba9b51558add4b9a0e1f7a453f9dcc6ee3f";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_opencv_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "50f5bc3538a8f3c3bd1ce977e5519715e99393329bc96cc5335647b5f77df1eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-roscpp/default.nix
+++ b/distros/jazzy/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, ros-environment, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-jazzy-swri-roscpp";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_roscpp/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "7bb69ee2b71c6d4362f95e23500fdf5b40a1f2d3db5e7d0daf3d6cf128c66636";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_roscpp/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "d5c20cc54248bdedcc8fc046a6b6785f8ee898db2015647e9a05ed56e12ce0e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-route-util/default.nix
+++ b/distros/jazzy/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-swri-route-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_route_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "afb5612ac1d24384c8cbfebb0406458abb0b79d63c485d8f08fdf6a5c06e2663";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_route_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "f618e22e3c339c6760d3d9098d468f1ecbf9ca1bb3ad8e34f8df9800feb31798";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-serial-util/default.nix
+++ b/distros/jazzy/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-jazzy-swri-serial-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_serial_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "fb195b5a617e799030193c9de62b1bd07644af7c4deb8abf0ca1d1d90b394331";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_serial_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "1216bf53d2446056655b3445b37b885d9d3427333fa5d98640c4aada7c53c77a";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-system-util/default.nix
+++ b/distros/jazzy/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-jazzy-swri-system-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_system_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "fb3849b41d8bdd7293f5af212ca4fd430c05f797d1024e6b4100f6b7d5e29f89";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_system_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "adb2ded5e6f18b2db072f677dda97fdaaf9c434cbea5c539c44a0419259f430b";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/swri-transform-util/default.nix
+++ b/distros/jazzy/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-python, ament-index-cpp, boost, cv-bridge, diagnostic-msgs, diagnostic-updater, geographic-msgs, geographiclib, geometry-msgs, geos, gps-msgs, launch-ros, launch-testing, launch-testing-ament-cmake, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros, yaml-cpp }:
 buildRosPackage {
   pname = "ros-jazzy-swri-transform-util";
-  version = "3.7.3-r1";
+  version = "3.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_transform_util/3.7.3-1.tar.gz";
-    name = "3.7.3-1.tar.gz";
-    sha256 = "f7dd59d8cdf0a7c36b9cb49731d9602ac6f903e37b024f0a01866caa3412e967";
+    url = "https://github.com/ros2-gbp/marti_common-release/archive/release/jazzy/swri_transform_util/3.7.4-1.tar.gz";
+    name = "3.7.4-1.tar.gz";
+    sha256 = "48e629f27d88bed02af33bfc6af3acbc753db2c4c838d83f28a9d3fcd37a2197";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/transmission-interface/default.nix
+++ b/distros/jazzy/transmission-interface/default.nix
@@ -2,25 +2,25 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gen-version-h, ament-cmake-gmock, hardware-interface, pluginlib, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-transmission-interface";
-  version = "4.27.0-r1";
+  version = "4.28.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.27.0-1.tar.gz";
-    name = "4.27.0-1.tar.gz";
-    sha256 = "29375a255e1fd246813a5e11220f498d9d8cf498b530820a18ad09c24ba24a3f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/jazzy/transmission_interface/4.28.0-1.tar.gz";
+    name = "4.28.0-1.tar.gz";
+    sha256 = "dc6787c43a1e1c7a0ceb05d7630453571049603583a9a05a2eb2bf0bc40a7873";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ament-cmake-gen-version-h ];
+  buildInputs = [ ament-cmake ament-cmake-gen-version-h ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock ros2-control-test-assets ];
   propagatedBuildInputs = [ hardware-interface pluginlib ];
   nativeBuildInputs = [ ament-cmake ament-cmake-gen-version-h ];
 
   meta = {
-    description = "transmission_interface contains data structures for representing mechanical transmissions, methods for propagating values between actuator and joint spaces and tooling to support this.";
+    description = "data structures for representing mechanical transmissions, methods for propagating values between actuator and joint spaces and tooling to support this.";
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/jazzy/tricycle-controller/default.nix
+++ b/distros/jazzy/tricycle-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-cmake, ament-cmake-gmock, backward-ros, builtin-interfaces, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, rcpputils, realtime-tools, ros2-control-cmake, ros2-control-test-assets, std-srvs, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "b7864f19c4a13cb99812890cd438d9bf40744ef583b2beadecd4fded978c0769";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "018b7d04a60b32eb04476c8ca99f6459819cc0eb604d4742d4aa1d5586ee0c69";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ ackermann-msgs backward-ros builtin-interfaces controller-interface geometry-msgs hardware-interface nav-msgs pluginlib rclcpp rclcpp-lifecycle rcpputils realtime-tools std-srvs tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/tricycle-steering-controller/default.nix
+++ b/distros/jazzy/tricycle-steering-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-test-assets, std-srvs, steering-controllers-library }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, control-msgs, controller-interface, controller-manager, generate-parameter-library, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, rclcpp-lifecycle, ros2-control-cmake, ros2-control-test-assets, std-srvs, steering-controllers-library }:
 buildRosPackage {
   pname = "ros-jazzy-tricycle-steering-controller";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "734a4c18e6bf34eda8256d5ab9898bc90f2e97ef4caa355c01845eeb8ebc367b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/tricycle_steering_controller/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "ae0c0ae624ca4c111b240e52fdfbffa25773debe46a5dffb85530cfab3bea518";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake generate-parameter-library ];
+  buildInputs = [ ament-cmake generate-parameter-library ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle std-srvs steering-controllers-library ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/turtlebot3-bringup/default.nix
+++ b/distros/jazzy/turtlebot3-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, hls-lfcd-lds-driver, robot-state-publisher, rviz2, turtlebot3-description, turtlebot3-node }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-bringup";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_bringup/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "a187a7d8772795e54565738c22d9cf5e0adf01b12ebccc903ca65deeb9b3a15e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ hls-lfcd-lds-driver robot-state-publisher rviz2 turtlebot3-description turtlebot3-node ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 launch scripts for starting the TurtleBot3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3-cartographer/default.nix
+++ b/distros/jazzy/turtlebot3-cartographer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cartographer-ros }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-cartographer";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_cartographer/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "7275c5f59fd8a1423e34d0aedda501b35eafc127060383ba4bcb2363f1aa7514";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ cartographer-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 launch scripts for cartographer";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3-description/default.nix
+++ b/distros/jazzy/turtlebot3-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-description";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_description/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "c580f2c43a433c519a671cec2d7af0a1497feed8cb6f50db92598ad5dcb6cf55";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "3D models of the TurtleBot3 for simulation and visualization";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3-example/default.nix
+++ b/distros/jazzy/turtlebot3-example/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, tf-transformations, turtlebot3-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-example";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_example/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "411b5de34bd02a09ab0262e1f232b9e64b86e5c90f4d82ead736a5f7fb36b1b9";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy sensor-msgs tf-transformations turtlebot3-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "This package provides four basic examples for TurtleBot3 (i.e., interactive marker, object detection, patrol and position control).";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3-navigation2/default.nix
+++ b/distros/jazzy/turtlebot3-navigation2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-navigation2";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_navigation2/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "05f18c52e3181463bd465fc077749f6dcc3251a2b1fd9a71368395399e8dd261";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ nav2-bringup ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 launch scripts for navigation2";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3-node/default.nix
+++ b/distros/jazzy/turtlebot3-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, dynamixel-sdk, geometry-msgs, message-filters, nav-msgs, rclcpp, rcutils, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-node";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_node/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "7b1359b1d4e53a40a2cf27cfc33faaed845149234fc501cd2010565dbaea9124";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ dynamixel-sdk geometry-msgs message-filters nav-msgs rclcpp rcutils sensor-msgs std-msgs std-srvs tf2 tf2-ros turtlebot3-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "TurtleBot3 driver node that include diff drive controller, odometry and tf node";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3-teleop/default.nix
+++ b/distros/jazzy/turtlebot3-teleop/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rclpy }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3-teleop";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3_teleop/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "311405ec8e15e81f08f4ab8d407eec557e02370c3ad3650a799b7a4216cd01b2";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs rclpy ];
+
+  meta = {
+    description = "Teleoperation node using keyboard for TurtleBot3.";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/turtlebot3/default.nix
+++ b/distros/jazzy/turtlebot3/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2025 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-bringup, turtlebot3-cartographer, turtlebot3-description, turtlebot3-example, turtlebot3-navigation2, turtlebot3-node, turtlebot3-teleop }:
+buildRosPackage {
+  pname = "ros-jazzy-turtlebot3";
+  version = "2.2.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/turtlebot3-release/archive/release/jazzy/turtlebot3/2.2.8-1.tar.gz";
+    name = "2.2.8-1.tar.gz";
+    sha256 = "0ca98ae10b5a39d2734f1511450ef3715c8fd2cc559de17681d7660022314e0a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ turtlebot3-bringup turtlebot3-cartographer turtlebot3-description turtlebot3-example turtlebot3-navigation2 turtlebot3-node turtlebot3-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = "ROS 2 packages for TurtleBot3";
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/jazzy/ur-calibration/default.nix
+++ b/distros/jazzy/ur-calibration/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, rclcpp, ur-client-library, ur-robot-driver, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-jazzy-ur-calibration";
-  version = "3.1.1-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "25ec21aee5dafd5c785d12ce9fe3f21dba263f54431b567494de403d5e4603bf";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_calibration/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7b8432eda6be04853e9a5d07eabe252ae6264ae5702a7b2d510614dbab6c0ddd";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp ];
+  propagatedBuildInputs = [ eigen rclcpp ur-client-library ur-robot-driver yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/jazzy/ur-controllers/default.nix
+++ b/distros/jazzy/ur-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, angles, control-msgs, controller-interface, controller-manager, generate-parameter-library, geometry-msgs, hardware-interface, hardware-interface-testing, joint-trajectory-controller, lifecycle-msgs, pluginlib, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ur-dashboard-msgs, ur-msgs }:
 buildRosPackage {
   pname = "ros-jazzy-ur-controllers";
-  version = "3.1.1-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "5b88e2df545c29e32db6836529a0adc192c868f8bb6cf7683e11d665acbecaee";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_controllers/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "df216a8b891cb2f10205e01c0bbd58a82f876871ce2a01d59cf3049ac1d25ff9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake ];
-  checkInputs = [ controller-manager ros2-control-test-assets ];
+  checkInputs = [ controller-manager hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ action-msgs angles control-msgs controller-interface generate-parameter-library geometry-msgs hardware-interface joint-trajectory-controller lifecycle-msgs pluginlib rclcpp-lifecycle rcutils realtime-tools std-msgs std-srvs tf2-geometry-msgs tf2-ros trajectory-msgs ur-dashboard-msgs ur-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/jazzy/ur-dashboard-msgs/default.nix
+++ b/distros/jazzy/ur-dashboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-jazzy-ur-dashboard-msgs";
-  version = "3.1.1-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "e6fcf3b36657368baebda63aa6c95e5c15574f471be66af6ef5b725640e63f7f";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_dashboard_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "0b93293a54ff513fe32468a80f7fe0adf2b9cc9226540cdb212786c767e61482";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-moveit-config/default.nix
+++ b/distros/jazzy/ur-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-configs-utils, moveit-kinematics, moveit-planners, moveit-planners-chomp, moveit-ros-move-group, moveit-ros-visualization, moveit-servo, moveit-simple-controller-manager, ur-description, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-moveit-config";
-  version = "3.1.1-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "72f80f7942a707b0b146b74a0d5145caf7ea895d8272264b5526a346a562f762";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_moveit_config/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "aae475f04b5833fd2333978c734f50b6f68ec488cfa48f68f655bdc328ca4304";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-robot-driver/default.nix
+++ b/distros/jazzy/ur-robot-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, backward-ros, controller-manager, controller-manager-msgs, force-torque-sensor-broadcaster, geometry-msgs, hardware-interface, joint-state-broadcaster, joint-state-publisher, joint-trajectory-controller, launch, launch-ros, launch-testing-ament-cmake, pluginlib, pose-broadcaster, position-controllers, rclcpp, rclcpp-lifecycle, rclpy, robot-state-publisher, ros2-controllers-test-nodes, rviz2, socat, std-msgs, std-srvs, tf2-geometry-msgs, ur-client-library, ur-controllers, ur-dashboard-msgs, ur-description, ur-msgs, urdf, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-robot-driver";
-  version = "3.1.1-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "9c0caf7c050ef89b41ce7ff5fb1571417519c9de0abef1343f94332d8ba152c0";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur_robot_driver/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f5fca268801b8153666803c765b4e1f52e9c514d8d2ba628f51b8816c1ec7f3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur-simulation-gz/default.nix
+++ b/distros/jazzy/ur-simulation-gz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, gz-ros2-control, joint-state-publisher, launch, launch-ros, launch-testing-ament-cmake, launch-testing-ros, ros-gz-bridge, ros-gz-sim, rviz2, ur-controllers, ur-description, ur-moveit-config, urdf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-jazzy-ur-simulation-gz";
-  version = "2.1.0-r2";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/jazzy/ur_simulation_gz/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "c49349d560154733cf36b0ea60bd12ce203416117be9a8209d56f202a746729a";
+    url = "https://github.com/ros2-gbp/ur_simulation_gz-release/archive/release/jazzy/ur_simulation_gz/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a066582dcc43b34aafbf169c0156ce473205801974292fa6fa7eac2fa87ea688";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/ur/default.nix
+++ b/distros/jazzy/ur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ur-calibration, ur-controllers, ur-dashboard-msgs, ur-moveit-config, ur-robot-driver }:
 buildRosPackage {
   pname = "ros-jazzy-ur";
-  version = "3.1.1-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "3867e12759061d4f4f03c1ea134181d7220d92fb0355cbeeb43868947a1377b0";
+    url = "https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release/archive/release/jazzy/ur/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "6d3b0aee30d8b6c636232d4987fdc3433efed79492741e20568cff5c436c5d18";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/velocity-controllers/default.nix
+++ b/distros/jazzy/velocity-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, backward-ros, controller-manager, forward-command-controller, hardware-interface, hardware-interface-testing, pluginlib, rclcpp, ros2-control-cmake, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-jazzy-velocity-controllers";
-  version = "4.22.0-r1";
+  version = "4.23.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.22.0-1.tar.gz";
-    name = "4.22.0-1.tar.gz";
-    sha256 = "c1ab7f81b2a23a784dbb43b22fe1a0452dc30a76187589b11e38eb3243ec4189";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/jazzy/velocity_controllers/4.23.0-1.tar.gz";
+    name = "4.23.0-1.tar.gz";
+    sha256 = "3e7dcc705cc5733a299bf186d18a26e311055f25d7f48e3cbe62cd9c75d55fd4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ros2-control-cmake ];
   checkInputs = [ ament-cmake-gmock controller-manager hardware-interface hardware-interface-testing ros2-control-test-assets ];
   propagatedBuildInputs = [ backward-ros forward-command-controller pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/jazzy/yasmin-demos/default.nix
+++ b/distros/jazzy/yasmin-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, example-interfaces, nav-msgs, python3Packages, rclcpp, rclpy, ros-environment, yasmin, yasmin-ros, yasmin-viewer }:
 buildRosPackage {
   pname = "ros-jazzy-yasmin-demos";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_demos/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "638fc08fcfce5998620821477cd37a9c979babb0aa45553267e2a7c5de772420";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_demos/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7da584699fb0871314f4667b573d481b836e37dcfd10fc4d038b3f7e3a10a72f";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/yasmin-msgs/default.nix
+++ b/distros/jazzy/yasmin-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-jazzy-yasmin-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "ca5ff35b03e8e19561336d0b5d3c6a700d01249ce787f57297f54248b507bdc9";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "29ab5078f5baf05fc9883c23ce9426de84f685079983c6ed35a4c8abecf3ae21";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/yasmin-ros/default.nix
+++ b/distros/jazzy/yasmin-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclcpp, rclcpp-action, rclpy, ros-environment, yasmin }:
 buildRosPackage {
   pname = "ros-jazzy-yasmin-ros";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_ros/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "2832c3e03d6edfa8c1827c995325c31a0046184ff57ef61f1d2a029aa348fba3";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_ros/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b43892deaf809a3cf2da7217021097aa1bf313c3c94da314a17ee86455e407c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/jazzy/yasmin-viewer/default.nix
+++ b/distros/jazzy/yasmin-viewer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages, rclcpp, rclpy, yasmin, yasmin-msgs, yasmin-ros }:
 buildRosPackage {
   pname = "ros-jazzy-yasmin-viewer";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_viewer/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "d13dc904182713ecf2abe5ceaa5390547ab59eaaf92e96c607cfe28e5cbe2586";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin_viewer/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "62c260e344eedc57992a95f1ba560e0e89378a392b2edda746022afe82730bb3";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
-    description = "TODO: Package description";
-    license = with lib.licenses; [ "TODO-License-declaration" ];
+    description = "YASMIN viewer for FSM";
+    license = with lib.licenses; [ gpl3 ];
   };
 }

--- a/distros/jazzy/yasmin/default.nix
+++ b/distros/jazzy/yasmin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-copyright, ament-flake8, ament-pep257, python3Packages }:
 buildRosPackage {
   pname = "ros-jazzy-yasmin";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "44960b6e74a00d7dd1d10798c8028ecc46063c3229a487388708b3a2402abc44";
+    url = "https://github.com/ros2-gbp/yasmin-release/archive/release/jazzy/yasmin/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "7d989cbcad1042b9bf7e8e3a5b8053634d5d592fcb42ae558ef491012105e1e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/camera-ros/default.nix
+++ b/distros/rolling/camera-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-cppcheck, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-mypy, ament-cmake-pep257, ament-cmake-pyflakes, ament-cmake-xmllint, ament-index-python, ament-lint-auto, camera-info-manager, clang, cv-bridge, image-view, libcamera, rclcpp, rclcpp-components, ros2launch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-rolling-camera-ros";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "43d2c75526a93b5730fa2dbb0020b2ab072c0efe9d12ffe19d00e815db46ddd9";
+    url = "https://github.com/ros2-gbp/camera_ros-release/archive/release/rolling/camera_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e85bd872845595f1a36701e291dc6c22ed3079b6927644cf451593bb16f4c0be";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/chomp-motion-planner/default.nix
+++ b/distros/rolling/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, rclcpp, rsl, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-chomp-motion-planner";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "95930b1ec207c441f02113a50e0d63c409ce24cc63872d170173e674cb29c12f";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/chomp_motion_planner/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "20dc7c50cf394fd35da7419fda2f10d440742d9c454d8bb0175262248102731c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/libcamera/default.nix
+++ b/distros/rolling/libcamera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, git, libyaml, meson, openssl, pkg-config, python3, python3Packages, udev }:
 buildRosPackage {
   pname = "ros-rolling-libcamera";
-  version = "0.5.0-r2";
+  version = "0.5.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.5.0-2.tar.gz";
-    name = "0.5.0-2.tar.gz";
-    sha256 = "6f28dc9215efe170c7f242c5f52a4ebfd7a9819744703392db5130dd562da4a6";
+    url = "https://github.com/ros2-gbp/libcamera-release/archive/release/rolling/libcamera/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "fd929eda59d4bd5cadd7ad405189e584528137883e9acbe0f1364c774fbf2741";
   };
 
   buildType = "meson";

--- a/distros/rolling/moveit-common/default.nix
+++ b/distros/rolling/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, backward-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-common";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "d645439c68e814e83611988e2eb633af0811c06c5b581663006922ce333b2f40";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_common/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "9fe99c080a732fee88b24d84e547f54da286287779c5a139e7cf2325ba7d8137";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-configs-utils/default.nix
+++ b/distros/rolling/moveit-configs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-param-builder, launch-ros, srdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-configs-utils";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "5d10eb5a14f1480ff82e531175921260dd95e4725292b5f369d50760964cb375";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_configs_utils/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "58111f2df65a0d17a2f7105a732913e2dc7c1d4cca944d1058aa310b97f89867";
   };
 
   buildType = "ament_python";

--- a/distros/rolling/moveit-core/default.nix
+++ b/distros/rolling/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-google-benchmark, ament-cmake-gtest, ament-index-cpp, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, generate-parameter-library, geometric-shapes, geometry-msgs, google-benchmark-vendor, kdl-parser, launch-testing-ament-cmake, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl-vendor, osqp-vendor, pkg-config, pluginlib, random-numbers, rcl-interfaces, rclcpp, rclpy, rsl, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-core";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "0098232912fdbed18c7bf77b8c434e3e647fd50f09677610a51f721dd57d2f41";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_core/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "c8b85b0042e2a8826509802d8c64faa236472f88a5d96782b92c1f60e7b8d531";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-hybrid-planning/default.nix
+++ b/distros/rolling/moveit-hybrid-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, controller-manager, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pluginlib, position-controllers, rclcpp, rclcpp-action, rclcpp-components, robot-state-publisher, ros-testing, rviz2, std-msgs, std-srvs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-hybrid-planning";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "7b93840c9c5c3f16d7f88b531eba47fe3aa1e9f3802c6f7370f6299afcf7392e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_hybrid_planning/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "ac0a8dc8bdd878bb7bc7a0960dab98201dfae4610122ea6b383525a63b24976f";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-kinematics/default.nix
+++ b/distros/rolling/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, generate-parameter-library, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl-vendor, pluginlib, python3Packages, ros-testing, rsl, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-rolling-moveit-kinematics";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "f1b0be77aed8d14dc2c5970eaaf1334351a751124a7d4d98ae788e150fa561f9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_kinematics/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "42998a4fd796f8461c161ed50817ed98e4e033566622530a8aa3fde981b31b28";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-chomp/default.nix
+++ b/distros/rolling/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, chomp-motion-planner, moveit-common, moveit-core, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-chomp";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "21bf6e7752aaeb3bc8ddc52f8905b3d460dfd6569a87bd1ff7d4a38e81c5e10e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_chomp/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "d590b6029f641f722cac925e1e479e559e636f9b1b9aba56d3e87458ee83d64c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-ompl/default.nix
+++ b/distros/rolling/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-ompl";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "76a2cceb2c874956a380ce52aa220309cdbce79b88c3d8463d5a7d75d9334bf8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_ompl/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "c32bd9a919dbd8ce0059e8330f124a835c4bf80631058b7bf8de2fc9965865f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners-stomp/default.nix
+++ b/distros/rolling/moveit-planners-stomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-common, moveit-core, rsl, std-msgs, stomp, tf2-eigen, visualization-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners-stomp";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "c8e88d5dc318bc9e9ac507e63eec7a4f0a0ba0195f18b019cad2c87a2cd476f9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners_stomp/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "93753f9af25a605683a3f75827f04a4d5adb1d8fe934302fd2b29d5cdc78e557";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-planners/default.nix
+++ b/distros/rolling/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, pilz-industrial-motion-planner }:
 buildRosPackage {
   pname = "ros-rolling-moveit-planners";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "cdad1eb83f1fb1720749353097eba829307128fe9c425ee4447186bde8abdb89";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_planners/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "6d9a42051324ffd29dc7ed4a67d03c85815c4598a9758487bfdba4c97df7ceec";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-plugins/default.nix
+++ b/distros/rolling/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-rolling-moveit-plugins";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "4e33dec9bbab9a0c8bfaf27532cda9d6ea79cbfa8221ab77e4e7222d11c1a037";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_plugins/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "0146e6baaffa5d0ffdb79f077874ced427c6690d871ff22aa1b29f3efdcc4b1c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-py/default.nix
+++ b/distros/rolling/moveit-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, geometry-msgs, moveit-core, moveit-ros-planning, moveit-ros-planning-interface, octomap-msgs, pybind11-vendor, python3Packages, rclcpp, rclpy }:
 buildRosPackage {
   pname = "ros-rolling-moveit-py";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "47eeee576d4f2b2d788ed99acce0331f37b792916d7f3da1f4d1ade460baba03";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_py/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "8c9faa63fa0e05887a4cd54899498330bcd9afc17cdb344166d8486100af2b9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/rolling/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, generate-parameter-library, moveit-core, pluginlib, rclcpp, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "a2055ed0b01ac999c9379315f30a9c8ecd32b2a30d1636159ce2745b51546427";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_ikfast_manipulator_plugin/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "688443ff79ecc765f05552bcc64b6b5704939a6d1546d80cdc211cb08bfc5da5";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/rolling/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, moveit-ros-move-group, robot-state-publisher, rviz2, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-moveit-config";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "e1c6caeb226bc77f45c44e8cb5f87c10b253b0d07d9d626ff070b2e18feea9a7";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_moveit_config/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "af8091427b4b42e13746883dfb7914220b2af4d2603c8257156af3f4149d0924";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-pg70-support";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "9efd2ef456b8f3df82c13967a13b9dd308205f0840ea71bfd50a3acaa9c2fe43";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_pg70_support/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "0c7ce6d489031090ce7e1bd28198f1c4061db7aecccb33693a3277eaa2f62445";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-resources-prbt-support/default.nix
+++ b/distros/rolling/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-resources-prbt-support";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "f42624e2e2f9f66df8a248d7b65dac0c823f9be5a7f3a1544c4a4492811d8200";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_resources_prbt_support/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "0f79e4c8f256e24932f5af59fcd596a61df3cab81181662e09d86c6db23952e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-benchmarks/default.nix
+++ b/distros/rolling/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-benchmarks";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "0a46220311a59d37f9aa8594d21385b128c425268ef2c547e41497a14fd4a806";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_benchmarks/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "8e0125f85bde86910b12ca6ce1262522f81d5e32cce7f3d0a9afca41d902ace7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-control-interface/default.nix
+++ b/distros/rolling/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-control-interface";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "ded06a0df66d914236fa02813d53cd805f93e18ebd27449e5eab010244b0eba9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_control_interface/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "0dd14550eb33031138169910c2dd25146194caafd6747fc63fc65807698c32f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-move-group/default.nix
+++ b/distros/rolling/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, fmt, moveit-common, moveit-configs-utils, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, ros-testing, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-move-group";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "2ed99651b88d5685e298b3eb3b080e579e20a270d2134391ae8544ceca609373";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_move_group/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "7a9a2b3b73eca899e6cc62fb00071140cb4f671b3c6b0ec7fb005af3f922cfe7";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/rolling/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-occupancy-map-monitor";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "1128fea3213584436bb2748a0c10babfa98190fd876f99b18a69730a9f9403c3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_occupancy_map_monitor/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "61a2a4a243a7aad62427ad98657cf3fb25dcf1837b0fb6e61eb659f073f8d1df";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-perception/default.nix
+++ b/distros/rolling/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-perception";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "3e29f6f2efdb8fc3ec4bc0ad40aa767d5d8bf11358a074db4b6a6d5520a8938b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_perception/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "d27ee53d98d5d09e73348a2cd35e8a3ebf555494a7ba5a1ddce2bf4bebc2243a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning-interface/default.nix
+++ b/distros/rolling/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning-interface";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "fdd3e99c7e54379fe10b1821dde0222d0f33e2a0970c0d2d586c14439705b2a3";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning_interface/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "7e704e2b38fde4b2fc17027d07f3d2d79fae22f3fe1d2e0f2ce95482a9021dcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-planning/default.nix
+++ b/distros/rolling/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, eigen, eigen3-cmake-module, fmt, generate-parameter-library, launch-testing-ament-cmake, message-filters, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, rclcpp-components, ros-testing, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-planning";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "3c573a0d0cb4fb363fe2d9d908f8cca2dca0bb40cb14d883e53e4018159ff6a1";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_planning/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "5fa41ad1fe82cd9f5f18062f3eddad6f45d5ebca788dfe91281b35bd212def31";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-robot-interaction/default.nix
+++ b/distros/rolling/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-robot-interaction";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "3c0f110397d59882700c82be65bb641dfc0a799790bc05c2ef7884f9da973f49";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_robot_interaction/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "88e518711244f6ddeef72b6a683e9f4439661526b0d5790f99d20e2801e7223c";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-tests/default.nix
+++ b/distros/rolling/moveit-ros-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, moveit-common, moveit-configs-utils, moveit-core, moveit-planners-chomp, moveit-planners-ompl, moveit-planners-stomp, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-simple-controller-manager, pilz-industrial-motion-planner, rclcpp, ros-testing, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-tests";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "4bc22261df5b84c0378f85c3eeedc9f3fb8a4faea44a6fca702498cd2073a18b";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_tests/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "b29c28ed2c0731c50ae7d740b955d38726a23d4a9098c3b328fa495561dae1d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-trajectory-cache/default.nix
+++ b/distros/rolling/moveit-ros-trajectory-cache/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-uncrustify, geometry-msgs, launch-pytest, launch-testing-ament-cmake, moveit-common, moveit-configs-utils, moveit-planners-ompl, moveit-resources, moveit-ros, moveit-ros-planning-interface, python3Packages, rclcpp, rclcpp-action, rmf-utils, robot-state-publisher, ros2-control, tf2-ros, trajectory-msgs, warehouse-ros-sqlite, xacro }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-trajectory-cache";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "9214e8e4b643d5cb8513c08cf6d28e7c907d57b87a501988ac724947c1ffae2c";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_trajectory_cache/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "dc642b8209ecad604d1e52585dede80487c5de163aae247df7c85d71620532d3";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-visualization/default.nix
+++ b/distros/rolling/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-visualization";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "01874472f2d82d0ea202abb71406e53ea33b34823bc5cd84d46940f0ec008974";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_visualization/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "0d95c8611bc80bbefbb8e0a6a160c286a2f182a92246fbae69eb039109c6b428";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros-warehouse/default.nix
+++ b/distros/rolling/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmt, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros-warehouse";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "9dc06b4b20e1fa054e4602d54bc8c4e6197653203cbcc5992001313e624607fd";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros_warehouse/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "95eaddec12da075a182385ad8c16b4267e70dfa6156e5ef1b5aa41b5db2e0550";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-ros/default.nix
+++ b/distros/rolling/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-ros";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "e721ef516962c98fe2420363242e5c8534180bc1243a9c373d330ead2b4a4cd4";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_ros/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "834c093a94b7a1f518a358bc2b078928949c7c05990d0225ff1ef6ebb8852104";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-runtime/default.nix
+++ b/distros/rolling/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-rolling-moveit-runtime";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "4a838c7ed6b78e6feee48d7003712a25d5006191b41f4388e2839dc338760a13";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_runtime/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "9785a021d5c7b841ae306400723a91caaed3053ee67c6d3215f80e1485745fba";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-servo/default.nix
+++ b/distros/rolling/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, control-msgs, controller-manager, generate-parameter-library, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, pluginlib, realtime-tools, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-rolling-moveit-servo";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "923ad1570ffc7a44e3a185cf4110ac56e4dc13b237162fcafb5da03d158319e1";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_servo/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "53b128145e8bf2b450f37a26147a4d3cc7846fe3f1eb167970737ab10bde7b9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-app-plugins/default.nix
+++ b/distros/rolling/moveit-setup-app-plugins/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, moveit-configs-utils, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-app-plugins";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "c4fd8c2678a1d772aff0b02d9c948fcd1d20d7f385527451f5444ae249da3b30";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_app_plugins/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "db34e74bd2ea90ea1360b3fbda249674dac47bc125ab22169d57a4ddab121f0e";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-index-cpp moveit-configs-utils moveit-ros-visualization moveit-setup-framework pluginlib rclcpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "Various specialty plugins for MoveIt Setup Assistant";

--- a/distros/rolling/moveit-setup-assistant/default.nix
+++ b/distros/rolling/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-panda-moveit-config, moveit-setup-app-plugins, moveit-setup-controllers, moveit-setup-core-plugins, moveit-setup-framework, moveit-setup-srdf-plugins, pluginlib, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-assistant";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "53ad4563e17f19904e72b336d3a305a2ec773ed80635d96df3cfb211323a9dd9";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_assistant/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "2821a951995b07085faad72ca27c669541649db202865cb7851ae7f132d47629";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit-setup-controllers/default.nix
+++ b/distros/rolling/moveit-setup-controllers/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, moveit-configs-utils, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-setup-framework, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-controllers";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "61ffa51687c4e41a5fde71346797cc676f131fc2653edba12eca5d16cc5965eb";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_controllers/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "355f196a1b693f14b00412c9a59b83ebaa5465b8e5b749bfa9683f04ee0bc336";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest moveit-configs-utils moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config ];
   propagatedBuildInputs = [ ament-index-cpp moveit-setup-framework pluginlib rclcpp ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "MoveIt Setup Steps for ROS 2 Control";

--- a/distros/rolling/moveit-setup-core-plugins/default.nix
+++ b/distros/rolling/moveit-setup-core-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, moveit-ros-visualization, moveit-setup-framework, pluginlib, rclcpp, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-core-plugins";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "5a8965f5520c3b71baf2ede734791ba01ad7a20a13fd5ed9dd723bb30e4cc539";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_core_plugins/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "67869a3dae1f9bb6d2a0f97701c6a66c9dc6b9254e5153d696e560b1582150b4";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   propagatedBuildInputs = [ ament-index-cpp moveit-ros-visualization moveit-setup-framework pluginlib rclcpp srdfdom urdf ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "Core (meta) plugins for MoveIt Setup Assistant";

--- a/distros/rolling/moveit-setup-framework/default.nix
+++ b/distros/rolling/moveit-setup-framework/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, fmt, moveit-common, moveit-core, moveit-ros-planning, moveit-ros-visualization, pluginlib, rclcpp, rviz-common, rviz-rendering, srdfdom, urdf }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-framework";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "323c0d535423c190184864fa6210ef4ec88c40bf7993868db062e402c38c8d96";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_framework/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "d1a6f9f0a20abc9357a7886841f682d8473e9539d37469516dab46621bc4144c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   propagatedBuildInputs = [ ament-index-cpp fmt moveit-common moveit-core moveit-ros-planning moveit-ros-visualization pluginlib rclcpp rviz-common rviz-rendering srdfdom urdf ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "C++ Interface for defining setup steps for MoveIt Setup Assistant";

--- a/distros/rolling/moveit-setup-srdf-plugins/default.nix
+++ b/distros/rolling/moveit-setup-srdf-plugins/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, moveit-resources-fanuc-description, moveit-setup-framework, pluginlib }:
 buildRosPackage {
   pname = "ros-rolling-moveit-setup-srdf-plugins";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "2fb54bd97a8ec65cdc8082fbe672ce3e904983639327c8732850f83352efefa8";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_setup_srdf_plugins/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "488c6b68b79c29b674cf5f832a63a7dee161a0a2dd332136a4659997cc7c7173";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   checkInputs = [ ament-cmake-gtest moveit-resources-fanuc-description ];
   propagatedBuildInputs = [ moveit-setup-framework pluginlib ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "SRDF-based plugins for MoveIt Setup Assistant";

--- a/distros/rolling/moveit-simple-controller-manager/default.nix
+++ b/distros/rolling/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-rolling-moveit-simple-controller-manager";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "a76345a0c30459a217a5820ebdeef09efbec93f5e1dc5b255d45b9fabfcd72bd";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit_simple_controller_manager/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "76594212b4c66a44c53ca7e8c5a666ab13d56c3758649b3aa95ab3d61d397efe";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/moveit/default.nix
+++ b/distros/rolling/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-rolling-moveit";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "466c4314d986ea9b767966cef928b0f935dffe9c8beed49c75f31172f750d466";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/moveit/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "77bc4c03fb68491ce38f34682d7d7a859a49adae216e124e306c74fb2b50bf56";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen3-cmake-module, moveit-common, moveit-core, moveit-msgs, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner-testutils";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "f1d8a67b41ef9a555b10b24a56fbc48db921c9d287cd53bb2be111d94acacc4d";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner_testutils/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "f6596ed52735e280ff8b5166a50689d70afa1f5168e228e58f821011ce889a87";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/pilz-industrial-motion-planner/default.nix
+++ b/distros/rolling/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, boost, eigen3-cmake-module, generate-parameter-library, geometry-msgs, launch-param-builder, moveit-common, moveit-configs-utils, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, orocos-kdl-vendor, pilz-industrial-motion-planner-testutils, pluginlib, rclcpp, ros-testing, tf2, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-rolling-pilz-industrial-motion-planner";
-  version = "2.13.0-r1";
+  version = "2.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.13.0-1.tar.gz";
-    name = "2.13.0-1.tar.gz";
-    sha256 = "148952aa1762970f501890b685db4f119078db4f983685550ebf2a2da3bb850e";
+    url = "https://github.com/ros2-gbp/moveit2-release/archive/release/rolling/pilz_industrial_motion_planner/2.13.2-1.tar.gz";
+    name = "2.13.2-1.tar.gz";
+    sha256 = "e1624ddaf73b9fff43ca249d6d1f19dcd5d515995d19fb7f68c8b9599990b732";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-demos/default.nix
+++ b/distros/rolling/polygon-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, angles, color-util, geometry-msgs, polygon-msgs, polygon-rviz-plugins, polygon-utils, rclcpp, rviz-common, rviz-default-plugins, rviz2 }:
 buildRosPackage {
   pname = "ros-rolling-polygon-demos";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_demos/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "670f997786033ad4e47ad68fe221a01da647125df6ba00503d5647cdf84e9899";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_demos/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "17cce693d276386967774faaae26287350497f6dff103df2ccadebf2f2ebb947";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-msgs/default.nix
+++ b/distros/rolling/polygon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-polygon-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "d5747eda77d185c70f3dc7bab99318d9fb708fb4bd90a24bcb9309fa2066d6d4";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2576a68e4b157b6060d0537748d14f56abb808bb6a3026c5d5873c648fc6a7c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/rolling/polygon-rviz-plugins/default.nix
+++ b/distros/rolling/polygon-rviz-plugins/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2025 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, color-util, geometry-msgs, pluginlib, polygon-msgs, polygon-utils, rviz-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, color-util, geometry-msgs, pluginlib, polygon-msgs, polygon-utils, rviz-common, std-msgs }:
 buildRosPackage {
   pname = "ros-rolling-polygon-rviz-plugins";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_rviz_plugins/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "8cb0ddafee28e3771a054a7251862650826d1e12995aad6b97906a7b4b5441f5";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_rviz_plugins/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a3816ddbce67e6888f1ae2858222ef05364d8ff7c2645cb7389ba555ad58ff9c";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake-ros ];
   propagatedBuildInputs = [ color-util geometry-msgs pluginlib polygon-msgs polygon-utils rviz-common std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = "RViz visualizations for polygons";

--- a/distros/rolling/polygon-utils/default.nix
+++ b/distros/rolling/polygon-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-cmake-python, geometry-msgs, polygon-msgs, python3Packages }:
 buildRosPackage {
   pname = "ros-rolling-polygon-utils";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_utils/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2de1d0f6f672f76e88d2632b1001b40060d8d69f1bc52abe7979e2a3179aa074";
+    url = "https://github.com/ros2-gbp/polygon_ros-release/archive/release/rolling/polygon_utils/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "31c0228d099e3627ef1f74928919808159e8f7d165830432335472c1c5750898";
   };
 
   buildType = "ament_cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['humble', 'jazzy', 'noetic', 'rolling'] from nix-ros-overlay commit 37c8b514bcf082bf980dd2e2cdf8253f0bdb10d6.
This pull request was generated by running the following command:

```
superflore-gen-nix --dry-run --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch develop --all
```

Changes:
========
Humble Changes:
---------------
* *ackermann-steering-controller 2.43.0-r1 --> 2.44.0-r1*
* *admittance-controller 2.43.0-r1 --> 2.44.0-r1*
* *bicycle-steering-controller 2.43.0-r1 --> 2.44.0-r1*
* *controller-interface 2.49.0-r1 --> 2.50.0-r1*
* *controller-manager 2.49.0-r1 --> 2.50.0-r1*
* *controller-manager-msgs 2.49.0-r1 --> 2.50.0-r1*
* *diff-drive-controller 2.43.0-r1 --> 2.44.0-r1*
* *dynamixel-hardware-interface 1.4.2-r1 --> 1.4.3-r1*
* *effort-controllers 2.43.0-r1 --> 2.44.0-r1*
* *fkie-message-filters 3.0.1-r1*
* *force-torque-sensor-broadcaster 2.43.0-r1 --> 2.44.0-r1*
* *forward-command-controller 2.43.0-r1 --> 2.44.0-r1*
* *franka-inria-inverse-dynamics-solver 1.0.0-r1*
* *gpio-controllers 2.43.0-r1 --> 2.44.0-r1*
* *gripper-controllers 2.43.0-r1 --> 2.44.0-r1*
* *hardware-interface 2.49.0-r1 --> 2.50.0-r1*
* *hardware-interface-testing 2.49.0-r1 --> 2.50.0-r1*
* *imu-sensor-broadcaster 2.43.0-r1 --> 2.44.0-r1*
* *inverse-dynamics-solver 1.0.0-r1*
* *joint-limits 2.49.0-r1 --> 2.50.0-r1*
* *joint-state-broadcaster 2.43.0-r1 --> 2.44.0-r1*
* *joint-trajectory-controller 2.43.0-r1 --> 2.44.0-r1*
* *kdl-inverse-dynamics-solver 1.0.0-r1*
* *ld08-driver 1.1.1-r1 --> 1.1.3-r1*
* *leo 1.2.4-r1 --> 1.3.0-r1*
* *leo-description 1.2.4-r1 --> 1.3.0-r1*
* *leo-gz-bringup 1.1.1-r1 --> 1.1.2-r1*
* *leo-gz-worlds 1.1.1-r1 --> 1.1.2-r1*
* *leo-msgs 1.2.4-r1 --> 1.3.0-r1*
* *leo-simulator 1.1.1-r1 --> 1.1.2-r1*
* *leo-teleop 1.2.4-r1 --> 1.3.0-r1*
* *libcaer-driver 1.1.3-r1 --> 1.5.0-r1*
* *mecanum-drive-controller 2.43.0-r1 --> 2.44.0-r1*
* *open-manipulator 3.0.1-r1*
* *open-manipulator-x-bringup 3.0.1-r1*
* *open-manipulator-x-description 3.0.1-r1*
* *open-manipulator-x-gui 3.0.1-r1*
* *open-manipulator-x-playground 3.0.1-r1*
* *open-manipulator-x-teleop 3.0.1-r1*
* *pid-controller 2.43.0-r1 --> 2.44.0-r1*
* *pose-broadcaster 2.43.0-r1 --> 2.44.0-r1*
* *position-controllers 2.43.0-r1 --> 2.44.0-r1*
* *range-sensor-broadcaster 2.43.0-r1 --> 2.44.0-r1*
* *ros2-control 2.49.0-r1 --> 2.50.0-r1*
* *ros2-control-test-assets 2.49.0-r1 --> 2.50.0-r1*
* *ros2-controllers 2.43.0-r1 --> 2.44.0-r1*
* *ros2-controllers-test-nodes 2.43.0-r1 --> 2.44.0-r1*
* *ros2controlcli 2.49.0-r1 --> 2.50.0-r1*
* *rqt-controller-manager 2.49.0-r1 --> 2.50.0-r1*
* *rqt-joint-trajectory-controller 2.43.0-r1 --> 2.44.0-r1*
* *steering-controllers-library 2.43.0-r1 --> 2.44.0-r1*
* *swri-cli-tools 3.7.3-r2 --> 3.7.4-r1*
* *swri-console-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-dbw-interface 3.7.3-r2 --> 3.7.4-r1*
* *swri-geometry-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-image-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-math-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-opencv-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-roscpp 3.7.3-r2 --> 3.7.4-r1*
* *swri-route-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-serial-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-system-util 3.7.3-r2 --> 3.7.4-r1*
* *swri-transform-util 3.7.3-r2 --> 3.7.4-r1*
* *transmission-interface 2.49.0-r1 --> 2.50.0-r1*
* *tricycle-controller 2.43.0-r1 --> 2.44.0-r1*
* *tricycle-steering-controller 2.43.0-r1 --> 2.44.0-r1*
* *turtlebot3 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-bringup 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-cartographer 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-description 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-example 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-navigation2 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-node 2.2.6-r1 --> 2.2.8-r1*
* *turtlebot3-teleop 2.2.6-r1 --> 2.2.8-r1*
* *ur 2.6.0-r1 --> 2.7.0-r1*
* *ur-bringup 2.6.0-r1 --> 2.7.0-r1*
* *ur-calibration 2.6.0-r1 --> 2.7.0-r1*
* *ur-controllers 2.6.0-r1 --> 2.7.0-r1*
* *ur-dashboard-msgs 2.6.0-r1 --> 2.7.0-r1*
* *ur-moveit-config 2.6.0-r1 --> 2.7.0-r1*
* *ur-robot-driver 2.6.0-r1 --> 2.7.0-r1*
* *ur-simulation-gz 0.1.1-r2 --> 0.2.0-r1*
* *ur10-inverse-dynamics-solver 1.0.0-r1*
* *velocity-controllers 2.43.0-r1 --> 2.44.0-r1*
* *yasmin 3.1.0-r1 --> 3.2.0-r2*
* *yasmin-demos 3.1.0-r1 --> 3.2.0-r2*
* *yasmin-msgs 3.1.0-r1 --> 3.2.0-r2*
* *yasmin-ros 3.1.0-r1 --> 3.2.0-r2*
* *yasmin-viewer 3.1.0-r1 --> 3.2.0-r2*

Jazzy Changes:
--------------
* *ackermann-steering-controller 4.22.0-r1 --> 4.23.0-r1*
* *admittance-controller 4.22.0-r1 --> 4.23.0-r1*
* *bicycle-steering-controller 4.22.0-r1 --> 4.23.0-r1*
* *clearpath-bt-joy 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-common 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-config 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-control 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-customization 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-description 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-generator-common 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-generator-gz 2.2.0-r1 --> 2.3.0-r1*
* *clearpath-gz 2.2.0-r1 --> 2.3.0-r1*
* *clearpath-manipulators 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-manipulators-description 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-motor-msgs 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-mounts-description 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-msgs 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-platform-description 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-platform-msgs 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-sensors-description 2.2.2-r1 --> 2.3.0-r1*
* *clearpath-simulator 2.2.0-r1 --> 2.3.0-r1*
* *clearpath-tests 2.3.0-r1 --> 2.3.1-r1*
* *controller-interface 4.27.0-r1 --> 4.28.0-r1*
* *controller-manager 4.27.0-r1 --> 4.28.0-r1*
* *controller-manager-msgs 4.27.0-r1 --> 4.28.0-r1*
* *depth-obstacle-detect-ros 2.0.0-r1*
* *depth-obstacle-detect-ros-msgs 2.0.0-r1*
* *diff-drive-controller 4.22.0-r1 --> 4.23.0-r1*
* *dynamixel-hardware-interface 1.4.2-r1 --> 1.4.3-r1*
* *effort-controllers 4.22.0-r1 --> 4.23.0-r1*
* *fkie-message-filters 3.0.1-r1*
* *force-torque-sensor-broadcaster 4.22.0-r1 --> 4.23.0-r1*
* *forward-command-controller 4.22.0-r1 --> 4.23.0-r1*
* *gpio-controllers 4.22.0-r1 --> 4.23.0-r1*
* *gps-sensor-broadcaster 4.23.0-r1*
* *gripper-controllers 4.22.0-r1 --> 4.23.0-r1*
* *hardware-interface 4.27.0-r1 --> 4.28.0-r1*
* *hardware-interface-testing 4.27.0-r1 --> 4.28.0-r1*
* *imu-sensor-broadcaster 4.22.0-r1 --> 4.23.0-r1*
* *joint-limits 4.27.0-r1 --> 4.28.0-r1*
* *joint-state-broadcaster 4.22.0-r1 --> 4.23.0-r1*
* *joint-trajectory-controller 4.22.0-r1 --> 4.23.0-r1*
* *ld08-driver 1.1.1-r1 --> 1.1.3-r1*
* *leo 3.0.4-r1 --> 3.1.0-r1*
* *leo-description 3.0.4-r1 --> 3.1.0-r1*
* *leo-gz-bringup 2.0.1-r1 --> 2.0.2-r1*
* *leo-gz-plugins 2.0.1-r1 --> 2.0.2-r1*
* *leo-gz-worlds 2.0.1-r1 --> 2.0.2-r1*
* *leo-msgs 3.0.4-r1 --> 3.1.0-r1*
* *leo-simulator 2.0.1-r1 --> 2.0.2-r1*
* *leo-teleop 3.0.4-r1 --> 3.1.0-r1*
* *libcaer-driver 1.3.3-r1 --> 1.5.0-r1*
* *mecanum-drive-controller 4.22.0-r1 --> 4.23.0-r1*
* *om-gravity-compensation-controller 3.2.1-r1*
* *om-joint-trajectory-command-broadcaster 3.2.1-r1*
* *om-spring-actuator-controller 3.2.1-r1*
* *open-manipulator 3.2.1-r1*
* *open-manipulator-bringup 3.2.1-r1*
* *open-manipulator-description 3.2.1-r1*
* *open-manipulator-gui 3.2.1-r1*
* *open-manipulator-moveit-config 3.2.1-r1*
* *open-manipulator-playground 3.2.1-r1*
* *open-manipulator-teleop 3.2.1-r1*
* *open-sound-control 0.0.2-r1*
* *open-sound-control-bridge 0.0.2-r1*
* *open-sound-control-msgs 0.0.2-r1*
* *parallel-gripper-controller 4.22.0-r1 --> 4.23.0-r1*
* *pid-controller 4.22.0-r1 --> 4.23.0-r1*
* *pose-broadcaster 4.22.0-r1 --> 4.23.0-r1*
* *position-controllers 4.22.0-r1 --> 4.23.0-r1*
* *range-sensor-broadcaster 4.22.0-r1 --> 4.23.0-r1*
* *ros2-control 4.27.0-r1 --> 4.28.0-r1*
* *ros2-control-test-assets 4.27.0-r1 --> 4.28.0-r1*
* *ros2-controllers 4.22.0-r1 --> 4.23.0-r1*
* *ros2-controllers-test-nodes 4.22.0-r1 --> 4.23.0-r1*
* *ros2controlcli 4.27.0-r1 --> 4.28.0-r1*
* *rqt-controller-manager 4.27.0-r1 --> 4.28.0-r1*
* *rqt-joint-trajectory-controller 4.22.0-r1 --> 4.23.0-r1*
* *steering-controllers-library 4.22.0-r1 --> 4.23.0-r1*
* *swri-cli-tools 3.7.3-r1 --> 3.7.4-r1*
* *swri-console-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-dbw-interface 3.7.3-r1 --> 3.7.4-r1*
* *swri-geometry-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-image-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-math-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-opencv-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-roscpp 3.7.3-r1 --> 3.7.4-r1*
* *swri-route-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-serial-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-system-util 3.7.3-r1 --> 3.7.4-r1*
* *swri-transform-util 3.7.3-r1 --> 3.7.4-r1*
* *transmission-interface 4.27.0-r1 --> 4.28.0-r1*
* *tricycle-controller 4.22.0-r1 --> 4.23.0-r1*
* *tricycle-steering-controller 4.22.0-r1 --> 4.23.0-r1*
* *turtlebot3 2.2.8-r1*
* *turtlebot3-bringup 2.2.8-r1*
* *turtlebot3-cartographer 2.2.8-r1*
* *turtlebot3-description 2.2.8-r1*
* *turtlebot3-example 2.2.8-r1*
* *turtlebot3-navigation2 2.2.8-r1*
* *turtlebot3-node 2.2.8-r1*
* *turtlebot3-teleop 2.2.8-r1*
* *ur 3.1.1-r1 --> 3.2.0-r1*
* *ur-calibration 3.1.1-r1 --> 3.2.0-r1*
* *ur-controllers 3.1.1-r1 --> 3.2.0-r1*
* *ur-dashboard-msgs 3.1.1-r1 --> 3.2.0-r1*
* *ur-moveit-config 3.1.1-r1 --> 3.2.0-r1*
* *ur-robot-driver 3.1.1-r1 --> 3.2.0-r1*
* *ur-simulation-gz 2.1.0-r2 --> 2.2.0-r1*
* *velocity-controllers 4.22.0-r1 --> 4.23.0-r1*
* *yasmin 3.1.0-r1 --> 3.2.0-r1*
* *yasmin-demos 3.1.0-r1 --> 3.2.0-r1*
* *yasmin-msgs 3.1.0-r1 --> 3.2.0-r1*
* *yasmin-ros 3.1.0-r1 --> 3.2.0-r1*
* *yasmin-viewer 3.1.0-r1 --> 3.2.0-r1*

Rolling Changes:
----------------
* *camera-ros 0.3.0-r1 --> 0.4.0-r1*
* *chomp-motion-planner 2.13.0-r1 --> 2.13.2-r1*
* *libcamera 0.5.0-r2 --> 0.5.0-r3*
* *moveit 2.13.0-r1 --> 2.13.2-r1*
* *moveit-common 2.13.0-r1 --> 2.13.2-r1*
* *moveit-configs-utils 2.13.0-r1 --> 2.13.2-r1*
* *moveit-core 2.13.0-r1 --> 2.13.2-r1*
* *moveit-hybrid-planning 2.13.0-r1 --> 2.13.2-r1*
* *moveit-kinematics 2.13.0-r1 --> 2.13.2-r1*
* *moveit-planners 2.13.0-r1 --> 2.13.2-r1*
* *moveit-planners-chomp 2.13.0-r1 --> 2.13.2-r1*
* *moveit-planners-ompl 2.13.0-r1 --> 2.13.2-r1*
* *moveit-planners-stomp 2.13.0-r1 --> 2.13.2-r1*
* *moveit-plugins 2.13.0-r1 --> 2.13.2-r1*
* *moveit-py 2.13.0-r1 --> 2.13.2-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 2.13.0-r1 --> 2.13.2-r1*
* *moveit-resources-prbt-moveit-config 2.13.0-r1 --> 2.13.2-r1*
* *moveit-resources-prbt-pg70-support 2.13.0-r1 --> 2.13.2-r1*
* *moveit-resources-prbt-support 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-benchmarks 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-control-interface 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-move-group 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-occupancy-map-monitor 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-perception 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-planning 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-planning-interface 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-robot-interaction 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-tests 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-trajectory-cache 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-visualization 2.13.0-r1 --> 2.13.2-r1*
* *moveit-ros-warehouse 2.13.0-r1 --> 2.13.2-r1*
* *moveit-runtime 2.13.0-r1 --> 2.13.2-r1*
* *moveit-servo 2.13.0-r1 --> 2.13.2-r1*
* *moveit-setup-app-plugins 2.13.0-r1 --> 2.13.2-r1*
* *moveit-setup-assistant 2.13.0-r1 --> 2.13.2-r1*
* *moveit-setup-controllers 2.13.0-r1 --> 2.13.2-r1*
* *moveit-setup-core-plugins 2.13.0-r1 --> 2.13.2-r1*
* *moveit-setup-framework 2.13.0-r1 --> 2.13.2-r1*
* *moveit-setup-srdf-plugins 2.13.0-r1 --> 2.13.2-r1*
* *moveit-simple-controller-manager 2.13.0-r1 --> 2.13.2-r1*
* *pilz-industrial-motion-planner 2.13.0-r1 --> 2.13.2-r1*
* *pilz-industrial-motion-planner-testutils 2.13.0-r1 --> 2.13.2-r1*
* *polygon-demos 1.1.0-r1 --> 1.2.0-r1*
* *polygon-msgs 1.1.0-r1 --> 1.2.0-r1*
* *polygon-rviz-plugins 1.1.0-r1 --> 1.2.0-r1*
* *polygon-utils 1.1.0-r1 --> 1.2.0-r1*


Missing Dependencies:
=====================
 * [ ] action_tutorials_interfaces
 * [ ] atlas
 * [ ] camera_info_manager_py
 * [ ] clpe_ros_msgs
 * [ ] festival
 * [ ] gazebo_ros2_control
 * [ ] gazebo_ros_pkgs
 * [ ] gurumdds-3.0
 * [ ] gurumdds-3.2
 * [ ] gz-plugin
 * [ ] gz-sim6
 * [ ] ignition-common4
 * [ ] ignition-fortress
 * [ ] ignition-fuel-tools7
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo6
 * [ ] ignition-gui6
 * [ ] ignition-msgs8
 * [ ] ignition-plugin
 * [ ] ignition-transport11
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libcoin80-dev
 * [ ] libmongoclient-dev
 * [ ] libopen3d-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqt5-serialport-dev
 * [ ] libserial-dev
 * [ ] pr2_teleop_general
 * [ ] ps3joy
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-omniorb
 * [ ] python-pygithub3
 * [ ] python-pytesseract-pip
 * [ ] python-slacker-cli
 * [ ] python-webrtcvad-pip
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-sphinx
 * [ ] python3-catkin-tools
 * [ ] python3-httpx
 * [ ] python3-icecream
 * [ ] python3-marisa
 * [ ] python3-platformdirs
 * [ ] python3-pyassimp
 * [ ] python3-pymap3d
 * [ ] python3-pysnmp-mibs
 * [ ] python3-pytorch-pip
 * [ ] python3-rosdep
 * [ ] python3-setproctitle
 * [ ] python3-torch-geometric-pip
 * [ ] python3-wheel
 * [ ] qtbase5-private-dev
 * [ ] ros_ign_bridge
 * [ ] ros_ign_gazebo
 * [ ] rviz_mesh_plugin
 * [ ] sdformat12
 * [ ] sound-theme-freedesktop
 * [ ] tesseract-ocr
 * [ ] tesseract-ocr-jpn
 * [ ] texlive-fonts-recommended
 * [ ] warehouse_ros_mongo
 * [ ] wiimote