### PR TITLE
Migrate top-level Python packages to pyproject format

### DIFF
--- a/pkgs/catkin-tools/default.nix
+++ b/pkgs/catkin-tools/default.nix
@@ -10,6 +10,9 @@ buildPythonPackage rec {
     hash = "sha256-BjVwOJRD8L5ESOKlZbiuAc/NQdAsvDoU8INr1FiMBjo=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [ setuptools osrf-pycommon pyyaml catkin-pkg ];
 
   # No tests in PyPi tarball

--- a/pkgs/colcon/argcomplete.nix
+++ b/pkgs/colcon/argcomplete.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, argcomplete }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, argcomplete, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-argcomplete";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-PnCjK30WuBanxyGCvbIN+YX/wBZ47Jxn1EZZgUphmH0=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core argcomplete ];
 

--- a/pkgs/colcon/bash.nix
+++ b/pkgs/colcon/bash.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-bash";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-KaIjpmgo4Yqtm421CH9xFOOIYBgwCRgwyhewla2iy6w=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/cargo.nix
+++ b/pkgs/colcon/cargo.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, catkin-pkg, colcon-cmake
 , colcon-core, colcon-pkg-config, colcon-python-setup-py, colcon-recursive-crawl
-, colcon-library-path, toml }:
+, colcon-library-path, toml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-cargo";
@@ -10,6 +10,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-FXp3Nso5NlvBqPA2Kv03mBNR8fwQELbDMU+mqmxTSWc=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     catkin-pkg

--- a/pkgs/colcon/cmake.nix
+++ b/pkgs/colcon/cmake.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path
-, colcon-test-result, cmake }:
+, colcon-test-result, cmake, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-cmake";
@@ -9,6 +9,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-8cChTiUw07c4+NBlnCfVnioKA9/vYB5hNpu1CD6/H2k=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   postPatch = ''
     substituteInPlace colcon_cmake/task/cmake/__init__.py \

--- a/pkgs/colcon/core.nix
+++ b/pkgs/colcon/core.nix
@@ -36,6 +36,9 @@ let
       hash = "sha256-vt3cD/+0rGpkoMCLHbbvV3dtlHjCaDl3e19lNQRdJ5c=";
     };
 
+    pyproject = true;
+    build-system = [ setuptools ];
+
     propagatedBuildInputs = [
       distlib
       empy_3

--- a/pkgs/colcon/defaults.nix
+++ b/pkgs/colcon/defaults.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-defaults";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-sPPMkAYmkGpGrp7lNB94sjeQjflXKhDlfQ8EHZRriOM=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     colcon-core

--- a/pkgs/colcon/devtools.nix
+++ b/pkgs/colcon/devtools.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-devtools";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-NK44d/YM4E9QrL8Rzq22YObq696Dfm2LA1q5+4yjbgU=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     colcon-core

--- a/pkgs/colcon/library-path.nix
+++ b/pkgs/colcon/library-path.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-library-path";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1qp94i5czv7zmp9aqf6z1b9zpznyg91zdzs53dvq4mmb3a8zr242";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/meson.nix
+++ b/pkgs/colcon/meson.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path, meson }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path, meson, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-meson";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-DqjGKFOJLXPEmFjo8TyDwHCY8H1gi4vtWTyxEMflILI=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     colcon-core

--- a/pkgs/colcon/metadata.nix
+++ b/pkgs/colcon/metadata.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-metadata";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1j0yjzdin19dzsb25g73nszld7jlr3dg1i499nf22a8fw4678z0k";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     colcon-core

--- a/pkgs/colcon/mixin.nix
+++ b/pkgs/colcon/mixin.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, pyyaml, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-mixin";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-4MNJz3sHCWEohm7BD6UI41QA2yCP7LvrhqVKsaHUnuk=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     colcon-core

--- a/pkgs/colcon/notification.nix
+++ b/pkgs/colcon/notification.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core, notify2 }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, notify2, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-notification";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-xFuJgHOo6YxFGDM7dYf56kmsG8Epp7xOE5AFkFcDH7g=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core notify2 ];
 

