### PR TITLE
Fix ompl build for ROS 2 distros

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -141,18 +141,6 @@ let
       })
     ];
 
-    ompl = rosSuper.ompl.overrideAttrs ({
-      patches ? [], ...
-    }: {
-      patches = patches ++ [
-        # Fix pkg-config paths
-        (self.fetchpatch {
-          url = "https://github.com/ompl/ompl/commit/d4e26fc3d86cae0c36941a10bf0307e02526db44.patch";
-          hash = "sha256-sAQLrWHoR/DhHk8TtUEy8E8VXqrvtXl2BGS5UvElJl8=";
-        })
-      ];
-    });
-
     plotjuggler = (rosSuper.plotjuggler.override {
       # plotjuggler is not yet compatible with newer versions
       protobuf = self.protobuf_23;

--- a/distros/ros1-overlay.nix
+++ b/distros/ros1-overlay.nix
@@ -136,6 +136,18 @@ rosSelf: rosSuper: with rosSelf.lib; {
     nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
   });
 
+  ompl = rosSuper.ompl.overrideAttrs ({
+    patches ? [], ...
+  }: {
+    patches = patches ++ [
+      # Fix pkg-config paths
+      (self.fetchpatch {
+        url = "https://github.com/ompl/ompl/commit/d4e26fc3d86cae0c36941a10bf0307e02526db44.patch";
+        hash = "sha256-sAQLrWHoR/DhHk8TtUEy8E8VXqrvtXl2BGS5UvElJl8=";
+      })
+    ];
+  });
+
   roscpp = patchBoostSignals rosSuper.roscpp;
 
   rqt-console = rosSuper.rqt-console.overrideAttrs ({


### PR DESCRIPTION
The patch, which was previously used for all distros, is now needed just for noetic.

This will be needed after next Superflore update.