### PR TITLE
Allow updating the overlay manually

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -18,6 +18,15 @@ jobs:
       - name: Install Superflore
         run: |
           nix build .#update-overlay
+      - name: Restore ROS tarball cache
+        uses: actions/cache/restore@v4
+        with:
+          # Use run_id to update the cache:
+          # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          key: tars-${{ github.run_id }}
+          restore-keys: tars
+          path: |
+            ~/.ros/tar
       - name: Update overlay
         env:
           GITHUB_RUNNER_TEMP: ${{ runner.temp }}
@@ -30,6 +39,14 @@ jobs:
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
           nix run .#update-overlay
+      - name: Remove untouched files from the cache
+        run: "find ~/.ros/tar -atime +1 | tee >(xargs -r ls -lh >&2) | xargs -r rm"
+      - name: Save ROS tarball cache
+        uses: actions/cache/save@v4
+        with:
+          key: tars-${{ github.run_id }}
+          path: |
+            ~/.ros/tar
       - name: Update ament_vendor info
         continue-on-error: true
         run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -17,15 +17,11 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: Install Superflore
         run: |
-          nix-env -f . -iA python3Packages.rosdep superflore
+          nix build .#update-overlay
       - name: Update overlay
         env:
-          ROS_OS_OVERRIDE: nixos
-          ROSDEP_SOURCE_PATH: rosdep-sources
+          GITHUB_RUNNER_TEMP: ${{ runner.temp }}
         run: |
-          mkdir -p "$ROSDEP_SOURCE_PATH"
-          curl https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list -o "$ROSDEP_SOURCE_PATH/20-default.list"
-          rosdep update
           git config --local user.email "superflore@github.com"
           git config --local user.name "Superflore"
           git config credential.helper '!
@@ -33,11 +29,7 @@ jobs:
               echo "username=lopsided98"
               echo "password=${SUPERFLORE_GITHUB_TOKEN}"
             }; f'
-          superflore-gen-nix --dry-run \
-            --tar-archive-dir "${{ runner.temp }}/tar" \
-            --output-repository-path . \
-            --upstream-branch develop \
-            --all
+          nix run .#update-overlay
       - name: Update ament_vendor info
         continue-on-error: true
         run: |
@@ -60,5 +52,6 @@ jobs:
             truncate -s 64K .pr-message.tmp
           fi
           superflore-gen-nix --pr-only \
+          nix run .#update-overlay -- --pr-only \
             --output-repository-path . \
             --upstream-branch develop \

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 result*
+.tar
+rosdep-sources

--- a/README.md
+++ b/README.md
@@ -135,3 +135,24 @@ This means all the system dependencies of `<package>` were available, so its Nix
 **Q: Why do some packages fail to build?**
 
 There are thousands of ROS packages, so it is infeasible to make sure every package builds. I generally aim to keep at least 80-90% of the packages in a distribution successfully building, but this percentage tends to decrease as distributions get older and develop incompatibilities with newer software. If a package you need does not build, please open an issue or try to fix it yourself. In many cases, build failures occur due to bugs in the packages themselves, and should be fixed upstream. In other cases, overrides may need to be added to this overlay to fix the auto-generated expressions.
+
+**Q: Can I update the overlay to match the latest ROS?**
+
+The overlay is updated semi-automatically approximately every few
+weeks. If you want to try a more recent ROS version, you can update
+the whole overlay locally by running the following command from
+repository root:
+
+```
+nix run .#update-overlay
+```
+
+It needs to download source tarballs of all ROS packages from all
+distributions, which can take long time. If you're interested in just
+a specific distribution, you can specify superflore arguments on the
+command line. For example, the following command updates just the
+`jazzy` distro:
+
+```
+nix run .#update-overlay -- --dry-run --output-repository-path . --tar-archive-dir .tar --no-branch --ros-distro jazzy
+```

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       };
     in {
       legacyPackages = pkgs.rosPackages;
+      packages.update-overlay = pkgs.callPackage ./maintainers/scripts/update-overlay.nix { };
 
       devShells = {
         example-turtlebot3-gazebo = import ./examples/turtlebot3-gazebo.nix { inherit pkgs; };

--- a/maintainers/scripts/update-overlay.nix
+++ b/maintainers/scripts/update-overlay.nix
@@ -1,0 +1,33 @@
+{
+  curl,
+  python3Packages,
+  superflore,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "update-overlay";
+
+  runtimeInputs = [
+    curl
+    superflore
+    python3Packages.rosdep
+  ];
+
+  runtimeEnv = {
+    ROS_OS_OVERRIDE = "nixos";
+    ROSDEP_SOURCE_PATH = "rosdep-sources";
+  };
+
+  text = ''
+    if [[ $# -eq 0 ]]; then
+      echo "No superflore parameters specified, using defaults."
+        set -- --dry-run --output-repository-path . --all \
+               --tar-archive-dir .tar --no-branch
+    fi
+    set -x
+    mkdir -p "$ROSDEP_SOURCE_PATH"
+    curl https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/sources.list.d/20-default.list -o "$ROSDEP_SOURCE_PATH/20-default.list"
+    rosdep update
+    superflore-gen-nix "$@"
+  '';
+}

--- a/maintainers/scripts/update-overlay.nix
+++ b/maintainers/scripts/update-overlay.nix
@@ -21,9 +21,9 @@ writeShellApplication {
   text = ''
     if [[ $# -eq 0 ]]; then
       echo "No superflore parameters specified, using defaults."
-      if [[ ''${GITHUB_RUNNER_TEMP:-} ]]; then
+      if [[ ''${GITHUB_ACTION:-} ]]; then
         set -- --dry-run --output-repository-path . --all \
-               --tar-archive-dir "$GITHUB_RUNNER_TEMP/tar" --upstream-branch develop
+               --tar-archive-dir ~/.ros/tar --upstream-branch develop
       else
         set -- --dry-run --output-repository-path . --all \
                --tar-archive-dir .tar --no-branch

--- a/maintainers/scripts/update-overlay.nix
+++ b/maintainers/scripts/update-overlay.nix
@@ -21,8 +21,13 @@ writeShellApplication {
   text = ''
     if [[ $# -eq 0 ]]; then
       echo "No superflore parameters specified, using defaults."
+      if [[ ''${GITHUB_RUNNER_TEMP:-} ]]; then
+        set -- --dry-run --output-repository-path . --all \
+               --tar-archive-dir "$GITHUB_RUNNER_TEMP/tar" --upstream-branch develop
+      else
         set -- --dry-run --output-repository-path . --all \
                --tar-archive-dir .tar --no-branch
+      fi
     fi
     set -x
     mkdir -p "$ROSDEP_SOURCE_PATH"


### PR DESCRIPTION
Given that the update GitHub Action is failing for multiple weeks (fix is in #640), it might be useful for users to perform the update locally. With this PR, one can update the overlay locally by running:

    nix run .#update-overlay

This executes more or less the same commands as the GitHub Action performing periodic updates. The second commit updates the action to use the same instead of duplicating the code in `update.yaml`. This is being tested in https://github.com/wentasah/nix-ros-overlay/actions/runs/15906983859/job/44864392480.

This functionality might also be useful for solving issues like #544.