--- a/pkgs/colcon/output.nix
+++ b/pkgs/colcon/output.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-output";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-RNLTSevbYWiLQeANVl6hoZno/Fwsd68nnPqsdNwBwE0=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/package-information.nix
+++ b/pkgs/colcon/package-information.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-package-information";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-IPUYSuGwXbCnbyRLyFYi9rJeSO9zmPVXhMz+RV1AvPs=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/package-selection.nix
+++ b/pkgs/colcon/package-selection.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-package-selection";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1nq327rycxf9710ml7k9ivd1jrnaxyk6k7sydp76kb676vc96i29";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/parallel-executor.nix
+++ b/pkgs/colcon/parallel-executor.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-parallel-executor";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-5xN/yvTGHbeSlV/WQb+tfbrUtBkoxrgf+Hp4M54RZkQ=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/pkg-config.nix
+++ b/pkgs/colcon/pkg-config.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-pkg-config";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "18xzqs78bv1w3881091wbwqsvkii79bhr5r3gfx3140m6z84dz41";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/python-setup-py.nix
+++ b/pkgs/colcon/python-setup-py.nix
@@ -9,6 +9,9 @@ buildPythonPackage rec {
     hash = "sha256-TYurLgW6M04p7uNxX73kkCgTQu2OAA4lITDlxRkVODo=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [ colcon-core setuptools ];
 
   # Requires unpackaged dependencies

--- a/pkgs/colcon/recursive-crawl.nix
+++ b/pkgs/colcon/recursive-crawl.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-recursive-crawl";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-/KX2GSFNIDBtqvAS+ROZ1NO2BTZLEh5d+AOZQyxVxgM=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/ros-cargo.nix
+++ b/pkgs/colcon/ros-cargo.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, colcon-core, colcon-library-path
-, colcon-cargo, colcon-ros }:
+, colcon-cargo, colcon-ros, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-ros-cargo";
@@ -10,6 +10,9 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-70taCMJRPSq2CPvO5aqudsc8RN0l194vLbT1UZWXfU8=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     colcon-core

--- a/pkgs/colcon/ros.nix
+++ b/pkgs/colcon/ros.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, catkin-pkg, colcon-cmake, colcon-core
 , colcon-pkg-config, colcon-python-setup-py
-, colcon-recursive-crawl }:
+, colcon-recursive-crawl, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-ros";
@@ -10,6 +10,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-eafon2+mNvfk/USoi3hg+x2pnVHwunvPC5tiShpXg2U=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     catkin-pkg

--- a/pkgs/colcon/test-result.nix
+++ b/pkgs/colcon/test-result.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-test-result";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1lvfqd3yfqnbjc3hgpc6ikphs5823r7s1rr1ywfrzpavd9qjalma";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/colcon/zsh.nix
+++ b/pkgs/colcon/zsh.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, colcon-core }:
+{ lib, buildPythonPackage, fetchPypi, colcon-core, setuptools }:
 
 buildPythonPackage rec {
   pname = "colcon-zsh";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-7/91xD3asmSYU1KeQc7jbg+DttTIZMBzY1PQ3s54M0o=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ colcon-core ];
 

--- a/pkgs/rosdep/default.nix
+++ b/pkgs/rosdep/default.nix
@@ -10,6 +10,9 @@ buildPythonPackage rec {
     hash = "sha256-oKcA3r27EykySLprt6+ZAHBQ1XH+pNLkzGEZzkRj3nI=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   # Tries to download files
   doCheck = false;
 

--- a/pkgs/rosdistro/default.nix
+++ b/pkgs/rosdistro/default.nix
@@ -9,6 +9,9 @@ buildPythonPackage rec {
     hash = "sha256-RwOCS1hwS8oZBhMuO9PUK6cq9zhh7QPVoZJUeKcr+ys=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [ pyyaml setuptools catkin-pkg rospkg ];
 
   meta = with lib; {

--- a/pkgs/rosinstall-generator/default.nix
+++ b/pkgs/rosinstall-generator/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, fetchpatch, catkin-pkg, rosdistro
-, rospkg, pyyaml, distutils, pytestCheckHook }:
+, rospkg, pyyaml, distutils, pytestCheckHook, setuptools }:
 
 buildPythonPackage rec {
   pname = "rosinstall_generator";
@@ -11,6 +11,9 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-4Kan5MGfr4dMsSNTBf4RXsC4ae8mzeU2tgBdAsOw2IY=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [ distutils ];
 

--- a/pkgs/rospkg/default.nix
+++ b/pkgs/rospkg/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, catkin-pkg, pyyaml, distro }:
+{ lib, buildPythonPackage, fetchPypi, catkin-pkg, pyyaml, distro, setuptools }:
 
 buildPythonPackage rec {
   pname = "rospkg";
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-/OdqdHd4bDcymBJiGY6iUPCX+I4NMynBDBEGm/QMpgQ=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ catkin-pkg pyyaml distro ];
 

--- a/pkgs/superflore/default.nix
+++ b/pkgs/superflore/default.nix
@@ -14,6 +14,9 @@ buildPythonPackage rec {
     hash = "sha256-it6cje1nkG4pjakn5Vvwhw0NGyc23xblmhXMEwUpTbg=";
   };
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [
     xmltodict
     termcolor


### PR DESCRIPTION
Evaluating Python packages against latest nixpkgs produces eval errors like this:

    error: python3.13-rosdep-0.25.1 does not configure a `format`. To
    build with setuptools as before, set `pyproject = true` and
    `build-system = [ setuptools ]`.`

This is caused by [this commit](https://github.com/NixOS/nixpkgs/pull/421660/commits/d2e9be2b076699b1a8e8d6b6f9ea4bebbd6956f9).

Here we fix all top-level packages with such an error. The fix is compatible with older nixpkgs currently used in this overlay.