### PR TITLE
kilted.urdfdom-headers: Remove override

### DIFF
--- a/distros/kilted/overrides.nix
+++ b/distros/kilted/overrides.nix
@@ -220,17 +220,4 @@ in {
       })
     ];
   });
-
-  urdfdom-headers = rosSuper.urdfdom-headers.overrideAttrs ({
-    patches ? [], ...
-  }: {
-    patches = patches ++ [
-      # Fix CMake relative install dir assumptions
-      # https://github.com/ros/urdfdom_headers/pull/66
-      (self.fetchpatch {
-        url = "https://github.com/ros/urdfdom_headers/commit/6e0cea148c3a7123f8367cd48d5709a4490c32f1.patch";
-        hash = "sha256-LC2TACGma/k6+WE9fTkzY98SgJYKsVuj5O9v84Q5mQ4=";
-      })
-    ];
-  });
 }


### PR DESCRIPTION
Patching fails and the patch is no longer needed.