### PR TITLE
workflows: Remove forgotten line from merge conflict

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -68,7 +68,6 @@ jobs:
             echo "PR body too long - truncating!"
             truncate -s 64K .pr-message.tmp
           fi
-          superflore-gen-nix --pr-only \
           nix run .#update-overlay -- --pr-only \
             --output-repository-path . \
             --upstream-branch develop \


### PR DESCRIPTION
This should have been a part of commit 8753f46405 ("workflows: Make GitHub use the newly added update-overlay "script"", 2025-06-24).