### PR TITLE
update jazzy mcap-vendor override

### DIFF
--- a/distros/jazzy/overrides.nix
+++ b/distros/jazzy/overrides.nix
@@ -142,8 +142,8 @@ in {
   };
 
   mcap-vendor = lib.patchVendorUrl rosSuper.mcap-vendor {
-    url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.3.0.tar.gz";
-    hash = "sha256-Qaz26F11VWxkQH8HfgVJLTHbHwmeByQu8ENkuyk5rPE=";
+    url = "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.3.1.tar.gz";
+    hash = "sha256-JCTITBfe8WrEBhWX0rkqLdnHN6qXidUCj1Xz0fmPnac=";
   };
 
   moveit-core = rosSuper.moveit-core.overrideAttrs ({


### PR DESCRIPTION
Hi,

This fix plotjuggler build on jazzy.

mcap-vendor otherwise seems OK on humble and rolling.

I guess those `patchVendorUrl` are manually updated, otherwise feel free to close this PR.

Also, if they are manual, it could be worth working on some automation.