### PR TITLE
workflows: Ensure that all vendored-source.json files are added to git

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -55,7 +55,8 @@ jobs:
           mkdir -p ~/.config/nixpkgs
           echo '{ permittedInsecurePackages = [ "freeimage-3.18.0-unstable-2024-04-18" ]; }' > ~/.config/nixpkgs/config.nix
           NIX_PATH=nixpkgs=$PWD ./maintainers/scripts/update-ament-vendor.sh || ret=$?
-          git commit -m 'Update vendored-source.json files' $(find -name vendored-source.json) || :
+          git add distros/*/*/vendored-source.json
+          git commit -m 'Update vendored-source.json files' || :
           exit $ret
       - name: Create PR
         env:


### PR DESCRIPTION
When adding a new ROS distro, new vendored-source.json files are generated automatically by GitHub Actions. If we don't add them to git, subsequent commit fails with error like:

    error: pathspec './distros/kilted/gz-plugin-vendor/vendored-source.json' did not match any file(s) known to git

The result is that no vendored-source.json updates are committed, which is not what we want.