### PR TITLE
workflows: Truncate PR message if it's longer than GitHub limit

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -55,6 +55,10 @@ jobs:
           # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#about-workflow-events
           SUPERFLORE_GITHUB_TOKEN: ${{ secrets.SUPERFLORE_GITHUB_TOKEN }}
         run: |
+          if [ $(stat --format='%s' .pr-message.tmp) -gt 65536 ]; then
+            echo "PR body too long - truncating!"
+            truncate -s 64K .pr-message.tmp
+          fi
           superflore-gen-nix --pr-only \
             --output-repository-path . \
             --upstream-branch develop \


### PR DESCRIPTION
Recently, updates started failing (e.g. https://github.com/lopsided98/nix-ros-overlay/actions/runs/15634988130/job/44047768366). This is either because GitHub decreased the limit for PR message length or ROS became bigger than ever before (perhaps due to the Kilted release) or both.

This PR blindly truncates the message if it is too long. Hopefully, it will not happen too often. If it happens, we can recognize it from GitHub Action log message.

This change was tested in my fork. The truncated PR generated by the proposed Action is https://github.com/wentasah/nix-ros-overlay/pull/23.