### PR TITLE
Remove dev outputs in ament-cmake-core and python-cmake-module

### DIFF
--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -13,7 +13,6 @@ rosSelf: rosSuper: with rosSelf.lib; {
   in {
     propagatedBuildInputs = [ setupHook ] ++ propagatedBuildInputs;
     nativeBuildInputs = [ setupHook ] ++ nativeBuildInputs;
-    outputs = [ "out" "dev" ];
   });
 
   ament-cmake-vendor-package = rosSuper.ament-cmake-vendor-package.overrideAttrs ({
@@ -183,7 +182,6 @@ rosSelf: rosSuper: with rosSelf.lib; {
     pythonLibrary = "${python}/lib/lib${python.libPrefix}${libExt}";
     pythonIncludeDir = "${python}/include/${python.libPrefix}";
     setupHook = ./python-cmake-module-setup-hook.sh;
-    outputs = [ "out" "dev" ];
   });
 
   rcutils = rosSuper.rcutils.overrideAttrs ({


### PR DESCRIPTION
These dev outputs prevent building of ROS packages with colcon inside buildEnv unless ament-colcon-core and python-cmake-module are explicitly installed. Specifically, if one installs only dependencies declared in package.xml, e.g., ament_cmake, the build fails because cmake complains about not finding ament_cmake_core.

As far as I understand, the reason is that buildEnv recursively includes all propagatedBuildInputs but uses their dev outputs if they exist. In case of the mentioned packages, these outputs are empty except nix-support/propagated-build-inputs. This file correctly propagates the "out" output of the same package, but this is not (by design) reflected inside buildEnv.

This change fixes the above problem and seems not to cause any new build failure in the overlay. This was verified by Hydra: https://hydra.iid.ciirc.cvut.cz/eval/3868?compare=lopsided98-develop&full=0.

The problem described above can be reproduced by the following sequence of commands:

    git clone https://github.com/ros2/demos -b jazzy
    cd demos/demo_nodes_cpp
    cat > shell.nix <<'EOF'
    {
      nix-ros-overlay ? builtins.fetchTarball "https://github.com/lopsided98/nix-ros-overlay/archive/master.tar.gz",
      pkgs ? import nix-ros-overlay { },
      rosDistro ? "jazzy",
    }:
    pkgs.mkShell {
      name = "ros2nix ${rosDistro} shell";
      packages = [
        (pkgs.rosPackages.${rosDistro}.buildEnv {
          wrapPrograms = false;
          paths =
            [
              pkgs.colcon
              pkgs.rosPackages.${rosDistro}.ros-core
            ]
            ++ (
              with pkgs;
              with pkgs.rosPackages.${rosDistro};
              [
                ament-cmake
                example-interfaces
                launch-ros
                launch-xml
                rcl
                rcl-interfaces
                rclcpp
                rclcpp-components
                rcpputils
                rcutils
                rmw
                std-msgs
              ]
            );
          }
        )
      ];
    }
    EOF
    nix-shell
    colcon build

If one enters the shell as:

    nix-shell --arg nix-ros-overlay /path/to/this/pr

then `colcon build` succeeds.